### PR TITLE
Queue stopped after disconnection #400

### DIFF
--- a/mxcube3/routes/Queue.py
+++ b/mxcube3/routes/Queue.py
@@ -71,7 +71,7 @@ def queue_pause():
               409: Queue could not be paused
     """
     mxcube.queue.queue_hwobj.pause(True)
-    msg = {'Signal': 'QueuePaused',
+    msg = {'Signal': qutils.queue_exec_state(),
            'Message': 'Queue execution paused',
            'State': 1}
     socketio.emit('queue', msg, namespace='/hwr')
@@ -89,7 +89,7 @@ def queue_unpause():
               409: Queue could not be unpause
     """
     mxcube.queue.queue_hwobj.pause(False)
-    msg = {'Signal': 'QueueStarted',
+    msg = {'Signal': qutils.queue_exec_state(),
            'Message': 'Queue execution started',
            'State': 1}
     socketio.emit('queue', msg, namespace='/hwr')

--- a/mxcube3/routes/qutils.py
+++ b/mxcube3/routes/qutils.py
@@ -268,7 +268,8 @@ def get_queue_state():
            "todo": todo,
            "loaded": loaded,
            "queue": queue,
-           "sample_order": order
+           "sample_order": order,
+           "queueStatus": queue_exec_state()
            }
 
     return res
@@ -393,6 +394,22 @@ def queue_to_dict_rec(node):
 
 
     return result
+
+
+def queue_exec_state():
+    """
+    :returns: The queue execution state, one of the strings 'QueueStopped',
+              'QueuePaused' or 'QueueStarted'
+
+    """
+    state = "QueueStopped"
+
+    if mxcube.queue.queue_hwobj.is_paused():
+        state = "QueuePaused"
+    elif mxcube.queue.queue_hwobj.is_executing():
+        state = "QueueStarted"
+
+    return state
 
 
 def get_entry(id):

--- a/mxcube3/routes/signals.py
+++ b/mxcube3/routes/signals.py
@@ -147,7 +147,7 @@ def centring_started(method, *args):
 
 
 def queue_execution_started(entry):
-    msg = {'Signal': 'QueueStarted',
+    msg = {'Signal': qutils.queue_exec_state(),
            'Message': 'Queue execution started',
            'State': 1}
 
@@ -155,7 +155,7 @@ def queue_execution_started(entry):
 
 
 def queue_execution_finished(entry):
-    msg = {'Signal': 'QueueStopped',
+    msg = {'Signal': qutils.queue_exec_state(),
            'Message': 'Queue execution stopped',
            'State': 1}
 
@@ -163,7 +163,7 @@ def queue_execution_finished(entry):
 
 
 def queue_execution_failed(entry):    
-    msg = {'Signal': 'QueueStopped',
+    msg = {'Signal': qutils.queue_exec_state(),
            'Message': 'Queue execution stopped',
            'State': 2}
 

--- a/mxcube3/ui/actions/general.js
+++ b/mxcube3/ui/actions/general.js
@@ -168,3 +168,9 @@ export function getInitialStatus() {
     });
   };
 }
+
+export function showConnectionLostDialog(show = true) {
+  return {
+    type: 'SHOW_CONNECTION_LOST_DIALOG', show
+  };
+}

--- a/mxcube3/ui/actions/queue.js
+++ b/mxcube3/ui/actions/queue.js
@@ -281,9 +281,9 @@ export function toggleChecked(sampleID, index) {
 }
 
 
