### PR TITLE
Queue serialization and persistent storage (in redis)

### DIFF
--- a/mxcube3/__init__.py
+++ b/mxcube3/__init__.py
@@ -91,7 +91,8 @@ if not app.debug or os.environ.get("WERKZEUG_RUN_MAIN") == "true":
 
     ### Importing all REST-routes
     from routes import (Main, Login, Beamline, Collection, Mockups, Utils,
-                        SampleCentring, SampleChanger, Diffractometer, lims)
+                        SampleCentring, SampleChanger, Diffractometer, Queue,
+                        lims, qutils)
 
     ### Install server-side UI state storage
     from mxcube3 import state_storage
@@ -110,6 +111,7 @@ if not app.debug or os.environ.get("WERKZEUG_RUN_MAIN") == "true":
         app.empty_queue = pickle.dumps(hwr.getHardwareObject(cmdline_options.queue_model))
         app.sample_changer = app.beamline.getObjectByRole("sample_changer")
         app.rest_lims = app.beamline.getObjectByRole("lims_rest_client")
+        app.queue = qutils.new_queue()
 
 
         try:

--- a/mxcube3/routes/Login.py
+++ b/mxcube3/routes/Login.py
@@ -46,6 +46,16 @@ def login():
 
         LOGGED_IN_USER = loginID
 
+        # Create a new queue just in case any previous queue was not cleared
+        # properly
+        mxcube.queue = qutils.new_queue()
+
+        # For the moment not loading queue from persistent storage (redis),
+        # uncomment to enable loading.
+        #qutils.load_queue(session)
+        #logging.getLogger('HWR').info('Loaded queue')
+        logging.getLogger('HWR').info('[QUEUE] %s ' % qutils.queue_to_json())
+
         if not remote_access.MASTER:
             remote_access.set_master(session.sid)
 
@@ -58,6 +68,9 @@ def signout():
     Signout from Mxcube3 and reset the session
     """
     global LOGGED_IN_USER
+
+    qutils.save_queue(session)
+    mxcube.queue = qutils.new_queue()
 
     LOGGED_IN_USER = None
     if remote_access.is_master(session.sid):
@@ -107,7 +120,7 @@ def loginInfo():
         session['loginInfo'] = login_info
 
     print 'SESSION SID =', session.sid  
-    mxcube.queue = qutils.get_queue(session)
+    mxcube.queue = qutils.load_queue(session)
     logging.getLogger('HWR').info('Loaded queue')
     logging.getLogger('HWR').info('[QUEUE] %s ' % qutils.queue_to_json())
 

--- a/mxcube3/routes/Login.py
+++ b/mxcube3/routes/Login.py
@@ -119,11 +119,7 @@ def loginInfo():
             remote_access.set_master(session.sid)
         session['loginInfo'] = login_info
 
-    print 'SESSION SID =', session.sid  
-    mxcube.queue = qutils.load_queue(session)
-    logging.getLogger('HWR').info('Loaded queue')
-    logging.getLogger('HWR').info('[QUEUE] %s ' % qutils.queue_to_json())
-
+    print 'SESSION SID =', session.sid
     login_info = login_info["loginRes"] if login_info is not None else {}
     login_info = limsutils.convert_to_dict(login_info)
 

--- a/mxcube3/routes/Queue.py
+++ b/mxcube3/routes/Queue.py
@@ -107,7 +107,7 @@ def queue_clear():
     """
     mxcube.diffractometer.savedCentredPos = []
     mxcube.queue = qutils.new_queue()
-    qutils.save_queue(session)
+    #qutils.save_queue(session)
     logging.getLogger('HWR').info('[QUEUE] Cleared  ' +
                                   str(mxcube.queue.get_model_root()._name))
     return Response(status=200)
@@ -164,7 +164,7 @@ def execute_entry_with_id(sid, tindex):
 def queue_add_item():
      qutils.queue_add_item(request.get_json())
      #logging.getLogger('HWR').info('[QUEUE] is:\n%s ' % qutils.queue_to_json())
