### PR TITLE
A first version of session management

### DIFF
--- a/mxcube3/ui/actions/samples_grid.js
+++ b/mxcube3/ui/actions/samples_grid.js
@@ -1,5 +1,5 @@
 import fetch from 'isomorphic-fetch'
-import { sendClearQueue } from './queue'
+import { sendClearQueue, sendState } from './queue'
 
 export function doUpdateSamples(samples_list) {
     return { type: "UPDATE_SAMPLES", samples_list }
@@ -133,6 +133,8 @@ export function sendAddSampleMethod(queue_id, sample_id, method) {
             return response.json();
         }).then(function(json) {
             dispatch(doAddMethod(queue_id, sample_id, json, method));
+            dispatch(sendState());
+
         });
        
 
@@ -156,6 +158,8 @@ export function sendChangeSampleMethod(sample_queue_id, method_queue_id, sample_
             return response.json();
         }).then(function(json) {
             dispatch(doChangeMethod(method_queue_id, sample_id, method));
+            dispatch(sendState());
+
         });
        
 
@@ -179,6 +183,8 @@ export function sendDeleteSampleMethod(parent_id, queue_id, sample_id, list_id) 
                 throw new Error("Server refused to remove sample");
             }else {
                 dispatch(doRemoveMethod(parent_id, queue_id, sample_id, list_id));
+                dispatch(sendState());
+
             }
         });
 

--- a/mxcube3/ui/containers/MXNavbarContainer.js
+++ b/mxcube3/ui/containers/MXNavbarContainer.js
@@ -4,13 +4,13 @@ import { connect } from 'react-redux';
 import { doLogin, getLoginInfo } from '../actions/login';
 import MXNavbar from '../components/MXNavbar/MXNavbar'
 import { doSignOut } from '../actions/login'
+import { sendState, getState } from '../actions/queue'
 
 
 
 class MXNavbarContainer extends Component {
 
   render() {
- 
     return (
     	<MXNavbar userInfo={this.props.userInfo} signOut={this.props.signOut} loggedIn={this.props.loggedIn} />
     )
@@ -21,13 +21,15 @@ class MXNavbarContainer extends Component {
 function mapStateToProps(state) {
         return { 
             userInfo: state.login.data,
-            loggedIn: state.login.loggedIn
+            loggedIn: state.login.loggedIn,
+            queueState: state.queue,
+            sampleGridState: state.samples_grid
         }
 }
 
 function mapDispatchToProps(dispatch) {
     return {
-        signOut: () => dispatch(doSignOut())
+        signOut: () => dispatch(doSignOut()),
     }
 }
 

--- a/mxcube3/ui/containers/SampleQueueContainer.js
+++ b/mxcube3/ui/containers/SampleQueueContainer.js
@@ -19,6 +19,12 @@ class SampleQueueContainer extends Component {
    componentDidMount() {
     const {doAddMethodResult} = this.props.sampleActions;
     const { socket} = this.props;
+    const {getState} = this.props.queueActions;
+
+    //Populate queue with previous state
+    getState();
+
+    // Start listening to socketIO to get results of method/sample execution
     socket.on('hwr_record', (record) => {
           console.log(record);
           doAddMethodResult(record.sample, record.queueId, record.state)

--- a/mxcube3/ui/reducers/queue.js
+++ b/mxcube3/ui/reducers/queue.js
@@ -141,6 +141,8 @@ export default (state={
                     todo: [],
                     history: []
                 });
+        case 'QUEUE_STATE':
+             return action.queueState;
         default:
             return state;
     }

--- a/mxcube3/ui/reducers/samples_grid.js
+++ b/mxcube3/ui/reducers/samples_grid.js
@@ -114,6 +114,8 @@ export default (state={ samples_list: {}, filter_text: "", selected: {}, manual_
              }}
           );
       }
+    case 'QUEUE_STATE':
+      return action.sampleGridState;
     default:
         return state
     }


### PR DESCRIPTION
This will retrieve the latest session from the server in case the client has crashed. This is as the title says a first version as the session is:

1. Not being saved to a particular user
2. The client sends the whole state to the server for saving on queue actions

In the future the server will save this data to the logged in user and it will also create the data needed to retrieve a session itself without the need for it to be sent from the client.
