### PR TITLE
[WIP]: Queue API

### DIFF
--- a/mxcube3/__init__.py
+++ b/mxcube3/__init__.py
@@ -7,7 +7,7 @@ from optparse import OptionParser
 import os
 import sys
 import logging
-import jsonpickle
+import cPickle as pickle
 import gevent
 import traceback
 
@@ -90,7 +90,7 @@ if not app.debug or os.environ.get("WERKZEUG_RUN_MAIN") == "true":
 	    # centring_motors_list is the list of roles corresponding to diffractometer motors
 	    app.diffractometer.centring_motors_list = app.diffractometer.getPositions().keys()
         app.db_connection = app.beamline.getObjectByRole("lims_client")
-        app.empty_queue = jsonpickle.encode(hwr.getHardwareObject(cmdline_options.queue_model))
+        app.empty_queue = pickle.dumps(hwr.getHardwareObject(cmdline_options.queue_model))
         app.sample_changer = app.beamline.getObjectByRole("sample_changer")
         try:
             routes.SampleCentring.init_signals()

--- a/mxcube3/routes/Queue.py
+++ b/mxcube3/routes/Queue.py
@@ -135,7 +135,7 @@ def queue_unpause():
     return Response(status=200)
 
 
-@mxcube.route("/mxcube/api/v0.1/queue/clear", methods=['PUT'])
+@mxcube.route("/mxcube/api/v0.1/queue/clear", methods=['PUT', 'GET'])
 def queue_clear():
     """
     Clear the queue.

--- a/mxcube3/routes/SampleChanger.py
+++ b/mxcube3/routes/SampleChanger.py
@@ -20,28 +20,37 @@ def get_samples_list():
             )
     return jsonify(samples)
 
-@mxcube.route("/mxcube/api/v0.1/sample_changer/<sample>/mount", methods=['PUT'])
-def mountSample(sample):
-    last_queue_node = session.get("last_queue_node")
 
+@mxcube.route("/mxcube/api/v0.1/sample_changer/<sample_location>/mount", methods=['PUT'])
+def mountSample(sample_location):
+    # Most of this code should be moved to diffractometer or more general
+    # beamline object. The route should probably not know details about if
+    # the diffractometer has phase ... We should just need to do
+    # beamline.mount_sample(location)
+   
     try:
-        sampleNode = mxcube.queue.get_node(int(sample))
-        sampleLocation = sampleNode.location
-        if mxcube.diffractometer.use_sc:
-             mxcube.queue.last_queue_node.update({'id': int(sample), 'sample': str(sampleLocation[0] + ':' + sampleLocation[1])})
-        else:  # manual, not using sample_changer
-             mxcube.diffractometer.set_phase("Centring")
-             mxcube.queue.last_queue_node.update({'id': int(sample), 'sample': str(sampleLocation[1])})
-        session["last_queue_node"] = last_queue_node
-        #mxcube.sample_changer.load_sample
-        #TODO: figure out how to identify the sample for the sc, selectsample&loadsamplae&etc
-        mxcube.diffractometer.savedCentredPos = []
-        mxcube.diffractometer.savedCentredPosCount = 1
-        logging.getLogger('HWR').info('[SC] %s sample mounted, location: %s' % (sample, sampleLocation))
-        return Response(status=200)
+        # We are not using the sample changer to mount the sample, set
+        # centering phase directly
+        if not mxcube.diffractometer.use_sc:
+            mxcube.diffractometer.set_phase("Centring")
+
+        # Make the necessary call to load sample on location sample_location
+        # The underlying sample changer object should handle mounting from
+        # string repr
+        # mxcube.sample_changer.load_sample(sample_location)
+
     except Exception:
         logging.getLogger('HWR').exception('[SC] sample could not be mounted')
         return Response(status=409)
+    else:       
+        # Clearing centered position
+        mxcube.diffractometer.savedCentredPos = []
+        mxcube.diffractometer.savedCentredPosCount = 1
+
+        logging.getLogger('HWR').info('[SC] mounted %s' % sample_location)
+
+        return Response(status=200)
+
 
 @mxcube.route("/mxcube/api/v0.1/sample_changer/<sample>/unmount", methods=['PUT'])
 def unmountSample(sample):

--- a/mxcube3/routes/Utils.py
+++ b/mxcube3/routes/Utils.py
@@ -16,13 +16,13 @@ def _proposal_id(session):
 def save_queue(session, redis=redis.Redis()):
     proposal_id = _proposal_id(session)
     if proposal_id is not None:
-        redis.set("mxcube:queue:%d" % proposal_id, jsonpickle.encode(mxcube.queue))
+        redis.set("mxcube:queue:%d" % proposal_id, pickle.dumps(mxcube.queue))
 
 
 def new_queue(serialized_queue=None):
     if not serialized_queue:
         serialized_queue = mxcube.empty_queue
-    queue = jsonpickle.decode(serialized_queue)
+    queue = pickle.loads(serialized_queue)
     import Queue
     Queue.init_signals(queue)
     return queue

--- a/mxcube3/routes/Utils.py
+++ b/mxcube3/routes/Utils.py
@@ -1,9 +1,68 @@
-from mxcube3 import app as mxcube
-from flask import Response, session
-from functools import wraps
 import logging
-import jsonpickle
+import cPickle as pickle
 import redis
+import json
+
+import queue_model_objects_v1 as qmo
+
+from mock import Mock
+from flask import jsonify
+from mxcube3 import app as mxcube
+
+
+class PickableMock(Mock):
+    def __reduce__(self):
+        return (Mock, ())
+
+
+def queue_to_dict(node):
+    return reduce(lambda x, y: x.update(y) or x, queue_to_json_rec(node), {})
+
+
+def queue_to_json(node, debug=False):
+    res = reduce(lambda x, y: x.update(y) or x, queue_to_json_rec(node), {})
+    return json.dumps(res, sort_keys=True, indent=4)
+
+
+def queue_to_json_response(node):
+    res = reduce(lambda x, y: x.update(y) or x, queue_to_json_rec(node), {})
+    return jsonify(res)
+
+
+def _handle_dc(sample_id, node):
+    parameters = node.as_dict()
+    parameters["point"] = node.get_point_index()
+    sample_id = node.get_parent().get_parent().loc_str
+    
+    parameters.pop('sample')
+    parameters.pop('acquisitions')
+    parameters.pop('acq_parameters')
+    parameters.pop('centred_position')
+    
+    res = {"label": "Data Collection",
+           "Type": "DataCollection",
+           "parameters": parameters,
+           "state": 0,
+           "sampleID": sample_id,
+           "queueID": node._node_id}
+
+    return res
+
+def queue_to_json_rec(node):
+    result = []
+
+    for node in node.get_children():
+        if isinstance(node, qmo.Sample):
+            result.append({node.loc_str: queue_to_json_rec(node)})
+        elif isinstance(node, qmo.DataCollection):
+            sample_id = node.get_parent().get_parent().loc_str
+            result.append(_handle_dc(sample_id, node))
+        elif isinstance(node, qmo.Characterisation):
+            pass
+        else:
+            result.extend(queue_to_json_rec(node))
+
+    return result
 
 
 def _proposal_id(session):

--- a/mxcube3/routes/Utils.py
+++ b/mxcube3/routes/Utils.py
@@ -33,12 +33,12 @@ def _handle_dc(sample_id, node):
     parameters = node.as_dict()
     parameters["point"] = node.get_point_index()
     sample_id = node.get_parent().get_parent().loc_str
-    
+
     parameters.pop('sample')
     parameters.pop('acquisitions')
     parameters.pop('acq_parameters')
     parameters.pop('centred_position')
-    
+ 
     res = {"label": "Data Collection",
            "Type": "DataCollection",
            "parameters": parameters,
@@ -47,6 +47,25 @@ def _handle_dc(sample_id, node):
            "queueID": node._node_id}
 
     return res
+
+
+def _handle_char(sample_id, node):
+    parameters = node.as_dict()
+    parameters["point"] = node.get_point_index()
+    sample_id = node.get_parent().get_parent().loc_str
+
+    import pdb
+    pdb.set_trace()
+
+    res = {"label": "Data Collection",
+           "Type": "DataCollection",
+           "parameters": parameters,
+           "state": 0,
+           "sampleID": sample_id,
+           "queueID": node._node_id}
+
+    return res
+
 
 def queue_to_json_rec(node):
     result = []
@@ -58,7 +77,8 @@ def queue_to_json_rec(node):
             sample_id = node.get_parent().get_parent().loc_str
             result.append(_handle_dc(sample_id, node))
         elif isinstance(node, qmo.Characterisation):
-            pass
+            sample_id = node.get_parent().get_parent().loc_str
+            result.append(_handle_char(sample_id, node))
         else:
             result.extend(queue_to_json_rec(node))
 

--- a/mxcube3/ui/actions/queue.js
+++ b/mxcube3/ui/actions/queue.js
@@ -120,6 +120,12 @@ export function collapseSample(queueID) {
   };
 }
 
+export function collapseTask(sampleID, taskIndex) {
+  return {
+    type: 'COLLAPSE_TASK', sampleID, taskIndex
+  };
+}
+
 export function setState(queueState) {
   return {
     type: 'QUEUE_STATE', queueState

--- a/mxcube3/ui/actions/queue.js
+++ b/mxcube3/ui/actions/queue.js
@@ -3,6 +3,40 @@ import { setLoading, showErrorPanel } from './general';
 import { showTaskForm } from './taskForm';
 
 
+export function setQueueAction(queue) {
+  return { type: 'SET_QUEUE', queue };
+}
+
+
+export function setQueueAndRun(sampleID, queue) {
+  return function (dispatch) {
+    dispatch(sendSetQueue(queue)).then(() => dispatch(sendRunSample(sampleID)));
+  }
+}
+
+
+export function sendSetQueue(queue) {
+  return function (dispatch) {
+    return fetch('mxcube/api/v0.1/queue', {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        Accept: 'application/json',
+        'Content-type': 'application/json'
+      },
+      body: JSON.stringify(queue)
+    }).then((response) => {
+      if (response.status >= 400) {
+        throw new Error('Could not set queue');
+      }
+      return response.json();
+    }).then((json) => {
+      dispatch(setQueueAction(json));
+    });
+  };
+}
+
+
 export function setSampleListAction(sampleList) {
   return { type: 'SET_SAMPLE_LIST', sampleList };
 }
@@ -368,7 +402,7 @@ export function deleteSampleTask(task) {
 
 
 export function addTaskResultAction(sampleID, taskQueueID, state) {
-  return { type: 'ADD_TASK_RESLT',
+  return { type: 'ADD_TASK_RESULT',
            sampleID,
            taskQueueID,
            state

--- a/mxcube3/ui/components/SampleGrid/SampleGrid.jsx
+++ b/mxcube3/ui/components/SampleGrid/SampleGrid.jsx
@@ -252,11 +252,10 @@ export default class SampleGrid extends React.Component {
     Object.keys(samplesList).forEach(key => {
       if (this.filter(key)) {
         const sample = samplesList[key];
-        const sampleID = this.props.queue.lookup_queueID[sample.id];
         const [acronym, name, tags] = [sample.proteinAcronym, sample.sampleName, []];
 
-        if (this.props.queue.queue[sampleID]) {
-          for (const task of this.props.queue.queue[sampleID]) {
+        if (this.props.queue.queue[sample.id]) {
+          for (const task of this.props.queue.queue[sample.id]) {
             tags.push(task);
           }
         }
@@ -266,7 +265,7 @@ export default class SampleGrid extends React.Component {
             ref={i}
             seqId={this.props.order[key]}
             itemKey={key}
-            sampleID={sampleID}
+            sampleID={sample.id}
             acronym={acronym}
             name={name}
             dm={sample.code}

--- a/mxcube3/ui/components/SampleQueue/CurrentTree.js
+++ b/mxcube3/ui/components/SampleQueue/CurrentTree.js
@@ -69,14 +69,14 @@ export default class CurrentTree extends React.Component {
   }
 
   render() {
-    const node = this.props.mounted;
+    const sampleId = this.props.mounted;
     let sampleData = {};
     let sampleTasks = [];
     let queueOptions = [];
 
-    if (node) {
-      sampleData = this.props.sampleInformation[this.props.lookup[node]];
-      sampleTasks = this.props.queue[node];
+    if (sampleId) {
+      sampleData = this.props.sampleInformation[sampleId];
+      sampleTasks = this.props.queue[sampleId];
       queueOptions = this.state.options[this.props.queueStatus];
     } else {
       sampleData.sampleName = 'No Sample Mounted';
@@ -84,8 +84,9 @@ export default class CurrentTree extends React.Component {
     }
 
     const bodyClass = cx('list-body', {
-      hidden: (this.props.show || !node)
+      hidden: (this.props.show || !sampleId)
     });
+
     return (
       <div className="m-tree">
           <div className="list-head">
@@ -95,10 +96,11 @@ export default class CurrentTree extends React.Component {
           </div>
           <div className={bodyClass}>
             {sampleTasks.map((taskData, i) => {
+              const key = this.props.queue[taskData.sampleID].indexOf(taskData);
               const task =
-                (<TaskItem key={taskData.queueID}
+                (<TaskItem key={key}
                   index={i}
-                  id={taskData.queueID}
+                  id={key}
                   data={taskData}
                   moveCard={this.moveCard}
                   deleteTask={this.deleteTask}
@@ -107,8 +109,8 @@ export default class CurrentTree extends React.Component {
                   checked={this.props.checked}
                   toggleChecked={this.props.toggleCheckBox}
                   rootPath={this.props.rootPath}
-                  collapseNode={this.props.collapseNode}
-                  show={this.props.collapsedNodes[taskData.queueID]}
+                  collapseTask={this.props.collapseTask}
+                  show={taskData.collapsed}
                 />);
               return task;
             })}

--- a/mxcube3/ui/components/SampleQueue/CurrentTree.js
+++ b/mxcube3/ui/components/SampleQueue/CurrentTree.js
@@ -46,7 +46,8 @@ export default class CurrentTree extends React.Component {
   }
 
   runSample() {
-    this.props.run(this.props.mounted);
+    this.props.setQueueAndRun(this.props.mounted, this.props.queue);
+    //this.props.run(this.props.mounted);
   }
 
   unMountSample() {

--- a/mxcube3/ui/components/SampleQueue/HistoryTree.js
+++ b/mxcube3/ui/components/SampleQueue/HistoryTree.js
@@ -20,14 +20,14 @@ export default class HistoryTree extends React.Component {
                     <hr className="queue-divider" />
                 </div>
                 <div className={bodyClass}>
-                    {this.props.list.map((id, i) => {
-                      let sampleData = this.props.sampleInformation[this.props.lookup[id]];
+                    {this.props.list.map((sampleId, i) => {
+                      let sampleData = this.props.sampleInformation[sampleId];
                       return (
                         <HistorySampleItem
                           data={sampleData}
-                          show={this.props.collapsedSamples[id]}
+                          show={sampleData.collapsed}
                           collapseSample={this.props.collapseSample}
-                          queue={this.props.queue} id={id} key={i}
+                          queue={this.props.queue} id={sampleId} key={i}
                         />
                       );
                     })}

--- a/mxcube3/ui/components/SampleQueue/TaskItem.js
+++ b/mxcube3/ui/components/SampleQueue/TaskItem.js
@@ -109,9 +109,10 @@ export default class TaskItem extends Component {
       error: data.state === 3,
       warning: data.state === 4
     });
+
     return connectDragSource(connectDropTarget(
       <div className="node node-sample" style={{ opacity }}>
-          <div className={taskCSS} onClick={this.collapseNode}>
+          <div className={taskCSS} onClick={this.collapseTask}>
             <p className="node-name">
               {`P${data.parameters.point} ${data.label}`}
             </p>

--- a/mxcube3/ui/components/SampleQueue/TaskItem.js
+++ b/mxcube3/ui/components/SampleQueue/TaskItem.js
@@ -90,8 +90,8 @@ export default class TaskItem extends Component {
     const { id, data } = this.props;
     this.showForm = this.showForm.bind(this);
     this.deleteTask = this.props.deleteTask.bind(this, data);
-    this.toggleChecked = this.props.toggleChecked.bind(this, id);
-    this.collapseNode = this.props.collapseNode.bind(this, id);
+    this.toggleChecked = this.props.toggleChecked.bind(this, data.sampleID);
+    this.collapseTask = this.props.collapseTask.bind(this, data.sampleID, id);
   }
 
   showForm() {

--- a/mxcube3/ui/components/SampleQueue/TodoTree.js
+++ b/mxcube3/ui/components/SampleQueue/TodoTree.js
@@ -31,12 +31,12 @@ export default class TodoTree extends React.Component {
                     <hr className="queue-divider" />
                 </div>
                 <div className={bodyClass}>
-                {this.props.list.map((id, i) => {
-                  const sampleData = this.props.sampleInformation[this.props.lookup[id]];
+                {this.props.list.map((sampleId, i) => {
+                  const sampleData = this.props.sampleInformation[id];
                   return (
-                        <SampleItem key={id}
+                        <SampleItem key={sampleId}
                           index={i}
-                          id={id}
+                          id={sampleId}
                           text={`Vial ${sampleData.id}`}
                           moveCard={this.moveCard}
                           deleteSample={this.props.deleteSample}

--- a/mxcube3/ui/components/Tasks/Characterisation.js
+++ b/mxcube3/ui/components/Tasks/Characterisation.js
@@ -40,17 +40,15 @@ class Characterisation extends React.Component {
 
     if (this.props.sampleIds.constructor === Array) {
       for (const sampleId of this.props.sampleIds) {
-        const queueId = this.props.lookup[sampleId];
-        if (queueId) {
-          this.props.addTask(queueId, sampleId, parameters, runNow);
+        if (this.props.queue[sampleId]) {
+          this.props.addTask(sampleId, parameters, runNow);
         } else {// the sample is not in queue yet
           this.props.addSampleAndTask(sampleId, parameters);
         }
       }
     } else {
-      const { lookup, taskData, sampleIds } = this.props;
-      const sampleQueueID = lookup[sampleIds];
-      this.props.changeTask(taskData, sampleIds, sampleQueueID, parameters, runNow);
+      const { taskData, sampleIds } = this.props;
+      this.props.changeTask(taskData, sampleIds, parameters, runNow);
     }
 
     this.props.hide();
@@ -375,7 +373,7 @@ class Characterisation extends React.Component {
               Run Now
             </button>
             <button type="button" className="btn btn-primary" onClick={this.addToQueue}>
-              {this.props.taskData.queueID ? 'Change' : 'Add to Queue'}
+              {this.props.taskData.sampleID ? 'Change' : 'Add to Queue'}
             </button>
         </Modal.Footer>
       </Modal>

--- a/mxcube3/ui/components/Tasks/DataCollection.js
+++ b/mxcube3/ui/components/Tasks/DataCollection.js
@@ -39,17 +39,15 @@ class DataCollection extends React.Component {
 
     if (this.props.sampleIds.constructor === Array) {
       for (const sampleId of this.props.sampleIds) {
-        const queueId = this.props.lookup[sampleId];
-        if (queueId) {
-          this.props.addTask(queueId, sampleId, parameters, runNow);
+        if (this.props.queue[sampleId]) {
+          this.props.addTask(sampleId, parameters, runNow);
         } else {
           this.props.addSampleAndTask(sampleId, parameters);
         }
       }
     } else {
-      const { lookup, taskData, sampleIds } = this.props;
-      const sampleQueueId = lookup[sampleIds];
-      this.props.changeTask(taskData, sampleIds, sampleQueueId, parameters, runNow);
+      const { taskData, sampleIds } = this.props;
+      this.props.changeTask(taskData, sampleIds, parameters, runNow);
     }
 
     this.props.hide();
@@ -355,7 +353,7 @@ class DataCollection extends React.Component {
               Run Now
             </Button>
             <Button bsStyle="primary" onClick={this.addToQueue}>
-              {this.props.taskData.queueID ? 'Change' : 'Add to Queue'}
+              {this.props.taskData.sampleID ? 'Change' : 'Add to Queue'}
             </Button>
           </Modal.Footer>
       </Modal>

--- a/mxcube3/ui/containers/SampleGridContainer.jsx
+++ b/mxcube3/ui/containers/SampleGridContainer.jsx
@@ -28,10 +28,8 @@ import {
   sendSyncSamples,
   sendManualMount,
   setSampleOrderAction,
-  sendAddSample,
-  sendDeleteSampleTask,
+  deleteSampleTask,
 } from '../actions/queue';
-
 
 import { showTaskForm } from '../actions/taskForm';
 import SampleTaskButtons from '../components/SampleGrid/TaskButtons';
@@ -276,10 +274,9 @@ function mapDispatchToProps(dispatch) {
     unselectAll: () => dispatch(pickAllAction(false)),
     filter: (filterText) => dispatch(filterAction(filterText)),
     syncSamples: (proposalId) => dispatch(sendSyncSamples(proposalId)),
-    addSampleToQueue: (id) => dispatch(sendAddSample(id)),
     setManualMount: (manual) => dispatch(sendManualMount(manual)),
     showTaskParametersForm: bindActionCreators(showTaskForm, dispatch),
-    deleteTask: bindActionCreators(sendDeleteSampleTask, dispatch),
+    deleteTask: bindActionCreators(deleteSampleTask, dispatch),
     toggleMovableAction: (key) => dispatch(toggleMovableAction(key)),
     select: (keys) => dispatch(selectAction(keys)),
     pickSamplesAction: (keys) => dispatch(pickSamplesAction(keys))

--- a/mxcube3/ui/containers/SampleQueueContainer.js
+++ b/mxcube3/ui/containers/SampleQueueContainer.js
@@ -52,6 +52,8 @@ export default class SampleQueueContainer extends React.Component {
     const {
       sendToggleCheckBox,
       sendRunSample,
+      sendSetQueue,
+      setQueueAndRun,
       sendPauseQueue,
       sendUnpauseQueue,
       sendStopQueue,
@@ -78,6 +80,8 @@ export default class SampleQueueContainer extends React.Component {
                   checked={checked}
                   deleteTask={deleteSampleTask}
                   run={sendRunSample}
+                  setQueue={sendSetQueue}
+                  setQueueAndRun={setQueueAndRun}
                   pause={sendPauseQueue}
                   unpause={sendUnpauseQueue}
                   stop={sendStopQueue}

--- a/mxcube3/ui/containers/SampleQueueContainer.js
+++ b/mxcube3/ui/containers/SampleQueueContainer.js
@@ -21,7 +21,6 @@ function mapStateToProps(state) {
     checked: state.queue.checked,
     select_all: state.queue.selectAll,
     mounted: state.queue.manualMount.set,
-    collapsedSamples: state.queue.collapsedSample,
     rootPath: state.queue.rootPath
   };
 }
@@ -46,7 +45,6 @@ export default class SampleQueueContainer extends React.Component {
       current,
       sampleInformation,
       queue,
-      collapsedSamples,
       showForm,
       queueStatus,
       rootPath
@@ -61,6 +59,7 @@ export default class SampleQueueContainer extends React.Component {
       changeTaskOrder,
       collapseList,
       collapseSample,
+      collapseTask,
       deleteSampleTask
     } = this.props.queueActions;
 
@@ -86,13 +85,11 @@ export default class SampleQueueContainer extends React.Component {
                   unmount={sendUnmountSample}
                   queueStatus={queueStatus}
                   rootPath={rootPath}
-                  collapseNode={collapseSample}
-                  collapsedNodes={collapsedSamples}
+                  collapseTask={collapseTask}
                 />
                 <HistoryTree
                   show={history.collapsed}
                   collapse={collapseList}
-                  collapsedSamples={collapsedSamples}
                   list={history.nodes}
                   sampleInformation={sampleInformation}
                   queue={queue}

--- a/mxcube3/ui/containers/SampleQueueContainer.js
+++ b/mxcube3/ui/containers/SampleQueueContainer.js
@@ -19,7 +19,6 @@ function mapStateToProps(state) {
     queue: state.queue.queue,
     sampleInformation: state.queue.sampleList,
     checked: state.queue.checked,
-    lookup: state.queue.lookup,
     select_all: state.queue.selectAll,
     mounted: state.queue.manualMount.set,
     collapsedSamples: state.queue.collapsedSample,
@@ -43,7 +42,6 @@ export default class SampleQueueContainer extends React.Component {
   render() {
     const {
       checked,
-      lookup,
       history,
       current,
       sampleInformation,
@@ -63,7 +61,7 @@ export default class SampleQueueContainer extends React.Component {
       changeTaskOrder,
       collapseList,
       collapseSample,
-      sendDeleteSampleTask
+      deleteSampleTask
     } = this.props.queueActions;
 
     return (
@@ -77,10 +75,9 @@ export default class SampleQueueContainer extends React.Component {
                   mounted={current.node}
                   sampleInformation={sampleInformation}
                   queue={queue}
-                  lookup={lookup}
                   toggleCheckBox={sendToggleCheckBox}
                   checked={checked}
-                  deleteTask={sendDeleteSampleTask}
+                  deleteTask={deleteSampleTask}
                   run={sendRunSample}
                   pause={sendPauseQueue}
                   unpause={sendUnpauseQueue}
@@ -99,7 +96,6 @@ export default class SampleQueueContainer extends React.Component {
                   list={history.nodes}
                   sampleInformation={sampleInformation}
                   queue={queue}
-                  lookup={lookup}
                   collapseSample={collapseSample}
                 />
             </div>

--- a/mxcube3/ui/containers/SampleViewContainer.js
+++ b/mxcube3/ui/containers/SampleViewContainer.js
@@ -16,7 +16,7 @@ class SampleViewContainer extends Component {
   render() {
     const { imageRatio, motorSteps, cinema } = this.props.sampleViewState;
     const { sendMotorPosition, setStepSize, sendStopMotor } = this.props.sampleViewActions;
-    const sampleId = this.props.lookup[this.props.current.node];
+    const sampleId = this.props.current.node;
 
     return (
       <div className="row">
@@ -68,7 +68,6 @@ function mapStateToProps(state) {
     sampleInformation: state.queue.sampleList,
     sampleViewState: state.sampleview,
     beamline: state.beamline,
-    lookup: state.queue.lookup,
     defaultParameters: state.taskForm.defaultParameters,
     logMessages: state.logger.logRecords
   };

--- a/mxcube3/ui/containers/TaskContainer.js
+++ b/mxcube3/ui/containers/TaskContainer.js
@@ -9,10 +9,11 @@ import { sendCurrentPhase } from '../actions/sampleview';
 
 
 import {
-  sendAddSampleAndTask,
-  sendAddSampleTask,
-  sendUpdateSampleTask,
-  sendAddSample
+  addSampleAndTask,
+  addTask,
+  updateSampleTask,
+  addSample,
+  appendSampleList,
 } from '../actions/queue';
 
 
@@ -23,16 +24,15 @@ class TaskContainer extends React.Component {
   }
 
   addSample(sampleID, parameters) {
+    this.props.appendSampleList(sampleID, parameters);
     this.props.addSample(sampleID, parameters);
   }
 
   render() {
-    const lookup = this.props.lookup_queueID;
     return (
       <div className="col-xs-12">
         <Characterisation
           pointId={this.props.pointId}
-          lookup={lookup}
           sampleIds={this.props.sampleIds}
           taskData={this.props.taskData}
           addSampleAndTask={this.props.addSampleAndTask}
@@ -42,11 +42,11 @@ class TaskContainer extends React.Component {
           apertureList={this.props.apertureList}
           show={this.props.showForm === 'Characterisation'}
           rootPath={this.props.path}
+          queue={this.props.queue}
         />
 
         <DataCollection
           pointId={this.props.pointId}
-          lookup={lookup}
           sampleIds={this.props.sampleIds}
           taskData={this.props.taskData}
           addSampleAndTask={this.props.addSampleAndTask}
@@ -56,6 +56,7 @@ class TaskContainer extends React.Component {
           apertureList={this.props.apertureList}
           show={this.props.showForm === 'DataCollection'}
           rootPath={this.props.path}
+          queue={this.props.queue}
         />
 
         <AddSample
@@ -74,8 +75,8 @@ class TaskContainer extends React.Component {
 
 function mapStateToProps(state) {
   return {
+    queue: state.queue.queue,
     showForm: state.taskForm.showForm,
-    lookup_queueID: state.queue.lookup_queueID,
     taskData: state.taskForm.taskData,
     sampleIds: state.taskForm.sampleIds,
     pointId: state.taskForm.pointId,
@@ -91,10 +92,11 @@ function mapDispatchToProps(dispatch) {
   return {
     showTaskParametersForm: bindActionCreators(showTaskForm, dispatch),
     hideTaskParametersForm: bindActionCreators(hideTaskParametersForm, dispatch),
-    addSampleAndTask: bindActionCreators(sendAddSampleAndTask, dispatch),
-    addTask: bindActionCreators(sendAddSampleTask, dispatch),
-    changeTask: bindActionCreators(sendUpdateSampleTask, dispatch),
-    addSample: bindActionCreators(sendAddSample, dispatch),
+    addSampleAndTask: bindActionCreators(addSampleAndTask, dispatch),
+    addTask: bindActionCreators(addTask, dispatch),
+    appendSampleList: bindActionCreators(appendSampleList, dispatch),
+    changeTask: bindActionCreators(updateSampleTask, dispatch),
+    addSample: bindActionCreators(addSample, dispatch),
     sendCurrentPhase: bindActionCreators(sendCurrentPhase, dispatch)
   };
 }

--- a/mxcube3/ui/reducers/SamplesGrid.js
+++ b/mxcube3/ui/reducers/SamplesGrid.js
@@ -90,9 +90,9 @@ export default (state = INITIAL_STATE, action) => {
       return Object.assign({}, state, { order: initialGridOrder(action.sampleList) });
     }
     // Append one sample to the list of samples (sampleList),
-    // (used when samples are mounted manually)
-    case 'ADD_SAMPLE': {
+    case 'APPEND_TO_SAMPLE_LIST': {
       const order = { ...state.order, [action.sampleID]: sampleOrder(state.order) };
+
       return Object.assign({}, state, { order });
     }
     // Set display order of samples in grid

--- a/mxcube3/ui/reducers/queue.js
+++ b/mxcube3/ui/reducers/queue.js
@@ -24,7 +24,6 @@ const initialState = {
   todo: { nodes: [], collapsed: false },
   history: { nodes: [], collapsed: false },
   checked: [],
-  collapsedSample: {},
   searchString: '',
   queueStatus: 'QueueStopped',
   showRestoreDialog: false,

--- a/mxcube3/ui/reducers/queue.js
+++ b/mxcube3/ui/reducers/queue.js
@@ -24,8 +24,6 @@ const initialState = {
   todo: { nodes: [], collapsed: false },
   history: { nodes: [], collapsed: false },
   checked: [],
-  lookup: {},
-  lookup_queueID: {},
   collapsedSample: {},
   searchString: '',
   queueStatus: 'QueueStopped',
@@ -86,6 +84,13 @@ export default (state = initialState, action) => {
     case 'SET_SAMPLE_LIST': {
       return Object.assign({}, state, { sampleList: initSampleList(action.sampleList) });
     }
+    case 'APPEND_TO_SAMPLE_LIST': {
+      const sampleData = action.sampleData || {};
+      Object.assign(sampleData, { collapsed: false, checked: false });
+
+      const sampleList = { ...state.sampleList, [action.sampleID]: sampleData };
+
+      return Object.assign({}, state, { sampleList });
     case 'SET_SAMPLE_ORDER': {
       const reorderKeys = Object.keys(action.keys).map(key => (action.keys[key] ? key : ''));
       const sampleList = recalculateQueueOrder(reorderKeys, action.order, state);
@@ -125,8 +130,7 @@ export default (state = initialState, action) => {
     }
 
     case 'ADD_TASK_RESULT': {
-      const queueID = state.lookup_queueID[action.sampleID];
-      const tasks = Array.from(state.queue[queueID]);
+      const tasks = Array.from(state.queue[action.sampleID]);
 
       // Find element with the right queueID (action.queueID) and update state
       // to action.state
@@ -136,7 +140,7 @@ export default (state = initialState, action) => {
         }
       }
 
-      return Object.assign({}, state, { queue: { ...state.queue, [queueID]: tasks } });
+      return Object.assign({}, state, { queue: { ...state.queue, [action.sampleID]: tasks } });
     }
     case 'SET_MANUAL_MOUNT': {
       const data = { manualMount: { ...state.manualMount, set: action.manual } };
@@ -145,17 +149,10 @@ export default (state = initialState, action) => {
 
     // Adding sample to queue
     case 'ADD_SAMPLE': {
-      const sampleList = { ...state.sampleList, [action.sampleID]: action.sampleData || {} };
-
       return Object.assign({}, state,
         {
-          todo: { ...state.todo, nodes: state.todo.nodes.concat(action.queueID) },
-          queue: { ...state.queue, [action.queueID]: [] },
-          lookup: { ...state.lookup, [action.queueID]: action.sampleID },
-          lookup_queueID: { ...state.lookup_queueID, [action.sampleID]: action.queueID },
-          collapsedSample: { ...state.collapsedSample, [action.queueID]: true },
-          manualMount: { ...state.manualMount, id: state.manualMount.id + 1 },
-          sampleList
+          todo: { ...state.todo, nodes: state.todo.nodes.concat(action.sampleID) },
+          queue: { ...state.queue, [action.sampleID]: [] },
         }
       );
     }
@@ -169,63 +166,53 @@ export default (state = initialState, action) => {
         // Removing sample from queue
     case 'REMOVE_SAMPLE':
       return Object.assign({}, state,
-        { todo: { ...state.todo, nodes: without(state.todo.nodes, action.queueID) },
-          queue: omit(state.queue, action.queueID),
-          lookup: omit(state.lookup, action.queueID),
-          collapsedSample: omit(state.collapsedSample, action.queueID),
-          lookup_queueID: omit(state.lookup_queueID, action.index)
+        { todo: { ...state.todo, nodes: without(state.todo.nodes, action.sampleID) },
+          queue: omit(state.queue, action.sampleID),
         });
 
         // Adding the new task to the queue
     case 'ADD_TASK': {
-      const queueID = state.lookup_queueID[action.sampleID];
-
       // Create a copy of the tasks (array) for a sample with given queueID,
       // or an empty array if no tasks exists for sampleID
-      let tasks = Array.from(state.queue[queueID] || []);
-      tasks = tasks.concat([{ type: action.taskType,
-                              label: action.taskType.split(/(?=[A-Z])/).join(' '),
+      let tasks = Array.from(state.queue[action.sampleID] || []);
+      tasks = tasks.concat([{ type: action.parameters.Type,
+                              label: action.parameters.Type.split(/(?=[A-Z])/).join(' '),
                               sampleID: action.sampleID,
-                              queueID: action.queueID,
-                              parentID: action.parentID,
+                              queueID: undefined,
                               parameters: action.parameters,
-                              state: 0
+                              state: 0,
+                              collapsed: false,
+                              checked: false
       }]);
 
-      const queue = { ...state.queue, [queueID]: tasks };
-      return Object.assign({}, state, { queue, checked: state.checked.concat(0) });
+      const queue = { ...state.queue, [action.sampleID]: tasks };
+      return Object.assign({}, state, { queue });
     }
     // Removing the task from the queue
     case 'REMOVE_TASK': {
-      const queueID = state.lookup_queueID[action.task.sampleID];
-      const tasks = without(state.queue[queueID], action.task);
-
-      return Object.assign({}, state, { queue: { ...state.queue, [queueID]: tasks },
-                                        checked: without(state.checked, action.queueID) });
+      const sampleID = action.task.sampleID;
+      const tasks = without(state.queue[sampleID], action.task);
+      return Object.assign({}, state, { queue: { ...state.queue, [sampleID]: tasks } });
     }
     case 'UPDATE_TASK': {
-      const queueID = state.lookup_queueID[action.sampleID];
-      const taskIndex = state.queue[queueID].indexOf(action.taskData);
-      const tasks = Array.from(state.queue[queueID]);
+      const taskIndex = state.queue[action.sampleID].indexOf(action.taskData);
+      const tasks = Array.from(state.queue[action.sampleID]);
 
       tasks[taskIndex] = { ...action.taskData,
                            type: action.parameters.Type,
                            parameters: action.parameters };
 
-      return Object.assign({}, state, { queue: { ...state.queue, [queueID]: tasks } });
+      return Object.assign({}, state, { queue: { ...state.queue, [action.sampleID]: tasks } });
     }
     // Run Mount, this will add the mounted sample to history
     case 'MOUNT_SAMPLE':
       return Object.assign({}, state,
         {
-          current: { ...state.current, node: action.queueID, running: false },
-          todo: { ...state.todo, nodes: without(state.todo.nodes, action.queueID) },
-          history: {
-            ...state.history,
-            nodes: (
-              state.current.node ?
-              state.history.nodes.concat(state.current.node) : state.history.nodes
-            )
+          current: { ...state.current, node: action.sampleID, running: false },
+          todo: { ...state.todo, nodes: without(state.todo.nodes, action.sampleID) },
+          history: { ...state.history,
+                     nodes: (state.current.node ?
+                             state.history.nodes.concat(state.current.node) : state.history.nodes)
           }
         }
       );
@@ -252,13 +239,9 @@ export default (state = initialState, action) => {
                         );
 
     case 'TOGGLE_CHECKED':
-      return Object.assign({}, state,
-        {
-          checked: xor(state.checked, [action.queueID])
-        }
-                        );
+      return Object.assign({}, state, { checked: xor(state.checked, [action.queueID]) });
 
-        // Collapse list
+     // Collapse list
     case 'COLLAPSE_LIST':
       return {
         ...state,
@@ -266,17 +249,20 @@ export default (state = initialState, action) => {
         collapsed: !state[action.list_name].collapsed
         }
       };
-    // Collapse list
-    case 'COLLAPSE_SAMPLE':
-      return {
-        ...state,
-        collapsedSample: {
-          ...state.collapsedSample,
-          [action.queueID]: !state.collapsedSample[action.queueID]
-        }
-      };
+    // Toggle sample collapse flag
+    case 'COLLAPSE_SAMPLE': {
+      const sampleList = Object.assign({}, state.sampleList);
+      sampleList[action.sampleID].collapsed = !sampleList[action.sampleID].collapsed;
+      return { ...state, sampleList };
+    }
+    // Toggle task collapse flag
+    case 'COLLAPSE_TASK': {
+      const queue = Object.assign({}, state.queue);
+      queue[action.sampleID][action.taskIndex].collapsed ^= true;
 
-        // Change order of samples in queue on drag and drop
+      return { ...state, queue };
+    }
+    // Change order of samples in queue on drag and drop
     case 'CHANGE_QUEUE_ORDER':
 
       return {

--- a/mxcube3/ui/reducers/queue.js
+++ b/mxcube3/ui/reducers/queue.js
@@ -30,7 +30,7 @@ const initialState = {
   showRestoreDialog: false,
   queueRestoreState: {},
   sampleList: {},
-  manualMount: { set: false, id: 0 }
+  manualMount: { set: false, id: 1 },
 };
 
 
@@ -91,6 +91,7 @@ export default (state = initialState, action) => {
       const sampleList = { ...state.sampleList, [action.sampleID]: sampleData };
 
       return Object.assign({}, state, { sampleList });
+    }
     case 'SET_SAMPLE_ORDER': {
       const reorderKeys = Object.keys(action.keys).map(key => (action.keys[key] ? key : ''));
       const sampleList = recalculateQueueOrder(reorderKeys, action.order, state);
@@ -153,6 +154,7 @@ export default (state = initialState, action) => {
         {
           todo: { ...state.todo, nodes: state.todo.nodes.concat(action.sampleID) },
           queue: { ...state.queue, [action.sampleID]: [] },
+          manualMount: { ...state.manualMount, id: state.manualMount.id + 1 }
         }
       );
     }
@@ -298,7 +300,7 @@ export default (state = initialState, action) => {
     case 'CLEAR_ALL':
       {
         return Object.assign({}, state, { ...initialState,
-                                          manualMount: { set: state.manualMount.set, id: 0 } });
+                                          manualMount: { set: state.manualMount.set, id: 1 } });
       }
     case 'SHOW_RESTORE_DIALOG':
       {
@@ -311,7 +313,7 @@ export default (state = initialState, action) => {
     case 'SET_INITIAL_STATUS':
       {
         return { ...state, rootPath: action.data.rootPath,
-                           manualMount: { set: state.manualMount.set, id: 0 } };
+                           manualMount: { set: state.manualMount.set, id: 1 } };
       }
     default:
       return state;

--- a/mxcube3/ui/reducers/queue.js
+++ b/mxcube3/ui/reducers/queue.js
@@ -80,6 +80,9 @@ function recalculateQueueOrder(keys, gridOrder, state) {
 
 export default (state = initialState, action) => {
   switch (action.type) {
+    case 'SET_QUEUE': {
+      return Object.assign({}, state, { queue: action.queue });
+    }
     case 'SET_SAMPLE_LIST': {
       return Object.assign({}, state, { sampleList: initSampleList(action.sampleList) });
     }

--- a/mxcube3/ui/reducers/taskForm.js
+++ b/mxcube3/ui/reducers/taskForm.js
@@ -24,16 +24,13 @@ export default (state = initialState, action) => {
       }
     case 'ADD_TASK':
       {
-        return {
-          ...state,
-          defaultParameters: {
-            ...state.defaultParameters,
-            [action.taskType.toLowerCase()]: {
-              ...action.parameters,
-              run_number: state.defaultParameters[action.taskType.toLowerCase()].run_number + 1
-            }
-          }
-        };
+        return { ...state, defaultParameters:
+                 { ...state.defaultParameters, [action.parameters.Type.toLowerCase()]: {
+                   ...action.parameters, run_number:
+                   state.defaultParameters[action.parameters.Type.toLowerCase()].run_number + 1
+                 }
+               }
+             };
       }
     case 'UPDATE_TASK':
       {


### PR DESCRIPTION
Hello !

Here is the first take of the Queue API refactoring that we discussed in issue #304. I wanted to share this preliminary work with you guys to get your ideas on it. The general idea with this first work is to decouple server internals like nodeId and to simplify the logic we use on the client. I then hope to be able to develop a simplified API for exchanging the queue. 

I've removed the mapping between server side nodeID's to samples and tasks (so far on the client side). The two lookup tables "lookup" and "queueID_lookup" have consequently been removed. The components have been updated to reflect this change. I'm currently using the sampleIDs and the position of a task in the queue to identify samples and tasks. 

The "display data" that were stored in queue state collapsedSamples and checked have been moved to sample and task data objects. This might not be the best solution but its easier to access this data directly rather than going through an extra state variable. I was thinking of creating a new state variable called displayData, with all the display data like label, collapsed and checked. I might do that in the end if we there is good reasons for it, for the moment I cant really see any. Let me know what you think !?.

Ive also removed the server calls for ADD, REMOVE and CHANGE tasks, which later will be replaced by the SET_QUEUE (not done yet). The mount sample route have been refactored to operate on sampleIDs instead of nodeIDs. 

Finally, the UI should work as before but no changes to the queue are sent to the server. So its of course not possible to run the queue yet.  The next thing to do is to implement the queue exchange functionality basically SET_QUEUE.

If anyone have some time over, take a look and let me know what you think. All input is welcome :).

Cheers,
Marcus