-     qutils.save_queue(session)
+     #qutils.save_queue(session)
      return Response(status=200)
 
 
@@ -186,7 +186,7 @@ def queue_update_item(sid, tindex):
         qutils.set_char_params(model, entry, data)
 
     logging.getLogger('HWR').info('[QUEUE] is:\n%s ' % qutils.queue_to_json())
-    qutils.save_queue(session)
+    #qutils.save_queue(session)
     return Response(status=200)
 
 
@@ -209,7 +209,7 @@ def queue_delete_item(sid, tindex):
     qutils.delete_entry(entry)
 
     #logging.getLogger('HWR').info('[QUEUE] is:\n%s ' % qutils.queue_to_json())
-    qutils.save_queue(session)
+    #qutils.save_queue(session)
     return Response(status=200)
 
 
@@ -217,7 +217,7 @@ def queue_delete_item(sid, tindex):
 def queue_swap_task_item(sid, ti1, ti2):
     qutils.swap_task_entry(sid, int(ti1), int(ti2))
     #logging.getLogger('HWR').info('[QUEUE] is:\n%s ' % qutils.queue_to_json())
-    qutils.save_queue(session)
+    #qutils.save_queue(session)
     return Response(status=200) 
    
 
@@ -244,7 +244,7 @@ def update_sample(sample_id):
         # TODO: update here the model with the new 'params'
         # missing lines...
         sample_entry.set_data_model(sample_node)
-        qutils.save_queue(session)
+        #qutils.save_queue(session)
         logging.getLogger('HWR').info('[QUEUE] sample updated')
         resp = jsonify({'QueueId': node_id})
         resp.status_code = 200
@@ -352,7 +352,7 @@ def add_centring(id):
 
     logging.getLogger('HWR').info('[QUEUE] centring added to sample')
 
