### PR TITLE
Issue 425: optimize initialization calls

### DIFF
--- a/mxcube3/routes/Beamline.py
+++ b/mxcube3/routes/Beamline.py
@@ -35,6 +35,7 @@ def init_signals():
 def beamline_get_all_attributes():
     ho = BeamlineSetupMediator(mxcube.beamline)
     data = ho.dict_repr()
+    data.update({'path': mxcube.session.get_base_image_directory()})
     return Response(json.dumps(data), status=200, mimetype='application/json')
 
 

--- a/mxcube3/routes/Diffractometer.py
+++ b/mxcube3/routes/Diffractometer.py
@@ -113,21 +113,6 @@ def get_movables_state():
     return resp
 
 
-@mxcube.route("/mxcube/api/v0.1/diffractometer/movables/limits", methods=['GET'])
-def get_movables_limits():
-    ret = {}
-    for name in mxcube.diffractometer.centring_motors_list:
-            motor_info = Utils.get_movable_limits(name)
-            if motor_info and motor_info[name]['limits'] is not None:
-                ret.update(motor_info)
-
-    ret.update(Utils.get_light_limits())
-
-    resp = jsonify(ret)
-    resp.status_code = 200
-    return resp
-
-
 @mxcube.route("/mxcube/api/v0.1/diffractometer/aperture", methods=['PUT'])
 def set_aperture():
     """

--- a/mxcube3/routes/Queue.py
+++ b/mxcube3/routes/Queue.py
@@ -409,25 +409,29 @@ def get_default_dc_params():
     """
     acq_parameters = mxcube.beamline.get_default_acquisition_parameters()
     resp = jsonify({
-        'first_image': acq_parameters.first_image,
-        'num_images': acq_parameters.num_images,
-        'osc_start': acq_parameters.osc_start,
-        'osc_range': acq_parameters.osc_range,
-        'kappa': acq_parameters.kappa,
-        'kappa_phi': acq_parameters.kappa_phi,
-        'overlap': acq_parameters.overlap,
-        'exp_time': acq_parameters.exp_time,
-        'num_passes': acq_parameters.num_passes,
-        'resolution': acq_parameters.resolution,
-        'energy': acq_parameters.energy,
-        'transmission': acq_parameters.transmission,
-        'shutterless': acq_parameters.shutterless,
-        'detector_mode': acq_parameters.detector_mode,
-        'inverse_beam': False,
-        'take_dark_current': True,
-        'skip_existing_images': False,
-        'take_snapshots': True,
+        'acq_parameters': {
+            'first_image': acq_parameters.first_image,
+            'num_images': acq_parameters.num_images,
+            'osc_start': acq_parameters.osc_start,
+            'osc_range': acq_parameters.osc_range,
+            'kappa': acq_parameters.kappa,
+            'kappa_phi': acq_parameters.kappa_phi,
+            'overlap': acq_parameters.overlap,
+            'exp_time': acq_parameters.exp_time,
+            'num_passes': acq_parameters.num_passes,
+            'resolution': acq_parameters.resolution,
+            'energy': acq_parameters.energy,
+            'transmission': acq_parameters.transmission,
+            'shutterless': acq_parameters.shutterless,
+            'detector_mode': acq_parameters.detector_mode,
+            'inverse_beam': False,
+            'take_dark_current': True,
+            'skip_existing_images': False,
+            'take_snapshots': True,
+        },
+        'limits': mxcube.beamline.get_acquisition_limit_values()
     })
+
     resp.status_code = 200
     return resp
 
