### PR TITLE
Smaller improvements to Sample View

### DIFF
--- a/mxcube3/ui/components/InOutSwitch/InOutSwitch.jsx
+++ b/mxcube3/ui/components/InOutSwitch/InOutSwitch.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'react-bootstrap-switch/src/less/bootstrap3/build.less';
-import { Button, ButtonGroup } from 'react-bootstrap';
+import { Button, ButtonGroup, OverlayTrigger, Popover } from 'react-bootstrap';
 
 import './style.css';
 
@@ -47,11 +47,20 @@ export default class InOutSwitch extends React.Component {
 
     return (
       <div>
-        <div className="">
+        <div className="inout-label">
           {this.props.labelText}
         </div>
+        <OverlayTrigger
+          placement="bottom"
+          overlay={(<Popover>
+                      {this.props.labelText} is:
+                      <div className={`inout-switch-msg ${msgBgStyle}`}>
+                        {this.props.data.msg}
+                      </div>
+                    </Popover>)}
+        >
         <ButtonGroup>
-          <div className={`inout-switch-msg ${msgBgStyle}`}>{this.props.data.msg}</div>
+
           <Button
             className=""
             bsStyle={inButtonStyle}
@@ -71,6 +80,7 @@ export default class InOutSwitch extends React.Component {
             {this.props.offText}
           </Button>
         </ButtonGroup>
+        </OverlayTrigger>
       </div>
     );
   }

--- a/mxcube3/ui/components/InOutSwitch/style.css
+++ b/mxcube3/ui/components/InOutSwitch/style.css
@@ -2,3 +2,9 @@
   text-align: center
 }
 
+.inout-label{ 
+  font-weight: bold
+}
+
+
+

--- a/mxcube3/ui/components/PopInput/style.css
+++ b/mxcube3/ui/components/PopInput/style.css
@@ -2,6 +2,7 @@
   display: inline-block;
   min-width: 90px;
   margin-right: 1rem;