-    qutils.save_queue(session)
+    #qutils.save_queue(session)
 
     resp = jsonify({'QueueId': new_node,
                     'Type': 'Centring',

--- a/mxcube3/routes/Queue.py
+++ b/mxcube3/routes/Queue.py
@@ -1,4 +1,3 @@
-import time
 import json
 import logging
 import signals
@@ -13,28 +12,6 @@ from mxcube3 import socketio
 from . import qutils
 
 qm = QueueManager.QueueManager('Mxcube3')
-
-
-def init_signals(queue):
-    """Initialize hwobj signals."""
-    for signal in signals.collect_signals:
-        mxcube.collect.connect(mxcube.collect, signal,
-                               signals.task_event_callback)
-    mxcube.collect.connect(mxcube.collect, 'collectOscillationStarted',
-                           signals.collect_oscillation_started)
-    mxcube.collect.connect(mxcube.collect, 'collectOscillationFailed',
-                           signals.collect_oscillation_failed)
-    mxcube.collect.connect(mxcube.collect, 'collectOscillationFinished',
-                           signals.collect_oscillation_finished)
-    queue.connect(queue, 'child_added', qutils.add_diffraction_plan)
-
-    queue.queue_hwobj.connect("queue_execute_started",
-                              signals.queue_execution_started)
-
-    queue.queue_hwobj.connect("queue_execution_finished",
-                              signals.queue_execution_finished)
-
-    queue.queue_hwobj.connect("collectEnded", signals.collect_ended)
 
 
 @mxcube.route("/mxcube/api/v0.1/queue/start", methods=['PUT'])

--- a/mxcube3/routes/qutils.py
+++ b/mxcube3/routes/qutils.py
@@ -16,9 +16,6 @@ from mxcube3 import app as mxcube
 from mxcube3 import socketio
 
 
-class PMock(Mock):
-    def __reduce__(self):
-        return (Mock, ())
 
 
 def node_index(node):
@@ -128,7 +125,7 @@ def queue_to_json(node=None):
              the TaskNode type (Datacollection, Chracterisation, Sample). The
              task dict can be directly used with the set_from_dict methods of
              the corresponding node.
-    """
+    """   
     if not node:
         node = mxcube.queue.get_model_root()
     
@@ -369,7 +366,7 @@ def add_sample(sample_id, item):
     else:
         sample_model.location = item['location'].split(':')
 
-    sample_entry = qe.SampleQueueEntry(PMock(), sample_model)
+    sample_entry = qe.SampleQueueEntry(Mock(), sample_model)
     sample_entry.set_enabled(True)
     
     mxcube.queue.add_child(mxcube.queue.get_model_root(), sample_model)
@@ -465,7 +462,7 @@ def _create_dc(task):
     :rtype: Tuple
     """
     dc_model = qmo.DataCollection()
-    dc_entry = qe.DataCollectionQueueEntry(PMock(), dc_model)
+    dc_entry = qe.DataCollectionQueueEntry(Mock(), dc_model)
 
     return dc_model, dc_entry
 
@@ -488,7 +485,7 @@ def add_characterisation(node_id, task):
     char_params = qmo.CharacterisationParameters().set_from_dict(params)
 
     char_model = qmo.Characterisation(refdc_model, char_params)
-    char_entry = qe.CharacterisationGroupQueueEntry(PMock(), char_model)
+    char_entry = qe.CharacterisationGroupQueueEntry(Mock(), char_model)
     char_entry.queue_model_hwobj = mxcube.queue
     # Set the characterisation and reference collection parameters 
     set_char_params(char_model, char_entry, task)
@@ -501,7 +498,7 @@ def add_characterisation(node_id, task):
     mxcube.queue.add_child(sample_model, refgroup_model)
     mxcube.queue.add_child(refgroup_model, char_model)
     
-    refgroup_entry = qe.TaskGroupQueueEntry(PMock(), refgroup_model)
+    refgroup_entry = qe.TaskGroupQueueEntry(Mock(), refgroup_model)
     refgroup_entry.set_enabled(True)
     sample_entry.enqueue(refgroup_entry)
     refgroup_entry.enqueue(char_entry)
@@ -539,7 +536,7 @@ def add_data_collection(node_id, task):
     mxcube.queue.add_child(sample_model, group_model)
     mxcube.queue.add_child(group_model, dc_model)
 
-    group_entry = qe.TaskGroupQueueEntry(PMock(), group_model)
+    group_entry = qe.TaskGroupQueueEntry(Mock(), group_model)
     group_entry.set_enabled(True)
     sample_entry.enqueue(group_entry)
     group_entry.enqueue(dc_entry)
@@ -608,8 +605,8 @@ def add_diffraction_plan(parent, child):
             # name example string 'Diffraction plan - 3'
             # then we do know that we need to add the entry here
             # Create a new entry for the new child, in this case a data collection
-            dc_entry = qe.DataCollectionQueueEntry(PMock(), child)
-            dcg_entry = qe.TaskGroupQueueEntry(PMock(), parent)
+            dc_entry = qe.DataCollectionQueueEntry(Mock(), child)
+            dcg_entry = qe.TaskGroupQueueEntry(Mock(), parent)
 
             parent.set_enabled(True)
             dcg_entry.set_enabled(True)

--- a/mxcube3/routes/qutils.py
+++ b/mxcube3/routes/qutils.py
@@ -16,8 +16,6 @@ from mxcube3 import app as mxcube
 from mxcube3 import socketio
 
 
-
-
 def node_index(node):
     """
     Get the position (index) in the queue, sample and node id of node <node>.
@@ -578,7 +576,6 @@ def load_queue(session, redis=redis.Redis()):
 
     :param session: Session for queue to load
     :param redis: Redis database
-    
     """
     proposal_id = Utils._proposal_id(session)
 
@@ -592,8 +589,7 @@ def add_diffraction_plan(parent, child):
     """
     Listen to the addition of elements to the queue ('child_added')
     and if it is a diff plan create the appropiate queue entry and
-    emit a s
-    ocketio signal.
+    emit a socketio signal.
     This is to overcome the fact that the Characterisation entry only
     creates the model of the diff plan.
     """
@@ -603,8 +599,8 @@ def add_diffraction_plan(parent, child):
 
         if 'Diffraction plan' in parent_model.get_name():
             # name example string 'Diffraction plan - 3'
-            # then we do know that we need to add the entry here
-            # Create a new entry for the new child, in this case a data collection
+            # Then we do know that we need to add the entry here, Create a
+            # new entry for the new child, in this case a data collection
             dc_entry = qe.DataCollectionQueueEntry(Mock(), child)
             dcg_entry = qe.TaskGroupQueueEntry(Mock(), parent)
 
@@ -619,12 +615,14 @@ def add_diffraction_plan(parent, child):
             # TODO: check if the parent entry exits in case multiple diff plans
             sample_entry.enqueue(dcg_entry)
 
-            # Add the entry to the newly created task group, brother to the characterisation
+            # Add the entry to the newly created task group, brother to the
+            # characterisation
             dcg_entry.enqueue(dc_entry)
 
             msg = _handle_dc(sample._node_id, child)
             msg['parameters']['typePrefix'] = 'P'
-            # TODO: add saved centring pos id, centred_position is removed in _handle_dc
+            # TODO: add saved centring pos id, centred_position is removed in
+            # _handle_dc
             socketio.emit('add_task', msg, namespace='/hwr')
 
 

--- a/mxcube3/ui/reducers/beamline.js
+++ b/mxcube3/ui/reducers/beamline.js
@@ -144,7 +144,11 @@ export default (state = INITIAL_STATE, action) => {
                 pixelsPerMm: action.data.pixelsPerMm[0]
       };
     case 'SAVE_MOTOR_POSITION':
-      return { ...state, motors: { ...state.motors, [action.name]: { position: action.value, Status: state.motors[action.name].Status } } };
+      return { ...state, motors: { ...state.motors, [action.name]:
+                                   { position: action.value,
+                                     Status: state.motors[action.name].Status }
+                                 }
+             };
     case 'SET_INITIAL_STATUS':
       return { ...state,
         motors: { ...state.motors, ...action.data.Motors },

--- a/mxcube3/ui/reducers/queue.js
+++ b/mxcube3/ui/reducers/queue.js
@@ -33,7 +33,7 @@ export default (state = initialState, action) => {
     case 'SET_SAMPLE_ORDER': {
       const sortedOrder = invert(action.order);
       const sampleOrder = [];
- 
+
       Object.values(sortedOrder).forEach((key) => {
         if (Reflect.has(state.queue, key)) {
           sampleOrder.push(key);


### PR DESCRIPTION
Hey !

Added some missing pieces to the queue serialization to for instance handle helical scans. Also added the routines necessary to load a queue from its serialized format. Which at the moment is a pickled dictionary (the one returned by queue_to_dict). We could use any queue_to method if we consider one representation being better than the other.

A side note, there is now a parameter in the parameters dict of the data collection named 'helical' its perhaps possible to renamed it to experimentType (or similar). This would match the internal model better and also makes it possible to easily add other types of data collection without adding an extra parameter.

Ive also disabled the loading for persistent storage, for the moment, since its causing us some problems with adding things to the queue. Not only because of PMock but also because the queue is loaded on login and not synchronized with the UI. We thus sometimes try to add the same samples twice which produces an error. 

The queue is currently saved on logout, the idea is also to save it on any other client disconnect event. And restore it on login if there is no "active" session.

Also note that restoring a queue from persistent storage also depends on the state of the hardware at the time of the save so it might not be as straightforward as just performing a load queue. So I prefer not to load the queue for the time being, until we have defined what to restore when ...

Cheers,
Marcus
