### PR TITLE
Fix for #366

### DIFF
--- a/mxcube3/__init__.py
+++ b/mxcube3/__init__.py
@@ -94,7 +94,7 @@ if not app.debug or os.environ.get("WERKZEUG_RUN_MAIN") == "true":
                         SampleCentring, SampleChanger, Diffractometer, lims)
 
     ### Install server-side UI state storage
-    import state_storage
+    from mxcube3 import state_storage
 
     def complete_initialization(app):
         app.beamline = hwr.getHardwareObject(cmdline_options.beamline_setup)

--- a/mxcube3/remote_access.py
+++ b/mxcube3/remote_access.py
@@ -1,0 +1,57 @@
+from flask import request, session
+from mxcube3 import socketio
+from collections import deque
+
+MASTER = None
+MASTER_ROOM = None
+PENDING_EVENTS = deque()
+
+def set_master(master_sid):
+    global MASTER
+    MASTER = master_sid
+
+def is_master(sid):
+    return MASTER == sid
+
+def flush():
+    global MASTER
+    global PENDING_EVENTS
+    MASTER = None
+    PENDING_EVENTS = deque()
+
+def _event_callback():
+    event_id, event, json_dict, kw = PENDING_EVENTS.popleft()
+    emit_pending_events()
+
+def emit_pending_events():
+    try:
+        event_id, event, json_dict, kwargs = PENDING_EVENTS[0] 
+    except IndexError:
+        pass
+    else:
+        return _emit(event, json_dict, **kwargs)
+
+def _emit(event, json_dict, **kwargs):
+    kw = dict(kwargs)
+    kw['callback'] = _event_callback
+    kw['room'] = MASTER_ROOM
+    socketio.emit(event, json_dict, **kw)
+
+def safe_emit(event, json_dict, **kwargs):
+    PENDING_EVENTS.append((id(json_dict), event, json_dict, kwargs))
+    if len(PENDING_EVENTS) == 1:
+        emit_pending_events()
+
+@socketio.on('connect', namespace='/hwr')
+def connect():
+    global MASTER_ROOM
+    if is_master(session.sid):
+        MASTER_ROOM = request.sid
+        emit_pending_events() 
+
+@socketio.on('setRaMaster', namespace='/hwr')
+def set_master_id():
+    global MASTER_ROOM
+    MASTER_ROOM = request.sid
+    emit_pending_events()
+ 

--- a/mxcube3/routes/signals.py
+++ b/mxcube3/routes/signals.py
@@ -4,6 +4,7 @@ from mxcube3 import socketio
 from mxcube3 import app as mxcube
 from mxcube3.routes import Utils
 from mxcube3.routes import qutils
+from mxcube3.remote_access import safe_emit
 
 
 def last_queue_node():
@@ -13,12 +14,6 @@ def last_queue_node():
         node = parent._children[0]  # but the rfdc children not here @#@#!!!
     return qutils.node_index(node)
 
-
-@socketio.on('connect', namespace='/hwr')
-def connect():
-    # this is needed to create the namespace, and the actual connection
-    # to the server, but we don't need to do anything more
-    pass
 
 collect_signals = ['collectStarted', 'testSignal', 'warning']
 collect_osc_signals = ['collectOscillationStarted', 'collectOscillationFailed', 'collectOscillationFinished']
@@ -137,7 +132,7 @@ def queue_execution_started(entry):
            'Message': 'Queue execution started',
            'State': 1}
 
-    socketio.emit('queue', msg, namespace='/hwr')
+    safe_emit('queue', msg, namespace='/hwr')
 
 
 def queue_execution_finished(entry):
@@ -145,7 +140,7 @@ def queue_execution_finished(entry):
            'Message': 'Queue execution stopped',
            'State': 1}
 
-    socketio.emit('queue', msg, namespace='/hwr')
+    safe_emit('queue', msg, namespace='/hwr')
 
 
 def queue_execution_failed(entry):    
