### PR TITLE
Removed mapping between sampleID/taskID and server side nodeID

### DIFF
--- a/mxcube3/routes/Queue.py
+++ b/mxcube3/routes/Queue.py
@@ -135,7 +135,7 @@ def queue_unpause():
     return Response(status=200)
 
 
-@mxcube.route("/mxcube/api/v0.1/queue/clear", methods=['PUT'])
+@mxcube.route("/mxcube/api/v0.1/queue/clear", methods=['PUT', 'GET'])
 def queue_clear():
     """
     Clear the queue.

--- a/mxcube3/routes/Queue.py
+++ b/mxcube3/routes/Queue.py
@@ -14,7 +14,6 @@ import Utils
 from mxcube3 import app as mxcube
 from mxcube3 import socketio
 
-from Utils import PickableMock
 from HardwareRepository.BaseHardwareObjects import Null as Mock
 
 qm = QueueManager.QueueManager('Mxcube3')
@@ -348,9 +347,9 @@ def add_sample():
     :statuscode: 409 sample could not be added, possibly because it already
                      exist in the queue
                        
-    :example request: POST http://host:port/mxcube/api/v0.1/queue
-                      Content-Type: application/json
-                      {"SampleId": "1:07"}
+    :example: POST http://host:port/mxcube/api/v0.1/queue
+              Content-Type: application/json
+              {"SampleId": "1:07"}
     """
     params = request.data
     params = json.loads(params)
@@ -382,7 +381,10 @@ def add_sample():
         msg = '[QUEUE] sample could not be added, %s' % str(ex)
         logging.getLogger('HWR').error(msg)  
 
-    sample_entry = qe.SampleQueueEntry(PickableMock(), sample_model)
+    sample_entry = qe.SampleQueueEntry(False, sample_model)
+    sample_entry._view = Mock()
+    sample_entry._set_background_color = Mock()
+    
     mxcube.queue.add_child(mxcube.queue.get_model_root(), sample_model)
     mxcube.queue.queue_hwobj.enqueue(sample_entry)
 

--- a/mxcube3/routes/Queue.py
+++ b/mxcube3/routes/Queue.py
@@ -14,9 +14,8 @@ import Utils
 from mxcube3 import app as mxcube
 from mxcube3 import socketio
 
-#for mocking the view of the queue, easier than adding sth like if not view:
+from Utils import PickableMock
 from HardwareRepository.BaseHardwareObjects import Null as Mock
-
 
 qm = QueueManager.QueueManager('Mxcube3')
 
@@ -336,61 +335,62 @@ def execute_entry_with_id(node_id):
 
 @mxcube.route("/mxcube/api/v0.1/queue", methods=['POST'])
 def add_sample():
-    '''
-    Add a sample to the queue.
-        :request Content-Type: application/json, {"SampleId": sampleId},
-        where sampleId is sample location (eg '1:01')
-        :response Content-Type: application/json, {"QueueId": node_id,
-            "SampleId": sampleId}, where sampleId is the same as the
-            caller id (eg '1:01') and node_id an integer which is used
-            for refering to this element from now onwards.
-        :statuscode: 200: no error
-        :statuscode: 409: sample could not be added, possibly because
-            it already exist in the queue
-        :example request:   * POST http://host:port/mxcube/api/v0.1/queue
-                            * Content-Type: application/json
-                            * {"SampleId": "1:07"}
-    '''
+    """
+    Adds a sample to the queue.
+
+    :request: application/json, {"SampleId": sampleId}, where sampleId is
+              sampleId, often a location (eg '1:01')
+                           
+    :response: application/json, {"QueueId": node_id, "SampleId": sampleId},
+               where sampleId is the sampleId
+
+    :statuscode: 200 no error
+    :statuscode: 409 sample could not be added, possibly because it already
+                     exist in the queue
+                       
+    :example request: POST http://host:port/mxcube/api/v0.1/queue
+                      Content-Type: application/json
+                      {"SampleId": "1:07"}
+    """
     params = request.data
     params = json.loads(params)
-    sample_id = params['SampleId']
+    sample_loc = params['sampleId']
 
-    sample_node = qmo.Sample()
-    sample_node.loc_str = sample_id
-    sample_node.lims_id = None
-    sample_node.lims_group_id = None
-    basket_number = None
+    sample_model = qmo.Sample()
+    sample_model.loc_str = sample_loc
 
+    # Is the sample with location sample_loc already in the queue,
+    # in that case, send error response
+    for sampleId, sample in serialize_queue_to_json().iteritems():
+        if sampleId == sample_loc:
+            msg = "[QUEUE] sample could not be added, already in the queue"
+            logging.getLogger('HWR').error(msg)
+
+            return Response(status=409)
+        
     try:
-        if mxcube.diffractometer.use_sc:    # use sample changer
-            basket_number, sample_number = sample_id.split(':')
+        # Are we using the sample changer or is a sample put on the pin
+        # manually
+        if mxcube.diffractometer.use_sc:
+            basket_number, sample_number = sample_loc.split(':')
         else:
-            sample_number = sample_id
+            basket_number, sample_number = (None, sample_loc)
+
+        sample_model.location = (basket_number, sample_number)
+
     except AttributeError as ex:
         msg = '[QUEUE] sample could not be added, %s' % str(ex)
-        logging.getLogger('HWR').error(msg)
+        logging.getLogger('HWR').error(msg)  
 
-    sample_node.location = (basket_number, sample_number)
-    sample_entry = qe.SampleQueueEntry()
-    sample_entry.set_data_model(sample_node)
-    sample_entry.set_queue_controller(qm)
-    sample_entry._view = Mock()
-    sample_entry._set_background_color = Mock()
-
-    # WARNING: serialize_queue_to_json() should only be used for sending to the client,
-    # here on the back-end side we should just always use mxcube.queue !
-    queue = serialize_queue_to_json()
-    for i in queue:
-        if queue[i]['SampleId'] == sample_id:
-            logging.getLogger('HWR').error('[QUEUE] sample could not be added, already in the queue')
-            return Response(status=409)
-
-    mxcube.queue.add_child(mxcube.queue._selected_model, sample_node)
-    node_id = sample_node._node_id
+    sample_entry = qe.SampleQueueEntry(PickableMock(), sample_model)
+    mxcube.queue.add_child(mxcube.queue.get_model_root(), sample_model)
     mxcube.queue.queue_hwobj.enqueue(sample_entry)
