### PR TITLE
implemented one global SIGNOUT reducer code...

### DIFF
--- a/mxcube3/ui/reducers/SamplesGrid.js
+++ b/mxcube3/ui/reducers/SamplesGrid.js
@@ -103,7 +103,7 @@ export default (state = INITIAL_STATE, action) => {
 
       return { ...state, sampleList,
                          manualMount: { ...state.manualMount, id: state.manualMount.id + 1 },
-                         order: initialGridOrder(sampleList)};
+                         order: initialGridOrder(sampleList) };
     }
     case 'SET_SAMPLE_ORDER': {
       const reorderKeys = Object.keys(state.picked).map(key => (state.picked[key] ? key : ''));

--- a/mxcube3/ui/reducers/SamplesGrid.js
+++ b/mxcube3/ui/reducers/SamplesGrid.js
@@ -94,9 +94,6 @@ function recalculateQueueOrder(keys, gridOrder, state) {
 
 export default (state = INITIAL_STATE, action) => {
   switch (action.type) {
-    case 'SIGNOUT': {
-      return Object.assign({}, INITIAL_STATE);
-    }
     case 'UPDATE_SAMPLE_LIST': {
       return Object.assign({}, state, { sampleList: initSampleList(action.sampleList),
                                         order: initialGridOrder(action.sampleList) });

--- a/mxcube3/ui/reducers/beamline.js
+++ b/mxcube3/ui/reducers/beamline.js
@@ -1,5 +1,5 @@
-import { INITIAL_STATE, 
-         BL_ATTR_SET, 
+import { INITIAL_STATE,
+         BL_ATTR_SET,
          BL_ATTR_GET_ALL,
          BL_ATTR_SET_STATE } from '../actions/beamline';
 

--- a/mxcube3/ui/reducers/general.js
+++ b/mxcube3/ui/reducers/general.js
@@ -26,10 +26,6 @@ export default (state = initialState, action) => {
           dialogMessage: action.message
         };
       }
-    case 'SIGNOUT':
-      {
-        return Object.assign({}, state, initialState);
-      }
     default:
       return state;
   }

--- a/mxcube3/ui/reducers/index.js
+++ b/mxcube3/ui/reducers/index.js
@@ -19,10 +19,11 @@ const mxcubeReducer = combineReducers({
   general,
   beamline,
   form: formReducer.plugin({
-    characterisation: (state, action) => { // <------ 'characterisation' is name of form given to reduxForm()
+    // <------ 'characterisation' is name of form given to reduxForm()
+    characterisation: (state, action) => {
       switch (action.type) {
         case 'ADD_METHOD':
-          return undefined;       // <--- blow away form data
+          return undefined; // <--- blow away form data
         default:
           return state;
       }
@@ -31,12 +32,12 @@ const mxcubeReducer = combineReducers({
 });
 
 const rootReducer = (state, action) => {
-  if (action.type == 'SIGNOUT') {
-    state = undefined
+  if (action.type === 'SIGNOUT') {
+    state = undefined;
   }
 
-  return mxcubeReducer(state, action)
-}
+  return mxcubeReducer(state, action);
+};
 
 export default rootReducer;
 

--- a/mxcube3/ui/reducers/index.js
+++ b/mxcube3/ui/reducers/index.js
@@ -9,8 +9,7 @@ import beamline from './beamline';
 import logger from './logger';
 import { reducer as formReducer } from 'redux-form';
 
-
-const rootReducer = combineReducers({
+const mxcubeReducer = combineReducers({
   login,
   queue,
   sampleGrid,
@@ -30,6 +29,14 @@ const rootReducer = combineReducers({
     }
   })
 });
+
+const rootReducer = (state, action) => {
+  if (action.type == 'SIGNOUT') {
+    state = undefined
+  }
+
+  return mxcubeReducer(state, action)
+}
 
 export default rootReducer;
 

--- a/mxcube3/ui/reducers/logger.js
+++ b/mxcube3/ui/reducers/logger.js
@@ -13,12 +13,7 @@ export default (state = initialState, action) => {
       {
         return { ...state, activePage: action.page };
       }
-    case 'SIGNOUT':
-      {
-        return Object.assign({}, state, initialState);
-      }
     default:
       return state;
-
   }
 };

--- a/mxcube3/ui/reducers/login.js
+++ b/mxcube3/ui/reducers/login.js
@@ -14,11 +14,6 @@ export default (state = initialState, action) => {
         }
         return Object.assign({}, state, action, { loggedIn: true });
       }
-    case 'SIGNOUT':
-      {
-        return Object.assign({}, state, initialState);
-      }
-
     case 'SET_LOGIN_INFO':
       {
         return Object.assign({}, state,

--- a/mxcube3/ui/reducers/queue.js
+++ b/mxcube3/ui/reducers/queue.js
@@ -180,10 +180,6 @@ export default (state = initialState, action) => {
       {
         return Object.assign({}, state, ...action.queueState);
       }
-    case 'SIGNOUT':
-      {
-        return Object.assign({}, state, initialState);
-      }
     case 'SET_INITIAL_STATUS':
       {
         return { ...state, rootPath: action.data.rootPath };

--- a/mxcube3/ui/reducers/sampleview.js
+++ b/mxcube3/ui/reducers/sampleview.js
@@ -166,11 +166,6 @@ export default (state = initialState, action) => {
           beamPosition: action.data.beamInfo.position
         };
       }
-    case 'SIGNOUT':
-      {
-        return Object.assign({}, state, initialState);
-      }
-
     default:
       return state;
   }

--- a/mxcube3/ui/reducers/taskForm.js
+++ b/mxcube3/ui/reducers/taskForm.js
@@ -74,10 +74,6 @@ export default (state = initialState, action) => {
       {
         return { ...state, showForm: '' };
       }
-    case 'SIGNOUT':
-      {
-        return Object.assign({}, state, initialState);
-      }
     default:
       return state;
   }


### PR DESCRIPTION
..., instead of handling SIGNOUT action separately in each reducer - code
inspired by Abramov answer for the corresponding question on
StackOverflow ; this ensures the state is really reset completely, while still
allowing for custom handling of SIGNOUT if needed