### PR TITLE
Manually mounted feature

### DIFF
--- a/mxcube3/routes/Login.py
+++ b/mxcube3/routes/Login.py
@@ -26,85 +26,20 @@ def convert_to_dict(ispyb_object):
 def login():
     beamline_name = os.environ.get("SMIS_BEAMLINE_NAME")
     content = request.get_json()
-    Proposal = content['proposal']
+    loginID = content['proposal']
     password = content['password']
-    proposal = "".join(itertools.takewhile(lambda c: not c.isdigit(), Proposal))
-    prop_number = Proposal[len(proposal):]
-    
-    prop = mxcube.db_connection.get_proposal(proposal, prop_number)
-    if prop['status']['code'] == 'error':
-        return jsonify(prop)
+    logging.getLogger('HWR').info(loginID)
 
-    # following code is from ProposalBrick2, almost untouched;
-    # this should be moved to the hardware object somehow
-    # or even better, to a web service on ISPyB side
-    sessions = prop.get('Session')
-    
-    # Check if there are sessions in the proposal
-    todays_session = None
-    if sessions:
-        # Check for today's session
-        for session in sessions:
-            beamline=session['beamlineName']
-            start_date="%s 00:00:00" % session['startDate'].split()[0]
-            end_date="%s 23:59:59" % session['endDate'].split()[0]
-            try:
-                start_struct=time.strptime(start_date,"%Y-%m-%d %H:%M:%S")
-            except ValueError:
-                pass
-            else:
-                try:
-                    end_struct=time.strptime(end_date,"%Y-%m-%d %H:%M:%S")
-                except ValueError:
-                    pass
-                else:
-                    start_time=time.mktime(start_struct)
-                    end_time=time.mktime(end_struct)
-                    current_time=time.time()
+    loginRes = mxcube.db_connection.login(loginID, password)
 
-                    # Check beamline name
-                    if beamline==beamline_name:
-                        # Check date
-                        if current_time>=start_time and current_time<=end_time:
-                            todays_session=session
-                            break
+#        loginRes structure
+#        {'status':{ "code": "ok", "msg": msg }, 'Proposal': proposal,
+#        'session': todays_session,
+#        "local_contact": self.get_session_local_contact(todays_session['session']['sessionId']),
+#        "person": prop['Person'],
+#        "laboratory": prop['Laboratory']}
 
-    if todays_session is None:
-        is_inhouse = mxcube.session.is_inhouse(proposal, prop_number)
-        if not is_inhouse:
-            res = { "status": { "code": "error", "msg": "No session scheduled for today" } }
-
-        current_time=time.localtime()
-        start_time=time.strftime("%Y-%m-%d 00:00:00", current_time)
-        end_time=time.mktime(current_time)+60*60*24
-        tomorrow=time.localtime(end_time)
-        end_time=time.strftime("%Y-%m-%d 07:59:59", tomorrow)
-
-        # Create a session
-        new_session_dict={}
-        new_session_dict['proposalId']=prop['Proposal']['proposalId']
-        new_session_dict['startDate']=start_time
-        new_session_dict['endDate']=end_time
-        new_session_dict['beamlineName']=beamline_name
-        new_session_dict['scheduled']=0
-        new_session_dict['nbShifts']=3
-        new_session_dict['comments']="Session created by the BCM"
-        session_id = mxcube.db_connection.createSession(new_session_dict)
-        new_session_dict['sessionId']=session_id
-
-        todays_session=new_session_dict
-        localcontact = None
-    else:
-        session_id = todays_session['sessionId']
-        
-    res = { "status": { "code": "ok", "msg": "" },
-            "proposal_title": prop['Proposal']['title'],
-            "local_contact": mxcube.db_connection.getSessionLocalContact(session_id),
-            "session": todays_session,
-            "person": prop['Person'],
-            "laboratory": prop['Laboratory'] }
-
-    return jsonify(res)
+    return jsonify(loginRes)
 
 
 @mxcube.route("/mxcube/api/v0.1/samples/<proposal_id>")
@@ -124,4 +59,3 @@ def proposal_samples(proposal_id):
              sample_info["containerSampleChangerLocation"] = "%d:%d" % (cell, puck)
 
    return jsonify({ "samples_info": samples_info_list })
-

--- a/mxcube3/ui/actions/queue.js
+++ b/mxcube3/ui/actions/queue.js
@@ -27,6 +27,11 @@ export function removeSample(index) {
 	}
 }
 
