### PR TITLE
removed unused and broken call

### DIFF
--- a/mxcube3/routes/Beamline.py
+++ b/mxcube3/routes/Beamline.py
@@ -126,17 +126,6 @@ def getBeamInfo():
         resp.status_code = 200
         return resp
 
-@mxcube.route("/mxcube/api/v0.1/sampleview/camera/info", methods=['GET'])
-def get_sample_video_dims():
-    try:
-        resp = jsonify({'pixelsPerMm': mxcube.diffractometer.get_pixels_per_mm(),
-            'imageWidth':  mxcube.diffractometer.image_width,
-            'imageHeight':  mxcube.diffractometer.image_height,
-        })
-    except Exception:
-        return Response(status=409)
-
-
 @mxcube.route("/mxcube/api/v0.1/beamline/datapath", methods=['GET'])
 def beamline_get_data_path():
     """


### PR DESCRIPTION
get camera info call was duplicated (in beamline.py and Samplecentring.py), the one in beamline.py was broken (missing return statement), so this pr removes it completely. We rely on the one in samplecentring.

Unless you have any reason for keeping it of course.