### PR TITLE
Redesign of queue in sampleview

### DIFF
--- a/mxcube3/ui/actions/queue.js
+++ b/mxcube3/ui/actions/queue.js
@@ -370,7 +370,7 @@ export function addSample(sampleData) {
 
     // Its perhaps possible to not even sendMountSample at this point,
     // does it even make sense ?
-    dispatch(sendMountSample(sampleData.sampleID));
+    //dispatch(sendMountSample(sampleData.sampleID));
   };
 }
 

--- a/mxcube3/ui/actions/queue.js
+++ b/mxcube3/ui/actions/queue.js
@@ -367,10 +367,6 @@ export function addSample(sampleData) {
 
     sendAddQueueItem([data]);
     dispatch(addSampleAction(data));
-
-    // Its perhaps possible to not even sendMountSample at this point,
-    // does it even make sense ?
-    //dispatch(sendMountSample(sampleData.sampleID));
   };
 }
 

--- a/mxcube3/ui/components/SampleQueue/CurrentTree.js
+++ b/mxcube3/ui/components/SampleQueue/CurrentTree.js
@@ -83,7 +83,7 @@ export default class CurrentTree extends React.Component {
       <div className="m-tree">
           <div className="list-head">
               {queueOptions.map((option) => this.renderOptions(option))}
-              <p className="queue-root" onClick={this.collapse}>Current: {sampleData.sampleName}</p>
+              <p className="queue-root" onClick={this.collapse}>Current Sample: {sampleData.sampleName}</p>
               <hr className="queue-divider" />
           </div>
           <div className={bodyClass}>

--- a/mxcube3/ui/components/SampleQueue/CurrentTree.js
+++ b/mxcube3/ui/components/SampleQueue/CurrentTree.js
@@ -17,20 +17,19 @@ export default class CurrentTree extends React.Component {
     this.state = {
       options: {
         QueueStarted: [
-        { text: 'Stop', color: 'danger', action: this.props.stop, key: 1 },
-        { text: 'Pause', color: 'warning', action: this.props.pause, key: 2 },
+        { text: 'Stop', class: 'btn-danger', action: this.props.stop, key: 1 },
+        { text: 'Pause', class: 'btn-warning pull-right', action: this.props.pause, key: 2 },
         ],
         QueueStopped: [
-        { text: 'New Sample', color: 'primary', action: this.showForm, key: 1 },
-        { text: 'Unmount', color: 'danger', action: this.unmount, key: 2 },
-        { text: 'Run', color: 'success', action: this.runSample, key: 3 }
+        { text: 'Run Sample', class: 'btn-success', action: this.runSample, key: 1 },
+        { text: 'Next Sample', class: 'btn-primary pull-right', action: this.showForm, key: 2 }
         ],
         QueuePaused: [
-        { text: 'Stop', color: 'danger', action: this.props.stop, key: 1 },
-        { text: 'Unpause', color: 'success', action: this.props.unpause, key: 2 }
+        { text: 'Stop', class: 'btn-danger', action: this.props.stop, key: 1 },
+        { text: 'Unpause', class: 'btn-success pull-right', action: this.props.unpause, key: 2 }
         ],
         NoSampleMounted: [
-        { text: 'New Sample', color: 'primary', action: this.showForm, key: 1 },
+        { text: 'New Sample', class: 'btn-primary', action: this.showForm, key: 1 },
         ]
       }
     };
@@ -48,13 +47,11 @@ export default class CurrentTree extends React.Component {
     this.props.unmount(this.props.queue[this.props.mounted].queueID);
   }
 
-  renderOptions(option, length) {
-    const width = 100 / length;
+  renderOptions(option) {
     return (
       <Button
-        bsStyle={option.color}
+        className={option.class}
         bsSize="sm"
-        style={{ width: `${width}%` }}
         onClick={option.action}
         key={option.key}
       >
@@ -85,8 +82,8 @@ export default class CurrentTree extends React.Component {
     return (
       <div className="m-tree">
           <div className="list-head">
+              {queueOptions.map((option) => this.renderOptions(option))}
               <p className="queue-root" onClick={this.collapse}>Current: {sampleData.sampleName}</p>
-              {queueOptions.map((option) => this.renderOptions(option, queueOptions.length))}
               <hr className="queue-divider" />
           </div>
           <div className={bodyClass}>

--- a/mxcube3/ui/components/SampleQueue/CurrentTree.js
+++ b/mxcube3/ui/components/SampleQueue/CurrentTree.js
@@ -83,7 +83,9 @@ export default class CurrentTree extends React.Component {
       <div className="m-tree">
           <div className="list-head">
               {queueOptions.map((option) => this.renderOptions(option))}
-              <p className="queue-root" onClick={this.collapse}>Current Sample: {sampleData.sampleName}</p>
+              <p className="queue-root" onClick={this.collapse}>
+                Current Sample: {sampleData.sampleName}
+              </p>
               <hr className="queue-divider" />
           </div>
           <div className={bodyClass}>

--- a/mxcube3/ui/components/SampleQueue/CurrentTree.js
+++ b/mxcube3/ui/components/SampleQueue/CurrentTree.js
@@ -13,6 +13,7 @@ export default class CurrentTree extends React.Component {
     this.collapse = props.collapse.bind(this, 'current');
     this.runSample = this.runSample.bind(this);
     this.unmount = this.unMountSample.bind(this);
+    this.nextSample = this.nextSample.bind(this);
     this.showForm = this.props.showForm.bind(this, 'AddSample');
     this.state = {
       options: {
@@ -22,7 +23,7 @@ export default class CurrentTree extends React.Component {
         ],
         QueueStopped: [
         { text: 'Run Sample', class: 'btn-success', action: this.runSample, key: 1 },
-        { text: 'Next Sample', class: 'btn-primary pull-right', action: this.showForm, key: 2 }
+        { text: 'Next Sample', class: 'btn-primary pull-right', action: this.nextSample, key: 2 }
         ],
         QueuePaused: [
         { text: 'Stop', class: 'btn-danger', action: this.props.stop, key: 1 },
@@ -33,6 +34,14 @@ export default class CurrentTree extends React.Component {
         ]
       }
     };
+  }
+
+  nextSample() {
+    if (this.props.manualMount.set) {
+      this.showForm();
+    } else if (this.props.todoList[0]) {
+      this.props.mount(this.props.todoList[0]);
+    }
   }
 
   moveCard(dragIndex, hoverIndex) {
@@ -70,21 +79,23 @@ export default class CurrentTree extends React.Component {
       sampleData = this.props.sampleInformation[sampleId];
       sampleTasks = this.props.queue[sampleId].tasks;
       queueOptions = this.state.options[this.props.queueStatus];
-    } else {
+    } else if (this.props.manualMount.set) {
       sampleData.sampleName = 'No Sample Mounted';
       queueOptions = this.state.options.NoSampleMounted;
+    } else {
+      sampleData.sampleName = 'Go To SampleGrid';
+      queueOptions = [];
     }
 
     const bodyClass = cx('list-body', {
       hidden: (this.props.show || !sampleId)
     });
-
     return (
       <div className="m-tree">
           <div className="list-head">
               {queueOptions.map((option) => this.renderOptions(option))}
               <p className="queue-root" onClick={this.collapse}>
-                Current Sample: {sampleData.sampleName}
+                Current Sample: {sampleData.sampleID}
               </p>
               <hr className="queue-divider" />
           </div>

--- a/mxcube3/ui/components/SampleQueue/QueueControl.js
+++ b/mxcube3/ui/components/SampleQueue/QueueControl.js
@@ -12,14 +12,12 @@ export default class QueueControl extends React.Component {
       options: {
         QueueStarted: [
         { text: 'Stop', class: 'btn-danger', action: this.props.stop, key: 1 },
-        { text: 'Pause', class: 'btn-warning pull-right', action: this.props.pause, key: 2 },
         ],
         QueueStopped: [
         { text: 'Run Queue', class: 'btn-success', action: this.showForm, key: 1 },
         ],
         QueuePaused: [
-        { text: 'Stop', class: 'btn-danger', action: this.props.stop, key: 1 },
-        { text: 'Unpause', class: 'btn-success pull-right', action: this.props.unpause, key: 2 }
+        { text: 'Run Queue', class: 'btn-success', action: this.showForm, key: 1 },
         ]
       }
     };
@@ -49,11 +47,15 @@ export default class QueueControl extends React.Component {
     return (
       <div className="m-tree">
         <div className="list-head">
+           <div className="left">
           {queueOptions.map((option) => this.renderOptions(option))}
-          <p className="queue-root">
+          <span className="queue-root">
             Total Progress {`${historyLength}/${totalSamples - current} `}:
-          </p>
+          </span>
+          </div>
+          <div className="right">
            <ProgressBar active now={progress} />
+          </div>
         </div>
       </div>
     );

--- a/mxcube3/ui/components/SampleQueue/QueueControl.js
+++ b/mxcube3/ui/components/SampleQueue/QueueControl.js
@@ -11,13 +11,13 @@ export default class QueueControl extends React.Component {
     this.state = {
       options: {
         QueueStarted: [
-        { text: 'Stop', class: 'btn-danger', action: this.props.stop, key: 1 },
+        { text: 'Stop', class: 'btn-danger', action: props.stopQueue, key: 1 },
         ],
         QueueStopped: [
-        { text: 'Run Queue', class: 'btn-success', action: this.showForm, key: 1 },
+        { text: 'Run Queue', class: 'btn-success', action: props.runQueue, key: 1 },
         ],
         QueuePaused: [
-        { text: 'Run Queue', class: 'btn-success', action: this.showForm, key: 1 },
+        { text: 'Run Queue', class: 'btn-success', action: props.runQueue, key: 1 },
         ]
       }
     };

--- a/mxcube3/ui/components/SampleQueue/QueueControl.js
+++ b/mxcube3/ui/components/SampleQueue/QueueControl.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import 'bootstrap';
+import './app.less';
+import { ProgressBar, Button } from 'react-bootstrap';
+
+export default class QueueControl extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      options: {
+        QueueStarted: [
+        { text: 'Stop', class: 'btn-danger', action: this.props.stop, key: 1 },
+        { text: 'Pause', class: 'btn-warning pull-right', action: this.props.pause, key: 2 },
+        ],
+        QueueStopped: [
+        { text: 'Run Queue', class: 'btn-success', action: this.showForm, key: 1 },
+        ],
+        QueuePaused: [
+        { text: 'Stop', class: 'btn-danger', action: this.props.stop, key: 1 },
+        { text: 'Unpause', class: 'btn-success pull-right', action: this.props.unpause, key: 2 }
+        ]
+      }
+    };
+  }
+
+  renderOptions(option) {
+    return (
+      <Button
+        className={option.class}
+        bsSize="sm"
+        onClick={option.action}
+        key={option.key}
+      >
+        {option.text}
+      </Button>
+    );
+  }
+
+  render() {
+    const { historyLength, todoLength, currentNode } = this.props;
+    const totalSamples = historyLength + todoLength + 1;
+    const progress = (100 / totalSamples) * historyLength;
+    const current = currentNode ? 0 : 1;
+
+    const queueOptions = this.state.options[this.props.queueStatus];
+
+    return (
+      <div className="m-tree">
+        <div className="list-head">
+          {queueOptions.map((option) => this.renderOptions(option))}
+          <p className="queue-root">
+            Total Progress {`${historyLength}/${totalSamples - current} `}:
+          </p>
+           <ProgressBar active now={progress} />
+        </div>
+      </div>
+    );
+  }
+}

--- a/mxcube3/ui/components/SampleQueue/TodoTree.js
+++ b/mxcube3/ui/components/SampleQueue/TodoTree.js
@@ -2,6 +2,8 @@ import React from 'react';
 import 'bootstrap-webpack';
 import './app.less';
 import cx from 'classnames';
+import { Button } from 'react-bootstrap';
+
 
 export default class TodoTree extends React.Component {
   constructor(props) {
@@ -21,12 +23,20 @@ export default class TodoTree extends React.Component {
                 </div>
                 <div className={bodyClass}>
                 {this.props.list.map((sampleId, id) => {
-                  const sampleData = this.props.sampleInformation[id];
+                  const sampleData = this.props.sampleInformation[sampleId];
                   return (
-                    <div className="node node-sample">
+                    <div className="node node-sample node-todo">
                       <div className="task-head">
                         <p className="node-name">
-                          {sampleData.sampleName}
+                          {`Sample ${sampleData.sampleName}`}
+                          <Button
+                            className="pull-right"
+                            bsSize="xs"
+                            key={id}
+                            onClick={() => this.props.mount(sampleData.sampleName)}
+                          >
+                            Mount
+                          </Button>
                         </p>
                       </div>
                     </div>

--- a/mxcube3/ui/components/SampleQueue/TodoTree.js
+++ b/mxcube3/ui/components/SampleQueue/TodoTree.js
@@ -25,15 +25,14 @@ export default class TodoTree extends React.Component {
                 {this.props.list.map((sampleId, id) => {
                   const sampleData = this.props.sampleInformation[sampleId];
                   return (
-                    <div className="node node-sample node-todo">
+                    <div key={id} className="node node-sample node-todo">
                       <div className="task-head">
                         <p className="node-name">
-                          {`Sample ${sampleData.sampleName}`}
+                          {`Sample ${sampleData.sampleID}`}
                           <Button
                             className="pull-right"
                             bsSize="xs"
-                            key={id}
-                            onClick={() => this.props.mount(sampleData.sampleName)}
+                            onClick={() => this.props.mount(sampleData.sampleID)}
                           >
                             Mount
                           </Button>

--- a/mxcube3/ui/components/SampleQueue/TodoTree.js
+++ b/mxcube3/ui/components/SampleQueue/TodoTree.js
@@ -16,7 +16,7 @@ export default class TodoTree extends React.Component {
     return (
             <div className="m-tree">
                 <div className="list-head">
-                    <span className="queue-root" onClick={this.collapse}>Upcoming: </span>
+                    <span className="queue-root" onClick={this.collapse}>Upcoming Samples</span>
                     <hr className="queue-divider" />
                 </div>
                 <div className={bodyClass}>

--- a/mxcube3/ui/components/SampleQueue/app.less
+++ b/mxcube3/ui/components/SampleQueue/app.less
@@ -173,3 +173,16 @@
     color: #1d26ab;
   }
 }
+
+.left{
+    display: table-cell;
+    min-width: 220px;
+}
+.right{
+    display: table-cell;
+    width: 100%;
+    vertical-align: top;
+    .progress{
+      margin-top: 6px;
+    }
+}

--- a/mxcube3/ui/components/SampleQueue/app.less
+++ b/mxcube3/ui/components/SampleQueue/app.less
@@ -186,3 +186,8 @@
       margin-top: 6px;
     }
 }
+
+.node-todo.node-sample{
+      border-style: solid;
+    border-width: 2px;
+}

--- a/mxcube3/ui/containers/SampleGridContainer.jsx
+++ b/mxcube3/ui/containers/SampleGridContainer.jsx
@@ -105,9 +105,8 @@ class SampleGridContainer extends React.Component {
   }
 
   addSamples() {
-    console.log(this.props.picked);
     Object.keys(this.props.picked).map((sampleID) => {
-      this.props.addSample({type: 'Sample', location: sampleID, sampleID: sampleID, sampleName: sampleID, proteinAcronym: sampleID});
+      this.props.addSample(this.props.sampleList[sampleID]);
     });
   }
 

--- a/mxcube3/ui/containers/SampleGridContainer.jsx
+++ b/mxcube3/ui/containers/SampleGridContainer.jsx
@@ -29,6 +29,7 @@ import {
   sendManualMount,
   setSampleOrderAction,
   deleteTask,
+  addSample
 } from '../actions/queue';
 
 import { showTaskForm } from '../actions/taskForm';
@@ -51,6 +52,7 @@ class SampleGridContainer extends React.Component {
     this.filterSampleGridClear = this.filterSampleGridClear.bind(this);
     this.filterSampleGridPicked = this.filterSampleGridPicked.bind(this);
     this.pickSelectedSamples = this.pickSelectedSamples.bind(this);
+    this.addSamples = this.addSamples.bind(this);
   }
 
 
@@ -100,6 +102,13 @@ class SampleGridContainer extends React.Component {
 
   numSamples() {
     return Object.keys(this.props.sampleList).length;
+  }
+
+  addSamples() {
+    console.log(this.props.picked);
+    Object.keys(this.props.picked).map((sampleID) => {
+      this.props.addSample({type: 'Sample', location: sampleID, sampleID: sampleID, sampleName: sampleID, proteinAcronym: sampleID});
+    });
   }
 
 
@@ -216,8 +225,9 @@ class SampleGridContainer extends React.Component {
                />
                <Button
                  className="btn btn-success pull-right"
-                 href="#/datacollection"
                  disabled={this.isCollectDisabled()}
+                 href="/#datacollection"
+                 onClick={this.addSamples}
                >
                  Collect {this.numSamplesPicked()}/{this.numSamples()}
                  <Glyphicon glyph="chevron-right" />
@@ -279,7 +289,8 @@ function mapDispatchToProps(dispatch) {
     deleteTask: bindActionCreators(deleteTask, dispatch),
     toggleMovableAction: (key) => dispatch(toggleMovableAction(key)),
     select: (keys) => dispatch(selectAction(keys)),
-    pickSamplesAction: (keys) => dispatch(pickSamplesAction(keys))
+    pickSamplesAction: (keys) => dispatch(pickSamplesAction(keys)),
+    addSample: (sampleData) => dispatch(addSample(sampleData))
   };
 }
 

--- a/mxcube3/ui/containers/SampleQueueContainer.js
+++ b/mxcube3/ui/containers/SampleQueueContainer.js
@@ -23,7 +23,8 @@ function mapStateToProps(state) {
     select_all: state.queue.selectAll,
     mounted: state.queue.manualMount.set,
     rootPath: state.queue.rootPath,
-    displayData: state.queue.displayData
+    displayData: state.queue.displayData,
+    manualMount: state.queue.manualMount
   };
 }
 
@@ -52,7 +53,8 @@ export default class SampleQueueContainer extends React.Component {
       showForm,
       queueStatus,
       rootPath,
-      displayData
+      displayData,
+      manualMount
     } = this.props;
     const {
       sendToggleCheckBox,
@@ -72,7 +74,6 @@ export default class SampleQueueContainer extends React.Component {
 
     return (
       <div>
-            <div className="queue-body">
                 <QueueControl
                   historyLength={history.nodes.length}
                   todoLength={todo.nodes.length}
@@ -81,6 +82,7 @@ export default class SampleQueueContainer extends React.Component {
                   runQueue={sendRunQueue}
                   stopQueue={sendStopQueue}
                 />
+              <div className="queue-body">
                 <CurrentTree
                   changeOrder={changeTaskOrder}
                   show={current.collapsed}
@@ -101,6 +103,9 @@ export default class SampleQueueContainer extends React.Component {
                   rootPath={rootPath}
                   collapseTask={collapseTask}
                   displayData={displayData}
+                  manualMount={manualMount}
+                  mount={mountSample}
+                  todoList={todo.nodes}
                 />
                 <TodoTree
                   show={todo.collapsed}

--- a/mxcube3/ui/containers/SampleQueueContainer.js
+++ b/mxcube3/ui/containers/SampleQueueContainer.js
@@ -57,6 +57,7 @@ export default class SampleQueueContainer extends React.Component {
     const {
       sendToggleCheckBox,
       sendRunSample,
+      sendRunQueue,
       sendPauseQueue,
       sendUnpauseQueue,
       sendStopQueue,
@@ -65,7 +66,8 @@ export default class SampleQueueContainer extends React.Component {
       collapseList,
       collapseTask,
       collapseSample,
-      deleteTask
+      deleteTask,
+      mountSample
     } = this.props.queueActions;
 
     return (
@@ -76,6 +78,8 @@ export default class SampleQueueContainer extends React.Component {
                   todoLength={todo.nodes.length}
                   currentNode={current.node}
                   queueStatus={queueStatus}
+                  runQueue={sendRunQueue}
+                  stopQueue={sendStopQueue}
                 />
                 <CurrentTree
                   changeOrder={changeTaskOrder}
@@ -102,10 +106,11 @@ export default class SampleQueueContainer extends React.Component {
                   show={todo.collapsed}
                   collapse={collapseList}
                   list={todo.nodes}
-                  sampleInformation={sampleInformation}
+                  sampleInformation={queue}
                   queue={queue}
                   collapseSample={collapseSample}
                   displayData={displayData}
+                  mount={mountSample}
                 />
             </div>
       </div>

--- a/mxcube3/ui/containers/SampleQueueContainer.js
+++ b/mxcube3/ui/containers/SampleQueueContainer.js
@@ -3,12 +3,12 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import CurrentTree from '../components/SampleQueue/CurrentTree';
 import TodoTree from '../components/SampleQueue/TodoTree';
+import QueueControl from '../components/SampleQueue/QueueControl';
 import * as QueueActions from '../actions/queue';
 import * as SampleViewActions from '../actions/sampleview';
 import { showTaskForm } from '../actions/taskForm';
 import { DragDropContext as dragDropContext } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
-import { ProgressBar } from 'react-bootstrap';
 
 function mapStateToProps(state) {
   return {
@@ -67,22 +67,16 @@ export default class SampleQueueContainer extends React.Component {
       collapseSample,
       deleteTask
     } = this.props.queueActions;
-    const totalSamples = history.nodes.length + todo.nodes.length + 1;
-    const progress = (100 / totalSamples) * history.nodes.length;
-    const currentNode = current.node ? 0 : 1;
+
     return (
       <div>
             <div className="queue-body">
-
-                <div className="m-tree">
-                  <div className="list-head">
-                    <label>
-                      Total Progress {`${history.nodes.length}/${totalSamples - currentNode} `}:
-                    </label>
-                     <ProgressBar active now={progress} />
-                  </div>
-                </div>
-
+                <QueueControl
+                  historyLength={history.nodes.length}
+                  todoLength={todo.nodes.length}
+                  currentNode={current.node}
+                  queueStatus={queueStatus}
+                />
                 <CurrentTree
                   changeOrder={changeTaskOrder}
                   show={current.collapsed}


### PR DESCRIPTION
I looked into Marcus WIP for SampleGrid and took some design inspiration on how we can merge samplegrid and sampleview.

The idea is to keep the queue in the sampleview looking the same no matter what mode you are in (semi automatic/ manual). 

Please take a look and give feedback.