### PR TITLE
Fix for issue #381

### DIFF
--- a/mxcube3/routes/SampleCentring.py
+++ b/mxcube3/routes/SampleCentring.py
@@ -24,25 +24,28 @@ def init_signals():
     mxcube.diffractometer.savedCentredPos = []
     mxcube.diffractometer.savedCentredPosCount = 1
     for signal in signals.microdiffSignals:
-        if signal in signals.motor_signals:
-            mxcube.diffractometer.connect(mxcube.diffractometer, signal,
-                                          signals.motor_event_callback)
-        elif signal in signals.task_signals:
+        if signal in signals.task_signals:
             mxcube.diffractometer.connect(mxcube.diffractometer,
                                           signal, signals.task_event_callback)
         else:
-            pass
+            mxcube.diffractometer.connect(mxcube.diffractometer, signal,
+                                          signals.motor_event_callback)
     for motor in mxcube.diffractometer.centring_motors_list:
         @Utils.RateLimited(3)
         def pos_cb(pos, motor=motor.lower(), **kw):
           signals.motor_position_callback(motor, pos)
+
+        def state_cb(state, motor=motor.lower(), **kw):
+          signals.motor_state_callback(motor, state)
+
         setattr(mxcube.diffractometer, "_%s_pos_callback" % motor, pos_cb)
+        setattr(mxcube.diffractometer, "_%s_state_callback" % motor, state_cb)
         mxcube.diffractometer.connect(mxcube.diffractometer.getObjectByRole(motor.lower()),
                                       "positionChanged",
                                       pos_cb)
         mxcube.diffractometer.connect(mxcube.diffractometer.getObjectByRole(motor.lower()),
                                       "stateChanged",
-                                      signals.motor_event_callback)
+                                      state_cb) #signals.motor_event_callback)
     try:
         frontlight_hwobj = mxcube.diffractometer.getObjectByRole('frontlight')
         frontlight_hwobj.connect(frontlight_hwobj, 'positionChanged',

--- a/mxcube3/routes/SampleCentring.py
+++ b/mxcube3/routes/SampleCentring.py
@@ -36,7 +36,7 @@ def init_signals():
           signals.motor_position_callback(motor, pos)
 
         def state_cb(state, motor=motor.lower(), **kw):
-          signals.motor_state_callback(motor, state)
+          signals.motor_state_callback(motor, state, **kw)
 
         setattr(mxcube.diffractometer, "_%s_pos_callback" % motor, pos_cb)
         setattr(mxcube.diffractometer, "_%s_state_callback" % motor, state_cb)

--- a/mxcube3/routes/Utils.py
+++ b/mxcube3/routes/Utils.py
@@ -11,7 +11,8 @@ def RateLimited(maxPerSecond):
             elapsed = time.time() - lastTimeCalled[0]
             leftToWait = minInterval - elapsed
             if leftToWait>0:
-                gevent.sleep(leftToWait)
+                # ignore update
+                return
             ret = func(*args,**kargs)
             lastTimeCalled[0] = time.time()
             return ret

--- a/mxcube3/routes/signals.py
+++ b/mxcube3/routes/signals.py
@@ -21,11 +21,9 @@ beam_signals = ['beamPosChanged', 'beamInfoChanged']
 
 queueSignals = ['queue_execution_finished', 'queue_paused', 'queue_stopped', 'testSignal', 'warning'] # 'centringAllowed',
 microdiffSignals = ['centringInvalid', 'newAutomaticCentringPoint', 'centringStarted','centringAccepted','centringMoving',\
-                    'centringFailed', 'centringSuccessful', 'progressMessage', 'centringSnapshots', 'warning', 'positionChanged', \
-                    'phiMotorStateChanged', 'phiyMotorStateChanged', 'phizMotorStateChanged', 'sampxMotorStateChanged', \
-                    'sampyMotorStateChanged', 'minidiffStateChanged', 'minidiffPhaseChanged', 'minidiffSampleIsLoadedChanged',\
-                    'zoomMotorPredefinedPositionChanged', 'minidiffTransferModeChanged', 'positionChanged', 'actuatorStateChanged',
-                    'stateChanged']
+                    'centringFailed', 'centringSuccessful', 'progressMessage', 'centringSnapshots', 'warning', 
+                    'minidiffPhaseChanged', 'minidiffSampleIsLoadedChanged',\
+                    'zoomMotorPredefinedPositionChanged', 'minidiffTransferModeChanged']
 
 okSignals = ['Successful', 'Finished', 'finished', 'Ended', 'Accepted']
 failedSignals = ['Failed', 'Invalid']
