### PR TITLE
Continuing LIMS and queue integration

### DIFF
--- a/mxcube3/routes/SampleChanger.py
+++ b/mxcube3/routes/SampleChanger.py
@@ -21,7 +21,7 @@ def get_samples_list():
         sample_dm = s.getID() or ""
         sample_data = {"sampleID": s.getAddress(),
                        "location": ":".join(map(str, s.getCoords())),
-                       "sampleName": "Sample %s" % s.getAddress(),
+                       "sampleName": "Sample-%s" % s.getAddress().replace(':', ''),
                        "code": sample_dm,
                        "type": "Sample"}
 

--- a/mxcube3/routes/SampleChanger.py
+++ b/mxcube3/routes/SampleChanger.py
@@ -1,7 +1,5 @@
 import logging
-import time
 
-import queue_model_objects_v1 as qmo
 import signals
 
 from flask import Response, jsonify
@@ -23,10 +21,11 @@ def get_samples_list():
         sample_dm = s.getID() or ""
         sample_data = {"sampleID": s.getAddress(),
                        "location": ":".join(map(str, s.getCoords())),
+                       "sampleName": "Sample %s" % s.getAddress(),
                        "code": sample_dm,
                        "type": "Sample"}
 
-        sample_data["defaultPrefix"] = limsutils.get_default_prefix()
+        sample_data["defaultPrefix"] = limsutils.get_default_prefix(sample_data, False)
         samples.update({s.getAddress(): sample_data})
 
     return jsonify(samples)

--- a/mxcube3/routes/SampleChanger.py
+++ b/mxcube3/routes/SampleChanger.py
@@ -1,10 +1,12 @@
 import logging
 import time
 
+import queue_model_objects_v1 as qmo
 import signals
 
 from flask import Response, jsonify
 from mxcube3 import app as mxcube
+from . import limsutils
 
 
 def init_signals():
@@ -16,20 +18,17 @@ def init_signals():
 def get_samples_list():
     samples_list = mxcube.sample_changer.getSampleList()
     samples = {}
+
     for s in samples_list:
         sample_dm = s.getID() or ""
-        samples.update(
-            {s.getAddress():
-                {
-                 "sampleID": s.getAddress(),
-                 "location": ":".join(map(str, s.getCoords())),
-                 "code": sample_dm,
-                 "type": "Sample",
-                 "sampleName": "XTAL01",
-                 "proteinAcronym": "TRYP"
-                }
-             }
-            )
+        sample_data = {"sampleID": s.getAddress(),
+                       "location": ":".join(map(str, s.getCoords())),
+                       "code": sample_dm,
+                       "type": "Sample"}
+
+        sample_data["defaultPrefix"] = limsutils.get_default_prefix()
+        samples.update({s.getAddress(): sample_data})
+
     return jsonify(samples)
 
 @mxcube.route("/mxcube/api/v0.1/sample_changer/contents", methods=['GET'])

--- a/mxcube3/routes/lims.py
+++ b/mxcube3/routes/lims.py
@@ -13,6 +13,7 @@ def proposal_samples(proposal_id):
     for sample_info in samples_info_list:
         sample_info["limsID"] = sample_info.pop("sampleId")
         sample_info["limsLink"] = mxcube.rest_lims.sample_link()
+        sample_info["defaultPrefix"] = limsutils.get_default_prefix(sample_info, false)
         
         try:
             basket = int(sample_info["containerSampleChangerLocation"])

--- a/mxcube3/routes/limsutils.py
+++ b/mxcube3/routes/limsutils.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import types
+import logging
+
 import queue_model_objects_v1 as qmo
 
 from mxcube3 import app as mxcube
@@ -7,11 +9,18 @@ from mxcube3 import app as mxcube
 
 def lims_login(loginID, password):
     login_res = mxcube.db_connection.login(loginID, password)
-    mxcube.session.session_id = login_res['session']['session']['sessionId']
-    mxcube.session.proposal_code = login_res['Proposal']['code']
-    mxcube.session.proposal_number = login_res['Proposal']['number']
 
-    mxcube.rest_lims.authenticate(loginID, password)
+    try:
+        mxcube.session.session_id = login_res['session']['session']['sessionId']
+        mxcube.session.proposal_code = login_res['Proposal']['code']
+        mxcube.session.proposal_number = login_res['Proposal']['number']
+    except:
+        logging.getLogger('HWR').info('[LIMS] Could not get LIMS session')
+
+    try:
+        mxcube.rest_lims.authenticate(loginID, password)
+    except:
+        logging.getLogger('HWR').info('[LIMS-REST] Could not authenticate')
 
     return login_res
 

--- a/mxcube3/routes/limsutils.py
+++ b/mxcube3/routes/limsutils.py
@@ -7,9 +7,7 @@ from mxcube3 import app as mxcube
 
 def lims_login(loginID, password):
     login_res = mxcube.db_connection.login(loginID, password)
-    lims_session = mxcube.db_connection.get_todays_session(login_res)
- 
-    mxcube.session.session_id = lims_session['session']['sessionId']
+    mxcube.session.session_id = login_res['session']['session']['sessionId']
     mxcube.session.proposal_code = login_res['Proposal']['code']
     mxcube.session.proposal_number = login_res['Proposal']['number']
 

--- a/mxcube3/routes/limsutils.py
+++ b/mxcube3/routes/limsutils.py
@@ -17,6 +17,16 @@ def lims_login(loginID, password):
     return loginRes
 
 
+def get_default_prefix(sample_data, generic_name):
+    sample = qmo.Sample()
+    sample.code = sample_data.code
+    sample.name = sample_data.sampleName
+    sample.location = sample_data.split(':')
+    sample.crystals[0].protein_acronym = sample_data.proteinAcronym
+    
+    return mxcube.session.get_default_prefix(sample, generic_name)
+
+
 def convert_to_dict(ispyb_object):
     d = {}
     

