### PR TITLE
[WIP ] ImageIO (MultiClient picture)

### DIFF
--- a/mxcube3/routes/SampleCentring.py
+++ b/mxcube3/routes/SampleCentring.py
@@ -121,7 +121,7 @@ def stream_video(camera_hwobj):
     while True:
         try:
             camera_hwobj.new_frame.wait()
-        socketio.emit('Image',base64.b64encode(SAMPLE_IMAGE), namespace='/hwr')
+            socketio.emit('Image',base64.b64encode(SAMPLE_IMAGE), namespace='/hwr')
         except Exception:
             pass
 

--- a/mxcube3/ui/components/SampleView/SampleImage.jsx
+++ b/mxcube3/ui/components/SampleView/SampleImage.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { makePoints, makeImageOverlay } from './shapes';
 import SampleControls from './SampleControls';
 import 'fabric';
+import io from 'socket.io-client';
 const fabric = window.fabric;
 
 export default class SampleImage extends React.Component {
@@ -11,9 +12,17 @@ export default class SampleImage extends React.Component {
     super(props);
     this.setImageRatio = this.setImageRatio.bind(this);
     this.canvas = {};
+    this.imgSocket = {};
   }
 
   componentDidMount() {
+    this.imgSocket = io.connect(`http://${document.domain}:${location.port}/hwr`);
+
+    this.imgSocket.on('Image', (data) => {
+      const img = document.getElementById('sample-img');
+      img.src = `data:image/jpeg;base64,${data}`;
+    });
+
     // Create fabric and set image background to sample
     this.canvas = new fabric.Canvas('canvas', { defaultCursor: 'crosshair' });
 
@@ -44,6 +53,7 @@ export default class SampleImage extends React.Component {
   }
 
   componentWillUnmount() {
+    this.imgSocket.disconnect();
     // Important to remove listener if component isn't active
     window.removeEventListener('resize', this.setImageRatio);
   }
@@ -181,7 +191,7 @@ export default class SampleImage extends React.Component {
                 <img
                   id= "sample-img"
                   className="img"
-                  src="/mxcube/api/v0.1/sampleview/camera/subscribe"
+                  src=""
                   alt="SampleView"
                 />
                 <canvas id="canvas" className="coveringCanvas" />


### PR DESCRIPTION
In this PR I have changed the way the client fetches the picture from the server.

Before we used "multipart/x-mixed-replace" served by flask as described by this tutorial:

http://blog.miguelgrinberg.com/post/video-streaming-with-flask

This does not work for multiple clients and as stated in the link above the most efficient ways of sending a picture is by websockets. 

Additionally the technology we are using is also slowly losing support:

https://bugs.chromium.org/p/chromium/issues/detail?id=249132

The problem I have encountered is that FireFox seems to handle the new approach quite badly and this is the reason I keep this as WIP. 

(Chrome works great no matter how many clients attached)