### PR TITLE
Removing right padding, adjusting label position and height

### DIFF
--- a/mxcube3/ui/components/SampleView/MotorControl.js
+++ b/mxcube3/ui/components/SampleView/MotorControl.js
@@ -15,7 +15,7 @@ export default class MotorControl extends React.Component {
 
             <div className="row">
 
-                <div className="col-sm-12">
+                <div className="col-sm-12 motor-input-container">
                     <p className="motor-name">Omega: </p>
                     <MotorInput
                       save={save}
@@ -30,7 +30,7 @@ export default class MotorControl extends React.Component {
                     />
                 </div>
 
-                <div className="col-sm-12">
+                <div className="col-sm-12 motor-input-container">
                     <p className="motor-name">Kappa: </p>
                     <MotorInput
                       save={save}
@@ -45,7 +45,7 @@ export default class MotorControl extends React.Component {
                     />
                 </div>
 
-                <div className="col-sm-12">
+                <div className="col-sm-12 motor-input-container">
                     <p className="motor-name">Phi: </p>
                     <MotorInput
                       save={save}
@@ -60,7 +60,7 @@ export default class MotorControl extends React.Component {
                     />
                 </div>
 
-                <div className="col-sm-12">
+                <div className="col-sm-12 motor-input-container">
                     <p className="motor-name">Y: </p>
                     <MotorInput
                       save={save}
@@ -75,7 +75,7 @@ export default class MotorControl extends React.Component {
                     />
                 </div>
 
-                <div className="col-sm-12">
+                <div className="col-sm-12 motor-input-container">
                     <p className="motor-name">Z: </p>
                     <MotorInput
                       save={save}
@@ -90,7 +90,7 @@ export default class MotorControl extends React.Component {
                     />
                 </div>
 
-               <div className="col-sm-12">
+               <div className="col-sm-12 motor-input-container">
                     <p className="motor-name">Focus: </p>
                     <MotorInput
                       save={save}
@@ -105,8 +105,8 @@ export default class MotorControl extends React.Component {
                     />
                 </div>
 
-                <div className="col-sm-12">
-                    <p className="motor-name">SampX: </p>
+                <div className="col-sm-12 motor-input-container">
+                    <p className="motor-name">Samp-X: </p>
                     <MotorInput
                       save={save}
                       value={Sampx.position}
@@ -120,8 +120,8 @@ export default class MotorControl extends React.Component {
                     />
                 </div>
 
-               <div className="col-sm-12">
-                    <p className="motor-name">SampY: </p>
+               <div className="col-sm-12 motor-input-container">
+                    <p className="motor-name">Samp-Y: </p>
                     <MotorInput
                       save={save}
                       value={Sampy.position}

--- a/mxcube3/ui/components/SampleView/SampleView.css
+++ b/mxcube3/ui/components/SampleView/SampleView.css
@@ -35,7 +35,6 @@
 }
 
 .motor-input-container{
-    padding-right: 0px !important;
     margin-bottom: 1em;
 }
 

--- a/mxcube3/ui/components/SampleView/SampleView.css
+++ b/mxcube3/ui/components/SampleView/SampleView.css
@@ -34,13 +34,17 @@
     margin-top: 10px;
 }
 
+.motor-input-container{
+    padding-right: 0px !important;
+    margin-bottom: 1em;
+}
+
 .motor-name{
-    line-height: 45px;
     font-size: 1.0em;
     margin-bottom: 0px;
-    margin-left: 5px;
     font-weight: bold;
 }
+
 .motor-value{
     font-size: 1.0em;
     font-weight: bold;
@@ -48,6 +52,7 @@
     border-bottom:1px dotted #f00;
     cursor:pointer;
 }
+
 
 
 .information-box{


### PR DESCRIPTION
Hello,

We are preparing a small demo version on ID30a-3 for some internal testing and to get some feedback from our scientists (using the real thing :) ). I noticed that the cancel button of the motor input ended up on a new row with the latest changes, so I made a simple fix for it. I also took the opportunity to adjust the position of the label and add some spacing between the inputs.

Maybe you already noticed this and fixed it, in that case you can just discard this PR. Not something very urgent but I thought Ill make a PR since I already made a fix for it :).

Cheers,
Marcus