+  font-weight: bold;
 }
 
 .popinput-input-value{

--- a/mxcube3/ui/components/SampleView/MotorControl.js
+++ b/mxcube3/ui/components/SampleView/MotorControl.js
@@ -21,131 +21,127 @@ export default class MotorControl extends React.Component {
     const stop = this.props.stop;
 
     return (
-
           <div className="row">
+            <div className="col-sm-12">
+              <MotorInput
+                save={save}
+                saveStep={saveStep}
+                step={phiStep}
+                value={phi.position}
+                motorName="Phi"
+                label="Omega:"
+                suffix="&deg;"
+                decimalPoints="2"
+                state={phi.Status}
+                stop={stop}
+              />
+            </div>
 
-              <div className="col-sm-12 motor-input-container">
-                  <p className="motor-name">Omega: </p>
-                  <MotorInput
-                    save={save}
-                    saveStep={saveStep}
-                    step={phiStep}
-                    value={phi.position}
-                    motorName="Phi"
-                    suffix="&deg;"
-                    decimalPoints="2"
-                    state={phi.Status}
-                    stop={stop}
-                  />
-              </div>
+            <div className="col-sm-12">
+              <MotorInput
+                save={save}
+                saveStep={saveStep}
+                step={kappaStep}
+                value={kappa.position}
+                motorName="Kappa"
+                label="Kappa:"
+                suffix="&deg;"
+                decimalPoints="2"
+                state={kappa.Status}
+                stop={stop}
+              />
+            </div>
 
-              <div className="col-sm-12 motor-input-container">
-                  <p className="motor-name">Kappa: </p>
-                  <MotorInput
-                    save={save}
-                    saveStep={saveStep}
-                    step={kappaStep}
-                    value={kappa.position}
-                    motorName="Kappa"
-                    suffix="&deg;"
-                    decimalPoints="2"
-                    state={kappa.Status}
-                    stop={stop}
-                  />
-              </div>
+            <div className="col-sm-12">
+              <MotorInput
+                save={save}
+                saveStep={saveStep}
+                step={kappaphiStep}
+                value={kappa_phi.position}
+                motorName="Kappa_phi"
+                label="Phi:"
+                suffix="&deg;"
+                decimalPoints="2"
+                state={kappa_phi.Status}
+                stop={stop}
+              />
+            </div>
 
-              <div className="col-sm-12 motor-input-container">
-                  <p className="motor-name">Phi: </p>
-                  <MotorInput
-                    save={save}
-                    saveStep={saveStep}
-                    step={kappaphiStep}
-                    value={kappa_phi.position}
-                    motorName="Kappa_phi"
-                    suffix="&deg;"
-                    decimalPoints="2"
-                    state={kappa_phi.Status}
-                    stop={stop}
-                  />
-              </div>
+            <div className="col-sm-12">
+              <MotorInput
+                save={save}
+                value={phiy.position}
+                saveStep={saveStep}
+                step={phiyStep}
+                motorName="PhiY"
+                label="Y:"
+                suffix="mm"
+                decimalPoints="2"
+                state={phiy.Status}
+                stop={stop}
+              />
+            </div>
 
-              <div className="col-sm-12 motor-input-container">
-                  <p className="motor-name">Y: </p>
-                  <MotorInput
-                    save={save}
-                    value={phiy.position}
-                    saveStep={saveStep}
-                    step={phiyStep}
-                    motorName="PhiY"
-                    suffix="mm"
-                    decimalPoints="2"
-                    state={phiy.Status}
-                    stop={stop}
-                  />
-              </div>
+            <div className="col-sm-12">
+              <MotorInput
+                save={save}
+                value={phiz.position}
+                saveStep={saveStep}
+                step={phizStep}
+                motorName="PhiZ"
+                label="Z:"
+                suffix="mm"
+                decimalPoints="2"
+                state={phiz.Status}
+                stop={stop}
+              />
+            </div>
 
-              <div className="col-sm-12 motor-input-container">
-                  <p className="motor-name">Z: </p>
-                  <MotorInput
-                    save={save}
-                    value={phiz.position}
-                    saveStep={saveStep}
-                    step={phizStep}
-                    motorName="PhiZ"
-                    suffix="mm"
-                    decimalPoints="2"
-                    state={phiz.Status}
-                    stop={stop}
-                  />
-              </div>
+            <div className="col-sm-12">
+              <MotorInput
+                save={save}
+                value={focus.position}
+                saveStep={saveStep}
+                step={focusStep}
+                motorName="Focus"
+                label="Focus:"
+                suffix="mm"
+                decimalPoints="2"
+                state={focus.Status}
+                stop={stop}
+              />
+            </div>
 
-             <div className="col-sm-12 motor-input-container">
-                  <p className="motor-name">Focus: </p>
-                  <MotorInput
-                    save={save}
-                    value={focus.position}
-                    saveStep={saveStep}
-                    step={focusStep}
-                    motorName="Focus"
-                    suffix="mm"
-                    decimalPoints="2"
-                    state={focus.Status}
-                    stop={stop}
-                  />
-              </div>
+            <div className="col-sm-12">
+              <MotorInput
+                save={save}
+                value={sampx.position}
+                saveStep={saveStep}
+                step={sampxStep}
+                motorName="SampX"
+                label="Samp-X:"
+                suffix="mm"
+                decimalPoints="2"
+                state={sampx.Status}
+                stop={stop}
+              />
+            </div>
 
-              <div className="col-sm-12 motor-input-container">
-                  <p className="motor-name">Samp-X: </p>
-                  <MotorInput
-                    save={save}
-                    value={sampx.position}
-                    saveStep={saveStep}
-                    step={sampxStep}
-                    motorName="SampX"
-                    suffix="mm"
-                    decimalPoints="2"
-                    state={sampx.Status}
-                    stop={stop}
-                  />
-              </div>
-
-             <div className="col-sm-12 motor-input-container">
-                  <p className="motor-name">Samp-Y: </p>
-                  <MotorInput
-                    save={save}
-                    value={sampy.position}
-                    saveStep={saveStep}
-                    step={sampyStep}
-                    motorName="SampY"
-                    suffix="mm"
-                    decimalPoints="2"
-                    state={sampy.Status}
-                    stop={stop}
-                  />
-              </div>
-
+            <div className="col-sm-12">
+               <MotorInput
+                 save={save}
+                 value={sampy.position}
+                 saveStep={saveStep}
+                 step={sampyStep}
+                 motorName="SampY"
+                 label="Samp-Y:"
+                 suffix="mm"
+                 decimalPoints="2"
+                 state={sampy.Status}
+                 stop={stop}
+               />
+            </div>
           </div>
-
       );
   }
 }