@@ -49,19 +47,11 @@ task_signals = {  # missing egyscan, xrf, etc...
 }
 
 motor_signals = {
-    'phiMotorStateChanged':         'phiMotorStateChanged',
-    'phiyMotorStateChanged':        'phiyMotorStateChanged',
-    'phizMotorStateChanged':        'phizMotorStateChanged',
-    'sampxMotorStateChanged':       'sampxMotorStateChanged',
-    'sampyMotorStateChanged':       'sampyMotorStateChanged',
-    'zoomMotorStateChanged':        'zoomMotorStateChanged',
     'actuatorStateChanged':         'actuatorStateChanged',
     'minidiffPhaseChanged':         'minidiffPhaseChanged',
     'minidiffTransferModeChanged':  'minidiffTransferModeChanged',
     'minidiffSampleIsLoadedChanged': 'minidiffSampleIsLoadedChanged',
     'zoomMotorPredefinedPositionChanged': 'zoomMotorPredefinedPositionChanged',
-    'diffractometerMoved':          'diffractometerMoved',
-    'stateChanged':                 'stateChanged'
 }
 
 mach_info_signals = {
@@ -243,6 +233,13 @@ def task_event_callback(*args, **kwargs):
 
 def motor_position_callback(motor, pos):
    socketio.emit('motor_position', { 'name': motor, 'position': pos }, namespace='/hwr')
+
+def motor_state_callback(motor, state):
+    centred_positions = dict()
+    for pos in mxcube.diffractometer.savedCentredPos:
+        centred_positions.update({pos['posId']: pos})
+            
+    socketio.emit('motor_state', { 'name': motor, 'state': state, "centredPositions": centred_positions }, namespace='/hwr')
 
 def motor_event_callback(*args, **kwargs):
     # logging.getLogger('HWR').debug('[MOTOR CALLBACK]')

--- a/mxcube3/routes/signals.py
+++ b/mxcube3/routes/signals.py
@@ -234,12 +234,16 @@ def task_event_callback(*args, **kwargs):
 def motor_position_callback(motor, pos):
    socketio.emit('motor_position', { 'name': motor, 'position': pos }, namespace='/hwr')
 
-def motor_state_callback(motor, state):
+def motor_state_callback(motor, state, sender=None, **kw):
     centred_positions = dict()
     for pos in mxcube.diffractometer.savedCentredPos:
         centred_positions.update({pos['posId']: pos})
-            
-    socketio.emit('motor_state', { 'name': motor, 'state': state, "centredPositions": centred_positions }, namespace='/hwr')
+    
+    if state == 2:
+      # READY
+      motor_position_callback(motor, sender.getPosition())
+        
+    socketio.emit('motor_state', { 'name': motor, 'state': state, 'centredPositions': centred_positions }, namespace='/hwr')
 
 def motor_event_callback(*args, **kwargs):
     # logging.getLogger('HWR').debug('[MOTOR CALLBACK]')

--- a/mxcube3/ui/actions/sampleview.js
+++ b/mxcube3/ui/actions/sampleview.js
@@ -122,6 +122,12 @@ export function saveMotorPosition(name, value) {
   };
 }
 
+export function updateMotorState(name, value) {
+  return {
+    type: 'UPDATE_MOTOR_STATE', name, value
+  };
+}
+
 export function updatePointsPosition(points) {
   return {
     type: 'UPDATE_POINTS_POSITION', points

--- a/mxcube3/ui/components/Main.css
+++ b/mxcube3/ui/components/Main.css
@@ -94,24 +94,24 @@ input[type="radio"], input[type="checkbox"] {
     background-color: #FFFF99 !important;
     color: transparent;
     text-shadow: 0 0 0 black;
-    transition: background-color 1000ms ease-in;
+    transition: background-color 300ms ease-in;
 }
 
 
 .input-bg-ready{
     background-color: #9BCE7B !important;
-    transition: background-color 1000ms ease-in;
+    transition: background-color 300ms ease-in;
 }
 
 
 .input-bg-fault{
     background-color: #FF9999 !important;
     color: #000;
-    transition: background-color 1000ms ease-in;
+    transition: background-color 300ms ease-in;
 }
 
 
 .input-bg-onlimit{
     background-color: #FF9900 !important;
-    transition: background-color 1000ms ease-in;
+    transition: background-color 300ms ease-in;
 }

--- a/mxcube3/ui/reducers/beamline.js
+++ b/mxcube3/ui/reducers/beamline.js
@@ -149,6 +149,12 @@ export default (state = INITIAL_STATE, action) => {
                                      Status: state.motors[action.name].Status }
                                  }
              };
+    case 'UPDATE_MOTOR_STATE':
+      return { ...state, motors: { ...state.motors, [action.name]:
+                                   { position: state.motors[action.name].position,
+                                     Status: action.value }
+                                 }
+             };
     case 'SET_INITIAL_STATUS':
       return { ...state,
         motors: { ...state.motors, ...action.data.Motors },

--- a/mxcube3/ui/serverIO.js
+++ b/mxcube3/ui/serverIO.js
@@ -4,6 +4,7 @@ import {
   updatePointsPosition,
   saveMotorPositions,
   saveMotorPosition,
+  updateMotorState,
   setCurrentPhase,
   setBeamInfo
 } from './actions/sampleview';
@@ -70,6 +71,11 @@ class ServerIO {
 
     this.hwrSocket.on('motor_position', (record) => {
       this.dispatch(saveMotorPosition(record.name, record.position));
+    });
+
+    this.hwrSocket.on('motor_state', (record) => {
+      this.dispatch(updatePointsPosition(record.centredPositions));
+      this.dispatch(updateMotorState(record.name, record.state));
     });
 
     this.hwrSocket.on('beam_changed', (record) => {


### PR DESCRIPTION
* rate limitation decorator now drops events received in the delay interval
* motor states are handled individually (like motor positions since #373)
* as a consequence, `signals.microdiffSignals` and `motor_signals` have been purged from
position and state signals
* CSS transition duration for motor states is 300 ms now instead of 1 s

We tested this on ID30A3 just now.