+export function clearAll() {
+        return {
+               type: "CLEAR_QUEUE"
+        }
+}
 
 export function sendAddSample(id) {
 	return function(dispatch) {

--- a/mxcube3/ui/actions/samples_grid.js
+++ b/mxcube3/ui/actions/samples_grid.js
@@ -1,4 +1,5 @@
 import fetch from 'isomorphic-fetch'
+import { clearAll } from './queue'
 
 export function doUpdateSamples(samples_list) {
     return { type: "UPDATE_SAMPLES", samples_list }
@@ -73,9 +74,11 @@ export function doToggleManualMount() {
         const { samples_grid } = getState();
         if (samples_grid.manual_mount) {
             dispatch(doSetManualMount(false));
+            dispatch(clearAll());
             dispatch(doGetSamplesList());
         } else {
             dispatch(doSetManualMount(true));
+            dispatch(clearAll());
             dispatch(doUpdateSamples([{id:"0", sample_info: { sampleName: "mounted sample"}}])); 
         }
     }

--- a/mxcube3/ui/actions/samples_grid.js
+++ b/mxcube3/ui/actions/samples_grid.js
@@ -68,6 +68,24 @@ export function doAddMethod(sample_id, method, parameters) {
               }
 }
 
+export function doToggleManualMount() {
+    return function(dispatch, getState) {
+        const { samples_grid } = getState();
+        if (samples_grid.manual_mount) {
+            dispatch(doSetManualMount(false));
+            dispatch(doGetSamplesList());
+        } else {
+            dispatch(doSetManualMount(true));
+            dispatch(doUpdateSamples([{id:"0", sample_info: { sampleName: "mounted sample"}}])); 
+        }
+    }
+}
+            
+export function doSetManualMount(manual) {
+    return { type: "SET_MANUAL_MOUNT", manual }
+}
+
+
 export function doChangeMethod(queue_id, sample_id, list_index, parameters) {
     return { type: "CHANGE_METHOD",
             index: sample_id,

--- a/mxcube3/ui/components/Login.jsx
+++ b/mxcube3/ui/components/Login.jsx
@@ -24,14 +24,14 @@ export default class LoginForm extends React.Component {
     render() {
         let login_input_form = "";
         let data = this.props.proposal.data;
-        let ok = false;
+                let ok = false;
         try {
             ok = data.status.code == 'ok';
         } catch(e) {
             ok = false;
-        } finally {       
+        } finally {
            if (ok) {
-                let label = this.refs.proposal.getValue() + " - " + data.proposal_title;
+                let label = this.refs.proposal.getValue() + " - " + data.Proposal.title;
                 login_input_form = (<div>
                                     <p className="navbar-text" style={{float: 'none', display: 'inline-block'}}>{label}</p>
                                     <button className="btn btn-sm btn-info" style={{marginRight: '15px'}} onClick={this.logOut.bind(this)}>Log out</button>
@@ -45,6 +45,5 @@ export default class LoginForm extends React.Component {
             }
         }
 	return (<Nav right eventKey={0}>{login_input_form}</Nav>);
-    }    
+    }
 }
-

--- a/mxcube3/ui/components/SampleGrid/SampleGridItem.jsx
+++ b/mxcube3/ui/components/SampleGrid/SampleGridItem.jsx
@@ -30,14 +30,14 @@ export default class SampleGridItem extends React.Component {
 	}
 
 	render() {
-      let sample_id = this.props.sample_id;
-		  let classes = classNames('samples-grid-item', {'samples-grid-item-selected': this.props.selected});
-		  let sc_location_classes = classNames("sc_location", "label", "label-default", {"label-success": this.props.loadable});
+                let sample_id = this.props.sample_id;
+		let classes = classNames('samples-grid-item', {'samples-grid-item-selected': this.props.selected});
+		let sc_location_classes = classNames("sc_location", "label", "label-default", {"label-success": this.props.loadable});
 
-		  return <div className={classes} onClick={this.props.onClick}>
+		return <div className={classes} onClick={this.props.onClick}>
 			<span className={sc_location_classes}>{this.props.location}</span>
 			<br></br>
-			<a href="#" ref='pacronym' className="protein-acronym" data-type="text" data-pk="1" data-url="/post" data-title="Enter protein acronym">{this.props.name+' ('+this.props.acronym+')'}</a>
+			<a href="#" ref='pacronym' className="protein-acronym" data-type="text" data-pk="1" data-url="/post" data-title="Enter protein acronym">{this.props.name+(this.props.acronym ? ' ('+this.props.acronym+')' : "")}</a>
 			<br></br>
 			<span className="dm">{this.props.dm}</span>
 			<br></br>

--- a/mxcube3/ui/containers/SampleGridContainer.js
+++ b/mxcube3/ui/containers/SampleGridContainer.js
@@ -2,8 +2,8 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { connect } from 'react-redux'
 import SampleGrid from '../components/SampleGrid/SampleGrid'
-import { Input, Button, Glyphicon, ButtonToolbar  } from "react-bootstrap"
-import { doGetSamplesList, doUpdateSamples, doToggleSelected, doSelectAll, doUnselectAll, doFilter, doSyncSamples } from '../actions/samples_grid'
+import { Input, Button, Glyphicon, ButtonToolbar, SplitButton, MenuItem  } from "react-bootstrap"
+import { doGetSamplesList, doUpdateSamples, doToggleSelected, doSelectAll, doFilter, doSyncSamples, doToggleManualMount } from '../actions/samples_grid'
 import { sendAddSample } from '../actions/queue'
 
 class SampleGridContainer extends React.Component {
@@ -42,8 +42,10 @@ class SampleGridContainer extends React.Component {
                                 </div>
                                 <div className="col-xs-5">
                                    <ButtonToolbar>
-                                       <Button className="btn-primary" onClick={this.props.getSamples}>Check sample changer contents</Button>
-                                       <Button className="btn-primary" onClick={ () => { return this.syncSamples() }}>
+                                       <SplitButton bsStyle="primary" pullRight="true" title={this.props.manual_mount ? "Manual mount" : "Check sample changer contents"} onClick={this.props.manual_mount ? undefined : this.props.getSamples} onSelect={this.props.toggleManualMount}>
+                                           <MenuItem eventKey="1">{this.props.manual_mount ? "Sample changer" : "Manual mount"}</MenuItem> 
+                                       </SplitButton>
+                                       <Button className="btn-primary" disabled={this.props.manual_mount ? true : false } onClick={ () => { this.syncSamples() }}>
                                             <Glyphicon glyph="refresh"/> Sync. ISPyB
                                        </Button>
                                    </ButtonToolbar>
@@ -78,6 +80,8 @@ function mapDispatchToProps(dispatch) {
         filter: (filter_text) => dispatch(doFilter(filter_text)),
         syncSamples: (proposal_id) => dispatch(doSyncSamples(proposal_id)),
         addSampleToQueue: (id) => dispatch(sendAddSample(id))
+        toggleManualMount: (manual) => dispatch(doToggleManualMount(manual)),
+        updateSamples: (samples_list) => dispatch(doUpdateSamples(samples_list))
     }
 }
 

--- a/mxcube3/ui/containers/SampleGridContainer.js
+++ b/mxcube3/ui/containers/SampleGridContainer.js
@@ -79,7 +79,7 @@ function mapDispatchToProps(dispatch) {
         unselectAll: () => dispatch(doUnselectAll()),
         filter: (filter_text) => dispatch(doFilter(filter_text)),
         syncSamples: (proposal_id) => dispatch(doSyncSamples(proposal_id)),
-        addSampleToQueue: (id) => dispatch(sendAddSample(id))
+        addSampleToQueue: (id) => dispatch(sendAddSample(id)),
         toggleManualMount: (manual) => dispatch(doToggleManualMount(manual)),
         updateSamples: (samples_list) => dispatch(doUpdateSamples(samples_list))
     }

--- a/mxcube3/ui/reducers/queue.js
+++ b/mxcube3/ui/reducers/queue.js
@@ -31,7 +31,8 @@ export default (state={
 
                                     }
                                     });
-
+        case 'CLEAR_QUEUE':
+             return Object.assign({}, state, {todo: []});
         default:
             return state;
     }

--- a/mxcube3/ui/reducers/samples_grid.js
+++ b/mxcube3/ui/reducers/samples_grid.js
@@ -1,4 +1,4 @@
-export default (state={ samples_list: {}, filter_text: "", manual_mount: false, login_data: {} }, action) => {
+export default (state={ samples_list: {}, filter_text: "", selected: {}, manual_mount: false, login_data: {} }, action) => {
     switch (action.type) {
     case "UPDATE_SAMPLES":
           // should have session samples

--- a/mxcube3/ui/reducers/samples_grid.js
+++ b/mxcube3/ui/reducers/samples_grid.js
@@ -1,4 +1,4 @@
-export default (state={ samples_list: {}, selected: {}, filter_text: "", login_data: {} }, action) => {
+export default (state={ samples_list: {}, filter_text: "", manual_mount: false, login_data: {} }, action) => {
     switch (action.type) {
     case "UPDATE_SAMPLES":
           // should have session samples
@@ -50,6 +50,10 @@ export default (state={ samples_list: {}, selected: {}, filter_text: "", login_d
               }
           });
           return Object.assign({}, state, { samples_list: samples_list });
+      }
+    case "SET_MANUAL_MOUNT":
+      {
+          return Object.assign({}, state, { manual_mount: action.manual });
       }
     case "ADD_METHOD":
       {


### PR DESCRIPTION
This PR adds the "Manually mounted" feature, it is made available thanks to a split button, instead of
having just "Check sample changer contents" and additional dropdown allows to select "Manual mount".
This disables ISPyB synchronization, and leaves the sample grid with only 1 sample, ie. the manually mounted one.

__Question__: the Queue has to be cleared, so I added a CLEAR_QUEUE action. I am not sure if this is the best way, since it just removes the queue on the UI side I guess it should be removed from the server too ? Or to switch to another queue ? I guess switching to another queue is better, if people want to come back to the previous queue they were doing before. Like, someone uses the sample changer, then puts a manually mounted sample, then comes back to using the sample changer... I think it is a legitimate use case.