### PR TITLE
Remove eventlisteners or they will be global over whole application

### DIFF
--- a/mxcube3/ui/containers/SampleGridContainer.jsx
+++ b/mxcube3/ui/containers/SampleGridContainer.jsx
@@ -74,6 +74,10 @@ class SampleGridContainer extends React.Component {
     document.addEventListener('click', this.onClick, false);
   }
 
+  componentWillUnmount() {
+    // Important to remove listener if component isn't active
+    document.removeEventListener('click', this.onClick);
+  }
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.queue.queue !== this.props.queue.queue) {

--- a/mxcube3/ui/containers/SampleGridContainer.jsx
+++ b/mxcube3/ui/containers/SampleGridContainer.jsx
@@ -74,17 +74,16 @@ class SampleGridContainer extends React.Component {
     document.addEventListener('click', this.onClick, false);
   }
 
-  componentWillUnmount() {
-    // Important to remove listener if component isn't active
-    document.removeEventListener('click', this.onClick);
-  }
-
   componentWillReceiveProps(nextProps) {
     if (nextProps.queue.queue !== this.props.queue.queue) {
       this.props.setSampleOrderAction(nextProps.order);
     }
   }
 
+  componentWillUnmount() {
+    // Important to remove listener if component isn't active
+    document.removeEventListener('click', this.onClick);
+  }
 
   onClick(e) {
     let res = true;


### PR DESCRIPTION
This fixes, that the contextmenu appears and disappears on righclick