### PR TITLE
Second try with this PR: Minor fixes made to improve fault-tolerance

### DIFF
--- a/mxcube3/__init__.py
+++ b/mxcube3/__init__.py
@@ -75,6 +75,10 @@ if not app.debug or os.environ.get("WERKZEUG_RUN_MAIN") == "true":
         app.session = app.beamline.getObjectByRole("session")
         app.collect = app.beamline.getObjectByRole("collect")
         app.diffractometer = app.beamline.getObjectByRole("diffractometer")
+        try:
+            routes.SampleCentring.init_signals()
+        except Exception:
+            sys.excepthook(*sys.exc_info())
         app.db_connection = app.beamline.getObjectByRole("lims_client")
         app.empty_queue = jsonpickle.encode(hwr.getHardwareObject(cmdline_options.queue_model))
         app.sample_changer = app.beamline.getObjectByRole("sample_changer")

--- a/mxcube3/__init__.py
+++ b/mxcube3/__init__.py
@@ -75,10 +75,6 @@ if not app.debug or os.environ.get("WERKZEUG_RUN_MAIN") == "true":
         app.session = app.beamline.getObjectByRole("session")
         app.collect = app.beamline.getObjectByRole("collect")
         app.diffractometer = app.beamline.getObjectByRole("diffractometer")
-        try:
-            routes.SampleCentring.init_signals()
-        except Exception:
-            sys.excepthook(*sys.exc_info())
         app.db_connection = app.beamline.getObjectByRole("lims_client")
         app.empty_queue = jsonpickle.encode(hwr.getHardwareObject(cmdline_options.queue_model))
         app.sample_changer = app.beamline.getObjectByRole("sample_changer")

--- a/mxcube3/routes/Login.py
+++ b/mxcube3/routes/Login.py
@@ -115,7 +115,11 @@ def get_initial_state():
     
     for light in ('BackLight','FrontLight'):
         hwobj = mxcube.diffractometer.getObjectByRole(light)
-        switch_state = 1 if hwobj.getActuatorState()=='in' else 0
+        if hasattr(hwobj, "getActuatorState"):
+            switch_state = 1 if hwobj.getActuatorState()=='in' else 0
+        else:
+            hwobj_switch = mxcube.diffractometer.getObjectByRole(light+'Switch')
+            switch_state = 1 if hwobj_switch.getActuatorState()=='in' else 0
         pos = hwobj.getPosition()
         data['Motors'].update({light: {"Status":hwobj.getState(), "position":hwobj.getPosition()}, light+'Switch': {"Status": switch_state, "position":0}})
 

--- a/mxcube3/routes/SampleCentring.py
+++ b/mxcube3/routes/SampleCentring.py
@@ -29,7 +29,7 @@ def init_signals():
     frontlight_hwobj.connect(frontlight_hwobj, 'positionChanged', signals.motor_event_callback)
     backlight_hwobj = mxcube.diffractometer.getObjectByRole('backlight')
     backlight_hwobj.connect(backlight_hwobj, 'positionChanged', signals.motor_event_callback)
-        #mxcube.diffractometer.connect(mxcube.diffractometer, signal, signals.signalCallback)
+    #mxcube.diffractometer.connect(mxcube.diffractometer, signal, signals.signalCallback)
     mxcube.diffractometer.connect(mxcube.diffractometer, "centringSuccessful", waitForCentringFinishes)
     mxcube.diffractometer.connect(mxcube.diffractometer, "centringFailed", waitForCentringFinishes)
     mxcube.diffractometer.image_width = mxcube.diffractometer.camera.getWidth()

--- a/mxcube3/ui/serverIO.js
+++ b/mxcube3/ui/serverIO.js
@@ -33,8 +33,6 @@ export default class ServerIO {
       }
     });
     
-    });
-    
     //this.hwrSocket.on('Task', (record) => {
     //     //console.log(record);
     //     //this.dispatch(doAddTaskResult(record.CentredPositions));

--- a/mxcube3/ui/serverIO.js
+++ b/mxcube3/ui/serverIO.js
@@ -8,21 +8,19 @@ import { beamlinePropertyValueAction } from './actions/beamline';
 export default class ServerIO {
 
   constructor(dispatch) {
-    this.dispatch = dispatch;
+      this.dispatch = dispatch;
   }
 
   listen() {
-    const socketHWR = io.connect('http://' + document.domain + ':' + location.port + '/hwr');
+    this.hwrSocket = io.connect(`http://${document.domain}:${location.port}/hwr`);
 
-    const socket = io.connect('http://' + document.domain + ':' + location.port + '/logging');
+    this.loggingSocket = io.connect(`http://${document.domain}:${location.port}/logging`);
 
-    const energy = io.connect(`http://${document.domain}:${location.port}/beamline/energy`);
-
-    socket.on('log_record', (record) => {
+    this.loggingSocket.on('log_record', (record) => {
         this.dispatch(addLogRecord(record));
     });
 
-    socketHWR.on('Motors', (record) => {
+    this.hwrSocket.on('Motors', (record) => {
       this.dispatch(updatePointsPosition(record.CentredPositions));
       this.dispatch(saveMotorPositions(record.Motors));
       switch (record.Signal) {
@@ -34,17 +32,13 @@ export default class ServerIO {
           break;
       }
     });
-
-    energy.on('value_change', (data) => {
-      this.dispatch(beamlinePropertyValueAction(data));
+    
     });
-
-    // socketHWR.on('Task', (record) => {
+    
+    //this.hwrSocket.on('Task', (record) => {
     //     //console.log(record);
     //     //this.dispatch(doAddTaskResult(record.CentredPositions));
     // });
-
-  }
-
+  }				
 }
 


### PR DESCRIPTION
I am sorry of the inconvenience with the nasty typos and bugs introduced with previous PR.
Hopefully this time we have it right...

Please give it a try :)

For `get_initial_state` : we have to agree on which hardware objects to use for front light and back
light, in order to have a common set of referenced hardware objects in the diffractometer object xml. We always had a specific hwobj acting both as an actuator and as a motor AFAIK, I think we should
continue with something like that. I have no time at the moment but I will try to have a look very
soon, I thought `MicrodiffLight` was doing the job. Which hardware objects are you using for the
front/back lights ? At the moment, I use Mikel's suggestion and I guess it is ok, it should work with
our both cases.