--- a/mxcube3/ui/components/SampleView/MotorInput.js
+++ b/mxcube3/ui/components/SampleView/MotorInput.js
@@ -58,61 +58,65 @@ export default class MotorInput extends React.Component {
     let data = { state: 'IMMEDIATE', value: step };
 
     return (
+        <div className="motor-input-container">
+          <p className="motor-name">{this.props.label}</p>
           <form className="inline form-inline form-group" onSubmit={this.handleKey} noValidate>
-
-              <div className="rw-widget rw-numberpicker">
-                <span className="rw-select">
-                  <button
-                    type="button"
-                    className="rw-btn"
-                    disabled={this.props.state !== 2}
-                    onClick={this.stepIncrement}
-                  >
-                    <i aria-hidden="true" className="rw-i rw-i-caret-up"></i>
-                  </button>
-                  <button
-                    type="button"
-                    className="rw-btn"
-                    disabled={this.props.state !== 2}
-                    onClick={this.stepDecrement}
-                  >
-                    <i aria-hidden="true" className="rw-i rw-i-caret-down"></i>
-                  </button>
-                </span>
-                <input
-                  ref="motorValue"
-                  className={inputCSS}
-                  onKeyUp={this.handleKey}
-                  type="number"
-                  step={step}
-                  defaultValue={valueCropped}
-                  name={motorName}
+            <div className="rw-widget rw-numberpicker">
+              <span className="rw-select">
+                <button
+                  type="button"
+                  className="rw-btn"
                   disabled={this.props.state !== 2}
-                />
-              </div>
-                <span>
-                {this.props.saveStep && this.props.state === 4 ?
-                  <Button
-                    className="btn-sm motor-abort"
-                    bsStyle="danger"
-                    disabled={this.props.state !== 4}
-                    onClick={this.stopMotor}
-                  >
-                    <i className="glyphicon glyphicon-remove" />
-                  </Button>
-                    : null
-                  }
-                  {this.props.saveStep ?
-                  <PopInput
-                    className="step-size"
-                    ref={motorName} name="Step size" pkey={`${motorName.toLowerCase()}Step`}
-                    data={data} onSave={this.props.saveStep} suffix={suffix}
-                  />
-                  : null
-                  }
-                </span>
+                  onClick={this.stepIncrement}
+                >
+                  <i aria-hidden="true" className="rw-i rw-i-caret-up"></i>
+                </button>
+                <button
+                  type="button"
+                  className="rw-btn"
+                  disabled={this.props.state !== 2}
+                  onClick={this.stepDecrement}
+                >
+                  <i aria-hidden="true" className="rw-i rw-i-caret-down"></i>
+                </button>
+              </span>
+              <input
+                ref="motorValue"
+                className={inputCSS}
+                onKeyUp={this.handleKey}
+                type="number"
+                step={step}
+                defaultValue={valueCropped}
+                name={motorName}
+                disabled={this.props.state !== 2}
+              />
+            </div>
+            <span>
+              {this.props.saveStep ?
+              <PopInput
+                className="step-size"
+                ref={motorName} name="Step size" pkey={`${motorName.toLowerCase()}Step`}
+                data={data} onSave={this.props.saveStep} suffix={suffix}
+              />
+              : null
+              }
+            </span>
+            <span>
+              {this.props.state === 4 ?
+                <Button
+                  className="btn-xs motor-abort"
+                  bsStyle="danger"
+                  disabled={this.props.state !== 4}
+                  onClick={this.stopMotor}
+                >
+                  <i className="glyphicon glyphicon-remove" />
+                </Button>
+                : null
+               }
+             </span>
 
           </form>
+        </div>
       );
   }
 }