-export function showRestoreDialog(queueState, show = true) {
+export function showResumeQueueDialog(show = true) {
   return {
-    type: 'SHOW_RESTORE_DIALOG', queueState, show
+    type: 'SHOW_RESUME_QUEUE_DIALOG', show
   };
 }
 

--- a/mxcube3/ui/actions/remoteAccess.js
+++ b/mxcube3/ui/actions/remoteAccess.js
@@ -3,11 +3,11 @@ import { serverIO } from '../serverIO';
 export function setMaster(master) {
   if (master) {
     return function (dispatch) {
-      serverIO.setRemoteAccessMaster(() => {
-        dispatch({ type: 'SET_MASTER', master });
+      serverIO.setRemoteAccessMaster((sid) => {
+        dispatch({ type: 'SET_MASTER', master, sid });
       });
     };
   }
-  return { type: 'SET_MASTER', master };
+  return { type: 'SET_MASTER', master, sid: null };
 }
 

--- a/mxcube3/ui/components/Main.jsx
+++ b/mxcube3/ui/components/Main.jsx
@@ -3,8 +3,11 @@ import MXNavbarContainer from '../containers/MXNavbarContainer';
 import TaskContainer from '../containers/TaskContainer';
 import PleaseWaitDialog from '../containers/PleaseWaitDialog';
 import ErrorNotificationPanel from '../containers/ErrorNotificationPanel';
-import QueueRestoreDialog from '../containers/QueueRestoreDialog';
+import ResumeQueueDialog from '../containers/ResumeQueueDialog';
 import LoggerOverlayContainer from '../containers/LoggerOverlayContainer';
+import ConnectionLostDialog from '../containers/ConnectionLostDialog';
+
+
 import './Main.css';
 export default class Main extends React.Component {
   render() {
@@ -13,7 +16,8 @@ export default class Main extends React.Component {
         <TaskContainer />
         <PleaseWaitDialog />
         <ErrorNotificationPanel />
-        <QueueRestoreDialog />
+        <ResumeQueueDialog />
+        <ConnectionLostDialog />
         <MXNavbarContainer location={this.props.location} />
         <div className="container-fluid o-wrapper" id="o-wrapper">
           <div className="row">

--- a/mxcube3/ui/containers/ConnectionLostDialog.jsx
+++ b/mxcube3/ui/containers/ConnectionLostDialog.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import 'bootstrap-webpack!bootstrap-webpack/bootstrap.config.js';
+import { Modal, Button } from 'react-bootstrap';
+import { showConnectionLostDialog } from '../actions/general';
+
+export class ConnectionLostDialog extends React.Component {
+  constructor(props) {
+    super(props);
+    this.accept = this.accept.bind(this);
+    this.reject = this.reject.bind(this);
+    this.intervalCb = this.intervalCb.bind(this);
+    this.seconds = 60;
+    this.timerid = undefined;
+  }
+
+  intervalCb() {
+    this.seconds--;
+
+    if (this.refs.countdown) {
+      this.refs.countdown.innerHTML = this.seconds;
+    }
+
+    if (this.seconds < 1) {
+      this.seconds = 0;
+      this.accept();
+    }
+  }
+
+  accept() {
+    this.forceUpdate();
+  }
+
+  reject() {
+    this.props.hide();
+  }
+
+  render() {
+    this.seconds = 60;
+
+    if (this.timerid) {
+      clearInterval(this.timerid);
+    }
+
+    this.timerid = setInterval(this.intervalCb, 1000);
+    setTimeout(() => { clearInterval(this.timerid); }, this.seconds * 1000);
+
+    return (
+      <Modal
+        show={this.props.show}
+        onHide={this.props.hide}
+      >
+        <Modal.Header>
+          <Modal.Title>
+          Connection lost
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          Ooops ! There seems to be a problem with the internet connection,
+          the connection to the server was lost. Trying to reconnect in <span ref="countdown">
+          {this.seconds}</span> s
+        </Modal.Body>
+        <Modal.Footer>
+          <Button onClick={this.accept}> Try again </Button>
+        </Modal.Footer>
+      </Modal>);
+  }
+}
+
+function mapStateToProps(state) {
+  return {
+    show: state.general.showConnectionLostDialog,
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    hide: bindActionCreators(showConnectionLostDialog.bind(this, false), dispatch),
+  };
+}
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(ConnectionLostDialog);

--- a/mxcube3/ui/containers/ResumeQueueDialog.jsx
+++ b/mxcube3/ui/containers/ResumeQueueDialog.jsx
@@ -3,10 +3,9 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import 'bootstrap-webpack!bootstrap-webpack/bootstrap.config.js';
 import { Modal, Button } from 'react-bootstrap';
-import { showRestoreDialog, setState, sendClearQueue } from '../actions/queue';
+import { showResumeQueueDialog } from '../actions/queue';
 
-export class QueueRestoreDialog extends React.Component {
-
+export class ResumeQueueDialog extends React.Component {
   constructor(props) {
     super(props);
     this.accept = this.accept.bind(this);
@@ -14,13 +13,11 @@ export class QueueRestoreDialog extends React.Component {
   }
 
   accept() {
-    this.props.restoreQueueState(this.props.savedQueueState);
     this.props.hide();
   }
 
   reject() {
     this.props.hide();
-    this.props.clearQueue();
   }
 
   render() {
@@ -29,12 +26,18 @@ export class QueueRestoreDialog extends React.Component {
         show={this.props.show}
         onHide={this.props.hide}
       >
+        <Modal.Header>
+          <Modal.Title>
+            Resume Queue
+          </Modal.Title>
+        </Modal.Header>
         <Modal.Body>
-          Do you want to restore the saved queue?
+          Ooops ! The application was closed or there was problems with the
+          connection while the queue was running. Just press Run Queue
+          (found above the queue) if you like to continue execution.
         </Modal.Body>
         <Modal.Footer>
-          <Button onClick={this.accept} bsStyle="primary"> Yes </Button>
-          <Button onClick={this.reject}> No </Button>
+          <Button onClick={this.reject}> OK </Button>
         </Modal.Footer>
       </Modal>);
   }
@@ -42,20 +45,17 @@ export class QueueRestoreDialog extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    show: state.queue.showRestoreDialog,
-    savedQueueState: state.queue.queueRestoreState
+    show: state.queue.showResumeQueueDialog,
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
-    hide: bindActionCreators(showRestoreDialog.bind(this, {}, false), dispatch),
-    restoreQueueState: bindActionCreators(setState.bind(this), dispatch),
-    clearQueue: bindActionCreators(sendClearQueue.bind(this), dispatch)
+    hide: bindActionCreators(showResumeQueueDialog.bind(this, false), dispatch),
   };
 }
 
 export default connect(
     mapStateToProps,
     mapDispatchToProps
-)(QueueRestoreDialog);
+)(ResumeQueueDialog);

--- a/mxcube3/ui/reducers/general.js
+++ b/mxcube3/ui/reducers/general.js
@@ -8,7 +8,8 @@ const initialState = {
   dialogMessage: '',
   dialogTitle: '',
   showDialog: false,
-  userMessages: []
+  userMessages: [],
+  showConnectionLostDialog: false
 };
 
 export default (state = initialState, action) => {
@@ -68,7 +69,10 @@ export default (state = initialState, action) => {
       {
         return { ...state, userMessages: {} };
       }
-
+    case 'SHOW_CONNECTION_LOST_DIALOG':
+      {
+        return { ...state, showConnectionLostDialog: action.show };
+      }
     default:
       return state;
   }

--- a/mxcube3/ui/reducers/queue.js
+++ b/mxcube3/ui/reducers/queue.js
@@ -10,8 +10,7 @@ const initialState = {
   history: [],
   searchString: '',
   queueStatus: 'QueueStopped',
-  showRestoreDialog: false,
-  queueRestoreState: {},
+  showResumeQueueDialog: false,
   sampleList: {},
   manualMount: { set: false, id: 1 },
   visibleList: 'current'
@@ -273,9 +272,9 @@ export default (state = initialState, action) => {
         return Object.assign({}, state, { ...initialState,
                                           manualMount: { set: state.manualMount.set, id: 1 } });
       }
-    case 'SHOW_RESTORE_DIALOG':
+    case 'SHOW_RESUME_QUEUE_DIALOG':
       {
-        return { ...state, showRestoreDialog: action.show, queueRestoreState: action.queueState };
+        return { ...state, showResumeQueueDialog: action.show };
       }
     case 'QUEUE_STATE':
       {

--- a/mxcube3/ui/reducers/remoteAccess.js
+++ b/mxcube3/ui/reducers/remoteAccess.js
@@ -8,7 +8,8 @@ export default (state = initialState, action) => {
       {
         return Object.assign({}, state,
           {
-            master: action.master
+            master: action.master,
+            sid: action.sid
           });
       }
 


### PR DESCRIPTION
Hey all !

For feature #400

So Ive started to implement this one, The queue is stopped when connection to the server is lost. This is
done on the socket.io disconnect callback. A dialog is shown to the user when reconnecting informing her
that the queue was stopped. The user then needs to take the appropriate action either running the queue
or clearing it.

A second dialog (entirely client driven) for connection loss to server have also been added.

Cheers,
Marcus

