### PR TITLE
Corrected small typo in TaskContainer

### DIFF
--- a/mxcube3/ui/containers/TaskContainer.js
+++ b/mxcube3/ui/containers/TaskContainer.js
@@ -6,12 +6,11 @@ import DataCollection from '../components/Tasks/DataCollection';
 import AddSample from '../components/Tasks/AddSample';
 import { hideTaskParametersForm, showTaskForm } from '../actions/taskForm';
 import { sendCurrentPhase } from '../actions/sampleview';
-import {
-  sendAddSampleTask,
-  sendChangeSampleTask,
-  sendAddSampleAndTask,
-  doAddSample
-} from '../actions/samplesGrid';
+import { sendAddSampleTask,
+	 sendChangeSampleTask,
+	 sendAddSampleAndTask,
+	 doAddSample
+       } from '../actions/SamplesGrid';
 
 class TaskContainer extends React.Component {
 


### PR DESCRIPTION
Hello,

I guess this one is for Fredirk or Anotnio, it seems like the last PR contained a typo (or am I mistaken).
The file called samplesGrid does not exist (as long as you did not rename it and maybe forgot to commit that). It should be SamplesGrid :).

Its a bit weird because this typo would normally prevent the application from running, and I guess its running at your side so I'm asking myself if there is a commit missing somewhere ?

I agree that the name SamplesGrid is not the best name and it should perhaps be either samplegrid in lower case so that we are consistent with the other reducers and actions. Or SampleGrid (without the s) so that we are consistent with the other UI files, however that would force us to change name of all other actions and reducers. So I think that maybe samplegrid would be the best alternative so that we are consistent within the actions and reducers folders. What do you think ?, I can take the responsibility of changing the name since Im doing some sample grid related refactoring in anyways.

Anyhow, this fixes the problem.

Thanks,
Marcus