-    logging.getLogger('HWR').info('[QUEUE] sample "%s" added with queue id "%s"' % (sample_id, node_id))
+
+    msg = "[QUEUE] sample %s added with queue id %s"
+    logging.getLogger('HWR').info(msg % (sample_loc, sample_model._node_id))
+
     Utils.save_queue(session)
-    return jsonify({'SampleId': sample_id, 'QueueId': node_id})
+    return jsonify({'SampleId': sample_loc, 'QueueId': sample_model._node_id})
 
 
 @mxcube.route("/mxcube/api/v0.1/queue/<sample_id>", methods=['PUT'])

--- a/mxcube3/routes/SampleChanger.py
+++ b/mxcube3/routes/SampleChanger.py
@@ -20,28 +20,37 @@ def get_samples_list():
             )
     return jsonify(samples)
 
-@mxcube.route("/mxcube/api/v0.1/sample_changer/<sample>/mount", methods=['PUT'])
-def mountSample(sample):
-    last_queue_node = session.get("last_queue_node")
 
+@mxcube.route("/mxcube/api/v0.1/sample_changer/<sample_location>/mount", methods=['PUT'])
+def mountSample(sample_location):
+    # Most of this code should be moved to diffractometer or more general
+    # beamline object. The route should probably not know details about if
+    # the diffractometer has phase ... We should just need to do
+    # beamline.mount_sample(location)
+   
     try:
-        sampleNode = mxcube.queue.get_node(int(sample))
-        sampleLocation = sampleNode.location
-        if mxcube.diffractometer.use_sc:
-             mxcube.queue.last_queue_node.update({'id': int(sample), 'sample': str(sampleLocation[0] + ':' + sampleLocation[1])})
-        else:  # manual, not using sample_changer
-             mxcube.diffractometer.set_phase("Centring")
-             mxcube.queue.last_queue_node.update({'id': int(sample), 'sample': str(sampleLocation[1])})
-        session["last_queue_node"] = last_queue_node
-        #mxcube.sample_changer.load_sample
-        #TODO: figure out how to identify the sample for the sc, selectsample&loadsamplae&etc
-        mxcube.diffractometer.savedCentredPos = []
-        mxcube.diffractometer.savedCentredPosCount = 1
-        logging.getLogger('HWR').info('[SC] %s sample mounted, location: %s' % (sample, sampleLocation))
-        return Response(status=200)
+        # We are not using the sample changer to mount the sample, set
+        # centering phase directly
+        if not mxcube.diffractometer.use_sc:
+            mxcube.diffractometer.set_phase("Centring")
+
+        # Make the necessary call to load sample on location sample_location
+        # The underlying sample changer object should handle mounting from
+        # string repr
+        # mxcube.sample_changer.load_sample(sample_location)
+
     except Exception:
         logging.getLogger('HWR').exception('[SC] sample could not be mounted')
         return Response(status=409)
+    else:       
+        # Clearing centered position
+        mxcube.diffractometer.savedCentredPos = []
+        mxcube.diffractometer.savedCentredPosCount = 1
+
+        logging.getLogger('HWR').info('[SC] mounted %s' % sample_location)
+
+        return Response(status=200)
+
 
 @mxcube.route("/mxcube/api/v0.1/sample_changer/<sample>/unmount", methods=['PUT'])
 def unmountSample(sample):

--- a/mxcube3/routes/Utils.py
+++ b/mxcube3/routes/Utils.py
@@ -1,9 +1,14 @@
-from mxcube3 import app as mxcube
-from flask import Response, session
-from functools import wraps
 import logging
 import jsonpickle
 import redis
+
+from mock import Mock
+from mxcube3 import app as mxcube
+
+
+class PickableMock(Mock):
+    def __reduce__(self):
+        return (Mock, ())
 
 
 def _proposal_id(session):