@@ -153,7 +148,7 @@ def queue_execution_failed(entry):
            'Message': 'Queue execution stopped',
            'State': 2}
 
-    socketio.emit('queue', msg, namespace='/hwr')
+    safe_emit('queue', msg, namespace='/hwr')
 
 
 def collect_oscillation_started(*args):
@@ -166,7 +161,7 @@ def collect_oscillation_started(*args):
 
     logging.getLogger('HWR').debug('[TASK CALLBACK] ' + str(msg))
     try:
-        socketio.emit('task', msg, namespace='/hwr')
+        safe_emit('task', msg, namespace='/hwr')
     except Exception:
         logging.getLogger("HWR").error('error sending message: ' + str(msg))
 
@@ -181,7 +176,7 @@ def collect_oscillation_failed(owner, status, state, lims_id, osc_id, params):
            'progress': 100}
     logging.getLogger('HWR').debug('[TASK CALLBACK]   ' + str(msg))
     try:
-        socketio.emit('task', msg, namespace='/hwr')
+        safe_emit('task', msg, namespace='/hwr')
     except Exception:
         logging.getLogger("HWR").error('error sending message: ' + str(msg))
 
@@ -198,7 +193,7 @@ def collect_oscillation_finished(owner, status, state, lims_id, osc_id, params):
            'progress': 100}
     logging.getLogger('HWR').debug('[TASK CALLBACK] ' + str(msg))
     try:
-        socketio.emit('task', msg, namespace='/hwr')
+        safe_emit('task', msg, namespace='/hwr')
     except Exception:
         logging.getLogger("HWR").error('error sending message: ' + str(msg))
 
@@ -214,7 +209,7 @@ def collect_ended(owner, success, message):
            'progress': 100}
     logging.getLogger('HWR').debug('[TASK CALLBACK] ' + str(msg))
     try:
-        socketio.emit('task', msg, namespace='/hwr')
+        safe_emit('task', msg, namespace='/hwr')
     except Exception:
         logging.getLogger("HWR").error('error sending message: ' + str(msg))
 
@@ -232,7 +227,7 @@ def task_event_callback(*args, **kwargs):
            'progress': get_signal_progress(kwargs['signal'])}
     logging.getLogger('HWR').debug('[TASK CALLBACK] ' + str(msg))
     try:
-        socketio.emit('task', msg, namespace='/hwr')
+        safe_emit('task', msg, namespace='/hwr')
     except Exception:
         logging.getLogger("HWR").error('error sending message: ' + str(msg))
     # try:

--- a/mxcube3/state_storage.py
+++ b/mxcube3/state_storage.py
@@ -1,10 +1,13 @@
 from flask import request
 from flask.ext.socketio import emit, join_room, leave_room
 from mxcube3 import socketio
-from routes import Login
 import json
 
 UI_STATE = dict()
+
+def flush():
+    global UI_STATE
+    UI_STATE = dict()
 
 @socketio.on('connect', namespace='/ui_state')
 def connect():
@@ -28,19 +31,16 @@ def ui_state_rm(k):
 
 @socketio.on('ui_state_set', namespace='/ui_state')
 def ui_state_update(key_val):
-    print request.sid, 'leaving slaves room'
-    leave_room('raSlaves')
+    leave_room("raSlaves")
 
     key, val = key_val
     print 'ui state SET', key
     UI_STATE[key.replace("reduxPersist:", "")] = json.loads(val)
-    #print ' '*10,json.loads(val)
 
     emit("state_update", json.dumps(UI_STATE), namespace="/ui_state", room="raSlaves")
 
 @socketio.on('ui_state_getkeys', namespace='/ui_state')
 def ui_state_getkeys(*args):
-    print request.sid,'entering slaves room'
     join_room("raSlaves")
 
     return ['reduxPersist:'+k for k in UI_STATE.iterkeys()]

