### PR TITLE
SampleView Improvements

### DIFF
--- a/mxcube3/routes/SampleCentring.py
+++ b/mxcube3/routes/SampleCentring.py
@@ -623,9 +623,7 @@ def pos_from_x_y():
             }
     # new positions:
     mot_y = mxcube.diffractometer.getObjectByRole('phiz')
-    print "ALING Z go to pos:  ", mot_y.getPosition() + data['Y']
     mot_x = mxcube.diffractometer.getObjectByRole('phiy')
-    print "ALING Y go to pos:  ", mot_x.getPosition() + data['X']
-    mot_y.moveRelative(data['Y'])
-    mot_x.moveRelative(data['X'])
+    mot_y.moveRelative(data['Y'])  # -1 md3
+    mot_x.moveRelative(-1*data['X'])  # -1 md2 and md3
     return Response(status=200)

--- a/mxcube3/routes/SampleCentring.py
+++ b/mxcube3/routes/SampleCentring.py
@@ -601,8 +601,31 @@ def accept_centring():
 
 @mxcube.route("/mxcube/api/v0.1/sampleview/centring/reject", methods=['PUT'])
 def reject_centring():
-    """
-    Reject the centring position.
-    """
+    """Reject the centring position."""
     mxcube.diffractometer.rejectCentring()
+    return Response(status=200)
+
+
+@mxcube.route("/mxcube/api/v0.1/sampleview/moveto", methods=['PUT'])
+def pos_from_x_y():
+    """Go to given x, y."""
+    params = request.data
+    params = json.loads(params)
+    click_position = params['clickPos']
+    logging.getLogger('HWR').info("A point submitted, x: %s, y: %s"
+                                  % (click_position['x'],
+                                     click_position['y']))
+    pixels_per_mm_x, pixels_per_mm_y = mxcube.diffractometer.get_pixels_per_mm()
+    center_x = mxcube.diffractometer.image_width / 2
+    center_y = mxcube.diffractometer.image_height / 2
+    data = {"X": (int(click_position['x']) - center_x) / pixels_per_mm_x,
+            "Y": (int(click_position['y']) - center_y) / pixels_per_mm_y
+            }
+    # new positions:
+    mot_y = mxcube.diffractometer.getObjectByRole('phiz')
+    print "ALING Z go to pos:  ", mot_y.getPosition() + data['Y']
+    mot_x = mxcube.diffractometer.getObjectByRole('phiy')
+    print "ALING Y go to pos:  ", mot_x.getPosition() + data['X']
+    mot_y.moveRelative(data['Y'])
+    mot_x.moveRelative(data['X'])
     return Response(status=200)

--- a/mxcube3/routes/SampleCentring.py
+++ b/mxcube3/routes/SampleCentring.py
@@ -606,24 +606,19 @@ def reject_centring():
     return Response(status=200)
 
 
-@mxcube.route("/mxcube/api/v0.1/sampleview/moveto", methods=['PUT'])
-def pos_from_x_y():
-    """Go to given x, y."""
+@mxcube.route("/mxcube/api/v0.1/sampleview/movetobeam", methods=['PUT'])
+def move_to_beam():
+    """Go to the beam position from the given (x, y) position."""
     params = request.data
     params = json.loads(params)
     click_position = params['clickPos']
     logging.getLogger('HWR').info("A point submitted, x: %s, y: %s"
                                   % (click_position['x'],
                                      click_position['y']))
-    pixels_per_mm_x, pixels_per_mm_y = mxcube.diffractometer.get_pixels_per_mm()
-    center_x = mxcube.diffractometer.image_width / 2
-    center_y = mxcube.diffractometer.image_height / 2
-    data = {"X": (int(click_position['x']) - center_x) / pixels_per_mm_x,
-            "Y": (int(click_position['y']) - center_y) / pixels_per_mm_y
-            }
-    # new positions:
-    mot_y = mxcube.diffractometer.getObjectByRole('phiz')
-    mot_x = mxcube.diffractometer.getObjectByRole('phiy')
-    mot_y.moveRelative(data['Y'])  # -1 md3
-    mot_x.moveRelative(-1*data['X'])  # -1 md2 and md3
+    if getattr(mxcube.diffractometer, 'moveToBeam') is None:
+        # v > 2.2, or perhaps start_move_to_beam?
+        mxcube.diffractometer.move_to_beam(click_position['x'], click_position['y'])
+    else:
+        # v <= 2.1
+        mxcube.diffractometer.moveToBeam(click_position['x'], click_position['y'])
     return Response(status=200)

