### PR TITLE
Small fix in routes.Diff

### DIFF
--- a/mxcube3/routes/Diffractometer.py
+++ b/mxcube3/routes/Diffractometer.py
@@ -49,10 +49,13 @@ def set_phase():
     phase = params['phase']
     try:
         mxcube.diffractometer.wait_device_ready(30)
+    except Exception:
+        logging.getLogger('HWR').warning('diffractometer might not be ready')
+    try:
         mxcube.diffractometer.set_phase(phase)
         return Response(status=200)
     except Exception:
-        logging.getLogger('HWR').exception('Could not change the diffractometer phase to ' % phase)
+        logging.getLogger('HWR').exception('Could not change the diffractometer phase to ' %phase)
         return Response(status=409)
 
 @mxcube.route("/mxcube/api/v0.1/diffractometer/usesc", methods=['GET'])


### PR DESCRIPTION
I am not proud of this extremely small pr... 
This should solve #249, the diffractometer mockup does not have ```wait_device_ready``` method and crashes there. In addition, if you want to add samples manually there must be no sample changer defined.