--- a/mxcube3/ui/actions/remoteAccess.js
+++ b/mxcube3/ui/actions/remoteAccess.js
@@ -1,4 +1,13 @@
+import { serverIO } from '../serverIO';
+
 export function setMaster(master) {
+  if (master) {
+    return function (dispatch) {
+      serverIO.setRemoteAccessMaster(() => {
+        dispatch({ type: 'SET_MASTER', master });
+      });
+    };
+  }
   return { type: 'SET_MASTER', master };
 }
 

--- a/mxcube3/ui/components/Login/Login.jsx
+++ b/mxcube3/ui/components/Login/Login.jsx
@@ -12,10 +12,6 @@ class Login extends React.Component {
     this.handleKeyPress = this.handleKeyPress.bind(this);
   }
 
-  componentWillMount() {
-    this.props.getLoginInfo();
-  }
-
   componentWillReceiveProps(nextProps) {
     if (nextProps.status.code === 'ok') {
       window.location.assign('#datacollection');

--- a/mxcube3/ui/main.jsx
+++ b/mxcube3/ui/main.jsx
@@ -15,7 +15,7 @@ import thunk from 'redux-thunk';
 import { persistStore, autoRehydrate } from 'redux-persist';
 import crosstabSync from 'redux-persist-crosstab';
 import rootReducer from './reducers';
-import ServerIO from './serverIO';
+import { serverIO } from './serverIO';
 import 'font-awesome-webpack';
 import { getLoginInfo } from './actions/login';
 require('file?name=[name].[ext]!index.html');
@@ -31,6 +31,8 @@ if (module.hot) {
 }
 
 function requireAuth(nextState, replace) {
+  store.dispatch(getLoginInfo());
+
   if (!store.getState().login.loggedIn) {
     replace(null, '/login');
   }
@@ -38,26 +40,22 @@ function requireAuth(nextState, replace) {
 
 
 class ServerStorage {
-  constructor(serverIO) {
-    this.serverIO = serverIO;
-  }
-
   setItem(key, value) {
     if (store.getState().remoteAccess.master) {
-      this.serverIO.uiStorage.setItem(key, value);
+      serverIO.uiStorage.setItem(key, value);
     }
   }
 
   getItem(key, cb) {
-    this.serverIO.uiStorage.getItem(key, cb);
+    serverIO.uiStorage.getItem(key, cb);
   }
 
   removeItem(key) {
-    this.serverIO.uiStorage.removeItem(key);
+    serverIO.uiStorage.removeItem(key);
   }
 
   getAllKeys(cb) {
-    this.serverIO.uiStorage.getAllKeys(cb);
+    serverIO.uiStorage.getAllKeys(cb);
   }
 }
 
@@ -67,21 +65,20 @@ export default class App extends React.Component {
     super(props);
 
     this.state = { initialized: false };
-    this.serverIO = new ServerIO(store);
   }
 
   componentWillMount() {
     const persistor = persistStore(store,
            { blacklist: ['remoteAccess', 'beamline', 'sampleChanger',
                          'form', 'login', 'general', 'logger', 'points'],
-             storage: new ServerStorage(this.serverIO) },
+             storage: new ServerStorage() },
              () => {
-               store.dispatch(getLoginInfo());
+               serverIO.listen(store);
                this.setState({ initialized: true });
              }
     );
 
-    this.serverIO.listen(persistor);
+    serverIO.connectStateSocket(persistor);
 
     crosstabSync(persistor);
   }


### PR DESCRIPTION
This is a fix for #366, and more generally it adds a `safe_emit` function that can be used to ensure the Master client will receive updates from server. It uses the 'callback' feature from socketio: events (= signals from Hardware Objects) are appended to a double-ended queue, and delivered in FIFO order. When callback is executed, it means the Master client has received the message so the event is deleted and the next one can be sent.
It is enough to send events to the Master client to get all clients up-to-date thanks to the mechanism already in place for Remote Access.
This PR also brings some little improvements to Remote Access, like a dedicated Python module and a new `setRaMaster` event which will also be used later when switching from one Master client to another.
It has been tested here and seems to work beautifully.