### PR TITLE
Rate limit motor position updates

### DIFF
--- a/mxcube3/routes/SampleCentring.py
+++ b/mxcube3/routes/SampleCentring.py
@@ -33,9 +33,13 @@ def init_signals():
         else:
             pass
     for motor in mxcube.diffractometer.centring_motors_list:
+        @Utils.RateLimited(3)
+        def pos_cb(pos, motor=motor.lower(), **kw):
+          signals.motor_position_callback(motor, pos)
+        setattr(mxcube.diffractometer, "_%s_pos_callback" % motor, pos_cb)
         mxcube.diffractometer.connect(mxcube.diffractometer.getObjectByRole(motor.lower()),
                                       "positionChanged",
-                                      signals.motor_event_callback)
+                                      pos_cb)
         mxcube.diffractometer.connect(mxcube.diffractometer.getObjectByRole(motor.lower()),
                                       "stateChanged",
                                       signals.motor_event_callback)

--- a/mxcube3/routes/Utils.py
+++ b/mxcube3/routes/Utils.py
@@ -1,5 +1,22 @@
 import logging
 from mxcube3 import app as mxcube
+import time
+import gevent
+
+def RateLimited(maxPerSecond):
+    minInterval = 1.0 / float(maxPerSecond)
+    def decorate(func):
+        lastTimeCalled = [0.0]
+        def rateLimitedFunction(*args,**kargs):
+            elapsed = time.time() - lastTimeCalled[0]
+            leftToWait = minInterval - elapsed
+            if leftToWait>0:
+                gevent.sleep(leftToWait)
+            ret = func(*args,**kargs)
+            lastTimeCalled[0] = time.time()
+            return ret
+        return rateLimitedFunction
+    return decorate
 
 
 def _proposal_id(session):

--- a/mxcube3/routes/signals.py
+++ b/mxcube3/routes/signals.py
@@ -242,6 +242,9 @@ def task_event_callback(*args, **kwargs):
     #     logging.getLogger("HWR").error('error sending message: ' + str(msg))
 
 
+def motor_position_callback(motor, pos):
+   socketio.emit('motor_position', { 'name': motor, 'position': pos }, namespace='/hwr')
+
 def motor_event_callback(*args, **kwargs):
     # logging.getLogger('HWR').debug('[MOTOR CALLBACK]')
     # logging.getLogger("HWR").debug(kwargs)

--- a/mxcube3/ui/reducers/beamline.js
+++ b/mxcube3/ui/reducers/beamline.js
@@ -143,7 +143,7 @@ export default (state = INITIAL_STATE, action) => {
                 pixelsPerMm: action.data.pixelsPerMm[0]
       };
     case 'SAVE_MOTOR_POSITION':
-      return { ...state, motors: { ...state.motors, [action.name]: { position: action.value } } };
+      return { ...state, motors: { ...state.motors, [action.name]: { position: action.value, Status: state.motors[action.name].Status } } };
     case 'SET_INITIAL_STATUS':
       return { ...state,
         motors: { ...state.motors, ...action.data.Motors },

--- a/mxcube3/ui/serverIO.js
+++ b/mxcube3/ui/serverIO.js
@@ -3,6 +3,7 @@ import { addLogRecord } from './actions/logger';
 import {
   updatePointsPosition,
   saveMotorPositions,
+  saveMotorPosition,
   setCurrentPhase,
   setBeamInfo
 } from './actions/sampleview';
@@ -61,6 +62,10 @@ export default class ServerIO {
           break;
         default:
       }
+    });
+
+    this.hwrSocket.on('motor_position', (record) => {
+      this.dispatch(saveMotorPosition(record.name, record.position));
     });
 
     this.hwrSocket.on('beam_changed', (record) => {


### PR DESCRIPTION
This PR improves motor position updates:
* limit to 3 events per motor per second (using token bucket algorithm)
* position updates have a dedicated callback, just transmitting to clients the new position instead of
doing all the stuff from `signals.motor_event_callback`