--- a/mxcube3/ui/actions/queue.js
+++ b/mxcube3/ui/actions/queue.js
@@ -471,7 +471,7 @@ export function deleteTask(task) {
 
 
 export function addTaskResultAction(sampleID, taskQueueID, state) {
-  return { type: 'ADD_TASK_RESLT',
+  return { type: 'ADD_TASK_RESULT',
            sampleID,
            taskQueueID,
            state

--- a/mxcube3/ui/actions/queue.js
+++ b/mxcube3/ui/actions/queue.js
@@ -87,23 +87,23 @@ export function setSampleOrderAction(newSampleOrder, keys) {
 }
 
 
-export function addSample(sampleID, queueID, sampleData) {
-  return {
-    type: 'ADD_SAMPLE', sampleID, queueID, sampleData
-  };
+export function addSampleAction(sampleID, sampleData, queueID) {
+  return { type: 'ADD_SAMPLE', sampleID, sampleData, queueID };
 }
 
-export function removeSample(queueID, sampleID) {
-  return {
-    type: 'REMOVE_SAMPLE', queueID, sampleID
-  };
+
+export function appendSampleListAction(sampleID, sampleData) {
+  return { type: 'APPEND_TO_SAMPLE_LIST', sampleID, sampleData };
+}
+
+
+export function removeSampleAction(sampleID) {
+  return { type: 'REMOVE_SAMPLE', sampleID };
 }
 
 
 export function setStatus(queueState) {
-  return {
-    type: 'SET_QUEUE_STATUS', queueState
-  };
+  return { type: 'SET_QUEUE_STATUS', queueState };
 }
 
 
@@ -114,9 +114,15 @@ export function collapseList(listName) {
   };
 }
 
-export function collapseSample(queueID) {
+export function collapseSample(sampleID) {
   return {
-    type: 'COLLAPSE_SAMPLE', queueID
+    type: 'COLLAPSE_SAMPLE', sampleID
+  };
+}
+
+export function collapseTask(sampleID, taskIndex) {
+  return {
+    type: 'COLLAPSE_TASK', sampleID, taskIndex
   };
 }
 
@@ -144,9 +150,9 @@ export function runSample(queueID) {
   };
 }
 
-export function mountSample(queueID) {
+export function mountSample(sampleID) {
   return {
-    type: 'MOUNT_SAMPLE', queueID
+    type: 'MOUNT_SAMPLE', sampleID
   };
 }
 
@@ -156,9 +162,9 @@ export function unmountSample(queueID) {
   };
 }
 
-export function toggleChecked(queueID) {
+export function toggleChecked(sampleID, index) {
   return {
-    type: 'TOGGLE_CHECKED', queueID
+    type: 'TOGGLE_CHECKED', sampleID, index
   };
 }
 
@@ -238,9 +244,9 @@ export function sendStopQueue() {
 }
 
 
-export function sendMountSample(queueID) {
+export function sendMountSample(sampleID) {
   return function (dispatch) {
-    fetch(`mxcube/api/v0.1/sample_changer/${queueID}/mount`, {
+    fetch(`mxcube/api/v0.1/sample_changer/${sampleID}/mount`, {
       method: 'PUT',
       credentials: 'include',
       headers: {
@@ -251,14 +257,25 @@ export function sendMountSample(queueID) {
       if (response.status >= 400) {
         throw new Error('Server refused to mount sample');
       } else {
-        dispatch(mountSample(queueID));
+        dispatch(mountSample(sampleID));
       }
     });
   };
 }
 
 
-export function sendAddSample(SampleId, sampleData) {
+export function addSample(sampleId, sampleData, queueID) {
+  return function (dispatch) {
+    dispatch(addSampleAction(sampleId, sampleData, queueID));
+
+    // Its perhaps possible to not even sendMountSample at this point,
+    // does it even make sense ?
+    dispatch(sendMountSample(sampleId));
+  };
+}
+
+
+export function sendAddSample(sampleId, sampleData) {
   return function (dispatch) {
     return fetch('mxcube/api/v0.1/queue', {
       method: 'POST',
@@ -267,40 +284,32 @@ export function sendAddSample(SampleId, sampleData) {
         Accept: 'application/json',
         'Content-type': 'application/json'
       },
-      body: JSON.stringify({ SampleId })
+      body: JSON.stringify({ sampleId })
     }).then((response) => {
       if (response.status >= 400) {
         throw new Error('Server refused to add sample to queue');
       }
       return response.json();
     }).then((json) => {
-      dispatch(addSample(json.SampleId, json.QueueId, sampleData));
-      dispatch(sendMountSample(json.QueueId));
+      dispatch(addSample(sampleId, sampleData, json.QueueId));
       return json.QueueId; // dispatch(sendState());
     });
   };
 }
 
 
-export function sendDeleteSample(queueID, sampleID) {
+export function appendSampleList(sampleID, sampleData) {
   return function (dispatch) {
-    return fetch(`mxcube/api/v0.1/queue/${queueID}`, {
-      method: 'DELETE',
-      credentials: 'include',
-      headers: {
-        Accept: 'application/json',
-        'Content-type': 'application/json'
-      }
-    }).then((response) => {
-      if (response.status >= 400) {
-        throw new Error('Server refused to remove sample');
-      } else {
-        dispatch(removeSample(queueID, sampleID));
-      }
-    });
+    dispatch(appendSampleListAction(sampleID, sampleData));
   };
 }
 
+
+export function deleteSample(sampleID) {
+  return function (dispatch) {
+    dispatch(removeSampleAction(sampleID));
+  };
+}
 
 export function sendRunSample(queueID) {
   return function (dispatch) {
@@ -322,18 +331,27 @@ export function sendRunSample(queueID) {
 }
 
 
-export function addTaskAction(sampleQueueID, sampleID, task, parameters) {
+export function addTaskAction(sampleID, parameters, queueID) {
   return { type: 'ADD_TASK',
-           taskType: task.Type,
            sampleID,
-           parentID: sampleQueueID,
-           queueID: task.QueueId,
+           queueID,
            parameters
   };
 }
 
 
-export function sendAddSampleTask(queueID, sampleID, parameters, runNow) {
+export function addTask(sampleID, parameters, runNow) {
+  return function (dispatch) {
+    if (runNow) {
+      dispatch(sendRunSample(sampleID));
+    }
+
+    dispatch(addTaskAction(sampleID, parameters));
+  };
+}
+
+
+export function sendAddTask(sampleID, queueID, parameters, runNow) {
   return function (dispatch) {
     fetch(`mxcube/api/v0.1/queue/${queueID}`, {
       method: 'POST',
@@ -352,7 +370,7 @@ export function sendAddSampleTask(queueID, sampleID, parameters, runNow) {
       if (runNow) {
         dispatch(sendRunSample(json.QueueId));
       }
-      dispatch(addTaskAction(queueID, sampleID, json, parameters));
+      dispatch(addTaskAction(sampleID, parameters, json.QueueId));
     });
   };
 }
@@ -360,10 +378,16 @@ export function sendAddSampleTask(queueID, sampleID, parameters, runNow) {
 
 export function sendAddSampleAndTask(sampleID, parameters) {
   return function (dispatch) {
-    dispatch(sendAddSample(sampleID)).then(
-      queueID => {
-        dispatch(sendAddSampleTask(queueID, sampleID, parameters));
-      });
+    dispatch(sendAddSample(sampleID)).
+      then((queueID) => { dispatch(sendAddTask(sampleID, queueID, parameters)); });
+  };
+}
+
+
+export function addSampleAndTask(sampleID, parameters) {
+  return function (dispatch) {
+    dispatch(addSample(sampleID));
+    dispatch(addTask(sampleID, parameters));
   };
 }
 
@@ -377,9 +401,9 @@ export function updateTaskAction(taskData, sampleID, parameters) {
 }
 
 
-export function sendUpdateSampleTask(taskData, sampleID, sampleQueueID, params, runNow) {
+export function sendUpdateTask(taskData, sampleID, params, runNow) {
   return function (dispatch) {
-    fetch(`mxcube/api/v0.1/queue/${sampleQueueID}/${taskData.queueID}`, {
+    fetch(`mxcube/api/v0.1/queue/${sampleID}/${taskData.queueID}`, {
       method: 'PUT',
       credentials: 'include',
       headers: {
@@ -402,14 +426,25 @@ export function sendUpdateSampleTask(taskData, sampleID, sampleQueueID, params, 
 }
 
 
+export function updateTask(taskData, sampleID, params, runNow) {
+  return function (dispatch) {
+    if (runNow) {
+      dispatch(sendRunSample(taskData.queueID));
+    }
+
+    dispatch(updateTaskAction(taskData, sampleID, params));
+  };
+}
+
+
 export function removeTaskAction(task) {
   return { type: 'REMOVE_TASK', task };
 }
 
 
-export function sendDeleteSampleTask(task, queueID) {
+export function sendDeleteTask(task) {
   return function (dispatch) {
-    fetch(`mxcube/api/v0.1/queue/${queueID}`, {
+    fetch(`mxcube/api/v0.1/queue/${task.queueID}`, {
       method: 'DELETE',
       credentials: 'include',
       headers: {
@@ -428,8 +463,15 @@ export function sendDeleteSampleTask(task, queueID) {
 }
 
 
+export function deleteTask(task) {
+  return function (dispatch) {
+    dispatch(removeTaskAction(task));
+  };
+}
+
+
 export function addTaskResultAction(sampleID, taskQueueID, state) {
-  return { type: 'ADD_TASK_RESULT',
+  return { type: 'ADD_TASK_RESLT',
            sampleID,
            taskQueueID,
            state
@@ -457,9 +499,9 @@ export function sendUnmountSample(queueID) {
 }
 
 
-export function sendToggleCheckBox(queueID) {
+export function sendToggleCheckBox(data, index) {
   return function (dispatch) {
-    fetch(`mxcube/api/v0.1/queue/${queueID}/toggle`, {
+    fetch(`mxcube/api/v0.1/queue/${data.queueID}/toggle`, {
       method: 'PUT',
       credentials: 'include',
       headers: {
@@ -470,7 +512,7 @@ export function sendToggleCheckBox(queueID) {
       if (response.status >= 400) {
         throw new Error('Server refused to toogle checked task');
       } else {
-        dispatch(toggleChecked(queueID));
+        dispatch(toggleChecked(data.sampleID, index));
       }
     });
   };

--- a/mxcube3/ui/components/SampleGrid/SampleGrid.jsx
+++ b/mxcube3/ui/components/SampleGrid/SampleGrid.jsx
@@ -252,11 +252,10 @@ export default class SampleGrid extends React.Component {
     Object.keys(samplesList).forEach(key => {
       if (this.filter(key)) {
         const sample = samplesList[key];
-        const sampleID = this.props.queue.lookup_queueID[sample.id];
         const [acronym, name, tags] = [sample.proteinAcronym, sample.sampleName, []];
 
-        if (this.props.queue.queue[sampleID]) {
-          for (const task of this.props.queue.queue[sampleID]) {
+        if (this.props.queue.queue[sample.id]) {
+          for (const task of this.props.queue.queue[sample.id]) {
             tags.push(task);
           }
         }
@@ -266,7 +265,7 @@ export default class SampleGrid extends React.Component {
             ref={i}
             seqId={this.props.order[key]}
             itemKey={key}
-            sampleID={sampleID}
+            sampleID={sample.id}
             acronym={acronym}
             name={name}
             dm={sample.code}

--- a/mxcube3/ui/components/SampleQueue/CurrentTree.js
+++ b/mxcube3/ui/components/SampleQueue/CurrentTree.js
@@ -69,14 +69,14 @@ export default class CurrentTree extends React.Component {
   }
 
   render() {
-    const node = this.props.mounted;
+    const sampleId = this.props.mounted;
     let sampleData = {};
     let sampleTasks = [];
     let queueOptions = [];
 
-    if (node) {
-      sampleData = this.props.sampleInformation[this.props.lookup[node]];
-      sampleTasks = this.props.queue[node];
+    if (sampleId) {
+      sampleData = this.props.sampleInformation[sampleId];
+      sampleTasks = this.props.queue[sampleId];
       queueOptions = this.state.options[this.props.queueStatus];
     } else {
       sampleData.sampleName = 'No Sample Mounted';
@@ -84,8 +84,9 @@ export default class CurrentTree extends React.Component {
     }
 
     const bodyClass = cx('list-body', {
-      hidden: (this.props.show || !node)
+      hidden: (this.props.show || !sampleId)
     });
+
     return (
       <div className="m-tree">
           <div className="list-head">
@@ -95,10 +96,11 @@ export default class CurrentTree extends React.Component {
           </div>
           <div className={bodyClass}>
             {sampleTasks.map((taskData, i) => {
+              const key = this.props.queue[taskData.sampleID].indexOf(taskData);
               const task =
-                (<TaskItem key={taskData.queueID}
+                (<TaskItem key={key}
                   index={i}
-                  id={taskData.queueID}
+                  id={key}
                   data={taskData}
                   moveCard={this.moveCard}
                   deleteTask={this.deleteTask}
@@ -107,8 +109,8 @@ export default class CurrentTree extends React.Component {
                   checked={this.props.checked}
                   toggleChecked={this.props.toggleCheckBox}
                   rootPath={this.props.rootPath}
-                  collapseNode={this.props.collapseNode}
-                  show={this.props.collapsedNodes[taskData.queueID]}
+                  collapseTask={this.props.collapseTask}
+                  show={taskData.collapsed}
                 />);
               return task;
             })}

--- a/mxcube3/ui/components/SampleQueue/CurrentTree.js
+++ b/mxcube3/ui/components/SampleQueue/CurrentTree.js
@@ -46,7 +46,8 @@ export default class CurrentTree extends React.Component {
   }
 
   runSample() {
-    this.props.run(this.props.mounted);
+    const queueID = this.props.sampleInformation[this.props.mounted].queueID;
+    this.props.run(queueID);
   }
 
   unMountSample() {

--- a/mxcube3/ui/components/SampleQueue/HistoryTree.js
+++ b/mxcube3/ui/components/SampleQueue/HistoryTree.js
@@ -20,14 +20,14 @@ export default class HistoryTree extends React.Component {
                     <hr className="queue-divider" />
                 </div>
                 <div className={bodyClass}>
-                    {this.props.list.map((id, i) => {
-                      let sampleData = this.props.sampleInformation[this.props.lookup[id]];
+                    {this.props.list.map((sampleId, i) => {
+                      let sampleData = this.props.sampleInformation[sampleId];
                       return (
                         <HistorySampleItem
                           data={sampleData}
-                          show={this.props.collapsedSamples[id]}
+                          show={sampleData.collapsed}
                           collapseSample={this.props.collapseSample}
-                          queue={this.props.queue} id={id} key={i}
+                          queue={this.props.queue} id={sampleId} key={i}
                         />
                       );
                     })}

--- a/mxcube3/ui/components/SampleQueue/TaskItem.js
+++ b/mxcube3/ui/components/SampleQueue/TaskItem.js
@@ -89,9 +89,13 @@ export default class TaskItem extends Component {
     super(props);
     const { id, data } = this.props;
     this.showForm = this.showForm.bind(this);
-    this.deleteTask = this.props.deleteTask.bind(this, data);
-    this.toggleChecked = this.props.toggleChecked.bind(this, id);
-    this.collapseNode = this.props.collapseNode.bind(this, id);
+    this.deleteTask = this.deleteTask.bind(this);
+    this.toggleChecked = this.props.toggleChecked.bind(this, data, id);
+    this.collapseTask = this.props.collapseTask.bind(this, data.sampleID, id);
+  }
+
+  deleteTask() {
+    this.props.deleteTask(this.props.data);
   }
 
   showForm() {
@@ -109,9 +113,10 @@ export default class TaskItem extends Component {
       error: data.state === 3,
       warning: data.state === 4
     });
+
     return connectDragSource(connectDropTarget(
       <div className="node node-sample" style={{ opacity }}>
-          <div className={taskCSS} onClick={this.collapseNode}>
+          <div className={taskCSS} onClick={this.collapseTask}>
             <p className="node-name">
               {`P${data.parameters.point} ${data.label}`}
             </p>

--- a/mxcube3/ui/components/SampleQueue/TodoTree.js
+++ b/mxcube3/ui/components/SampleQueue/TodoTree.js
@@ -31,12 +31,12 @@ export default class TodoTree extends React.Component {
                     <hr className="queue-divider" />
                 </div>
                 <div className={bodyClass}>
-                {this.props.list.map((id, i) => {
-                  const sampleData = this.props.sampleInformation[this.props.lookup[id]];
+                {this.props.list.map((sampleId, i) => {
+                  const sampleData = this.props.sampleInformation[id];
                   return (
-                        <SampleItem key={id}
+                        <SampleItem key={sampleId}
                           index={i}
-                          id={id}
+                          id={sampleId}
                           text={`Vial ${sampleData.id}`}
                           moveCard={this.moveCard}
                           deleteSample={this.props.deleteSample}

--- a/mxcube3/ui/components/Tasks/Characterisation.js
+++ b/mxcube3/ui/components/Tasks/Characterisation.js
@@ -40,17 +40,16 @@ class Characterisation extends React.Component {
 
     if (this.props.sampleIds.constructor === Array) {
       for (const sampleId of this.props.sampleIds) {
-        const queueId = this.props.lookup[sampleId];
-        if (queueId) {
-          this.props.addTask(queueId, sampleId, parameters, runNow);
+        if (this.props.queue[sampleId]) {
+          const queueId = this.props.sampleList[sampleId].queueID;
+          this.props.addTask(sampleId, queueId, parameters, runNow);
         } else {// the sample is not in queue yet
           this.props.addSampleAndTask(sampleId, parameters);
         }
       }
     } else {
-      const { lookup, taskData, sampleIds } = this.props;
-      const sampleQueueID = lookup[sampleIds];
-      this.props.changeTask(taskData, sampleIds, sampleQueueID, parameters, runNow);
+      const { taskData, sampleIds } = this.props;
+      this.props.changeTask(taskData, sampleIds, parameters, runNow);
     }
 
     this.props.hide();
@@ -375,7 +374,7 @@ class Characterisation extends React.Component {
               Run Now
             </button>
             <button type="button" className="btn btn-primary" onClick={this.addToQueue}>
-              {this.props.taskData.queueID ? 'Change' : 'Add to Queue'}
+              {this.props.taskData.sampleID ? 'Change' : 'Add to Queue'}
             </button>
         </Modal.Footer>
       </Modal>

--- a/mxcube3/ui/components/Tasks/DataCollection.js
+++ b/mxcube3/ui/components/Tasks/DataCollection.js
@@ -39,17 +39,16 @@ class DataCollection extends React.Component {
 
     if (this.props.sampleIds.constructor === Array) {
       for (const sampleId of this.props.sampleIds) {
-        const queueId = this.props.lookup[sampleId];
-        if (queueId) {
-          this.props.addTask(queueId, sampleId, parameters, runNow);
+        if (this.props.queue[sampleId]) {
+          const queueId = this.props.sampleList[sampleId].queueID;
+          this.props.addTask(sampleId, queueId, parameters, runNow);
         } else {
           this.props.addSampleAndTask(sampleId, parameters);
         }
       }
     } else {
-      const { lookup, taskData, sampleIds } = this.props;
-      const sampleQueueId = lookup[sampleIds];
-      this.props.changeTask(taskData, sampleIds, sampleQueueId, parameters, runNow);
+      const { taskData, sampleIds } = this.props;
+      this.props.changeTask(taskData, sampleIds, parameters, runNow);
     }
 
     this.props.hide();
@@ -355,7 +354,7 @@ class DataCollection extends React.Component {
               Run Now
             </Button>
             <Button bsStyle="primary" onClick={this.addToQueue}>
-              {this.props.taskData.queueID ? 'Change' : 'Add to Queue'}
+              {this.props.taskData.sampleID ? 'Change' : 'Add to Queue'}
             </Button>
           </Modal.Footer>
       </Modal>

--- a/mxcube3/ui/containers/SampleGridContainer.jsx
+++ b/mxcube3/ui/containers/SampleGridContainer.jsx
@@ -28,10 +28,8 @@ import {
   sendSyncSamples,
   sendManualMount,
   setSampleOrderAction,
-  sendAddSample,
-  sendDeleteSampleTask,
+  sendDeleteTask,
 } from '../actions/queue';
-
 
 import { showTaskForm } from '../actions/taskForm';
 import SampleTaskButtons from '../components/SampleGrid/TaskButtons';
@@ -276,10 +274,9 @@ function mapDispatchToProps(dispatch) {
     unselectAll: () => dispatch(pickAllAction(false)),
     filter: (filterText) => dispatch(filterAction(filterText)),
     syncSamples: (proposalId) => dispatch(sendSyncSamples(proposalId)),
-    addSampleToQueue: (id) => dispatch(sendAddSample(id)),
     setManualMount: (manual) => dispatch(sendManualMount(manual)),
     showTaskParametersForm: bindActionCreators(showTaskForm, dispatch),
-    deleteTask: bindActionCreators(sendDeleteSampleTask, dispatch),
+    deleteTask: bindActionCreators(sendDeleteTask, dispatch),
     toggleMovableAction: (key) => dispatch(toggleMovableAction(key)),
     select: (keys) => dispatch(selectAction(keys)),
     pickSamplesAction: (keys) => dispatch(pickSamplesAction(keys))

--- a/mxcube3/ui/containers/SampleQueueContainer.js
+++ b/mxcube3/ui/containers/SampleQueueContainer.js
@@ -19,10 +19,8 @@ function mapStateToProps(state) {
     queue: state.queue.queue,
     sampleInformation: state.queue.sampleList,
     checked: state.queue.checked,
-    lookup: state.queue.lookup,
     select_all: state.queue.selectAll,
     mounted: state.queue.manualMount.set,
-    collapsedSamples: state.queue.collapsedSample,
     rootPath: state.queue.rootPath
   };
 }
@@ -43,12 +41,10 @@ export default class SampleQueueContainer extends React.Component {
   render() {
     const {
       checked,
-      lookup,
       history,
       current,
       sampleInformation,
       queue,
-      collapsedSamples,
       showForm,
       queueStatus,
       rootPath
@@ -63,7 +59,8 @@ export default class SampleQueueContainer extends React.Component {
       changeTaskOrder,
       collapseList,
       collapseSample,
-      sendDeleteSampleTask
+      collapseTask,
+      sendDeleteTask
     } = this.props.queueActions;
 
     return (
@@ -77,10 +74,9 @@ export default class SampleQueueContainer extends React.Component {
                   mounted={current.node}
                   sampleInformation={sampleInformation}
                   queue={queue}
-                  lookup={lookup}
                   toggleCheckBox={sendToggleCheckBox}
                   checked={checked}
-                  deleteTask={sendDeleteSampleTask}
+                  deleteTask={sendDeleteTask}
                   run={sendRunSample}
                   pause={sendPauseQueue}
                   unpause={sendUnpauseQueue}
@@ -89,17 +85,14 @@ export default class SampleQueueContainer extends React.Component {
                   unmount={sendUnmountSample}
                   queueStatus={queueStatus}
                   rootPath={rootPath}
-                  collapseNode={collapseSample}
-                  collapsedNodes={collapsedSamples}
+                  collapseTask={collapseTask}
                 />
                 <HistoryTree
                   show={history.collapsed}
                   collapse={collapseList}
-                  collapsedSamples={collapsedSamples}
                   list={history.nodes}
                   sampleInformation={sampleInformation}
                   queue={queue}
-                  lookup={lookup}
                   collapseSample={collapseSample}
                 />
             </div>

--- a/mxcube3/ui/containers/SampleViewContainer.js
+++ b/mxcube3/ui/containers/SampleViewContainer.js
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import SampleImage from '../components/SampleView/SampleImage';
 import MotorControl from '../components/SampleView/MotorControl';
 import ContextMenu from '../components/SampleView/ContextMenu';
-import UserLog from '../components/SampleView/UserLog';
 import * as SampleViewActions from '../actions/sampleview';
 import { showTaskForm } from '../actions/taskForm';
 import BeamlineSetupContainer from './BeamlineSetupContainer';
@@ -31,9 +30,6 @@ class SampleViewContainer extends Component {
         </div>
         <div className={cinema ? 'col-xs-9' : 'col-xs-8'}>
             <div className="row">
-              <div className={cinema ? 'hidden' : 'col-xs-12'}>
-                <UserLog messages={this.props.logMessages} />
-              </div>
               <div className="col-xs-12">
                 <ContextMenu
                   {...this.props.sampleViewState.contextMenu}

--- a/mxcube3/ui/containers/SampleViewContainer.js
+++ b/mxcube3/ui/containers/SampleViewContainer.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import SampleImage from '../components/SampleView/SampleImage';
 import MotorControl from '../components/SampleView/MotorControl';
 import ContextMenu from '../components/SampleView/ContextMenu';
+import UserLog from '../components/SampleView/UserLog';
 import * as SampleViewActions from '../actions/sampleview';
 import { showTaskForm } from '../actions/taskForm';
 import BeamlineSetupContainer from './BeamlineSetupContainer';
@@ -15,7 +16,7 @@ class SampleViewContainer extends Component {
   render() {
     const { imageRatio, motorSteps, cinema } = this.props.sampleViewState;
     const { sendMotorPosition, setStepSize, sendStopMotor } = this.props.sampleViewActions;
-    const sampleId = this.props.lookup[this.props.current.node];
+    const sampleId = this.props.current.node;
 
     return (
       <div className="row">
@@ -30,6 +31,9 @@ class SampleViewContainer extends Component {
         </div>
         <div className={cinema ? 'col-xs-9' : 'col-xs-8'}>
             <div className="row">
+              <div className={cinema ? 'hidden' : 'col-xs-12'}>
+                <UserLog messages={this.props.logMessages} />
+              </div>
               <div className="col-xs-12">
                 <ContextMenu
                   {...this.props.sampleViewState.contextMenu}
@@ -64,8 +68,8 @@ function mapStateToProps(state) {
     sampleInformation: state.queue.sampleList,
     sampleViewState: state.sampleview,
     beamline: state.beamline,
-    lookup: state.queue.lookup,
-    defaultParameters: state.taskForm.defaultParameters
+    defaultParameters: state.taskForm.defaultParameters,
+    logMessages: state.logger.logRecords
   };
 }
 

--- a/mxcube3/ui/containers/TaskContainer.js
+++ b/mxcube3/ui/containers/TaskContainer.js
@@ -10,9 +10,10 @@ import { sendCurrentPhase } from '../actions/sampleview';
 
 import {
   sendAddSampleAndTask,
-  sendAddSampleTask,
-  sendUpdateSampleTask,
-  sendAddSample
+  sendAddTask,
+  sendUpdateTask,
+  sendAddSample,
+  appendSampleList,
 } from '../actions/queue';
 
 
@@ -23,16 +24,15 @@ class TaskContainer extends React.Component {
   }
 
   addSample(sampleID, parameters) {
+    this.props.appendSampleList(sampleID, parameters);
     this.props.addSample(sampleID, parameters);
   }
 
   render() {
-    const lookup = this.props.lookup_queueID;
     return (
       <div className="col-xs-12">
         <Characterisation
           pointId={this.props.pointId}
-          lookup={lookup}
           sampleIds={this.props.sampleIds}
           taskData={this.props.taskData}
           addSampleAndTask={this.props.addSampleAndTask}
@@ -42,11 +42,12 @@ class TaskContainer extends React.Component {
           apertureList={this.props.apertureList}
           show={this.props.showForm === 'Characterisation'}
           rootPath={this.props.path}
+          queue={this.props.queue}
+          sampleList={this.props.sampleList}
         />
 
         <DataCollection
           pointId={this.props.pointId}
-          lookup={lookup}
           sampleIds={this.props.sampleIds}
           taskData={this.props.taskData}
           addSampleAndTask={this.props.addSampleAndTask}
@@ -56,6 +57,8 @@ class TaskContainer extends React.Component {
           apertureList={this.props.apertureList}
           show={this.props.showForm === 'DataCollection'}
           rootPath={this.props.path}
+          queue={this.props.queue}
+          sampleList={this.props.sampleList}
         />
 
         <AddSample
@@ -74,8 +77,9 @@ class TaskContainer extends React.Component {
 
 function mapStateToProps(state) {
   return {
+    queue: state.queue.queue,
+    sampleList: state.queue.sampleList,
     showForm: state.taskForm.showForm,
-    lookup_queueID: state.queue.lookup_queueID,
     taskData: state.taskForm.taskData,
     sampleIds: state.taskForm.sampleIds,
     pointId: state.taskForm.pointId,
@@ -92,8 +96,9 @@ function mapDispatchToProps(dispatch) {
     showTaskParametersForm: bindActionCreators(showTaskForm, dispatch),
     hideTaskParametersForm: bindActionCreators(hideTaskParametersForm, dispatch),
     addSampleAndTask: bindActionCreators(sendAddSampleAndTask, dispatch),
-    addTask: bindActionCreators(sendAddSampleTask, dispatch),
-    changeTask: bindActionCreators(sendUpdateSampleTask, dispatch),
+    addTask: bindActionCreators(sendAddTask, dispatch),
+    appendSampleList: bindActionCreators(appendSampleList, dispatch),
+    changeTask: bindActionCreators(sendUpdateTask, dispatch),
     addSample: bindActionCreators(sendAddSample, dispatch),
     sendCurrentPhase: bindActionCreators(sendCurrentPhase, dispatch)
   };

--- a/mxcube3/ui/reducers/SamplesGrid.js
+++ b/mxcube3/ui/reducers/SamplesGrid.js
@@ -90,9 +90,9 @@ export default (state = INITIAL_STATE, action) => {
       return Object.assign({}, state, { order: initialGridOrder(action.sampleList) });
     }
     // Append one sample to the list of samples (sampleList),
-    // (used when samples are mounted manually)
-    case 'ADD_SAMPLE': {
+    case 'APPEND_TO_SAMPLE_LIST': {
       const order = { ...state.order, [action.sampleID]: sampleOrder(state.order) };
+
       return Object.assign({}, state, { order });
     }
     // Set display order of samples in grid

--- a/mxcube3/ui/reducers/queue.js
+++ b/mxcube3/ui/reducers/queue.js
@@ -24,15 +24,13 @@ const initialState = {
   todo: { nodes: [], collapsed: false },
   history: { nodes: [], collapsed: false },
   checked: [],
-  lookup: {},
-  lookup_queueID: {},
   collapsedSample: {},
   searchString: '',
   queueStatus: 'QueueStopped',
   showRestoreDialog: false,
   queueRestoreState: {},
   sampleList: {},
-  manualMount: { set: false, id: 0 }
+  manualMount: { set: false, id: 1 },
 };
 
 
@@ -86,6 +84,14 @@ export default (state = initialState, action) => {
     case 'SET_SAMPLE_LIST': {
       return Object.assign({}, state, { sampleList: initSampleList(action.sampleList) });
     }
+    case 'APPEND_TO_SAMPLE_LIST': {
+      const sampleData = action.sampleData || {};
+      Object.assign(sampleData, { collapsed: false, checked: false });
+
+      const sampleList = { ...state.sampleList, [action.sampleID]: sampleData };
+
+      return Object.assign({}, state, { sampleList });
+    }
     case 'SET_SAMPLE_ORDER': {
       const reorderKeys = Object.keys(action.keys).map(key => (action.keys[key] ? key : ''));
       const sampleList = recalculateQueueOrder(reorderKeys, action.order, state);
@@ -125,8 +131,7 @@ export default (state = initialState, action) => {
     }
 
     case 'ADD_TASK_RESULT': {
-      const queueID = state.lookup_queueID[action.sampleID];
-      const tasks = Array.from(state.queue[queueID]);
+      const tasks = Array.from(state.queue[action.sampleID]);
 
       // Find element with the right queueID (action.queueID) and update state
       // to action.state
@@ -136,7 +141,7 @@ export default (state = initialState, action) => {
         }
       }
 
-      return Object.assign({}, state, { queue: { ...state.queue, [queueID]: tasks } });
+      return Object.assign({}, state, { queue: { ...state.queue, [action.sampleID]: tasks } });
     }
     case 'SET_MANUAL_MOUNT': {
       const data = { manualMount: { ...state.manualMount, set: action.manual } };
@@ -145,17 +150,11 @@ export default (state = initialState, action) => {
 
     // Adding sample to queue
     case 'ADD_SAMPLE': {
-      const sampleList = { ...state.sampleList, [action.sampleID]: action.sampleData || {} };
-
       return Object.assign({}, state,
         {
-          todo: { ...state.todo, nodes: state.todo.nodes.concat(action.queueID) },
-          queue: { ...state.queue, [action.queueID]: [] },
-          lookup: { ...state.lookup, [action.queueID]: action.sampleID },
-          lookup_queueID: { ...state.lookup_queueID, [action.sampleID]: action.queueID },
-          collapsedSample: { ...state.collapsedSample, [action.queueID]: true },
-          manualMount: { ...state.manualMount, id: state.manualMount.id + 1 },
-          sampleList
+          todo: { ...state.todo, nodes: state.todo.nodes.concat(action.sampleID) },
+          queue: { ...state.queue, [action.sampleID]: [] },
+          manualMount: { ...state.manualMount, id: state.manualMount.id + 1 }
         }
       );
     }
@@ -169,63 +168,53 @@ export default (state = initialState, action) => {
         // Removing sample from queue
     case 'REMOVE_SAMPLE':
       return Object.assign({}, state,
-        { todo: { ...state.todo, nodes: without(state.todo.nodes, action.queueID) },
-          queue: omit(state.queue, action.queueID),
-          lookup: omit(state.lookup, action.queueID),
-          collapsedSample: omit(state.collapsedSample, action.queueID),
-          lookup_queueID: omit(state.lookup_queueID, action.index)
+        { todo: { ...state.todo, nodes: without(state.todo.nodes, action.sampleID) },
+          queue: omit(state.queue, action.sampleID),
         });
 
         // Adding the new task to the queue
     case 'ADD_TASK': {
-      const queueID = state.lookup_queueID[action.sampleID];
-
       // Create a copy of the tasks (array) for a sample with given queueID,
       // or an empty array if no tasks exists for sampleID
-      let tasks = Array.from(state.queue[queueID] || []);
-      tasks = tasks.concat([{ type: action.taskType,
-                              label: action.taskType.split(/(?=[A-Z])/).join(' '),
+      let tasks = Array.from(state.queue[action.sampleID] || []);
+      tasks = tasks.concat([{ type: action.parameters.Type,
+                              label: action.parameters.Type.split(/(?=[A-Z])/).join(' '),
                               sampleID: action.sampleID,
-                              queueID: action.queueID,
-                              parentID: action.parentID,
+                              queueID: undefined,
                               parameters: action.parameters,
-                              state: 0
+                              state: 0,
+                              collapsed: false,
+                              checked: false
       }]);
 
-      const queue = { ...state.queue, [queueID]: tasks };
-      return Object.assign({}, state, { queue, checked: state.checked.concat(0) });
+      const queue = { ...state.queue, [action.sampleID]: tasks };
+      return Object.assign({}, state, { queue });
     }
     // Removing the task from the queue
     case 'REMOVE_TASK': {
-      const queueID = state.lookup_queueID[action.task.sampleID];
-      const tasks = without(state.queue[queueID], action.task);
-
-      return Object.assign({}, state, { queue: { ...state.queue, [queueID]: tasks },
-                                        checked: without(state.checked, action.queueID) });
+      const sampleID = action.task.sampleID;
+      const tasks = without(state.queue[sampleID], action.task);
+      return Object.assign({}, state, { queue: { ...state.queue, [sampleID]: tasks } });
     }
     case 'UPDATE_TASK': {
-      const queueID = state.lookup_queueID[action.sampleID];
-      const taskIndex = state.queue[queueID].indexOf(action.taskData);
-      const tasks = Array.from(state.queue[queueID]);
+      const taskIndex = state.queue[action.sampleID].indexOf(action.taskData);
+      const tasks = Array.from(state.queue[action.sampleID]);
 
       tasks[taskIndex] = { ...action.taskData,
                            type: action.parameters.Type,
                            parameters: action.parameters };
 
-      return Object.assign({}, state, { queue: { ...state.queue, [queueID]: tasks } });
+      return Object.assign({}, state, { queue: { ...state.queue, [action.sampleID]: tasks } });
     }
     // Run Mount, this will add the mounted sample to history
     case 'MOUNT_SAMPLE':
       return Object.assign({}, state,
         {
-          current: { ...state.current, node: action.queueID, running: false },
-          todo: { ...state.todo, nodes: without(state.todo.nodes, action.queueID) },
-          history: {
-            ...state.history,
-            nodes: (
-              state.current.node ?
-              state.history.nodes.concat(state.current.node) : state.history.nodes
-            )
+          current: { ...state.current, node: action.sampleID, running: false },
+          todo: { ...state.todo, nodes: without(state.todo.nodes, action.sampleID) },
+          history: { ...state.history,
+                     nodes: (state.current.node ?
+                             state.history.nodes.concat(state.current.node) : state.history.nodes)
           }
         }
       );
@@ -252,13 +241,9 @@ export default (state = initialState, action) => {
                         );
 
     case 'TOGGLE_CHECKED':
-      return Object.assign({}, state,
-        {
-          checked: xor(state.checked, [action.queueID])
-        }
-                        );
+      return Object.assign({}, state, { checked: xor(state.checked, [action.queueID]) });
 
-        // Collapse list
+     // Collapse list
     case 'COLLAPSE_LIST':
       return {
         ...state,
@@ -266,17 +251,20 @@ export default (state = initialState, action) => {
         collapsed: !state[action.list_name].collapsed
         }
       };
-    // Collapse list
-    case 'COLLAPSE_SAMPLE':
-      return {
-        ...state,
-        collapsedSample: {
-          ...state.collapsedSample,
-          [action.queueID]: !state.collapsedSample[action.queueID]
-        }
-      };
+    // Toggle sample collapse flag
+    case 'COLLAPSE_SAMPLE': {
+      const sampleList = Object.assign({}, state.sampleList);
+      sampleList[action.sampleID].collapsed = !sampleList[action.sampleID].collapsed;
+      return { ...state, sampleList };
+    }
+    // Toggle task collapse flag
+    case 'COLLAPSE_TASK': {
+      const queue = Object.assign({}, state.queue);
+      queue[action.sampleID][action.taskIndex].collapsed ^= true;
 
-        // Change order of samples in queue on drag and drop
+      return { ...state, queue };
+    }
+    // Change order of samples in queue on drag and drop
     case 'CHANGE_QUEUE_ORDER':
 
       return {
@@ -312,7 +300,7 @@ export default (state = initialState, action) => {
     case 'CLEAR_ALL':
       {
         return Object.assign({}, state, { ...initialState,
-                                          manualMount: { set: state.manualMount.set, id: 0 } });
+                                          manualMount: { set: state.manualMount.set, id: 1 } });
       }
     case 'SHOW_RESTORE_DIALOG':
       {
@@ -325,7 +313,7 @@ export default (state = initialState, action) => {
     case 'SET_INITIAL_STATUS':
       {
         return { ...state, rootPath: action.data.rootPath,
-                           manualMount: { set: state.manualMount.set, id: 0 } };
+                           manualMount: { set: state.manualMount.set, id: 1 } };
       }
     default:
       return state;

--- a/mxcube3/ui/reducers/taskForm.js
+++ b/mxcube3/ui/reducers/taskForm.js
@@ -24,16 +24,13 @@ export default (state = initialState, action) => {
       }
     case 'ADD_TASK':
       {
-        return {
-          ...state,
-          defaultParameters: {
-            ...state.defaultParameters,
-            [action.taskType.toLowerCase()]: {
-              ...action.parameters,
-              run_number: state.defaultParameters[action.taskType.toLowerCase()].run_number + 1
-            }
-          }
-        };
+        return { ...state, defaultParameters:
+                 { ...state.defaultParameters, [action.parameters.Type.toLowerCase()]: {
+                   ...action.parameters, run_number:
+                   state.defaultParameters[action.parameters.Type.toLowerCase()].run_number + 1
+                 }
+               }
+             };
       }
     case 'UPDATE_TASK':
       {


### PR DESCRIPTION
Hello all,

Here is the first commit from the split of #318. Removing the mapping between sampleIDs, taskID's and server side nodeID's. Simply using the sampleIDs for samples and the position in the queue for tasks. Keeping the per action based (ADD, CHANGE, REMOVE) queue API intact. 

Except for MOUNT_SAMPLE which I changed to operate on sampleID instead of nodeID. Since we want to
mount a sample based on its own ID and not the queueID. The sample might not even be in the queue when we want to mount it.

Also moved collapsed and checked data to task and sample data items, collapsed and label of each item
might be moved to another state variable called i.e displayData (as discussed previously). However checked should be included on each task or sample since its a functional part of the queue.

Cheers,
Marcus