--- a/mxcube3/ui/components/SampleView/SampleControls.js
+++ b/mxcube3/ui/components/SampleView/SampleControls.js
@@ -176,7 +176,6 @@ export default class SampleControls extends React.Component {
               onClick={this.setZoom}
               name="zoomIn"
             />
-
             <Button
               type="button"
               data-toggle="tooltip"
@@ -186,16 +185,18 @@ export default class SampleControls extends React.Component {
               onClick={this.toggleBackLight}
               active={motors.BackLightSwitch.Status === 1}
             />
-            <MotorInput
-              title="BackLight"
-              save={this.props.sampleActions.sendMotorPosition}
-              value={motors.BackLight.position}
-              motorName="BackLight"
-              step="0.1"
-              decimalPoints="2"
-              state={motors.BackLight.Status}
-            />
-
+            <div style={{ display: 'inline-block', width: '100px !important' }}>
+              <MotorInput
+                className="motor-input-sm"
+                title="BackLight"
+                save={this.props.sampleActions.sendMotorPosition}
+                value={motors.BackLight.position}
+                motorName="BackLight"
+                step="0.1"
+                decimalPoints="2"
+                state={motors.BackLight.Status}
+              />
+            </div>
             <Button
               type="button"
               data-toggle="tooltip"
@@ -205,15 +206,17 @@ export default class SampleControls extends React.Component {
               onClick={this.toggleFrontLight}
               active={motors.FrontLightSwitch.Status === 1}
             />
-            <MotorInput
-              title="FrontLight"
-              save={this.props.sampleActions.sendMotorPosition}
-              value={motors.FrontLight.position}
-              motorName="FrontLight"
-              step="0.1"
-              decimalPoints="2"
-              state={motors.FrontLight.Status}
-            />
+            <div style={{ display: 'inline-block', width: '100px !important' }}>
+              <MotorInput
+                title="FrontLight"
+                save={this.props.sampleActions.sendMotorPosition}
+                value={motors.FrontLight.position}
+                motorName="FrontLight"
+                step="0.1"
+                decimalPoints="2"
+                state={motors.FrontLight.Status}
+              />
+            </div>
             <Button
               type="button"
               data-toggle="tooltip"

--- a/mxcube3/ui/components/SampleView/motor.css
+++ b/mxcube3/ui/components/SampleView/motor.css
@@ -1,12 +1,13 @@
 .motor-input-container{
     padding-right: 0px;
+    margin-bottom: 1em;
 }
 
 .motor-name{
     font-size: 1.0em;
     margin-bottom: 0px;
     font-weight: bold;
-    line-height: 3;
+    display: inline;
 }
 
 .motor-value{
@@ -17,10 +18,14 @@
     cursor:pointer;
 }
 
+.motor-input-sm{ 
+    width: '100px !important';
+}
+
 .motor-group{
     padding-top: 20px;
     padding-left: 20px;
-    padding-right: 20px;
+    padding-right: 0px;
     padding-bottom: 0px;
 }
 
@@ -28,8 +33,16 @@
     margin: 15px !important;
 }
 
+.motor-abort{
+    float:right;
+}
+
 .motor-step{
     font-size: 0.7em;
+}
+
+.step-size{ 
+    display:inline;
 }
 
 
@@ -41,9 +54,8 @@
 }
 
 .rw-widget{
-    width:100px !important;
-    display: inline-block;
 }
+
 .rw-widget input{
     border-bottom-right-radius: 0px;
     border-top-right-radius: 0px;

--- a/mxcube3/ui/containers/BeamlineSetupContainer.jsx
+++ b/mxcube3/ui/containers/BeamlineSetupContainer.jsx
@@ -41,105 +41,93 @@ class BeamlineSetupContainer extends React.Component {
     return (
         <div className="beamline-setup-container">
           <div className="beamline-setup-content">
-            <table>
-              <tbody>
-                <tr>
-                  <td>
-                    <PopInput
-                      ref="transmission"
-                      name="Transmission"
-                      pkey="transmission"
-                      suffix="%"
-                      data={this.props.data.transmission}
-                      onSave={this.onSaveHandler}
-                      onCancel={this.onCancelHandler}
-                    />
-                  </td>
-                  <td>
-                    <PopInput
-                      ref="resolution"
-                      name="Resolution"
-                      pkey="resolution"
-                      placement="left"
-                      suffix="&Aring;"
-                      data={this.props.data.resolution}
-                      onSave={this.onSaveHandler}
-                      onCancel={this.onCancelHandler}
-                    />
-                  </td>
-                </tr>
-                <tr>
-                  <td>
-                    <PopInput
-                      ref="energy"
-                      name="Energy"
-                      pkey="energy"
-                      suffix="keV"
-                      data={this.props.data.energy}
-                      onSave={this.onSaveHandler}
-                      onCancel={this.onCancelHandler}
-                    />
-                  </td>
-                  <td>
-                    <PopInput
-                      ref="dtox"
-                      name="Detector Distance"
-                      pkey="dtox"
-                      suffix="mm"
-                      data={this.props.data.dtox}
-                      onSave={this.onSaveHandler}
-                      onCancel={this.onCancelHandler}
-                    />
-                  </td>
-                  <td>
-                  </td>
-                </tr>
-                <tr>
-                  <td>
-                    <InOutSwitch
-                      onText="Open"
-                      offText="Close"
-                      labelText="Fast Shutter"
-                      pkey="fast_shutter"
-                      data={this.props.data.fast_shutter}
-                      onSave={this.onSaveHandler}
-                    />
-                  </td>
-                  <td>
-                    <InOutSwitch
-                      onText="Open"
-                      offText="Close"
-                      labelText="Safety Shutter"
-                      pkey="safety_shutter"
-                      data={this.props.data.safety_shutter}
-                      onSave={this.onSaveHandler}
-                    />
-                  </td>
-                </tr>
-                <tr>
-                  <td>
-                    <InOutSwitch
-                      onText="In"
-                      offText="Out"
-                      labelText="Beamstop"
-                      pkey="beamstop"
-                      data={this.props.data.beamstop}
-                      onSave={this.onSaveHandler}
-                    />
-                  </td>
-                  <td>
-                    <InOutSwitch
-                      onText="In"
-                      offText="Out"
-                      labelText="Capillary"
-                      pkey="capillary"
-                      data={this.props.data.capillary}
-                      onSave={this.onSaveHandler}
-                    />
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+            <div className="row" style={{ 'margin-bottom': '1em' }}>
+              <div className="col-sm-6">
+                <div className="col-sm-3" style={{ 'padding-left': '0px' }}>
+                <InOutSwitch
+                  onText="Open"
+                  offText="Close"
+                  labelText="Fast Shutter"
+                  pkey="fast_shutter"
+                  data={this.props.data.fast_shutter}
+                  onSave={this.onSaveHandler}
+                />
+              </div>
+              <div className="col-sm-3">
+                <InOutSwitch
+                  onText="Open"
+                  offText="Close"
+                  labelText="Safety Shutter"
+                  pkey="safety_shutter"
+                  data={this.props.data.safety_shutter}
+                  onSave={this.onSaveHandler}
+                />
+              </div>
+              <div className="col-sm-3">
+                <InOutSwitch
+                  onText="In"
+                  offText="Out"
+                  labelText="Beamstop"
+                  pkey="beamstop"
+                  data={this.props.data.beamstop}
+                  onSave={this.onSaveHandler}
+                />
+              </div>
+              <div className="col-sm-3">
+                <InOutSwitch
+                  onText="In"
+                  offText="Out"
+                  labelText="Capillary"
+                  pkey="capillary"
+                  data={this.props.data.capillary}
+                  onSave={this.onSaveHandler}
+                />
+              </div>
+              </div>
+              <div className="col-sm-6">
+              <div className="col-sm-6" style={{ 'padding-top': '1em' }}>
+                <PopInput
+                  ref="energy"
+                  name="Energy"
+                  pkey="energy"
+                  suffix="keV"
+                  data={this.props.data.energy}
+                  onSave={this.onSaveHandler}
+                  onCancel={this.onCancelHandler}
+                />
+                <PopInput
+                  ref="resolution"
+                  name="Resolution"
+                  pkey="resolution"
+                  placement="left"
+                  suffix="&Aring;"
+                  data={this.props.data.resolution}
+                  onSave={this.onSaveHandler}
+                  onCancel={this.onCancelHandler}
+                />
+              </div>
+              <div className="col-sm-6" style={{ 'padding-top': '1em' }}>
+                <PopInput
+                  ref="transmission"
+                  name="Transmission"
+                  pkey="transmission"
+                  suffix="%"
+                  data={this.props.data.transmission}
+                  onSave={this.onSaveHandler}
+                  onCancel={this.onCancelHandler}
+                />
+                <PopInput
+                  ref="dtox"
+                  name="Detector Distance"
+                  pkey="dtox"
+                  suffix="mm"
+                  data={this.props.data.dtox}
+                  onSave={this.onSaveHandler}
+                  onCancel={this.onCancelHandler}
+                />
+              </div>
+              </div>
+            </div>
           </div>
         </div>
     );

--- a/mxcube3/ui/containers/BeamlineSetupContainer.jsx
+++ b/mxcube3/ui/containers/BeamlineSetupContainer.jsx
@@ -43,7 +43,7 @@ class BeamlineSetupContainer extends React.Component {
           <div className="beamline-setup-content">
             <div className="row" style={{ 'margin-bottom': '1em' }}>
               <div className="col-sm-6">
-                <div className="col-sm-3" style={{ 'padding-left': '0px' }}>
+                <div style={{ 'padding-left': '0px', display: 'inline-block' }}>
                 <InOutSwitch
                   onText="Open"
                   offText="Close"
@@ -53,7 +53,7 @@ class BeamlineSetupContainer extends React.Component {
                   onSave={this.onSaveHandler}
                 />
               </div>
-              <div className="col-sm-3">
+              <div style={{ 'margin-left': '4em', display: 'inline-block' }}>
                 <InOutSwitch
                   onText="Open"
                   offText="Close"
@@ -63,7 +63,7 @@ class BeamlineSetupContainer extends React.Component {
                   onSave={this.onSaveHandler}
                 />
               </div>
-              <div className="col-sm-3">
+              <div style={{ 'margin-left': '4em', display: 'inline-block' }}>
                 <InOutSwitch
                   onText="In"
                   offText="Out"
@@ -73,7 +73,7 @@ class BeamlineSetupContainer extends React.Component {
                   onSave={this.onSaveHandler}
                 />
               </div>
-              <div className="col-sm-3">
+              <div style={{ 'margin-left': '4em', display: 'inline-block' }}>
                 <InOutSwitch
                   onText="In"
                   offText="Out"
@@ -83,9 +83,9 @@ class BeamlineSetupContainer extends React.Component {
                   onSave={this.onSaveHandler}
                 />
               </div>
-              </div>
-              <div className="col-sm-6">
-              <div className="col-sm-6" style={{ 'padding-top': '1em' }}>
+            </div>
+            <div className="col-sm-6">
+              <div style={{ 'padding-top': '1em', 'margin-left': '4em', display: 'inline-block' }}>
                 <PopInput
                   ref="energy"
                   name="Energy"
@@ -106,7 +106,7 @@ class BeamlineSetupContainer extends React.Component {
                   onCancel={this.onCancelHandler}
                 />
               </div>
-              <div className="col-sm-6" style={{ 'padding-top': '1em' }}>
+              <div style={{ 'padding-top': '1em', 'margin-left': '4em', display: 'inline-block' }}>
                 <PopInput
                   ref="transmission"
                   name="Transmission"

--- a/mxcube3/ui/containers/SampleGridContainer.jsx
+++ b/mxcube3/ui/containers/SampleGridContainer.jsx
@@ -107,6 +107,7 @@ class SampleGridContainer extends React.Component {
   addSamples() {
     Object.keys(this.props.picked).map((sampleID) => {
       this.props.addSample(this.props.sampleList[sampleID]);
+      return sampleID;
     });
   }
 

--- a/mxcube3/ui/containers/SampleViewContainer.js
+++ b/mxcube3/ui/containers/SampleViewContainer.js
@@ -40,6 +40,7 @@ class SampleViewContainer extends Component {
                   defaultParameters={this.props.defaultParameters}
                   imageRatio={imageRatio}
                 />
+                <BeamlineSetupContainer />
                 <SampleImage
                   sampleActions={this.props.sampleViewActions}
                   sampleViewState={this.props.sampleViewState}
@@ -49,7 +50,6 @@ class SampleViewContainer extends Component {
             </div>
         </div>
         <div className={cinema ? 'col-xs-2' : 'col-xs-3'}>
-          <BeamlineSetupContainer />
           <SampleQueueContainer />
         </div>
       </div>

--- a/mxcube3/ui/containers/SampleViewContainer.js
+++ b/mxcube3/ui/containers/SampleViewContainer.js
@@ -19,7 +19,9 @@ class SampleViewContainer extends Component {
 
     return (
       <div className="row">
-        <div className="col-xs-1">
+        <div className="col-xs-1"
+          style={{ 'margin-top': '0em', 'padding-right': '5px', 'padding-left': '1.5em' }}
+        >
             <MotorControl
               save={sendMotorPosition}
               saveStep={setStepSize}


### PR DESCRIPTION
Hey !

Since we have electrical cuts on our test beamline today we had some time over so we took the opportunity to move the beamline setup above the sample video. The InOut components was also
improved slightly so that they are more compact and hopefully look a bit better. 

We also changed the motor inputs a bit so that we can have the same margin everywhere around the
sample video. That meant moving the abort button, since the abort button gives the component variable width, and putting it next to step size.

In general this new layout frees alot of space on the right for the queue.

Thanks,
Marcus