### PR TITLE
fixing the run_number after updating a task

### DIFF
--- a/mxcube3/ui/reducers/taskForm.js
+++ b/mxcube3/ui/reducers/taskForm.js
@@ -40,7 +40,8 @@ export default (state = initialState, action) => {
           defaultParameters: {
             ...state.defaultParameters,
             [action.taskData.parameters.type.toLowerCase()]: {
-              ...action.taskData.parameters
+              ...action.taskData.parameters, run_number:
+             state.defaultParameters[action.taskData.parameters.type.toLowerCase()].run_number
             }
           }
         };


### PR DESCRIPTION
after updating a task the run number was not properly set, so the next task could be added but was not being displayed in the ui (two tasks with the same run_number)