--- a/mxcube3/routes/limsutils.py
+++ b/mxcube3/routes/limsutils.py
@@ -1,28 +1,29 @@
 # -*- coding: utf-8 -*-
 import types
+import queue_model_objects_v1 as qmo
+
 from mxcube3 import app as mxcube
 
 
 def lims_login(loginID, password):
-    loginRes = mxcube.db_connection.login(loginID, password)
-
-    limsSession = mxcube.db_connection.get_todays_session(loginRes)
+    login_res = mxcube.db_connection.login(loginID, password)
+    lims_session = mxcube.db_connection.get_todays_session(login_res)
  
-    mxcube.session.session_id = limsSession['session']['sessionId']
-    mxcube.session.proposal_code = loginRes['Proposal']['code']
-    mxcube.session.proposal_number = loginRes['Proposal']['number']
+    mxcube.session.session_id = lims_session['session']['sessionId']
+    mxcube.session.proposal_code = login_res['Proposal']['code']
+    mxcube.session.proposal_number = login_res['Proposal']['number']
 
     mxcube.rest_lims.authenticate(loginID, password)
 
-    return loginRes
+    return login_res
 
 
 def get_default_prefix(sample_data, generic_name):
     sample = qmo.Sample()
-    sample.code = sample_data.code
-    sample.name = sample_data.sampleName
-    sample.location = sample_data.split(':')
-    sample.crystals[0].protein_acronym = sample_data.proteinAcronym
+    sample.code = sample_data.get("code", "")
+    sample.name = sample_data.get("sampleName", "")
+    sample.location = sample_data.get("location", "").split(':')
+    sample.crystals[0].protein_acronym = sample_data.get("proteinAcronym", "")
     
     return mxcube.session.get_default_prefix(sample, generic_name)
 

