### PR TITLE
Removed some hard-coded paths (see last PR) and added command line options

### DIFF
--- a/mxcube3/__init__.py
+++ b/mxcube3/__init__.py
@@ -25,7 +25,7 @@ opt_parser.add_option("-l", "--log-file",
 opt_parser.add_option("-s", "--beamline-setup", 
                       dest="beamline_setup", 
                       help="Beamline setup HWR file", 
-                      default='/beamline_setup')
+                      default='/beamline-setup')
 opt_parser.add_option("-q", "--queue-model", 
                       dest="queue_model", 
                       help="Queue model HWR file", 

--- a/mxcube3/__init__.py
+++ b/mxcube3/__init__.py
@@ -21,6 +21,14 @@ opt_parser.add_option("-l", "--log-file",
                       dest="log_file", 
                       help="Hardware Repository log file name", 
                       default=os.path.join(os.path.dirname(__file__), 'log/mxcube3.log'))
+opt_parser.add_option("-s", "--beamline-setup", 
+                      dest="beamline_setup", 
+                      help="Beamline setup HWR file", 
+                      default='/beamline_setup')
+opt_parser.add_option("-q", "--queue-model", 
+                      dest="queue_model", 
+                      help="Queue model HWR file", 
+                      default='/queue-model')
 cmdline_options, args = opt_parser.parse_args()
 
 ###Initialization of the HardwareObjects
@@ -30,16 +38,16 @@ HardwareRepository.addHardwareObjectsDirs([os.path.join(os.path.dirname(__file__
 sys.path.insert(0, os.path.dirname(__file__))
 
 hwr_directory = cmdline_options.hwr_directory
-hwr_directory = './mxcube3/HardwareObjects.xml/'
 hwr = HardwareRepository.HardwareRepository(os.path.abspath(os.path.expanduser(hwr_directory)))
 hwr.connect()
 log_file = cmdline_options.log_file
 setLogFile(log_file)
-#app.resolution = hwr.getHardwareObject("/resolution-mockup")
-app.diffractometer = hwr.getHardwareObject("/md2-9113")
-#app.diffractometer = hwr.getHardwareObject("/minidiff")
-#app.beamline = hwr.getHardwareObject("/beamline-setup")
-#app.queue = hwr.getHardwareObject("/queue-model")
+
+app.beamline = hwr.getHardwareObject(cmdline_options.beamline_setup)
+app.diffractometer = app.beamline.getObjectByRole("diffractometer")
+#app.resolution = app.beamline.getObjectByRole("resolution")
+#app.queue = hwr.getHardwareObject(cmdline_options.queue_model)
 
 ###Importing all REST-routes
 import routes.Main, routes.Beamline, routes.Collection, routes.Mockups, routes.Sample, routes.SampleCentring
+

--- a/mxcube3/__init__.py
+++ b/mxcube3/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from flask import Flask, session, redirect, url_for, render_template, request, Response
 from flask.ext.socketio import SocketIO
 from optparse import OptionParser
@@ -32,13 +33,13 @@ opt_parser.add_option("-q", "--queue-model",
 cmdline_options, args = opt_parser.parse_args()
 
 ###Initialization of the HardwareObjects
-from .HardwareRepository import HardwareRepository, setLogFile
-HardwareRepository.addHardwareObjectsDirs([os.path.join(os.path.dirname(__file__), 'HardwareObjects')])
 # this is to allow Hardware Objects to do 'from HardwareRepository import ...'
-sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.dirname(__file__)) 
+from HardwareRepository import HardwareRepository as hwr, setLogFile
+hwr.addHardwareObjectsDirs([os.path.join(os.path.dirname(__file__), 'HardwareObjects')])
 
 hwr_directory = cmdline_options.hwr_directory
-hwr = HardwareRepository.HardwareRepository(os.path.abspath(os.path.expanduser(hwr_directory)))
+hwr = hwr.HardwareRepository(os.path.abspath(os.path.expanduser(hwr_directory)))
 hwr.connect()
 log_file = cmdline_options.log_file
 setLogFile(log_file)

--- a/mxcube3/routes/Beamline.py
+++ b/mxcube3/routes/Beamline.py
@@ -1,5 +1,5 @@
 from flask import session, redirect, url_for, render_template, request, Response
-from .. import app as mxcube
+from mxcube3 import app as mxcube
 
 import logging
 

--- a/mxcube3/routes/Collection.py
+++ b/mxcube3/routes/Collection.py
@@ -1,5 +1,5 @@
 from flask import session, redirect, url_for, render_template, request, Response
-from .. import app as mxcube
+from mxcube3 import app as mxcube
 
 import logging
 

--- a/mxcube3/routes/Main.py
+++ b/mxcube3/routes/Main.py
@@ -1,6 +1,6 @@
 from flask import session, redirect, url_for, render_template, request, Response
+from mxcube3 import app as mxcube
 import logging
-from .. import app as mxcube
 
 @mxcube.route("/")
 def serve_static_file():

--- a/mxcube3/routes/Mockups.py
+++ b/mxcube3/routes/Mockups.py
@@ -1,5 +1,5 @@
 from flask import session, redirect, url_for, render_template, request, Response
-from .. import app as mxcube
+from mxcube3 import app as mxcube
 # from . import mockups#samplecentring, sample, beamline, collection
 
 import logging

--- a/mxcube3/routes/Sample.py
+++ b/mxcube3/routes/Sample.py
@@ -1,5 +1,5 @@
 from flask import session, redirect, url_for, render_template, request, Response
-from .. import app as mxcube
+from mxcube3 import app as mxcube
 
 import logging
 

--- a/mxcube3/routes/SampleCentring.py
+++ b/mxcube3/routes/SampleCentring.py
@@ -1,5 +1,5 @@
 from flask import session, redirect, url_for, render_template, request, Response, stream_with_context
-from .. import app as mxcube
+from mxcube3 import app as mxcube
 import time, logging, collections
 import gevent.event
 import os, json

--- a/mxcube3/routes/signals.py
+++ b/mxcube3/routes/signals.py
@@ -1,6 +1,6 @@
 import logging, json
 from flask.ext.socketio import emit
-from .. import socketio
+from mxcube3 import socketio
 MaxLabMicrodiff_signals = ['minidiffReady','minidiffNotReady','phizMotorStateChanged','phiyMotorStateChanged','zoomMotorPredefinedPositionChanged','zoomMotorStateChanged','sampxMotorStateChanged','sampyMotorStateChanged','centringInvalid','newAutomaticCentringPoint','centringStarted','centringAccepted','centringMoving','centringFailed','centringSuccessful','progressMessage','centringSnapshots'] #'phiMotorStateChanged','minidiffStateChanged', 'diffractometerMoved', removed to cleanup the log
 
 BL9113MultiCollect_signals = ['collectConnected', 'collectReady',  'collectNumberOfFrames', 'collectImageTaken','collectReady','collectStarted','collectOscillationStarted', 'collectOscillationFailed', 'collectOscillationFinished','collectEnded']


### PR DESCRIPTION
Last committed code introduced some hard-coded paths, this PR removes that.

The solution for not having hard-coded paths can be the following:
- use of "-r" command line switch to specify HWR directory
- use of "-s" command line switch to specify beamline setup hardware object (defaults to "/beamline-setup"
- normally, diffractometer and other devices are all loaded by beamline setup so we can use this
object to get access to all others
- except "queue-model", so I added a "-q" switch

Otherwise be careful not committing hard-coded paths ;-) 
Anyway the command line options are needed so it's good to add them.

I also enabled absolute imports, it is the new Python standard (since 2.7 I think ?) ; also, it fixes a weird
bug I had with Hardware Repository package (I am still running Python 2.6 here...). Should not make any difference for you.