### PR TITLE
Fix for #392 (Forbid removal of past data collections)

### DIFF
--- a/mxcube3/ui/actions/sampleGrid.js
+++ b/mxcube3/ui/actions/sampleGrid.js
@@ -19,7 +19,7 @@ export function addSamplesToList(samplesData) {
     for (const sampleData of samplesData) {
       if (! sampleData.sampleID) {
         lastSampleID++;
-        sampleData.sampleID = lastSampleID;
+        sampleData.sampleID = lastSampleID.toString();
       }
     }
 

--- a/mxcube3/ui/components/SampleGrid/SampleGridItem.jsx
+++ b/mxcube3/ui/components/SampleGrid/SampleGridItem.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { OverlayTrigger, Tooltip, Popover } from 'react-bootstrap';
 import classNames from 'classnames';
+import { TASK_UNCOLLECTED } from '../../constants';
 import 'bootstrap-webpack!bootstrap-webpack/bootstrap.config.js';
 
 import './SampleGrid.css';
@@ -30,6 +31,8 @@ export class SampleGridItem extends React.Component {
     this.taskStateClass = this.taskStateClass.bind(this);
     this.handleClick = this.handleClick.bind(this);
     this.taskResult = this.taskResult.bind(this);
+    this.deleteTask = this.deleteTask.bind(this);
+    this.getDeleteButton = this.getDeleteButton.bind(this);
   }
 
 
@@ -75,6 +78,23 @@ export class SampleGridItem extends React.Component {
     }
   }
 
+
+  getDeleteButton(task, i) {
+    const deleteTask = this.deleteTask.bind(this, i);
+    let content = (<span> <i className="fa fa-times" onClick={deleteTask} /> </span>);
+
+    if (task.state !== TASK_UNCOLLECTED) {
+      content = (<span> </span>);
+    }
+
+    return content;
+  }
+
+
+  deleteTask(i, e) {
+    e.stopPropagation();
+    return this.props.deleteTask(this.props.sampleID, i);
+  }
 
   contextMenu(e) {
     e.preventDefault();
@@ -548,11 +568,6 @@ export class SampleGridItem extends React.Component {
                   return this.handleClick(tag, this.props.sampleID);
                 };
 
-                let deleteTask = (e) => {
-                  e.stopPropagation();
-                  return this.props.deleteTask(this.props.sampleID, i);
-                };
-
                 content = (
                   <div key={i}>
                     <OverlayTrigger
@@ -574,7 +589,7 @@ export class SampleGridItem extends React.Component {
                         onClick={showForm}
                       >
                         {this.taskTagName(tag.type)}
-                        <i className="fa fa-times" onClick={deleteTask} />
+                        {this.getDeleteButton(tag, i)}
                       </span>
                     </OverlayTrigger>
                   </div>

--- a/mxcube3/ui/components/SampleQueue/SampleItem.js
+++ b/mxcube3/ui/components/SampleQueue/SampleItem.js
@@ -90,6 +90,8 @@ export default class SampleItem extends Component {
     this.deleteSample = () => this.props.deleteSample(this.props.id, this.props.sampleId);
   }
 
+  
+
   render() {
     const { text, isDragging, connectDragSource, connectDropTarget } = this.props;
     const opacity = isDragging ? 0 : 1;
@@ -99,7 +101,7 @@ export default class SampleItem extends Component {
          <div className="pull-right">
              <i className="fa fa-sign-in" onClick={this.mountSample}></i>
              <i className="fa fa-times" onClick={this.deleteSample}></i>
-           </div>
+        </div>
       </div>
     ));
   }

--- a/mxcube3/ui/components/SampleQueue/TaskItem.js
+++ b/mxcube3/ui/components/SampleQueue/TaskItem.js
@@ -3,6 +3,7 @@ import { Button, Collapse } from 'react-bootstrap';
 import { findDOMNode } from 'react-dom';
 import { DragSource as dragSource, DropTarget as dropTarget } from 'react-dnd';
 import cx from 'classnames';
+import { TASK_UNCOLLECTED } from '../../constants';
 
 const cardSource = {
   beginDrag(props) {
@@ -109,6 +110,16 @@ export default class TaskItem extends Component {
     this.props.deleteTask(this.props.sampleId, this.props.index);
   }
 
+  deleteButton() {
+    let content = (<Button bsSize="sm" onClick={this.deleteTask}>Delete</Button>);
+
+    if (this.props.state !== TASK_UNCOLLECTED) {
+      content = (<span> </span>);
+    }
+
+    return content;
+  }
+
   showForm() {
     const { data, sampleId } = this.props;
     const { type, parameters } = data;
@@ -187,7 +198,7 @@ export default class TaskItem extends Component {
                 </span>
               </div>
                 <Button bsSize="sm" onClick={this.showForm}>Change</Button>
-                <Button bsSize="sm" onClick={this.deleteTask}>Delete</Button>
+                {this.deleteButton()}
                 <Button bsSize="sm" disabled={state !== 2}>Results</Button>
             </form>
           </div>

--- a/mxcube3/ui/constants.js
+++ b/mxcube3/ui/constants.js
@@ -9,10 +9,10 @@ export const QUEUE_RUNNING = 'QueueStarted';
 export const QUEUE_STOPPED = 'QueueStopped';
 export const QUEUE_PAUSED = 'QueuePaused';
 export const SAMPLE_MOUNTED = 0x8;
-export const SAMPLE_COLLECTED = 0x4;
-export const SAMPLE_COLLECT_FAILED = 0x2;
-export const SAMPLE_RUNNING = 0x1;
-export const SAMPLE_UNCOLLECTED = 0x0;
+export const TASK_COLLECTED = 0x4;
+export const TASK_COLLECT_FAILED = 0x2;
+export const TASK_RUNNING = 0x1;
+export const TASK_UNCOLLECTED = 0x0;
 
 
 /* eslint-enable no-unused-vars */

--- a/mxcube3/ui/reducers/sampleGrid.js
+++ b/mxcube3/ui/reducers/sampleGrid.js
@@ -13,7 +13,7 @@
 *  filterText: Current filter text
 */
 import update from 'react/lib/update';
-import { SAMPLE_MOUNTED, SAMPLE_UNCOLLECTED } from '../constants';
+import { SAMPLE_MOUNTED, TASK_UNCOLLECTED } from '../constants';
 
 const INITIAL_STATE = { selected: {},
                         sampleList: {},
@@ -121,7 +121,7 @@ export default (state = INITIAL_STATE, action) => {
         sampleList[task.sampleID] = {
           ...sampleList[task.sampleID],
           tasks: [...sampleList[task.sampleID].tasks, task],
-          state: SAMPLE_UNCOLLECTED
+          state: TASK_UNCOLLECTED
         };
       });
 


### PR DESCRIPTION
Hey !

Fix for #392 (Forbid removal of past data collections)

 - Removed the delete controls when a task is in a collected state ( state != TASK_UNCOLLECTED)
 - Preventing delete in action if state is other then TASK_UNCOLLECTED, (not sure that's actually needed)

I did not work anything on the layout of the TaskItem since we discussed some changes to it when you were here. I'm only hiding the delete button for the moment, Ill let you guys do the redesign as you like. Or just let me know if you prefer that I do it ...

Cheers,
Marcus