--- a/mxcube3/ui/actions/sampleview.js
+++ b/mxcube3/ui/actions/sampleview.js
@@ -144,7 +144,7 @@ export function sendCentringPoint(x, y) {
 
 export function sendGoToPosition(x, y) {
   return function () {
-    fetch('/mxcube/api/v0.1/sampleview/postion/click', {
+    fetch('/mxcube/api/v0.1/sampleview/moveto', {
       method: 'PUT',
       credentials: 'include',
       headers: {

--- a/mxcube3/ui/actions/sampleview.js
+++ b/mxcube3/ui/actions/sampleview.js
@@ -142,6 +142,24 @@ export function sendCentringPoint(x, y) {
   };
 }
 
+export function sendGoToPosition(x, y) {
+  return function () {
+    fetch('/mxcube/api/v0.1/sampleview/postion/click', {
+      method: 'PUT',
+      credentials: 'include',
+      headers: {
+        Accept: 'application/json',
+        'Content-type': 'application/json'
+      },
+      body: JSON.stringify({ clickPos: { x, y } })
+    }).then((response) => {
+      if (response.status >= 400) {
+        throw new Error('Server refused move to position');
+      }
+    });
+  };
+}
+
 export function sendStartAutoCentring() {
   return function () {
     fetch('/mxcube/api/v0.1/sampleview/centring/startauto', {

--- a/mxcube3/ui/actions/sampleview.js
+++ b/mxcube3/ui/actions/sampleview.js
@@ -142,9 +142,9 @@ export function sendCentringPoint(x, y) {
   };
 }
 
-export function sendGoToPosition(x, y) {
+export function sendGoToBeam(x, y) {
   return function () {
-    fetch('/mxcube/api/v0.1/sampleview/moveto', {
+    fetch('/mxcube/api/v0.1/sampleview/movetobeam', {
       method: 'PUT',
       credentials: 'include',
       headers: {
@@ -154,7 +154,7 @@ export function sendGoToPosition(x, y) {
       body: JSON.stringify({ clickPos: { x, y } })
     }).then((response) => {
       if (response.status >= 400) {
-        throw new Error('Server refused move to position');
+        throw new Error('Server refused move to beam');
       }
     });
   };

--- a/mxcube3/ui/components/SampleView/ContextMenu.js
+++ b/mxcube3/ui/components/SampleView/ContextMenu.js
@@ -25,7 +25,7 @@ export default class ContextMenu extends React.Component {
         { text: 'Delete Line', action: () => this.removeObject(), key: 2 }
         ],
         NONE: [
-          { text: 'Please mount a sample', action: undefined, key: 1 },
+          { text: 'Go To Position', action: () => this.goToPosition(), key: 1 },
         ]
       }
     };
@@ -72,6 +72,12 @@ export default class ContextMenu extends React.Component {
   goToPoint() {
     this.props.sampleActions.showContextMenu(false);
     this.props.sampleActions.sendGoToPoint(this.props.shape.id);
+  }
+
+  goToPosition() {
+    const { x, y } = this.props;
+    this.props.sampleActions.showContextMenu(false);
+    this.props.sampleActions.sendGoToPosition(x, y);
   }
 
   removeObject() {

--- a/mxcube3/ui/components/SampleView/ContextMenu.js
+++ b/mxcube3/ui/components/SampleView/ContextMenu.js
@@ -59,7 +59,7 @@ export default class ContextMenu extends React.Component {
 
   showContextMenu(x, y) {
     document.getElementById('contextMenu').style.top = `${y}px`;
-    document.getElementById('contextMenu').style.left = `${x}px`;
+    document.getElementById('contextMenu').style.left = `${x + 15}px`;
     document.getElementById('contextMenu').style.display = 'block';
   }
 

--- a/mxcube3/ui/components/SampleView/ContextMenu.js
+++ b/mxcube3/ui/components/SampleView/ContextMenu.js
@@ -75,9 +75,9 @@ export default class ContextMenu extends React.Component {
   }
 
   goToPosition() {
-    const { x, y } = this.props;
+    const { x, y, imageRatio } = this.props;
     this.props.sampleActions.showContextMenu(false);
-    this.props.sampleActions.sendGoToPosition(x, y);
+    this.props.sampleActions.sendGoToPosition(x * imageRatio, y * imageRatio);
   }
 
   removeObject() {

--- a/mxcube3/ui/components/SampleView/ContextMenu.js
+++ b/mxcube3/ui/components/SampleView/ContextMenu.js
@@ -25,7 +25,7 @@ export default class ContextMenu extends React.Component {
         { text: 'Delete Line', action: () => this.removeObject(), key: 2 }
         ],
         NONE: [
-          { text: 'Go To Position', action: () => this.goToPosition(), key: 1 },
+          { text: 'Go To Beam', action: () => this.goToBeam(), key: 1 },
         ]
       }
     };
@@ -74,10 +74,10 @@ export default class ContextMenu extends React.Component {
     this.props.sampleActions.sendGoToPoint(this.props.shape.id);
   }
 
-  goToPosition() {
+  goToBeam() {
     const { x, y, imageRatio } = this.props;
     this.props.sampleActions.showContextMenu(false);
-    this.props.sampleActions.sendGoToPosition(x * imageRatio, y * imageRatio);
+    this.props.sampleActions.sendGoToBeam(x * imageRatio, y * imageRatio);
   }
 
   removeObject() {

--- a/mxcube3/ui/components/SampleView/SampleImage.jsx
+++ b/mxcube3/ui/components/SampleView/SampleImage.jsx
@@ -97,6 +97,9 @@ export default class SampleImage extends React.Component {
         this.props.sampleActions.showContextMenu(true, obj, obj.left, obj.top);
       }
     });
+    if (!objectFound) {
+      this.props.sampleActions.showContextMenu(true, { type: 'NONE' }, e.offsetX, e.offsetY);
+    }
   }
 
   leftClick(option) {

--- a/mxcube3/ui/components/SampleView/SampleImage.jsx
+++ b/mxcube3/ui/components/SampleView/SampleImage.jsx
@@ -26,7 +26,7 @@ export default class SampleImage extends React.Component {
     // Bind mouse scroll up/down to function manually with javascript
     imageOverlay.addEventListener('wheel', (e) => this.wheel(e), false);
     // Bind mouse double click to function manually with javascript
-    imageOverlay.addEventListener('dblclick', (e) => this.goToPosition(e), false);
+    imageOverlay.addEventListener('dblclick', (e) => this.goToBeam(e), false);
 
     this.setImageRatio();
 
@@ -117,11 +117,11 @@ export default class SampleImage extends React.Component {
     }
   }
 
-  goToPosition(e) {
+  goToBeam(e) {
     const { sampleActions, sampleViewState } = this.props;
     const { imageRatio } = sampleViewState;
-    const { sendGoToPosition } = sampleActions;
-    sendGoToPosition(e.layerX * imageRatio, e.layerY * imageRatio);
+    const { sendGoToBeam } = sampleActions;
+    sendGoToBeam(e.layerX * imageRatio, e.layerY * imageRatio);
   }
 
   wheel(e) {

--- a/mxcube3/ui/components/SampleView/SampleImage.jsx
+++ b/mxcube3/ui/components/SampleView/SampleImage.jsx
@@ -25,6 +25,8 @@ export default class SampleImage extends React.Component {
     imageOverlay.addEventListener('contextmenu', (e) => this.rightClick(e), false);
     // Bind mouse scroll up/down to function manually with javascript
     imageOverlay.addEventListener('wheel', (e) => this.wheel(e), false);
+    // Bind mouse double click to function manually with javascript
+    imageOverlay.addEventListener('dblclick', (e) => this.goToPosition(e), false);
 
     this.setImageRatio();
 
@@ -115,18 +117,35 @@ export default class SampleImage extends React.Component {
     }
   }
 
+  goToPosition(e) {
+    const { sampleActions, sampleViewState } = this.props;
+    const { imageRatio } = sampleViewState;
+    const { sendGoToPosition } = sampleActions;
+    sendGoToPosition(e.layerX * imageRatio, e.layerY * imageRatio);
+  }
+
   wheel(e) {
+    e.preventDefault();
+    e.stopPropagation();
     const { sampleActions, sampleViewState } = this.props;
     const { motors, motorSteps, zoom } = sampleViewState;
     const { sendMotorPosition, sendZoomPos } = sampleActions;
     if (e.ctrlKey) {
       // then we rotate phi axis by the step size defined in its box
-      if (e.deltaY > 0) {
+      if (e.deltaX > 0 || e.deltaY > 0) {
         // zoom in
         sendMotorPosition('Phi', motors.phi.position + parseInt(motorSteps.phiStep, 10));
-      } else if (e.deltaY < 0) {
+      } else if (e.deltaX < 0 || e.deltaY < 0) {
         // zoom out
         sendMotorPosition('Phi', motors.phi.position - parseInt(motorSteps.phiStep, 10));
+      }
+    } else if (e.altKey) {
+      if (e.deltaY > 0) {
+        // Focus in
+        sendMotorPosition('Focus', motors.focus.position + parseFloat(motorSteps.focusStep, 10));
+      } else if (e.deltaY < 0) {
+        // Focus out
+        sendMotorPosition('Focus', motors.focus.position - parseFloat(motorSteps.focusStep, 10));
       }
     } else {
       // in this case zooming

--- a/mxcube3/ui/containers/SampleViewContainer.js
+++ b/mxcube3/ui/containers/SampleViewContainer.js
@@ -33,14 +33,6 @@ class SampleViewContainer extends Component {
 
     return (
       <div className="row">
-        <ContextMenu
-          {...this.props.sampleViewState.contextMenu}
-          sampleActions={this.props.sampleViewActions}
-          showForm={this.props.showForm}
-          sampleId={sampleId}
-          samplesInformation={this.props.sampleInformation}
-          defaultParameters={this.props.defaultParameters}
-        />
         <div className="col-xs-1">
             <MotorControl
               save={sendMotorPosition}
@@ -56,6 +48,14 @@ class SampleViewContainer extends Component {
                 <UserLog messages={this.props.logMessages} />
               </div>
               <div className="col-xs-12">
+                <ContextMenu
+                  {...this.props.sampleViewState.contextMenu}
+                  sampleActions={this.props.sampleViewActions}
+                  showForm={this.props.showForm}
+                  sampleId={sampleId}
+                  samplesInformation={this.props.sampleInformation}
+                  defaultParameters={this.props.defaultParameters}
+                />
                 <SampleImage
                   sampleActions={this.props.sampleViewActions}
                   sampleViewState={this.props.sampleViewState}

--- a/mxcube3/ui/containers/SampleViewContainer.js
+++ b/mxcube3/ui/containers/SampleViewContainer.js
@@ -55,6 +55,7 @@ class SampleViewContainer extends Component {
                   sampleId={sampleId}
                   samplesInformation={this.props.sampleInformation}
                   defaultParameters={this.props.defaultParameters}
+                  imageRatio={imageRatio}
                 />
                 <SampleImage
                   sampleActions={this.props.sampleViewActions}


### PR DESCRIPTION
This PR contains a few shortcuts in operating the SampleView to make the life of a user a bit easier.

We have added a few listeners on top of the SampleView:

1. Scroll
2. Double Click

With the scroll you now have three actions when over the SampleView:

1. Scroll to Zoom in/out
2. Hold Ctrl and Scroll to rotate omega (Using stepsize set by user for the motor)
3. Hold Alt and Scroll to focus (Using stepsize set by user for the motor)

And with the double click we have implemented goToPosition, this function can also be accessed by the context menu.

