### PR TITLE
Faster updates of sample grid

### DIFF
--- a/mxcube3/ui/actions/queue.js
+++ b/mxcube3/ui/actions/queue.js
@@ -24,6 +24,11 @@ export function addSamplesToQueueAction(samplesData) {
 }
 
 
+export function removeSamplesFromQueueAction(sampleIDList) {
+  return { type: 'REMOVE_SAMPLES_FROM_QUEUE', sampleIDList };
+}
+
+
 export function sendAddQueueItem(items) {
   return fetch('mxcube/api/v0.1/queue', {
     method: 'POST',
@@ -67,11 +72,13 @@ export function sendMountSample(sampleData) {
 
 export function addSamplesToQueue(sampleDataList) {
   return function (dispatch) {
+    dispatch(addSamplesToQueueAction(sampleDataList));
+
     sendAddQueueItem(sampleDataList).then((response) => {
       if (response.status >= 400) {
         dispatch(showErrorPanel(true, 'Server refused to add sample'));
-      } else {
-        dispatch(addSamplesToQueueAction(sampleDataList));
+        const sampleIDList = sampleDataList.map((sampleData) => (sampleData.sampleID));
+        dispatch(removeSamplesFromQueueAction(sampleIDList));
       }
     });
   };
@@ -178,11 +185,6 @@ export function sendDeleteQueueItem(itemPosList) {
 
 export function setStatus(queueState) {
   return { type: 'SET_QUEUE_STATUS', queueState };
-}
-
-
-export function removeSamplesFromQueueAction(sampleIDList) {
-  return { type: 'REMOVE_SAMPLES_FROM_QUEUE', sampleIDList };
 }
 
 

--- a/mxcube3/ui/components/SampleGrid/SampleGrid.css
+++ b/mxcube3/ui/components/SampleGrid/SampleGrid.css
@@ -2,6 +2,7 @@
 }
 
 .samples-grid ul {
+  margin: 0px auto;
   list-style-type: none;
 }
 
@@ -10,8 +11,8 @@
   background-color: #F6F6F6;
   margin-left: auto; 
   margin-right: auto;
-  padding-left: 20px;
-  padding-right: 28px;
+  padding-left: 4em;
+  padding-right: 4em;
 }
 
 

--- a/mxcube3/ui/components/SampleGrid/SampleGridItem.jsx
+++ b/mxcube3/ui/components/SampleGrid/SampleGridItem.jsx
@@ -18,6 +18,8 @@ export class SampleGridItem extends React.Component {
     this.pickButtonOnClick = this.pickButtonOnClick.bind(this);
     this.sampleItemOnClick = this.sampleItemOnClick.bind(this);
     this.moveButtonOnClick = this.moveButtonOnClick.bind(this);
+    this.pickButtonMouseUp = this.pickButtonMouseUp.bind(this);
+    this.pickButtonMouseDown = this.pickButtonMouseDown.bind(this);
 
     this.moveItem = this.moveItem.bind(this);
     this.moveItemUp = this.moveItemUp.bind(this);
@@ -49,6 +51,14 @@ export class SampleGridItem extends React.Component {
     }
   }
 
+  pickButtonMouseDown(e) {
+    e.stopPropagation();
+  }
+
+  pickButtonMouseUp(e) {
+    e.stopPropagation();
+  }
+
   moveItem(e, direction) {
     if (this.props.onMoveHandler) {
       this.props.onMoveHandler(e, this.props.sampleData.sampleID, direction);
@@ -72,6 +82,8 @@ export class SampleGridItem extends React.Component {
           bsStyle="default"
           bsSize="s"
           onClick={this.pickButtonOnClick}
+          onMouseUp={this.pickButtonMouseUp}
+          onMouseDown={this.pickButtonMouseDown}
           disabled={this.props.current}
         >
           <i className={iconClassName} />

--- a/mxcube3/ui/reducers/sampleGrid.js
+++ b/mxcube3/ui/reducers/sampleGrid.js
@@ -185,7 +185,7 @@ export default (state = INITIAL_STATE, action) => {
     }
     // Toggles a samples movable flag
     case 'TOGGLE_MOVABLE_SAMPLE': {
-      const moving = {};
+      const moving = { };
       moving[action.key] = (!state.moving[action.key]);
       return Object.assign({}, state, { moving });
     }
@@ -196,7 +196,7 @@ export default (state = INITIAL_STATE, action) => {
 
       for (const key of action.keys) {
         selectedItems[key] = action.selected;
-        movingItems[action.key] = (state.moving[action.key] && state.selected[action.key]);
+        movingItems[key] = (state.moving[key] && state.selected[key]);
       }
 
       return Object.assign({}, state, { selected: selectedItems, moving: movingItems });


### PR DESCRIPTION
Hey,
 
Ive "optimized" the sample grid a little bit, so it now reacts as fast as one would expect. Ive tried with up
to 1000 samples on the same page. It starts to become noticeably slower, but still usable, after 500 samples, using the production build speeds things up a bit. However I'm not sure that we will or should have 1000 samples on the same page, we should perhaps provide some default filtering, paging, dynamic loading or other mechanism to handle that.

Ive also added some visual effects to the grid, don't pay to much attention to that. However I do think its nice to have some kind of animation when samples are moved or filtered.

Marcus 