### PR TITLE
Improvements regarding server-side Queue management (fixes #187 and #172)

### DIFF
--- a/mxcube3/__init__.py
+++ b/mxcube3/__init__.py
@@ -6,6 +6,7 @@ from optparse import OptionParser
 import os
 import sys
 import logging
+import jsonpickle
 import gevent
 
 opt_parser = OptionParser()
@@ -73,7 +74,7 @@ if not app.debug or os.environ.get("WERKZEUG_RUN_MAIN") == "true":
         app.diffractometer = app.beamline.getObjectByRole("diffractometer")
         routes.SampleCentring.init_signals()
         app.db_connection = app.beamline.getObjectByRole("lims_client")
-        app.queue = hwr.getHardwareObject(cmdline_options.queue_model)
+        app.empty_queue = jsonpickle.encode(hwr.getHardwareObject(cmdline_options.queue_model))
         routes.Queue.init_signals()
         app.sample_changer = app.beamline.getObjectByRole("sample_changer")
 

--- a/mxcube3/__init__.py
+++ b/mxcube3/__init__.py
@@ -65,7 +65,7 @@ if not app.debug or os.environ.get("WERKZEUG_RUN_MAIN") == "true":
     app.log_handler = custom_log_handler
 
     ###Importing all REST-routes
-    import routes.Main, routes.Login, routes.Beamline, routes.Collection, routes.Mockups, routes.SampleCentring, routes.SampleChanger, routes.Queue, routes.Diffractometer
+    import routes.Main, routes.Login, routes.Beamline, routes.Collection, routes.Mockups, routes.SampleCentring, routes.SampleChanger, routes.Diffractometer
 
     def complete_initialization(app):
         app.beamline = hwr.getHardwareObject(cmdline_options.beamline_setup)
@@ -75,7 +75,6 @@ if not app.debug or os.environ.get("WERKZEUG_RUN_MAIN") == "true":
         routes.SampleCentring.init_signals()
         app.db_connection = app.beamline.getObjectByRole("lims_client")
         app.empty_queue = jsonpickle.encode(hwr.getHardwareObject(cmdline_options.queue_model))
-        routes.Queue.init_signals()
         app.sample_changer = app.beamline.getObjectByRole("sample_changer")
 
     # starting from here, requests can be received by server;

--- a/mxcube3/__init__.py
+++ b/mxcube3/__init__.py
@@ -31,6 +31,7 @@ cmdline_options, args = opt_parser.parse_args()
 socketio = SocketIO()
 app = Flask(__name__, static_url_path='')
 app.config['SESSION_TYPE'] = "redis"
+app.config['SESSION_KEY_PREFIX'] = "mxcube:session:"
 app.config['SECRET_KEY'] = "nosecretfornow"
 sess = Session()
 sess.init_app(app)

--- a/mxcube3/__init__.py
+++ b/mxcube3/__init__.py
@@ -72,10 +72,13 @@ if not app.debug or os.environ.get("WERKZEUG_RUN_MAIN") == "true":
         app.session = app.beamline.getObjectByRole("session")
         app.collect = app.beamline.getObjectByRole("collect")
         app.diffractometer = app.beamline.getObjectByRole("diffractometer")
-        routes.SampleCentring.init_signals()
         app.db_connection = app.beamline.getObjectByRole("lims_client")
         app.empty_queue = jsonpickle.encode(hwr.getHardwareObject(cmdline_options.queue_model))
         app.sample_changer = app.beamline.getObjectByRole("sample_changer")
+        try:
+            routes.SampleCentring.init_signals()
+        except Exception:
+            sys.excepthook(*sys.exc_info())
 
     # starting from here, requests can be received by server;
     # however, objects are not all initialized, so requests can return errors

--- a/mxcube3/routes/Login.py
+++ b/mxcube3/routes/Login.py
@@ -32,32 +32,21 @@ def login():
         :statuscode: 200: no error
         :statuscode: 409: could not log in
     """
-
-#    beamline_name = os.environ.get("SMIS_BEAMLINE_NAME")
     content = request.get_json()
     loginID = content['proposal']
     password = content['password']
-    logging.getLogger('HWR').info(loginID)
-
     loginRes = mxcube.db_connection.login(loginID, password)
+   
     if loginRes['status']['code'] == 'ok':
-        session['proposal_id'] = loginID
         session['loginInfo'] = { 'loginID': loginID, 'password': password, 'loginRes': loginRes }
-        mxcube.session.proposal_id = loginID #do we still need this?
 #        loginRes structure
 #        {'status':{ "code": "ok", "msg": msg }, 'Proposal': proposal,
 #        'session': todays_session,
 #        "local_contact": self.get_session_local_contact(todays_session['session']['sessionId']),
 #        "person": prop['Person'],
 #        "laboratory": prop['Laboratory']}
-        serialized_queue = session.get("queue") or mxcube.empty_queue
-        mxcube.queue = jsonpickle.decode(serialized_queue)
-        try:
-            Queue.init_signals()
-        except Exception: 
-            sys.excepthook(*sys.exc_info())
 
-    return jsonify(convert_to_dict(loginRes))
+    return make_response(loginRes['status']['code'], 200)
 
 @mxcube.route("/mxcube/api/v0.1/signout")
 def signout():

--- a/mxcube3/routes/Login.py
+++ b/mxcube3/routes/Login.py
@@ -49,11 +49,9 @@ def login():
 #        "local_contact": self.get_session_local_contact(todays_session['session']['sessionId']),
 #        "person": prop['Person'],
 #        "laboratory": prop['Laboratory']}
-        session_queue = session.get("queueList", "{}")
-        if len(session_queue) == 0:
-          mxcube.queue = None
-        else:
-          mxcube.queue = jsonpickle.decode(session_queue)
+        serialized_queue = session.get("queue") or mxcube.empty_queue
+        mxcube.queue = jsonpickle.decode(serialized_queue)
+
     return jsonify(convert_to_dict(loginRes))
 
 @mxcube.route("/mxcube/api/v0.1/signout")

--- a/mxcube3/routes/Login.py
+++ b/mxcube3/routes/Login.py
@@ -1,9 +1,8 @@
 from flask import session, request, jsonify, make_response
 from mxcube3 import app as mxcube
-from mxcube3.routes import Queue
+from mxcube3.routes import Queue, Utils
 import logging
 import os
-import jsonpickle
 import types
 
 
@@ -22,6 +21,7 @@ def convert_to_dict(ispyb_object):
                 val = dict([(k, convert_to_dict(x) if type(x) == types.InstanceType else x) for k, x in val.iteritems()])
             d[key] = val
     return d
+
 
 @mxcube.route("/mxcube/api/v0.1/login", methods=["POST"])
 def login():
@@ -71,18 +71,8 @@ def loginInfo():
     if loginInfo is not None:
         loginInfo["loginRes"] = mxcube.db_connection.login(loginInfo["loginID"], loginInfo["password"])
         session['loginInfo'] = loginInfo
-    
-    serialized_queue = session.get("queue")
-    print 'saved queue =', serialized_queue
-    if not serialized_queue:
-       print 'making new queue'
-       serialized_queue = mxcube.empty_queue
-    mxcube.queue = jsonpickle.decode(serialized_queue)
- 
-    try:
-        Queue.init_signals()
-    except Exception: 
-        sys.excepthook(*sys.exc_info())
+  
+    mxcube.queue = Utils.get_queue(session) 
  
     return jsonify(
                     { "synchrotron_name": mxcube.session.synchrotron_name,

--- a/mxcube3/routes/Login.py
+++ b/mxcube3/routes/Login.py
@@ -53,9 +53,9 @@ def signout():
     """
     Signout from Mxcube3 and clean the session
     """
-    session['loginInfo'] = None
-    session['queueList'] = None
-    return ""
+    session.clear()
+    mxcube.queue = None
+    return make_response("", 200)
 
 # information to display on the login page
 @mxcube.route("/mxcube/api/v0.1/login_info", methods=["GET"])

--- a/mxcube3/routes/Login.py
+++ b/mxcube3/routes/Login.py
@@ -1,5 +1,6 @@
 from flask import session, request, jsonify, Response
 from mxcube3 import app as mxcube
+from mxcube3.routes import Queue
 import logging
 import os, jsonpickle
 import types
@@ -51,6 +52,10 @@ def login():
 #        "laboratory": prop['Laboratory']}
         serialized_queue = session.get("queue") or mxcube.empty_queue
         mxcube.queue = jsonpickle.decode(serialized_queue)
+        try:
+            Queue.init_signals()
+        except Exception: 
+            sys.excepthook(*sys.exc_info())
 
     return jsonify(convert_to_dict(loginRes))
 

--- a/mxcube3/routes/Queue.py
+++ b/mxcube3/routes/Queue.py
@@ -127,7 +127,7 @@ def queueClear():
         mxcube.queue.clear_model('sc_one')
         mxcube.queue._selected_model._children = []
         mxcube.queue.queue_hwobj.clear()
-        session["queueList"] = {} # OR jsonpickle.encode(mxcube.queue)
+        session.pop("queue", None) #remove queue from session, it will be added later when needed
         logging.getLogger('HWR').info('[QUEUE] Queue cleared  '+ str(mxcube.queue.get_model_root()._name))
         return Response(status=200)
     except Exception:
@@ -159,7 +159,7 @@ def queueGet():
     """
     logging.getLogger('HWR').info('[QUEUE] Queue getting data')
     try:
-        resp = jsonify(jsonParser())
+        resp = jsonify(serializeQueueToJson())
         resp.status_code = 200
         return resp
     except Exception:
@@ -190,7 +190,7 @@ def queueSaveState():
     #queueState = jsonpickle.encode(mxcube.queue) #.update(params['queueState'])
 
     try:
-        session["queueList"] = jsonpickle.encode(mxcube.queue)
+        session["queue"] = jsonpickle.encode(mxcube.queue)
     except Exception:
         return Response(status=409)
 
@@ -224,7 +224,7 @@ def queueLoadState():
 
         if mxcube.queue.queue_hwobj._queue_entry_list:
             logging.getLogger('HWR').info('[QUEUE] Looks like a queue was stored...')
-            resp = jsonify({'queueState': jsonParser(), 'sampleList': samples})
+            resp = jsonify({'queueState': serializeQueueToJson(), 'sampleList': samples})
             resp.status_code = 200
             return resp
         else:
@@ -235,16 +235,6 @@ def queueLoadState():
     except Exception:
         return Response(status=409)
 
-# @mxcube.route("/mxcube/api/v0.1/queue/load", methods=['GET'])
-# def queueLoad():
-#     """Queue: load the queue from a file, filename automatically selected under ./routes folder and based on the proposal name
-#     Args: None
-#     Return: queue data plus http status response, 200 ok, 409 something bad happened
-#     """
-#     resp = jsonify(jsonParser(True))
-#     resp.status_code = 200
-#     return resp
-   
 # @mxcube.route("/mxcube/api/v0.1/queue/entry/", methods=['GET'])
 # def getCurrentEntry():
 #     """Queue: get current entry. NOT IMPLEMENTED
@@ -269,7 +259,7 @@ def queueLoadState():
 #         logging.getLogger('HWR').error('[QUEUE] Queue could not get current entry')
 #         return Response(status=409)
 
-@mxcube.route("/mxcube/api/v0.1/queue/<nodeId>/execute", methods=['PUT'])
+@mxcube.route("/mxcube/api/v0.1/queue/<int:nodeId>/execute", methods=['PUT'])
 def executeEntryWithId(nodeId):
     """
     Execute the given queue entry
@@ -278,17 +268,18 @@ def executeEntryWithId(nodeId):
         :statuscode: 409: queue entry could not be executed
     """
     lastQueueNode = mxcube.queue.lastQueueNode
-    queueList = jsonParser() #session.get("queueList")
+    ## WARNING: serializeQueueToJson() should only be used for sending to the client,
+    ## here on the back-end side we should just always use mxcube.queue !
+    queue = serializeQueueToJson() 
 
     try:
-        nodeId = int(nodeId)
         node = mxcube.queue.get_node(nodeId)
         entry = mxcube.queue.queue_hwobj.get_entry_with_model(node)
 
         if isinstance(entry, qe.SampleQueueEntry):
             logging.getLogger('HWR').info('[QUEUE] Queue going to execute sample entry with id: %s' % nodeId)
             #this is a sample entry, thus, go through its checked children and execute those
-            for elem in queueList[nodeId]['methods']:
+            for elem in queue[nodeId]['methods']:
                 if int(elem['checked']) == 1:
                     logging.getLogger('HWR').info('[QUEUE] Queue executing children entry with id: %s' % elem['QueueId'])
                     childNode = mxcube.queue.get_node(elem['QueueId'])
@@ -302,7 +293,7 @@ def executeEntryWithId(nodeId):
                             logging.getLogger('HWR').info('[QUEUE] Cannot execute, queue is paused. Waiting for unpause')
                             #mxcube.queue.queue_hwobj.set_pause(False)
                             mxcube.queue.queue_hwobj.wait_for_pause_event()
-                        mxcube.queue.lastQueueNode.update({'id': elem['QueueId'], 'sample': queueList[nodeId]['SampleId']})
+                        mxcube.queue.lastQueueNode.update({'id': elem['QueueId'], 'sample': queue[nodeId]['SampleId']})
                         #mxcube.queue.lastQueueNode = lastQueueNode
                         # mxcube.queue.queue_hwobj.execute_entry = types.MethodType(Utils.my_execute_entry, mxcube.queue.queue_hwobj)
                         mxcube.queue.queue_hwobj.execute_entry(childEntry)
@@ -326,7 +317,7 @@ def executeEntryWithId(nodeId):
                 parentNode = parentNode.get_parent()
             parent = int(parentNode._node_id)
 
-            mxcube.queue.lastQueueNode.update({'id': nodeId, 'sample': queueList[parent]['SampleId']})
+            mxcube.queue.lastQueueNode.update({'id': nodeId, 'sample': queue[parent]['SampleId']})
             # mxcube.queue.queue_hwobj.execute_entry = types.MethodType(Utils.my_execute_entry, mxcube.queue.queue_hwobj)
             mxcube.queue.queue_hwobj.execute_entry(entry)
         return Response(status=200)
@@ -373,9 +364,11 @@ def addSample():
     sampleEntry._view = Mock()
     sampleEntry._set_background_color = Mock()
 
-    queueList = jsonParser()
-    for i in queueList:
-        if queueList[i]['SampleId'] == sampleId:
+    ## WARNING: serializeQueueToJson() should only be used for sending to the client,
+    ## here on the back-end side we should just always use mxcube.queue !
+    queue = serializeQueueToJson()
+    for i in queue:
+        if queue[i]['SampleId'] == sampleId:
             logging.getLogger('HWR').error('[QUEUE] sample could not be added, already in the queue')
             return Response(status=409)
     try:
@@ -383,8 +376,8 @@ def addSample():
         nodeId = sampleNode._node_id
         mxcube.queue.queue_hwobj.enqueue(sampleEntry)
         logging.getLogger('HWR').info('[QUEUE] sample "%s" added with queue id "%s"' %(sampleId, nodeId))
-        #queueList.update({nodeId: {'SampleId': sampleId, 'QueueId': nodeId, 'checked': 0, 'methods': []}})
-        session["queueList"] = jsonpickle.encode(mxcube.queue)
+        #queue.update({nodeId: {'SampleId': sampleId, 'QueueId': nodeId, 'checked': 0, 'methods': []}})
+        session["queue"] = jsonpickle.encode(mxcube.queue)
         return jsonify({'SampleId': sampleId, 'QueueId': nodeId})
     except Exception:
         logging.getLogger('HWR').exception('[QUEUE] sample could not be added')
@@ -409,7 +402,7 @@ def updateSample(sampleId):
             #TODO: update here the model with the new 'params'
             ### missing lines...
             sampleEntry.set_data_model(sampleNode)
-            session["queueList"] = jsonpickle.encode(mxcube.queue)
+            session["queue"] = jsonpickle.encode(mxcube.queue)
             logging.getLogger('HWR').info('[QUEUE] sample updated')
             resp = jsonify({'QueueId': nodeId})
             resp.status_code = 200
@@ -432,7 +425,9 @@ def toggleNode(id):
     nodeId = int(id)  # params['QueueId']
     node = mxcube.queue.get_node(nodeId)
     entry = mxcube.queue.queue_hwobj.get_entry_with_model(node)
-    queueList = jsonParser()
+    ## WARNING: serializeQueueToJson() should only be used for sending to the client,
+    ## here on the back-end side we should just always use mxcube.queue !
+    queue = serializeQueueToJson()
 
     try:
         if isinstance(entry, qe.SampleQueueEntry):
@@ -446,7 +441,7 @@ def toggleNode(id):
                 node.set_enabled(True)
 
             new_state = entry.is_enabled()
-            for elem in queueList[nodeId]['methods']:              
+            for elem in queue[nodeId]['methods']:              
                 childNode = mxcube.queue.get_node(elem['QueueId'])
                 childEntry = mxcube.queue.queue_hwobj.get_entry_with_model(childNode)
                 if new_state:
@@ -470,7 +465,7 @@ def toggleNode(id):
             #check if the brother&sisters are enabled (and enable the parent)
             checked = 0
 
-            for i in queueList[parent]['methods']:
+            for i in queue[parent]['methods']:
                 if i['QueueId'] != nodeId and i['checked'] == 1: # at least one brother is enabled, no need to change parent
                     checked = 1
                     break
@@ -483,7 +478,7 @@ def toggleNode(id):
                 node.set_enabled(True)
 
             new_state = entry.is_enabled()
-            for met in queueList[parent]['methods']:
+            for met in queue[parent]['methods']:
                 if int(met.get('QueueId')) == nodeId:
                     if new_state == 0 and checked == 0:
                         parentEntry.set_enabled(False)
@@ -504,8 +499,6 @@ def deleteSampleOrMethod(id):
         :statuscode: 200: no error
         :statuscode: 409: node could not be deleted
     """
-    queueList = jsonParser() #session.get("queueList")
-
     try:
         nodeToRemove = mxcube.queue.get_node(int(id))
         parent = nodeToRemove.get_parent()
@@ -519,7 +512,7 @@ def deleteSampleOrMethod(id):
         else:  # we are removing a sample, the parent of a sample is 'rootnode', which is not a Model
             mxcube.queue.queue_hwobj.dequeue(entryToRemove)
 
-        session["queueList"] = jsonpickle.encode(mxcube.queue)
+        session["queue"] = jsonpickle.encode(mxcube.queue)
 
         return Response(status=200)
     except Exception:
@@ -544,7 +537,7 @@ def deleteMethod(sampleid, methodid):
         parentEntry.dequeue(entryToRemove)
         parent = parent._node_id
         nodeToRemove = nodeToRemove._node_id
-        session["queueList"] = jsonpickle.encode(mxcube.queue)
+        session["queue"] = jsonpickle.encode(mxcube.queue)
 
         return Response(status=200)
     except Exception:
@@ -576,7 +569,7 @@ def addCentring(id):
 
         logging.getLogger('HWR').info('[QUEUE] centring added to sample')
 
-        session["queueList"] = jsonpickle.encode(mxcube.queue)
+        session["queue"] = jsonpickle.encode(mxcube.queue)
 
         resp = jsonify({'QueueId': newNode, 'Type': 'Centring', 'Params': params})
         resp.status_code = 200
@@ -634,7 +627,7 @@ def addCharacterisation(id):
         characNode.set_enabled(True)
         logging.getLogger('HWR').info('[QUEUE] characterisation added to sample')
 
-        session["queueList"] = jsonpickle.encode(mxcube.queue)
+        session["queue"] = jsonpickle.encode(mxcube.queue)
 
         resp = jsonify({'QueueId': newNode, 'Type': 'Characterisation'})
         resp.status_code = 200
@@ -682,7 +675,7 @@ def addDataCollection(id):
         newNode = mxcube.queue.add_child_at_id(task1Id, colNode)  # add_child does not return id!
         task1Entry.enqueue(colEntry)
 
-        session["queueList"] = jsonpickle.encode(mxcube.queue)
+        session["queue"] = jsonpickle.encode(mxcube.queue)
 
         logging.getLogger('HWR').info('[QUEUE] datacollection added to sample')
         resp = jsonify({'QueueId': newNode, 'Type': 'DataCollection'})
@@ -746,7 +739,7 @@ def updateMethod(sampleid, methodid):
             pass
         ####
 
-        session["queueList"] = jsonpickle.encode(mxcube.queue)
+        session["queue"] = jsonpickle.encode(mxcube.queue)
 
         logging.getLogger('HWR').info('[QUEUE] method updated')
         resp = jsonify({'QueueId': methodid})
@@ -766,12 +759,15 @@ def getSample(id):
         :statuscode: 409: sample could not be retrieved
     """
     try:
-        queueList = jsonParser()
-        if not queueList[int(id)]:
+        ## WARNING: serializeQueueToJson() should only be used for sending to the client,
+        ## here on the back-end side we should just always use mxcube.queue !
+        queue = serializeQueueToJson()
+
+        if not queue[int(id)]:
             logging.getLogger('HWR').error('[QUEUE] sample info could not be retrieved')
             return Response(status=409)
         else:
-            resp = jsonify(queueList[int(id)])
+            resp = jsonify(queue[int(id)])
             resp.status_code = 200
             return resp
     except Exception:
@@ -789,12 +785,15 @@ def getMethod(sampleid, methodid):
         :statuscode: 409: task could not be added to the sample
     """
     try:
-        queueList = jsonParser()
-        if not queueList[int(sampleid)]:
+        ## WARNING: serializeQueueToJson() should only be used for sending to the client,
+        ## here on the back-end side we should just always use mxcube.queue !
+        queue = serializeQueueToJson()
+
+        if not queue[int(sampleid)]:
             logging.getLogger('HWR').error('[QUEUE] sample info could not be retrieved')
             return Response(status=409)
         else:
-            methods = queueList[int(sampleid)]['methods']
+            methods = queue[int(sampleid)]['methods']
             #find the required one
             for met in methods:
                 if met['QueueId'] == int(methodid):
@@ -815,7 +814,7 @@ def serialize():
         logging.getLogger("HWR").exception("[QUEUE] cannot serialize")
         return Response(status=409)
 
-def jsonParser(fromSession = False):
+def serializeQueueToJson():
     """
       {
       "1": {
@@ -826,11 +825,9 @@ def jsonParser(fromSession = False):
           }
        }
     """
-    if not fromSession:
-        jsonobj = jsonpickle.encode(mxcube.queue)
-        queueEntryList = json.loads(jsonobj)['py/state']['_HardwareObjectNode__objects'][0][0]['py/state']['_queue_entry_list']
-    else:
-        queueEntryList = session['queueList']['py/state']['_HardwareObjectNode__objects'][0][0]['py/state']['_queue_entry_list']
+    jsonobj = jsonpickle.encode(mxcube.queue)
+    queueEntryList = json.loads(jsonobj)['py/state']['_HardwareObjectNode__objects'][0][0]['py/state']['_queue_entry_list']
+
     try:
         parent = queueEntryList[0]['py/state']['_data_model']['_parent'] ## is it always the first entry?
     except Exception:

--- a/mxcube3/routes/Utils.py
+++ b/mxcube3/routes/Utils.py
@@ -1,12 +1,11 @@
 from mxcube3 import app as mxcube
-from flask import Response
+from flask import Response, session
 from functools import wraps
 
 def mxlogin_required(func):
     """
     If you decorate a view with this, it will ensure that the current user is
-    logged in calling the actual view. It checks the session hardware object
-    to see if the proposal_id has a number (the routes.login does that)
+    logged in calling the actual view. 
     TODO: how much secure is this? need to implement OAuth2 as well
     For example::
 
@@ -20,7 +19,7 @@ def mxlogin_required(func):
     """
     @wraps(func)
     def decorated_view(*args, **kwargs):
-        if not mxcube.session.proposal_id:
+        if not session.get("loginInfo"):
             return Response(status=401)
         return func(*args, **kwargs)
     return decorated_view
@@ -73,7 +72,7 @@ def my_execute_entry(self, entry):
 
 def __execute_entry(self, entry):
     print "my execute_entry"
-    from routes.Queue import queueList, lastQueueNode
+    from routes.Queue import queue, lastQueueNode
     import logging
     logging.getLogger('queue_exec').info('Executing mxcube3 customized entry')
 
@@ -83,7 +82,7 @@ def __execute_entry(self, entry):
     #if this is a sample, parentId will be '0'
     if parentId == 0:  # Sample... 0 is your father...
         parentId = nodeId
-    lastQueueNode.update({'id': nodeId, 'sample': queueList[parentId]['SampleId']})
+    lastQueueNode.update({'id': nodeId, 'sample': queue[parentId]['SampleId']})
     print "enabling....", entry
     #entry.set_enabled(True)
     if not entry.is_enabled() or self._is_stopped:

--- a/mxcube3/ui/actions/login.js
+++ b/mxcube3/ui/actions/login.js
@@ -46,7 +46,7 @@ export function getLoginInfo() {
             if (loginInfo.loginRes.Proposal) {
               dispatch(afterLogin(loginInfo.loginRes));
               dispatch(getInitialStatus());
-              dispatch(synchState());
+              dispatch(synchState(loginInfo.queue));
             }
           }, () => {
             throw new Error('Server connection problem (getLoginInfo)');

--- a/mxcube3/ui/actions/login.js
+++ b/mxcube3/ui/actions/login.js
@@ -14,12 +14,10 @@ export function doLogin(proposal, password) {
            },
         credentials: 'include',
         body: JSON.stringify({ proposal, password })
-      }).then(response => response.json())
-          .then(loginRes => {
-              // Here one should check if login is successfull and if so get initial state of MxCube
+      }).then(response => {
             dispatch(showErrorPanel(false));
-            dispatch(afterLogin(loginRes));
-            dispatch(getInitialStatus());
+            dispatch(setLoading(false));
+            dispatch(getLoginInfo());
           }, () => {
             dispatch(showErrorPanel(true));
             dispatch(setLoading(false));

--- a/mxcube3/ui/actions/queue.js
+++ b/mxcube3/ui/actions/queue.js
@@ -92,34 +92,15 @@ export function toggleChecked(queue_id) {
       };
 }
 
-export function synchState() {
-  return function (dispatch) {
-
-        fetch('mxcube/api/v0.1/queue/state', {
-          method: 'GET',
-          credentials: 'include',
-          headers: {
-            'Accept': 'application/json',
-            'Content-type': 'application/json'
-          }
-        }).then(function (response) {
-      if (response.status >= 400) {
-            throw new Error('Server refused send state');
-          }
-      return response.json();
-    })
-    .then(function (json) {
-
-      json.queueState.current = {};
-      json.queueState.todo = { nodes:[] };
-      json.queueState.history = { nodes:[] };
-      if (Object.keys(json.queueState).length > 0) {
-            dispatch(showRestoreDialog(json.queueState));
-          } else {
-            dispatch(setState(json.queueState, {})); // TODO: json.sampleList));
-          }
-    });
-      };
+export function synchState(saved_queue) {
+  if (Object.keys(saved_queue).length > 0) {
+      saved_queue.current = {};
+      saved_queue.todo = { nodes:[] };
+      saved_queue.history = { nodes:[] };
+      return showRestoreDialog(saved_queue);
+  } else {
+      return {};
+  }
 }
 
 export function showRestoreDialog(queueState, show = true) {

--- a/mxcube3/ui/actions/queue.js
+++ b/mxcube3/ui/actions/queue.js
@@ -99,8 +99,8 @@ export function synchState(saved_queue) {
       saved_queue.history = { nodes:[] };
       return showRestoreDialog(saved_queue);
   } else {
-      return {};
-  }
+      return showRestoreDialog(saved_queue, false);
+  } 
 }
 
 export function showRestoreDialog(queueState, show = true) {

--- a/mxcube3/ui/reducers/samples_grid.js
+++ b/mxcube3/ui/reducers/samples_grid.js
@@ -1,5 +1,4 @@
 import { omit } from 'lodash/object';
-
 const initialState = { samples_list: {},
                        filter_text: '',
                        selected: {},
@@ -9,6 +8,8 @@ const initialState = { samples_list: {},
 
 export default (state = initialState, action) => {
   switch (action.type) {
+    case "SIGNOUT":
+      return Object.assign({}, initialState);
     case 'UPDATE_SAMPLES':
           // should have session samples
       return Object.assign({}, state, { samples_list: action.samples_list });

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ scipy
 mock
 jsonpickle
 pillow
+suds
+python-ldap
+lxml


### PR DESCRIPTION
See detailed info in commit messages.

One remark : I am not so convinced any more that we should hold the queue state entirely in the
server, I started to experiment with `redux-persist` in order to have persistence on the client side (I created a branch for that, this is a work in progress). While doing this I ended up thinking we should almost only store on the client... So the opposite compared to what we are doing now ! I will come back on this later.