@@ -438,16 +442,6 @@ def get_default_char_params():
     returns the default values for a characterisation.
     """
     resp = jsonify(mxcube.beamline.get_default_characterisation_parameters().as_dict())
-    resp.status_code = 200
-    return resp
-
-
-@mxcube.route("/mxcube/api/v0.1/queue/acq/limits", methods=['GET'])
-def get_default_acquisition_limits():
-    """
-    returns the limit values for an acquisition, stored in an xml file.
-    """
-    resp = jsonify(mxcube.beamline.get_acquisition_limit_values())
     resp.status_code = 200
     return resp
 

--- a/mxcube3/routes/Utils.py
+++ b/mxcube3/routes/Utils.py
@@ -47,7 +47,8 @@ def get_light_state_and_intensity():
             hwobj_switch = mxcube.diffractometer.getObjectByRole(light + 'Switch')
             switch_state = 1 if hwobj_switch.getActuatorState() == 'in' else 0
 
-        ret.update({light: {"Status": hwobj.getState(), "position": hwobj.getPosition()},
+        ret.update({light: {"Status": hwobj.getState(), "position": hwobj.getPosition(),
+                            'limits': hwobj.getLimits()},
                     light + 'Switch': {"Status": switch_state, "position": 0}
                     })
 
@@ -109,37 +110,30 @@ def get_movable_limits(item_name):
         hwobj = mxcube.diffractometer.getObjectByRole(item_role)
 
         if hwobj is None:
-            logging.getLogger("HWR").error('[UTILS.GET_MOVABLE_STATE_AND_POSITION] No movable with role "%s"' % item_role)
+            logging.getLogger("HWR").error('[UTILS.GET_MOVABLE_LIMIT] No movable with role "%s"' % item_role)
             limits = ()
         else:
             limits = hwobj.getLimits()
 
             return {item_name: {'limits': limits}}
     except Exception:
-        logging.getLogger('HWR').exception('[UTILS.GET_MOVABLE_STATE_AND_POSITION] could not get item "%s"' % item_name)
-
-
-# def get_parameters_limits():
-#     """
-#     returns the limit values for the acquisition and for the moveables.
-#     """
-#     acq_limits = mxcube.beamline.get_acquisition_limit_values()
-#     ret = dict()
-#     for name in mxcube.diffractometer.centring_motors_list:
-#         motor_info = get_movable_state_and_position(name)
-#         if motor_info and motor_info[name]['position'] is not None:
-#             ret.update(motor_info)
-
+        logging.getLogger('HWR').exception('[UTILS.GET_MOVABLE_LIMIT] could not get item "%s"' % item_name)
 
 def get_centring_motors_info():
     # the centring motors are: ["phi", "focus", "phiz", "phiy", "zoom", "sampx", "sampy", "kappa", "kappa_phi"]
     ret = dict()
     for name in mxcube.diffractometer.centring_motors_list:
+        print name
         motor_info = get_movable_state_and_position(name)
         if motor_info and motor_info[name]['position'] is not None:
             ret.update(motor_info)
-
+#        print ret
+        motor_limits = get_movable_limits(name)
+        if motor_limits and motor_limits[name]['limits'] is not None:
+            ret[name].update(motor_limits[name])
+#        print ret
     return ret
+
 
 def my_execute_entry(self, entry):
     import queue_entry as qe

--- a/mxcube3/ui/actions/general.js
+++ b/mxcube3/ui/actions/general.js
@@ -92,14 +92,6 @@ export function getInitialStatus() {
         'Content-type': 'application/json'
       }
     });
