### PR TITLE
Do not allow new movements of motor if already moving

### DIFF
--- a/mxcube3/ui/actions/sampleview.js
+++ b/mxcube3/ui/actions/sampleview.js
@@ -223,7 +223,7 @@ export function sendDeletePoint(id) {
 }
 
 export function sendZoomPos(level) {
-  return function (dispatch) {
+  return function () {
     fetch('/mxcube/api/v0.1/sampleview/zoom', {
       method: 'PUT',
       credentials: 'include',
@@ -236,9 +236,6 @@ export function sendZoomPos(level) {
       if (response.status >= 400) {
         throw new Error('Server refused to zoom');
       }
-      return response.json();
-    }).then((json) => {
-      dispatch(setZoom(level, json.pixelsPerMm[0]));
     });
   };
 }

--- a/mxcube3/ui/actions/sampleview.js
+++ b/mxcube3/ui/actions/sampleview.js
@@ -1,6 +1,12 @@
 import fetch from 'isomorphic-fetch';
 import { showErrorPanel } from './general';
 
+export function setMotorMoving(name) {
+  return {
+    type: 'SET_MOTOR_MOVING', name
+  };
+}
+
 export function setBeamInfo(info) {
   return {
     type: 'SET_BEAM_INFO', info
@@ -223,7 +229,8 @@ export function sendDeletePoint(id) {
 }
 
 export function sendZoomPos(level) {
-  return function () {
+  return function (dispatch) {
+    dispatch(setMotorMoving('zoom'));
     fetch('/mxcube/api/v0.1/sampleview/zoom', {
       method: 'PUT',
       credentials: 'include',
@@ -297,6 +304,7 @@ export function sendStopMotor(motorName) {
 
 export function sendMotorPosition(motorName, value) {
   return function (dispatch) {
+    dispatch(setMotorMoving(motorName));
     fetch(`/mxcube/api/v0.1/sampleview/${motorName}/${value}`, {
       method: 'PUT',
       credentials: 'include',

--- a/mxcube3/ui/actions/sampleview.js
+++ b/mxcube3/ui/actions/sampleview.js
@@ -1,9 +1,9 @@
 import fetch from 'isomorphic-fetch';
 import { showErrorPanel } from './general';
 
-export function setMotorMoving(name) {
+export function setMotorMoving(name, status) {
   return {
-    type: 'SET_MOTOR_MOVING', name
+    type: 'SET_MOTOR_MOVING', name, status
   };
 }
 
@@ -230,7 +230,7 @@ export function sendDeletePoint(id) {
 
 export function sendZoomPos(level) {
   return function (dispatch) {
-    dispatch(setMotorMoving('zoom'));
+    dispatch(setMotorMoving('zoom', 4));
     fetch('/mxcube/api/v0.1/sampleview/zoom', {
       method: 'PUT',
       credentials: 'include',
@@ -304,7 +304,7 @@ export function sendStopMotor(motorName) {
 
 export function sendMotorPosition(motorName, value) {
   return function (dispatch) {
-    dispatch(setMotorMoving(motorName));
+    dispatch(setMotorMoving(motorName, 4));
     fetch(`/mxcube/api/v0.1/sampleview/${motorName}/${value}`, {
       method: 'PUT',
       credentials: 'include',
@@ -315,6 +315,7 @@ export function sendMotorPosition(motorName, value) {
     }).then((response) => {
       if (response.status === 406) {
         dispatch(showErrorPanel(true, response.headers.get('msg')));
+        dispatch(setMotorMoving(motorName, 2));
         throw new Error('Server refused to move motors: out of limits');
       }
       if (response.status >= 400) {

--- a/mxcube3/ui/components/SampleView/SampleImage.jsx
+++ b/mxcube3/ui/components/SampleView/SampleImage.jsx
@@ -131,7 +131,7 @@ export default class SampleImage extends React.Component {
     const { sampleActions, sampleViewState } = this.props;
     const { motors, motorSteps, zoom } = sampleViewState;
     const { sendMotorPosition, sendZoomPos } = sampleActions;
-    if (e.ctrlKey) {
+    if (e.ctrlKey & motors.phi.Status === 2) {
       // then we rotate phi axis by the step size defined in its box
       if (e.deltaX > 0 || e.deltaY > 0) {
         // zoom in
@@ -140,7 +140,7 @@ export default class SampleImage extends React.Component {
         // zoom out
         sendMotorPosition('Phi', motors.phi.position - parseInt(motorSteps.phiStep, 10));
       }
-    } else if (e.altKey) {
+    } else if (e.altKey && motors.focus.Status === 2) {
       if (e.deltaY > 0) {
         // Focus in
         sendMotorPosition('Focus', motors.focus.position + parseFloat(motorSteps.focusStep, 10));
@@ -148,7 +148,7 @@ export default class SampleImage extends React.Component {
         // Focus out
         sendMotorPosition('Focus', motors.focus.position - parseFloat(motorSteps.focusStep, 10));
       }
-    } else {
+    } else if(!e.ctrlKey && !e.altKey && motors.zoom.Status === 2){
       // in this case zooming
       if (e.deltaY > 0 && zoom < 10) {
         // zoom in

--- a/mxcube3/ui/components/SampleView/SampleImage.jsx
+++ b/mxcube3/ui/components/SampleView/SampleImage.jsx
@@ -11,6 +11,11 @@ export default class SampleImage extends React.Component {
     super(props);
     this.setImageRatio = this.setImageRatio.bind(this);
     this.canvas = {};
+    this.state = {
+      phiReady: true,
+      focusReady: true,
+      zoomReady: true
+    };
   }
 
   componentDidMount() {
@@ -36,6 +41,12 @@ export default class SampleImage extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     const { imageWidth, cinema } = this.props;
+    const motors = nextProps.sampleViewState.motors;
+    this.setState({
+      phiReady: motors.phi.Status === 2,
+      focusReady: motors.focus.Status === 2,
+      zoomReady: motors.zoom.Status === 2
+    });
     if (nextProps.imageWidth !== imageWidth || nextProps.cinema !== cinema) {
       this.setImageRatio();
     } else {
@@ -131,29 +142,35 @@ export default class SampleImage extends React.Component {
     const { sampleActions, sampleViewState } = this.props;
     const { motors, motorSteps, zoom } = sampleViewState;
     const { sendMotorPosition, sendZoomPos } = sampleActions;
-    if (e.ctrlKey & motors.phi.Status === 2) {
+    if (e.ctrlKey && this.state.phiReady) {
       // then we rotate phi axis by the step size defined in its box
       if (e.deltaX > 0 || e.deltaY > 0) {
         // zoom in
+        this.setState({ phiReady: false });
         sendMotorPosition('Phi', motors.phi.position + parseInt(motorSteps.phiStep, 10));
       } else if (e.deltaX < 0 || e.deltaY < 0) {
         // zoom out
+        this.setState({ phiReady: false });
         sendMotorPosition('Phi', motors.phi.position - parseInt(motorSteps.phiStep, 10));
       }
-    } else if (e.altKey && motors.focus.Status === 2) {
+    } else if (e.altKey && this.state.focusReady) {
       if (e.deltaY > 0) {
         // Focus in
+        this.setState({ focusReady: false });
         sendMotorPosition('Focus', motors.focus.position + parseFloat(motorSteps.focusStep, 10));
       } else if (e.deltaY < 0) {
         // Focus out
+        this.setState({ focusReady: false });
         sendMotorPosition('Focus', motors.focus.position - parseFloat(motorSteps.focusStep, 10));
       }
-    } else if (!e.ctrlKey && !e.altKey && motors.zoom.Status === 2) {
+    } else if (!e.ctrlKey && !e.altKey && this.state.zoomReady) {
       // in this case zooming
       if (e.deltaY > 0 && zoom < 10) {
+        this.setState({ zoomReady: false });
         // zoom in
         sendZoomPos(zoom + 1);
       } else if (e.deltaY < 0 && zoom > 1) {
+        this.setState({ zoomReady: false });
         // zoom out
         sendZoomPos(zoom - 1);
       }

--- a/mxcube3/ui/components/SampleView/SampleImage.jsx
+++ b/mxcube3/ui/components/SampleView/SampleImage.jsx
@@ -148,7 +148,7 @@ export default class SampleImage extends React.Component {
         // Focus out
         sendMotorPosition('Focus', motors.focus.position - parseFloat(motorSteps.focusStep, 10));
       }
-    } else if(!e.ctrlKey && !e.altKey && motors.zoom.Status === 2){
+    } else if (!e.ctrlKey && !e.altKey && motors.zoom.Status === 2) {
       // in this case zooming
       if (e.deltaY > 0 && zoom < 10) {
         // zoom in

--- a/mxcube3/ui/components/SampleView/SampleImage.jsx
+++ b/mxcube3/ui/components/SampleView/SampleImage.jsx
@@ -11,11 +11,6 @@ export default class SampleImage extends React.Component {
     super(props);
     this.setImageRatio = this.setImageRatio.bind(this);
     this.canvas = {};
-    this.state = {
-      phiReady: true,
-      focusReady: true,
-      zoomReady: true
-    };
   }
 
   componentDidMount() {
@@ -41,12 +36,6 @@ export default class SampleImage extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     const { imageWidth, cinema } = this.props;
-    const motors = nextProps.sampleViewState.motors;
-    this.setState({
-      phiReady: motors.phi.Status === 2,
-      focusReady: motors.focus.Status === 2,
-      zoomReady: motors.zoom.Status === 2
-    });
     if (nextProps.imageWidth !== imageWidth || nextProps.cinema !== cinema) {
       this.setImageRatio();
     } else {
@@ -142,35 +131,29 @@ export default class SampleImage extends React.Component {
     const { sampleActions, sampleViewState } = this.props;
     const { motors, motorSteps, zoom } = sampleViewState;
     const { sendMotorPosition, sendZoomPos } = sampleActions;
-    if (e.ctrlKey && this.state.phiReady) {
+    if (e.ctrlKey && motors.phi.Status === 2) {
       // then we rotate phi axis by the step size defined in its box
       if (e.deltaX > 0 || e.deltaY > 0) {
         // zoom in
-        this.setState({ phiReady: false });
         sendMotorPosition('Phi', motors.phi.position + parseInt(motorSteps.phiStep, 10));
       } else if (e.deltaX < 0 || e.deltaY < 0) {
         // zoom out
-        this.setState({ phiReady: false });
         sendMotorPosition('Phi', motors.phi.position - parseInt(motorSteps.phiStep, 10));
       }
-    } else if (e.altKey && this.state.focusReady) {
+    } else if (e.altKey && motors.focus.Status === 2) {
       if (e.deltaY > 0) {
         // Focus in
-        this.setState({ focusReady: false });
         sendMotorPosition('Focus', motors.focus.position + parseFloat(motorSteps.focusStep, 10));
       } else if (e.deltaY < 0) {
         // Focus out
-        this.setState({ focusReady: false });
         sendMotorPosition('Focus', motors.focus.position - parseFloat(motorSteps.focusStep, 10));
       }
-    } else if (!e.ctrlKey && !e.altKey && this.state.zoomReady) {
+    } else if (!e.ctrlKey && !e.altKey && motors.zoom.Status === 2) {
       // in this case zooming
       if (e.deltaY > 0 && zoom < 10) {
-        this.setState({ zoomReady: false });
         // zoom in
         sendZoomPos(zoom + 1);
       } else if (e.deltaY < 0 && zoom > 1) {
-        this.setState({ zoomReady: false });
         // zoom out
         sendZoomPos(zoom - 1);
       }

--- a/mxcube3/ui/reducers/sampleview.js
+++ b/mxcube3/ui/reducers/sampleview.js
@@ -94,7 +94,7 @@ export default (state = initialState, action) => {
           motors: { ...state.motors,
             [action.name.toLowerCase()]: {
               ...state.motors[action.name.toLowerCase()],
-              Status: 4
+              Status: action.status
             }
           }
         };

--- a/mxcube3/ui/reducers/sampleview.js
+++ b/mxcube3/ui/reducers/sampleview.js
@@ -87,6 +87,18 @@ export default (state = initialState, action) => {
           pixelsPerMm: action.pixelsPerMm
         };
       }
+    case 'SET_MOTOR_MOVING':
+      {
+        return {
+          ...state,
+          motors: { ...state.motors,
+            [action.name.toLowerCase()]: {
+              ...state.motors[action.name.toLowerCase()],
+              Status: 4
+            }
+          }
+        };
+      }
     case 'SAVE_MOTOR_POSITIONS':
       {
         return {


### PR DESCRIPTION
When using the scroll function to move motors it is possible to send hundreds of calls in a matter of seconds. 

In this PR I attempt to limit this by setting a motor to moving before making the server request and checking if that motor is in ready state before allowing a new request.

This check should also be done in the server, that could return a 409 or something if a movement is active.