### PR TITLE
Motor state

### DIFF
--- a/mxcube3/ho_mediators/beamline_setup.py
+++ b/mxcube3/ho_mediators/beamline_setup.py
@@ -1,35 +1,6 @@
 # -*- coding: utf-8 -*-
 from mxcube3 import socketio
-
-
-class MOTOR_STATE:
-    NOTINITIALIZED = "NOTINITIALIZED"
-    UNUSABLE = "UNUSABLE"
-    READY = "READY"
-    MOVESTARTED = "MOVESTARTED"
-    MOVING = "MOVING"
-    ONLIMIT = "ONLIMIT"
-
-    VALUE_TO_STR = {0: "NOTINITIALIZED",
-                    1: "UNUSABLE",
-                    2: "READY",
-                    3: "MOVESTARTED",
-                    4: "MOVING",
-                    5: "ONLIMIT"}
-
-
-class INOUT_STATE:
-    IN = "in"
-    OUT = "out"
-    UNDEFINED = "undefined"
-
-    VALUE_TO_STR = {0: IN,
-                    1: OUT,
-                    2: UNDEFINED}
-
-    STR_TO_VALUE = {IN: 0,
-                    OUT: 1,
-                    UNDEFINED: 2}
+from .statedefs import (MOTOR_STATE, INOUT_STATE)
 
 
 BEAMLINE_SETUP = None

--- a/mxcube3/ho_mediators/statedefs.py
+++ b/mxcube3/ho_mediators/statedefs.py
@@ -1,0 +1,38 @@
+#/usr/bin/python
+
+
+class MOTOR_STATE:
+    """
+    Motor states, to be added to AbstractMotor definition when the web-
+    application is in a more mature state.
+    """
+    NOTINITIALIZED = "NOTINITIALIZED"
+    UNUSABLE = "UNUSABLE"
+    READY = "READY"
+    MOVESTARTED = "MOVESTARTED"
+    MOVING = "MOVING"
+    ONLIMIT = "ONLIMIT"
+
+    VALUE_TO_STR = {0: "NOTINITIALIZED",
+                    1: "UNUSABLE",
+                    2: "READY",
+                    3: "MOVESTARTED",
+                    4: "MOVING",
+                    5: "ONLIMIT"}
+
+
+class INOUT_STATE:
+    """
+    States for inout devices, to be added to a future AbstractInOutDevice.
+    """
+    IN = "in"
+    OUT = "out"
+    UNDEFINED = "undefined"
+
+    VALUE_TO_STR = {0: IN,
+                    1: OUT,
+                    2: UNDEFINED}
+
+    STR_TO_VALUE = {IN: 0,
+                    OUT: 1,
+                    UNDEFINED: 2}


### PR DESCRIPTION
Hi all,

I've extracted the motor and inout state definitions from the beamline_setup.py mediator and added them into a new module statedefs.py. This will make it easier to use the state definitions from other files and also to integrate them back into the corresponding hardware object once we decide to do so.

This closes the issue ( #186 Motor status).

Regards,
Marcus