--- a/mxcube3/ui/components/SampleGrid/SampleGrid.jsx
+++ b/mxcube3/ui/components/SampleGrid/SampleGrid.jsx
@@ -284,7 +284,7 @@ export default class SampleGrid extends React.Component {
             dm={sample.code}
             loadable={false}
             location={sample.location}
-            queueOrder={sample.queueOrder}
+            queueOrder={this.props.queue.sampleOrder.indexOf(sample.sampleID)}
             tags={tags}
             selected={this.props.selected}
             deleteTask={this.props.deleteTask}

--- a/mxcube3/ui/components/SampleGrid/SampleGrid.jsx
+++ b/mxcube3/ui/components/SampleGrid/SampleGrid.jsx
@@ -49,9 +49,9 @@ export default class SampleGrid extends React.Component {
 
 
   shouldComponentUpdate(nextProps) {
-    this._doReorder = false;
-
-    if (this.props.order !== nextProps.order || this.props.sampleList !== nextProps.sampleList) {
+    if (this.props.order !== nextProps.order ||
+        this.props.sampleList !== nextProps.sampleList ||
+        this._doReorder) {
       this._doReorder = true;
     }
 
@@ -64,6 +64,7 @@ export default class SampleGrid extends React.Component {
       this.isotope.reloadItems();
       this.isotope.layout();
       this.isotope.arrange({ sortBy: 'seqId' });
+      this._doReorder = false;
     }
   }
 

--- a/mxcube3/ui/components/SampleGrid/SampleGrid.jsx
+++ b/mxcube3/ui/components/SampleGrid/SampleGrid.jsx
@@ -273,6 +273,9 @@ export default class SampleGrid extends React.Component {
           }
         }
 
+        const deleteTaskFun = this.props.queue.queueStatus === 'QueueStopped' ?
+                              this.props.deleteTask : '';
+
         sampleGrid.push(
           <SampleGridItem
             ref={i}
@@ -288,7 +291,7 @@ export default class SampleGrid extends React.Component {
             queueOrder={this.props.queue.sampleOrder.indexOf(sample.sampleID)}
             tags={tags}
             selected={this.props.selected}
-            deleteTask={this.props.deleteTask}
+            deleteTask={deleteTaskFun}
             showTaskParametersForm={this.props.showTaskParametersForm}
             toggleMovable={this.props.toggleMovable}
             picked={this.props.queue.queue[sample.sampleID]}

--- a/mxcube3/ui/components/SampleGrid/SampleGridItem.jsx
+++ b/mxcube3/ui/components/SampleGrid/SampleGridItem.jsx
@@ -406,8 +406,6 @@ export class SampleGridItem extends React.Component {
   handleClick(task) {
     if (task.state === 0) {
       this.props.showTaskParametersForm(task.type, task.sampleID, task);
-    } else if (task.state === 2) {
-      console.log("RESULTS");
     }
   }
 

--- a/mxcube3/ui/components/SampleGrid/SampleGridItem.jsx
+++ b/mxcube3/ui/components/SampleGrid/SampleGridItem.jsx
@@ -28,6 +28,7 @@ export class SampleGridItem extends React.Component {
     this.taskSummary = this.taskSummary.bind(this);
     this.taskTitle = this.taskTitle.bind(this);
     this.taskStateClass = this.taskStateClass.bind(this);
+    this.handleClick = this.handleClick.bind(this);
   }
 
 
@@ -361,25 +362,25 @@ export class SampleGridItem extends React.Component {
   }
 
 
-  taskTitle(task, i) {
+  taskTitle(task) {
     const point = task.parameters.point !== -1 ? ` at P-${task.parameters.point}` : '';
     let taskStatus = 'To be collected';
 
-    if (this.props.displayData.tasks[i].state === 1) {
+    if (task.state === 1) {
       taskStatus = 'In progress';
-    } else if (this.props.displayData.tasks[i].state === 2) {
+    } else if (task.state === 2) {
       taskStatus = 'Collected';
     }
 
     return `${task.label}${point} (${taskStatus})`;
   }
 
-  taskStateClass(task, i) {
+  taskStateClass(task) {
     let cls = 'btn-primary';
 
-    if (this.props.displayData.tasks[i].state === 1) {
+    if (task.state === 1) {
       cls = 'btn-warning';
-    } else if (this.props.displayData.tasks[i].state === 2) {
+    } else if (task.state === 2) {
       cls = 'btn-success';
     }
 
@@ -400,6 +401,16 @@ export class SampleGridItem extends React.Component {
 
     return result;
   }
+
+
+  handleClick(task) {
+    if (task.state === 0) {
+      this.props.showTaskParametersForm(task.type, task.sampleID, task);
+    } else if (task.state === 2) {
+      console.log("RESULTS");
+    }
+  }
+
 
   render() {
     const itemKey = this.props.itemKey;
@@ -453,7 +464,7 @@ export class SampleGridItem extends React.Component {
                 // assuming a Task
                 let showForm = (e) => {
                   e.stopPropagation();
-                  return this.props.showTaskParametersForm(tag.type, this.props.sampleID, tag);
+                  return this.handleClick(tag, this.props.sampleID);
                 };
 
                 let deleteTask = (e) => {
@@ -467,14 +478,14 @@ export class SampleGridItem extends React.Component {
                     overlay={(
                       <Popover
                         style={{ 'min-width': '700px !important', 'padding-bottom': '1em' }}
-                        title={(<b>{this.taskTitle(tag, i)}</b>)}
+                        title={(<b>{this.taskTitle(tag)}</b>)}
                       >
                          {this.taskSummary(tag)}
                       </Popover>) }
                   >
                    <span
                      key={i}
-                     className={`${this.taskStateClass(tag, i)} label`}
+                     className={`${this.taskStateClass(tag)} label`}
                      style={style}
                      onClick={showForm}
                    >

--- a/mxcube3/ui/components/SampleGrid/TaskButtons.jsx
+++ b/mxcube3/ui/components/SampleGrid/TaskButtons.jsx
@@ -11,7 +11,8 @@ export default class SampleTaskButtons extends React.Component {
 
   handleSubmit(formName) {
     const parameters = { parameters:
-                         { ...this.props.defaultParameters[formName.toLowerCase()] }
+                         { ...this.props.defaultParameters[formName.toLowerCase()],
+                           prefix: node.defaultPrefix }
                        };
 
     const selected = []

--- a/mxcube3/ui/components/SampleQueue/CurrentTree.js
+++ b/mxcube3/ui/components/SampleQueue/CurrentTree.js
@@ -115,7 +115,7 @@ export default class CurrentTree extends React.Component {
                   rootPath={this.props.rootPath}
                   collapseTask={this.props.collapseTask}
                   show={this.props.displayData[taskData.sampleID].tasks[i].collapsed}
-                  state={this.props.displayData[taskData.sampleID].tasks[i].state}
+                  state={this.props.queue[taskData.sampleID].tasks[i].state}
                 />);
               return task;
             })}

--- a/mxcube3/ui/components/SampleView/ContextMenu.js
+++ b/mxcube3/ui/components/SampleView/ContextMenu.js
@@ -47,7 +47,7 @@ export default class ContextMenu extends React.Component {
       { parameters:
         { path: node.sampleName,
           ...defaultParameters[modalName.toLowerCase()],
-          prefix: `${node.proteinAcronym}-${node.sampleName}`
+          prefix: node.defaultPrefix
         }
       },
       shape.id

--- a/mxcube3/ui/components/Tasks/AddSample.js
+++ b/mxcube3/ui/components/Tasks/AddSample.js
@@ -20,7 +20,7 @@ class AddSample extends React.Component {
     let prefix = this.props.values.sampleName ? this.props.values.sampleName : 'noname';
 
     if (this.props.values.proteinAcronym && this.props.values.sampleName) {
-      prefix += `-${prefix}`;
+      prefix += `-${this.props.values.proteinAcronym}`;
     }
 
     this.props.add({ ...this.props.values, type: 'Sample', defaultPrefix: prefix,

--- a/mxcube3/ui/components/Tasks/AddSample.js
+++ b/mxcube3/ui/components/Tasks/AddSample.js
@@ -17,7 +17,13 @@ class AddSample extends React.Component {
 
 
   handleSubmit() {
-    this.props.add({ ...this.props.values, type: 'Sample',
+    let prefix = this.props.values.sampleName ? this.props.values.sampleName : 'noname';
+
+    if (this.props.values.proteinAcronym && this.props.values.sampleName) {
+      prefix += `-${prefix}`;
+    }
+
+    this.props.add({ ...this.props.values, type: 'Sample', defaultPrefix: prefix,
                      location: 'Manual', sampleID: this.props.id.toString() });
     this.props.hide();
   }

--- a/mxcube3/ui/components/Tasks/AddSample.js
+++ b/mxcube3/ui/components/Tasks/AddSample.js
@@ -18,7 +18,7 @@ class AddSample extends React.Component {
 
   handleSubmit() {
     this.props.add({ ...this.props.values, type: 'Sample',
-                     location: 'Manual', sampleID: this.props.id });
+                     location: 'Manual', sampleID: this.props.id.toString() });
     this.props.hide();
   }
 

--- a/mxcube3/ui/containers/BeamlineSetupContainer.jsx
+++ b/mxcube3/ui/containers/BeamlineSetupContainer.jsx
@@ -85,7 +85,7 @@ class BeamlineSetupContainer extends React.Component {
               </div>
             </div>
             <div className="col-sm-6">
-              <div style={{ paddingTop: '1em', 'marginLeft': '4em', display: 'inline-block' }}>
+              <div style={{ paddingTop: '1em', marginLeft: '4em', display: 'inline-block' }}>
                 <PopInput
                   ref="energy"
                   name="Energy"
@@ -106,7 +106,7 @@ class BeamlineSetupContainer extends React.Component {
                   onCancel={this.onCancelHandler}
                 />
               </div>
-              <div style={{ paddingTop: '1em', 'marginLeft': '4em', display: 'inline-block' }}>
+              <div style={{ paddingTop: '1em', marginLeft: '4em', display: 'inline-block' }}>
                 <PopInput
                   ref="transmission"
                   name="Transmission"

--- a/mxcube3/ui/containers/BeamlineSetupContainer.jsx
+++ b/mxcube3/ui/containers/BeamlineSetupContainer.jsx
@@ -43,7 +43,7 @@ class BeamlineSetupContainer extends React.Component {
           <div className="beamline-setup-content">
             <div className="row" style={{ 'margin-bottom': '1em' }}>
               <div className="col-sm-6">
-                <div style={{ 'padding-left': '0px', display: 'inline-block' }}>
+                <div style={{ paddingLeft: '0px', display: 'inline-block' }}>
                 <InOutSwitch
                   onText="Open"
                   offText="Close"
@@ -53,7 +53,7 @@ class BeamlineSetupContainer extends React.Component {
                   onSave={this.onSaveHandler}
                 />
               </div>
-              <div style={{ 'margin-left': '4em', display: 'inline-block' }}>
+              <div style={{ marginLeft: '4em', display: 'inline-block' }}>
                 <InOutSwitch
                   onText="Open"
                   offText="Close"
@@ -63,7 +63,7 @@ class BeamlineSetupContainer extends React.Component {
                   onSave={this.onSaveHandler}
                 />
               </div>
-              <div style={{ 'margin-left': '4em', display: 'inline-block' }}>
+              <div style={{ marginLeft: '4em', display: 'inline-block' }}>
                 <InOutSwitch
                   onText="In"
                   offText="Out"
@@ -73,7 +73,7 @@ class BeamlineSetupContainer extends React.Component {
                   onSave={this.onSaveHandler}
                 />
               </div>
-              <div style={{ 'margin-left': '4em', display: 'inline-block' }}>
+              <div style={{ marginLeft: '4em', display: 'inline-block' }}>
                 <InOutSwitch
                   onText="In"
                   offText="Out"
@@ -85,7 +85,7 @@ class BeamlineSetupContainer extends React.Component {
               </div>
             </div>
             <div className="col-sm-6">
-              <div style={{ 'padding-top': '1em', 'margin-left': '4em', display: 'inline-block' }}>
+              <div style={{ paddingTop: '1em', 'marginLeft': '4em', display: 'inline-block' }}>
                 <PopInput
                   ref="energy"
                   name="Energy"
@@ -106,7 +106,7 @@ class BeamlineSetupContainer extends React.Component {
                   onCancel={this.onCancelHandler}
                 />
               </div>
-              <div style={{ 'padding-top': '1em', 'margin-left': '4em', display: 'inline-block' }}>
+              <div style={{ paddingTop: '1em', 'marginLeft': '4em', display: 'inline-block' }}>
                 <PopInput
                   ref="transmission"
                   name="Transmission"

--- a/mxcube3/ui/containers/SampleGridContainer.jsx
+++ b/mxcube3/ui/containers/SampleGridContainer.jsx
@@ -102,15 +102,16 @@ class SampleGridContainer extends React.Component {
 
   handleSubmit(formName) {
     let prefix = '';
+    let path = '';
 
     if (Object.keys(this.props.selected).length === 1) {
       prefix = this.props.sampleList[Object.keys(this.props.selected)[0]].defaultPrefix;
+      path = this.props.sampleList[Object.keys(this.props.selected)[0]].sampleName;
     }
 
-    const parameters = { parameters:
-                         { ...this.props.defaultParameters[formName.toLowerCase()],
-                           prefix, path: prefix }
-                       };
+    const parameters = { parameters: {
+      ...this.props.defaultParameters[formName.toLowerCase()],
+      prefix, path } };
 
     const selected = [];
 
@@ -304,6 +305,7 @@ class SampleGridContainer extends React.Component {
 
     return content;
   }
+
 
   render() {
     const gridWidth = this.calcGridWidth();

--- a/mxcube3/ui/containers/SampleGridContainer.jsx
+++ b/mxcube3/ui/containers/SampleGridContainer.jsx
@@ -13,7 +13,7 @@ import {
   MenuItem,
   ButtonGroup,
   OverlayTrigger,
-  Tooltip
+  Tooltip,
 } from 'react-bootstrap';
 
 import {
@@ -109,7 +109,7 @@ class SampleGridContainer extends React.Component {
 
     const parameters = { parameters:
                          { ...this.props.defaultParameters[formName.toLowerCase()],
-                           prefix }
+                           prefix, path: prefix }
                        };
 
     const selected = [];
@@ -305,17 +305,45 @@ class SampleGridContainer extends React.Component {
     return content;
   }
 
-
   render() {
     const gridWidth = this.calcGridWidth();
     const innerSearchIcon = (
-      <DropdownButton title="" id="filter-drop-down">
-        <MenuItem onClick={this.filterSampleGridClear}>
-          Clear
-        </MenuItem>
-        <MenuItem onClick={this.filterSampleGridPicked}>
-          Picked
-        </MenuItem>
+      <DropdownButton bstyle="default" id="filter-drop-down">
+        <div style={{ padding: '1em', width: '300px' }}>
+          <b>Filter:</b>
+          <form style={{ marginTop: '1em' }}>
+            <div className="row">
+              <div className="col-xs-12">
+                <div className="col-xs-6">
+                  <span><Input type="radio" name="picked" value="picked"/> <b>Picked</b></span>
+                </div>
+                <div className="col-xs-6">
+                  <span><Input type="radio" name="picked" value="notPicked"/> <b>Not Picked</b></span>
+                </div>
+              </div>
+            </div>
+            <div className="row">
+              <div className="col-xs-12">
+                <div className="col-xs-6">
+                  <span><Input type="radio" name="collected" value="picked"/> <b>Collected</b></span>
+                </div>
+                <div className="col-xs-6">
+                  <span><Input type="radio" name="collected" value="notPicked"/> <b>Not Collected</b></span>
+                </div>
+              </div>
+            </div>
+            <div className="pull-right" style={{ paddingTop: '1em', paddingBottom: '1em' }}>
+              <ButtonGroup>
+                <Button eventKey="1">
+                  Clear
+                </Button>
+                <Button eventKey="2">
+                  Apply
+                </Button>
+              </ButtonGroup>
+            </div>
+          </form>
+        </div>
       </DropdownButton>
     );
 

--- a/mxcube3/ui/containers/SampleGridContainer.jsx
+++ b/mxcube3/ui/containers/SampleGridContainer.jsx
@@ -317,20 +317,28 @@ class SampleGridContainer extends React.Component {
             <div className="row">
               <div className="col-xs-12">
                 <div className="col-xs-6">
-                  <span><Input type="radio" name="picked" value="picked"/> <b>Picked</b></span>
+                  <span>
+                    <Input type="radio" name="picked" value="picked" /> <b>Picked</b>
+                  </span>
                 </div>
                 <div className="col-xs-6">
-                  <span><Input type="radio" name="picked" value="notPicked"/> <b>Not Picked</b></span>
+                  <span>
+                    <Input type="radio" name="picked" value="notPicked" /> <b>Not Picked</b>
+                  </span>
                 </div>
               </div>
             </div>
             <div className="row">
               <div className="col-xs-12">
                 <div className="col-xs-6">
-                  <span><Input type="radio" name="collected" value="picked"/> <b>Collected</b></span>
+                  <span>
+                    <Input type="radio" name="collected" value="picked" /> <b>Collected</b>
+                  </span>
                 </div>
                 <div className="col-xs-6">
-                  <span><Input type="radio" name="collected" value="notPicked"/> <b>Not Collected</b></span>
+                  <span>
+                    <Input type="radio" name="collected" value="notPicked" /> <b>Not Collected</b>
+                  </span>
                 </div>
               </div>
             </div>

--- a/mxcube3/ui/containers/SampleGridContainer.jsx
+++ b/mxcube3/ui/containers/SampleGridContainer.jsx
@@ -62,6 +62,7 @@ class SampleGridContainer extends React.Component {
     this.showCharacterisationForm = this.handleSubmit.bind(this, 'Characterisation');
     this.showDataCollectionForm = this.handleSubmit.bind(this, 'DataCollection');
     this.onClick = this.onClick.bind(this);
+    this.collectButton = this.collectButton.bind(this);
   }
 
 
@@ -246,6 +247,28 @@ class SampleGridContainer extends React.Component {
   }
 
 
+  collectButton() {
+    let button = (
+      <Button
+        className="btn btn-success pull-right"
+        href="#/datacollection"
+        disabled={this.isCollectDisabled()}
+      >
+        Collect {this.numSamplesPicked()}/{this.numSamples()}
+        <Glyphicon glyph="chevron-right" />
+      </Button>);
+
+    if (this.props.queue.queueStatus === 'QueueRunning') {
+      button = (
+        <Button className="btn btn-danger pull-right" >
+          <b> Stop queue </b>
+        </Button>);
+    }
+
+    return button;
+  }
+
+
   render() {
     const gridWidth = this.calcGridWidth();
     const innerSearchIcon = (
@@ -309,7 +332,7 @@ class SampleGridContainer extends React.Component {
           stickyStyle={{ padding: '10px' }}
         >
           <div className="row">
-            <div style={{ paddingLeft: '0px' }} className="col-xs-9">
+            <div style={{ paddingLeft: '0px' }} className="col-xs-5">
               <div className="form-inline">
                 <span >Select: </span>
                 <OverlayTrigger
@@ -372,24 +395,10 @@ class SampleGridContainer extends React.Component {
                   buttonAfter={innerSearchIcon}
                   onChange={this.filterSampleGrid}
                 />
-                <span style={{ marginLeft: '5em' }} >Grid size: </span>
-                <ButtonGroup>
-                  <Button>S</Button>
-                  <Button>M</Button>
-                  <Button>L</Button>
-                </ButtonGroup>
-                <span style={{ marginLeft: '5em' }} ></span>
               </div>
              </div>
              <div className="col-xs-2 pull-right">
-               <Button
-                 className="btn btn-success pull-right"
-                 href="#/datacollection"
-                 disabled={this.isCollectDisabled()}
-               >
-                 Collect {this.numSamplesPicked()}/{this.numSamples()}
-                 <Glyphicon glyph="chevron-right" />
-               </Button>
+               {this.collectButton()}
              </div>
           </div>
         </Sticky>

--- a/mxcube3/ui/containers/SampleGridContainer.jsx
+++ b/mxcube3/ui/containers/SampleGridContainer.jsx
@@ -94,8 +94,15 @@ class SampleGridContainer extends React.Component {
 
 
   handleSubmit(formName) {
+    let prefix = '';
+
+    if (Object.keys(this.props.selected).length === 1) {
+      prefix = this.props.sampleList[Object.keys(this.props.selected)[0]].defaultPrefix;
+    }
+
     const parameters = { parameters:
-                         { ...this.props.defaultParameters[formName.toLowerCase()] }
+                         { ...this.props.defaultParameters[formName.toLowerCase()],
+                           prefix }
                        };
 
     const selected = [];

--- a/mxcube3/ui/containers/SampleGridContainer.jsx
+++ b/mxcube3/ui/containers/SampleGridContainer.jsx
@@ -40,6 +40,9 @@ import SampleGrid from '../components/SampleGrid/SampleGrid';
 import { SAMPLE_ITEM_WIDTH, SAMPLE_ITEM_SPACE } from '../components/SampleGrid/SampleGridItem';
 import '../components/SampleGrid/SampleGrid.css';
 
+const QUEUE_STOPPED = 'QueueStopped';
+const QUEUE_RUNNING = 'QueueStarted';
+
 
 class SampleGridContainer extends React.Component {
 
@@ -63,6 +66,7 @@ class SampleGridContainer extends React.Component {
     this.showDataCollectionForm = this.handleSubmit.bind(this, 'DataCollection');
     this.onClick = this.onClick.bind(this);
     this.collectButton = this.collectButton.bind(this);
+    this.headerContent = this.headerContent.bind(this);
   }
 
 
@@ -81,7 +85,9 @@ class SampleGridContainer extends React.Component {
   onClick(e) {
     let res = true;
 
-    if (e.target.className.indexOf('samples-grid-item') > -1 && e.button === 2) {
+    if (this.props.queue.queueStatus === QUEUE_RUNNING) {
+      document.getElementById('contextMenu').style.display = 'none';
+    } else if (e.target.className.indexOf('samples-grid-item') > -1 && e.button === 2) {
       document.getElementById('contextMenu').style.top = `${e.clientY - 2}px`;
       document.getElementById('contextMenu').style.left = `${e.clientX - 65}px`;
       document.getElementById('contextMenu').style.display = 'block';
@@ -258,7 +264,7 @@ class SampleGridContainer extends React.Component {
         <Glyphicon glyph="chevron-right" />
       </Button>);
 
-    if (this.props.queue.queueStatus === 'QueueRunning') {
+    if (this.props.queue.queueStatus === QUEUE_RUNNING) {
       button = (
         <Button className="btn btn-danger pull-right" >
           <b> Stop queue </b>
@@ -266,6 +272,37 @@ class SampleGridContainer extends React.Component {
     }
 
     return button;
+  }
+
+
+  headerContent() {
+    let content = '';
+
+    if (this.props.queue.queueStatus === QUEUE_STOPPED) {
+      content = (
+        <ButtonToolbar>
+          <SplitButton
+            bsStyle="primary"
+            title={this.props.manualMount ? 'Manual Mount' : 'Check sample changer contents'}
+            onClick={this.props.manualMount ? this.showAddSampleForm : this.props.getSamples}
+            onSelect={this.manualMount}
+            id="split-button-sample-changer-selection"
+          >
+            <MenuItem eventKey="1">
+              {this.props.manualMount ? 'Sample changer' : 'Manual mount'}
+            </MenuItem>
+          </SplitButton>
+          <Button
+            className="btn-primary"
+            disabled={this.props.manualMount}
+            onClick={this.syncSamples}
+          >
+            <Glyphicon glyph="refresh" /> Sync. ISPyB
+          </Button>
+        </ButtonToolbar>);
+    }
+
+    return content;
   }
 
 
@@ -304,26 +341,7 @@ class SampleGridContainer extends React.Component {
         </ul>
         <div style={{ marginBottom: '20px' }} className="row row-centered">
           <div className="col-centered" >
-            <ButtonToolbar>
-              <SplitButton
-                bsStyle="primary"
-                title={this.props.manualMount ? 'Manual Mount' : 'Check sample changer contents'}
-                onClick={this.props.manualMount ? this.showAddSampleForm : this.props.getSamples}
-                onSelect={this.manualMount}
-                id="split-button-sample-changer-selection"
-              >
-                <MenuItem eventKey="1">
-                  {this.props.manualMount ? 'Sample changer' : 'Manual mount'}
-                </MenuItem>
-              </SplitButton>
-              <Button
-                className="btn-primary"
-                disabled={this.props.manualMount}
-                onClick={this.syncSamples}
-              >
-                <Glyphicon glyph="refresh" /> Sync. ISPyB
-              </Button>
-            </ButtonToolbar>
+            {this.headerContent()}
           </div>
         </div>
         <Sticky
@@ -354,6 +372,7 @@ class SampleGridContainer extends React.Component {
                   overlay={(<Tooltip>Add Tasks</Tooltip>)}
                 >
                   <DropdownButton
+                    disabled={this.props.queue.queueStatus === QUEUE_RUNNING}
                     bsStyle="default"
                     title={<span><Glyphicon glyph="plus" /></span>}
                     id="pipeline-mode-dropdown"
@@ -375,6 +394,7 @@ class SampleGridContainer extends React.Component {
                   overlay={(<Tooltip>Remove Tasks</Tooltip>)}
                 >
                   <DropdownButton
+                    disabled={this.props.queue.queueStatus === QUEUE_RUNNING}
                     bsStyle="default"
                     title={<span><Glyphicon glyph="minus" /></span>}
                     id="pipeline-mode-dropdown"

--- a/mxcube3/ui/containers/TaskContainer.js
+++ b/mxcube3/ui/containers/TaskContainer.js
@@ -34,6 +34,7 @@ class TaskContainer extends React.Component {
     this.props.clearQueue();
     this.props.appendSampleList(sampleData);
     this.props.addSample(sampleData);
+    this.props.selectSamples([sampleData.sampleID], true);
     this.props.setCurrentSample(sampleData.sampleID);
   }
 

--- a/mxcube3/ui/reducers/queue.js
+++ b/mxcube3/ui/reducers/queue.js
@@ -132,10 +132,13 @@ export default (state = initialState, action) => {
 
       // Not creating a copy here since we know that the reference
       // displayData[sampleID] did not exist before
-      action.sampleData.tasks.map((task) => {
+      for (const task of action.sampleData.tasks) {
         displayData[sampleID].tasks.push({ collapsed: false, state: 0 });
-        return task;
-      });
+
+        if (task.parameters.prefix === '') {
+          task.parameters.prefix = state.sampleList[sampleID].defaultPrefix;
+        }
+      }
 
       return Object.assign({}, state,
         {
@@ -166,12 +169,17 @@ export default (state = initialState, action) => {
         // Adding the new task to the queue
     case 'ADD_TASK': {
       const sampleID = action.task.sampleID;
+      const task = action.task;
+
+      if (task.parameters.prefix === '') {
+        task.parameters.prefix = state.sampleList[sampleID].defaultPrefix;
+      }
 
       const queue = {
         ...state.queue,
         [sampleID]: {
           ...state.queue[sampleID],
-          tasks: [...state.queue[sampleID].tasks, action.task]
+          tasks: [...state.queue[sampleID].tasks, task]
         }
       };
 

--- a/mxcube3/ui/reducers/queue.js
+++ b/mxcube3/ui/reducers/queue.js
@@ -186,7 +186,7 @@ export default (state = initialState, action) => {
         }
       };
 
-      const sampleOrder = [...state.order, sampleID];
+      const sampleOrder = [...state.sampleOrder, sampleID];
 
       return Object.assign({}, state, { displayData, queue, sampleOrder });
     }

--- a/mxcube3/ui/reducers/queue.js
+++ b/mxcube3/ui/reducers/queue.js
@@ -35,14 +35,14 @@ export default (state = initialState, action) => {
     }
     case 'SET_SAMPLE_ORDER': {
       const sortedOrder = Object.entries(action.order).sort((a, b) => a[1] > b[1]);
-      const sampleOrder = [...state.sampleOrder];     
+      const sampleOrder = [...state.sampleOrder];
       let i = 0;
 
       // Use the grid order to generate the order of the samples in the queue
       // iterate over the sorted grid order, updating only those indexes that
       // have changed
       for (const [key] of sortedOrder) {
-        if (Object.keys(state.queue).includes(key)) {          
+        if (Object.keys(state.queue).includes(key)) {
           if (sampleOrder[i] !== key) {
             sampleOrder[i] = key;
           }
@@ -186,7 +186,7 @@ export default (state = initialState, action) => {
         }
       };
 
-      const sampleOrder = [ ...state.order, sampleID];
+      const sampleOrder = [...state.order, sampleID];
 
       return Object.assign({}, state, { displayData, queue, sampleOrder });
     }
@@ -210,7 +210,7 @@ export default (state = initialState, action) => {
         }
       };
 
-      const sampleOrder = without(state.order, sampleID);
+      const sampleOrder = without(state.order, action.sampleID);
 
       return Object.assign({}, state, { displayData, queue, sampleOrder });
     }

--- a/mxcube3/ui/reducers/queue.js
+++ b/mxcube3/ui/reducers/queue.js
@@ -27,10 +27,7 @@ export default (state = initialState, action) => {
       return Object.assign({}, state, { sampleList: action.sampleList });
     }
     case 'APPEND_TO_SAMPLE_LIST': {
-      const sampleData = action.sampleData;
-      const sampleList = { ...state.sampleList };
-      sampleList[sampleData.sampleID] = sampleData;
-
+      const sampleList = { ...state.sampleList, [action.sampleData.sampleID]: action.sampleData };
       return Object.assign({}, state, { sampleList });
     }
     case 'SET_SAMPLE_ORDER': {
@@ -130,8 +127,8 @@ export default (state = initialState, action) => {
     // Adding sample to queue
     case 'ADD_SAMPLE': {
       const sampleID = action.sampleData.sampleID;
-      const displayData = { ...state.displayData };
-      displayData[sampleID] = { collapsed: false, state: 0, tasks: [] };
+      const displayData = { ...state.displayData,
+                            [sampleID]: { collapsed: false, state: 0, tasks: [] } };
 
       // Not creating a copy here since we know that the reference
       // displayData[sampleID] did not exist before

--- a/mxcube3/ui/reducers/queue.js
+++ b/mxcube3/ui/reducers/queue.js
@@ -90,7 +90,8 @@ export default (state = initialState, action) => {
             {
               ...state.queue[action.sampleID].tasks[action.taskIndex],
               checked: false,
-              limsID: action.limsID
+              limsID: action.limsID,
+              state: action.state
             },
             ...state.queue[action.sampleID].tasks.slice(action.taskIndex + 1)
           ]
@@ -105,7 +106,6 @@ export default (state = initialState, action) => {
             ...state.displayData[action.sampleID].tasks.slice(0, action.taskIndex),
             {
               ...state.displayData[action.sampleID].tasks[action.taskIndex],
-              state: action.state,
               progress: action.progress
             },
             ...state.displayData[action.sampleID].tasks.slice(action.taskIndex + 1)
@@ -127,13 +127,13 @@ export default (state = initialState, action) => {
     // Adding sample to queue
     case 'ADD_SAMPLE': {
       const sampleID = action.sampleData.sampleID;
-      const displayData = { ...state.displayData,
-                            [sampleID]: { collapsed: false, state: 0, tasks: [] } };
+      const displayData = { ...state.displayData, [sampleID]: { collapsed: false, tasks: [] } };
 
       // Not creating a copy here since we know that the reference
       // displayData[sampleID] did not exist before
       for (const task of action.sampleData.tasks) {
-        displayData[sampleID].tasks.push({ collapsed: false, state: 0 });
+        displayData[sampleID].tasks.push({ collapsed: false });
+        task.state = 0;
 
         if (task.parameters.prefix === '') {
           task.parameters.prefix = state.sampleList[sampleID].defaultPrefix;
@@ -144,7 +144,7 @@ export default (state = initialState, action) => {
         {
           displayData,
           todo: { ...state.todo, nodes: state.todo.nodes.concat(sampleID) },
-          queue: { ...state.queue, [sampleID]: action.sampleData },
+          queue: { ...state.queue, [sampleID]: { ...action.sampleData, state: 0 } },
           sampleOrder: [...state.sampleOrder, sampleID],
           manualMount: { ...state.manualMount, id: state.manualMount.id + 1 }
         }
@@ -179,7 +179,7 @@ export default (state = initialState, action) => {
         ...state.queue,
         [sampleID]: {
           ...state.queue[sampleID],
-          tasks: [...state.queue[sampleID].tasks, task]
+          tasks: [...state.queue[sampleID].tasks, { ...task, state: 0 }]
         }
       };
 
@@ -187,7 +187,7 @@ export default (state = initialState, action) => {
         ...state.displayData,
         [sampleID]: {
           ...state.displayData[sampleID],
-          tasks: [...state.displayData[sampleID].tasks, { collapsed: false, state: 0 }]
+          tasks: [...state.displayData[sampleID].tasks, { collapsed: false }]
         }
       };
 

--- a/test/HardwareObjectsMockup.xml/lims-rest.xml
+++ b/test/HardwareObjectsMockup.xml/lims-rest.xml
@@ -6,7 +6,7 @@
    ESRF
   </site>
   <exi_root>
-   https://yout.exi.org/mx/
+   https://your.exi.org
   </exi_root>
   <restUserName></restUserName>
   <restPass></restPass>

--- a/test/HardwareObjectsMockup.xml/lims-rest.xml
+++ b/test/HardwareObjectsMockup.xml/lims-rest.xml
@@ -1,30 +1,16 @@
-<object class="ISPyBRestClient">
+<object class="ISPyBClient2Mockup">
   <restRoot>
-    https://ispyvalid.esrf.fr:8080/ispyb/ispyb-ws/rest/
+   https://your.lims.org
   </restRoot>
   <site>
    ESRF
   </site>
   <exi_root>
-   https://exi.esrf.fr/mx/
+   https://yout.exi.org/mx/
   </exi_root>
   <restUserName></restUserName>
   <restPass></restPass>
 
   <object role="session" href="/session"/>
 
-  <proposals>
-    <proposal>
-      <code>ifx</code>
-      <ispyb>fx</ispyb>
-      <gui>fx</gui>
-    </proposal>
-  </proposals>
-
-  <inhouse>
-    <proposal>
-      <code>opid</code>
-      <number>30</number>
-    </proposal>
-  </inhouse>
 </object>

--- a/test/HardwareObjectsMockup.xml/lims.xml
+++ b/test/HardwareObjectsMockup.xml/lims.xml
@@ -1,27 +1,9 @@
-<object class="ISPyBClient2">
+<object class="ISPyBClient2Mockup">
   <ws_root>
-    http://ispybvalid.esrf.fr:8080/ispyb/ispyb-ws/ispybWS/
-    <!-- http://160.103.210.1:8080/ispyb-ejb3/ispybWS/
-    http://160.103.210.124:8080/ispyb-ws/ispybWS/ -->
+    https://your.lims.org
   </ws_root>
   <ws_username></ws_username>
   <ws_password></ws_password>
   <object role="session" href="/session"/>
   <object role="ldapServer" href="/ldapconnection"/>
-  <beamline_name>ID30A-3</beamline_name>
-
-  <proposals>
-    <proposal>
-      <code>ifx</code>
-      <ispyb>fx</ispyb>
-      <gui>fx</gui>
-    </proposal>
-  </proposals>
-
-  <inhouse>
-    <proposal>
-      <code>opid</code>
-      <number>30</number>
-    </proposal>
-  </inhouse>
 </object>


### PR DESCRIPTION
Dear all,

I wanted to divide this PR into two PRs, one for queue integration and one for LIMS but I finally decided that it was easier to just have one. In anyways, that's why there are both LIMS and queue related features in the same PR :). Ill try to avoid this in the future ...

I started to take care of the sample order, since the JS object is non ordered. Ive created a structure called sampleOrder and refactored the grid-ordering slightly for that purpose. The next thing to do is to use this in the queue and finally of course on the back end so that the samples are executed in order :). Exactly how to use this have to be determined it could perhaps be replaced by or replace the existing todo structure.

The "execution state" of a task was moved from dislpayData to queue. There are also some smaller improvements to the grid, like disabling certain controls while executing.

For the lims part, Ive started to prepare for having the data collection results being shown (LIMS collection ID being sent as part of the result) . The prefix is now taken from the Session object. There is also a new UI for filtering (although not completely done yet).

The mockup objects for lims are also used by default :)

Ive not yet had the time to take care of the proposal list for the "one login" to "many proposal" mapping. Ill try to do it next week (when our shutdown is over).

Cheers,
Marcus