-    const motorsLimits = fetch('mxcube/api/v0.1/diffractometer/movables/limits', {
-      method: 'GET',
-      credentials: 'include',
-      headers: {
-        Accept: 'application/json',
-        'Content-type': 'application/json'
-      }
-    });
     const beamInfo = fetch('mxcube/api/v0.1/beam/info', {
       method: 'GET',
       credentials: 'include',
@@ -176,7 +168,6 @@ export function getInitialStatus() {
     const pchains = [
       queue.then(parse).then(json => { state.queue = json; }).catch(notify),
       motors.then(parse).then(json => { state.Motors = json; }).catch(notify),
-      motorsLimits.then(parse).then(json => { state.motorsLimits = json; }).catch(notify),
       beamInfo.then(parse).then(json => { state.beamInfo = json; }).catch(notify),
       beamlineSetup.then(parse).then(json => { state.beamlineSetup = json; }).catch(notify),
       sampleVideoInfo.then(parse).then(json => { state.Camera = json; }).catch(notify),

--- a/mxcube3/ui/actions/general.js
+++ b/mxcube3/ui/actions/general.js
@@ -161,8 +161,8 @@ export function getInitialStatus() {
       queue.then(parse).then(json => { state.queue = json; }).catch(notify),
       motors.then(parse).then(json => { state.Motors = json; }).catch(notify),
       beamInfo.then(parse).then(json => { state.beamInfo = json; }).catch(notify),
-      beamlineSetup.then(parse).then(json => { state.beamlineSetup = json; }).catch(notify),
-      beamlineSetup.then(parse).then(path => { state.beamlineSetup = path; }).catch(notify),
+      beamlineSetup.then(parse).then(json => { state.beamlineSetup = json; return json;}).then(
+        json => { state.datapath = json.path; }).catch(notify),
       sampleVideoInfo.then(parse).then(json => { state.Camera = json; }).catch(notify),
       diffractometerInfo.then(parse).then(json => { Object.assign(state, json); }).catch(notify),
       dcParameters.then(parse).then(json => { state.dcParameters = json; }).catch(notify),

--- a/mxcube3/ui/actions/general.js
+++ b/mxcube3/ui/actions/general.js
@@ -132,14 +132,6 @@ export function getInitialStatus() {
         'Content-type': 'application/json'
       }
     });
-    const acqParametersLimits = fetch('mxcube/api/v0.1/queue/acq/limits', {
-      method: 'GET',
-      credentials: 'include',
-      headers: {
-        Accept: 'application/json',
-        'Content-type': 'application/json'
-      }
-    });
     const savedPoints = fetch('mxcube/api/v0.1/sampleview/centring', {
       method: 'GET',
       credentials: 'include',
@@ -165,9 +157,9 @@ export function getInitialStatus() {
         json => { state.datapath = json.path; }).catch(notify),
       sampleVideoInfo.then(parse).then(json => { state.Camera = json; }).catch(notify),
       diffractometerInfo.then(parse).then(json => { Object.assign(state, json); }).catch(notify),
-      dcParameters.then(parse).then(json => { state.dcParameters = json; }).catch(notify),
-      acqParametersLimits.then(parse).then(
-        json => { state.acqParametersLimits = json; }).catch(notify),
+      dcParameters.then(parse).then(
+        json => { state.dcParameters = json.acq_parameters; return json; }).then(
+        json => { state.acqParametersLimits = json.limits; }).catch(notify),
       savedPoints.then(parse).then(json => { state.points = json; }).catch(notify),
       sampleChangerContents.then(parse).then(json => {
         state.sampleChangerContents = json;

--- a/mxcube3/ui/actions/general.js
+++ b/mxcube3/ui/actions/general.js
@@ -124,14 +124,6 @@ export function getInitialStatus() {
         'Content-type': 'application/json'
       }
     });
-    const dataPath = fetch('mxcube/api/v0.1/beamline/datapath', {
-      method: 'GET',
-      credentials: 'include',
-      headers: {
-        Accept: 'application/json',
-        'Content-type': 'application/json'
-      }
-    });
     const dcParameters = fetch('mxcube/api/v0.1/queue/dc', {
       method: 'GET',
       credentials: 'include',
@@ -170,9 +162,9 @@ export function getInitialStatus() {
       motors.then(parse).then(json => { state.Motors = json; }).catch(notify),
       beamInfo.then(parse).then(json => { state.beamInfo = json; }).catch(notify),
       beamlineSetup.then(parse).then(json => { state.beamlineSetup = json; }).catch(notify),
+      beamlineSetup.then(parse).then(path => { state.beamlineSetup = path; }).catch(notify),
       sampleVideoInfo.then(parse).then(json => { state.Camera = json; }).catch(notify),
       diffractometerInfo.then(parse).then(json => { Object.assign(state, json); }).catch(notify),
-      dataPath.then(parse).then(path => { state.rootPath = path; }).catch(notify),
       dcParameters.then(parse).then(json => { state.dcParameters = json; }).catch(notify),
       acqParametersLimits.then(parse).then(
         json => { state.acqParametersLimits = json; }).catch(notify),

--- a/mxcube3/ui/components/Tasks/validate.js
+++ b/mxcube3/ui/components/Tasks/validate.js
@@ -36,7 +36,7 @@ const validate = (values, props) => {
         currEnergy < props.motorLimits.energy.limits[1])) {
     errors.energy = 'Energy outside working range';
   }
-  if (values.num_images === '' || values.osc_range > props.acqParametersLimits.osc_range) {
+  if (values.osc_range === '' || values.osc_range > props.acqParametersLimits.osc_range) {
     errors.osc_range = 'Oscillation range outside the limit';
   }
   return errors;


### PR DESCRIPTION
I removed three calls from the last PR (#398). Merging the following:
* Motors and limits
* beamline attributes and datapath
* Default parameters and param limits

Any further improvement might start messing around with the redux-state or with the return dict of current api... so I am a but cautious with that. Possible enhancements:
* Add the saved centred positions into the queue_state
* beam_info with the beamline

You can either accept this PR as it is, or we keep it on hold and I ask Fredrik for help with the last two enhancements (delaying this pr a few days)
______
Solving https://github.com/mxcube/mxcube3/issues/425

