### PR TITLE
Using unified definition for input background colors

### DIFF
--- a/mxcube3/ui/components/InOutSwitch/InOutSwitch.jsx
+++ b/mxcube3/ui/components/InOutSwitch/InOutSwitch.jsx
@@ -36,12 +36,12 @@ export default class InOutSwitch extends React.Component {
     const isIn = this.props.data.state === 'in';
     const inButtonStyle = isIn ? 'success' : 'default';
     const outButtonStyle = isIn ? 'default' : 'success';
-    let msgBgStyle = 'bg-warning';
+    let msgBgStyle = 'input-bg-moving';
 
     if (this.props.data.state === 'in') {
-      msgBgStyle = 'bg-success';
+      msgBgStyle = 'input-bg-ready';
     } else if (this.props.data.state === 'out') {
-      msgBgStyle = 'bg-danger';
+      msgBgStyle = 'input-bg-fault';
     }
 
 

--- a/mxcube3/ui/components/InOutSwitch/style.css
+++ b/mxcube3/ui/components/InOutSwitch/style.css
@@ -1,3 +1,4 @@
 .inout-switch-msg{ 
   text-align: center
 }
+

--- a/mxcube3/ui/components/Main.css
+++ b/mxcube3/ui/components/Main.css
@@ -3,10 +3,12 @@
     font-size: 14px;
 }
 
+
 body{
     background-color: rgba(0,0,0,0.035);
     font-size: 12px;
 }
+
 
 label {
     font-weight: normal;
@@ -17,15 +19,18 @@ label {
     text-align: initial !important;
 }
 
+
 input[type="radio"], input[type="checkbox"] {
     margin: 4px 4px 0;
     margin-top: 1px \9;
     line-height: normal;
 }
 
+
 .ReactModal__Overlay{
   z-index: 2;
 }
+
 
 .main-content{
     padding-top: 10px;
@@ -37,6 +42,8 @@ input[type="radio"], input[type="checkbox"] {
         font-size: 14px; 
     }
 }
+
+
 @media all and (max-width: 1400px) { /* screen size until 1200px */
     body {
         font-size: 12px; 
@@ -76,8 +83,35 @@ input[type="radio"], input[type="checkbox"] {
     text-decoration: none;
 }
 
+
 .icon:focus, .icon:hover{
     text-decoration: none !important;
     background-color: #5D5D5D;
 }
 
+
+.input-bg-moving{
+    background-color: #FFFF99 !important;
+    color: transparent;
+    text-shadow: 0 0 0 black;
+    transition: background-color 1000ms ease-in;
+}
+
+
+.input-bg-ready{
+    background-color: #9BCE7B !important;
+    transition: background-color 1000ms ease-in;
+}
+
+
+.input-bg-fault{
+    background-color: #FF9999 !important;
+    color: #000;
+    transition: background-color 1000ms ease-in;
+}
+
+
+.input-bg-onlimit{
+    background-color: #FF9900 !important;
+    transition: background-color 1000ms ease-in;
+}

--- a/mxcube3/ui/components/PopInput/DefaultInput.jsx
+++ b/mxcube3/ui/components/PopInput/DefaultInput.jsx
@@ -41,7 +41,7 @@ export default class DefaultInput extends React.Component {
         <Input ref="input" type={this.props.dataType} style={{ width: this.props.inputSize }}
           placeholder="" className="input-sm" defaultValue={this.props.value}
         />
-        <ButtonToolbar className="editable-buttons">
+        <ButtonToolbar style={{ 'margin-left': '0px' }}  className="form-group editable-buttons">
           <Button bsStyle="primary" className="btn-sm" onClick={this.save}>
             <i className="glyphicon glyphicon-ok" />
           </Button>

--- a/mxcube3/ui/components/PopInput/PopInput.jsx
+++ b/mxcube3/ui/components/PopInput/PopInput.jsx
@@ -185,12 +185,12 @@ export default class PopInput extends React.Component {
     const inputVisibility = !this.isBusy() ? '' : 'hidden';
     const title = (this.props.title === '') ? this.props.name : this.props.title;
 
-    let stateClass = '';
+    let stateClass = 'value-label-enter-success';
 
     if (this.isBusy()) {
-      stateClass = 'value-label-enter-loading';
+      stateClass = 'input-bg-moving';
     } else if (this.isAborted()) {
-      stateClass = 'value-label-enter-error';
+      stateClass = 'input-bg-fault';
     }
 
     const popover = (

--- a/mxcube3/ui/components/PopInput/style.css
+++ b/mxcube3/ui/components/PopInput/style.css
@@ -24,16 +24,6 @@
   display: inline;
 }
 
-.value-label-enter-loading {
-  background-color: #FF0;
-}
-
 .value-label-enter-success{
   transition: background-color 1000ms ease-out;
-}
-
-.value-label-enter-error{
-  color: #000;
-  background-color: #F66;
-  transition: background-color 1000ms ease-in;
 }

--- a/mxcube3/ui/components/SampleView/MotorInput.js
+++ b/mxcube3/ui/components/SampleView/MotorInput.js
@@ -47,10 +47,10 @@ export default class MotorInput extends React.Component {
     const { value, motorName, step, suffix, decimalPoints } = this.props;
     const valueCropped = value.toFixed(decimalPoints);
     let inputCSS = cx('form-control input-sm', {
-      'motor-moving': this.props.state === 4 || this.props.state === 3,
-      'motor-ready': this.props.state === 2,
-      'motor-fault': this.props.state <= 1,
-      'motor-onlimit': this.props.state === 5
+      'input-bg-moving': this.props.state === 4 || this.props.state === 3,
+      'input-bg-ready': this.props.state === 2,
+      'input-bg-fault': this.props.state <= 1,
+      'input-bg-onlimit': this.props.state === 5
     });
 
     let data = { state: 'IMMEDIATE', value: step };

--- a/mxcube3/ui/components/SampleView/motor.css
+++ b/mxcube3/ui/components/SampleView/motor.css
@@ -27,21 +27,4 @@
     font-size: 0.7em;
 }
 
-.motor-moving{
-    background-color: #ffff99 !important;
-    color: transparent;
-    text-shadow: 0 0 0 black;
-}
-
-.motor-ready{
-    background-color: #9BCE7B !important;
-}
-
-.motor-fault{
-    background-color: #ff9999 !important;
-}
-
-.motor-onlimit{
-    background-color: #ff9900 !important;
-}
 


### PR DESCRIPTION
Hey,

I wanted to update the color scheme used for the beamline setup inputs so that they corresponded to the rest of the UI. Doing this I thought that it was better to define common css classes for the various states. So I added those to Main.css so that its easier to reuse.

I also added a css transition since I was using this for the beamline setup, I honestly don't know if thats very nice/good. Let me know what you think, I don't mind removing that. I initially though that it was nicer than just changing colors, but the intermediate grey-brown is not that nice either :).

Cheers,
Marcus