### PR TITLE
[WIP] fixes

### DIFF
--- a/mxcube3/routes/SampleCentring.py
+++ b/mxcube3/routes/SampleCentring.py
@@ -11,6 +11,7 @@ import json
 import signals
 import PIL
 import cStringIO
+from . import scutils
 
 SAMPLE_IMAGE = None
 CLICK_COUNT = 0
@@ -575,6 +576,11 @@ def wait_for_centring_finishes(*args, **kwargs):
     Executed when a centring is finished. It updates the temporary
     centred point.
     """
+    # we do not send/save any centring sata if there is no sample
+    # to avoid the 2d centring when no sample is mounted
+    if scutils.get_current_sample() == '':
+        return
+
     motor_positions = mxcube.diffractometer.centringStatus["motors"]
     motor_positions.pop('zoom', None)
     motor_positions.pop('beam_y', None)

--- a/mxcube3/routes/qutils.py
+++ b/mxcube3/routes/qutils.py
@@ -205,7 +205,7 @@ def get_queue_state():
               }
     """
     queue = queue_to_dict()
-    queue_to_dict().pop("sample_order") if queue else queue
+    queue.pop("sample_order") if queue else queue
 
     res = { "loaded": scutils.get_current_sample(),
             "autoMountNext": get_auto_mount_sample(),

--- a/mxcube3/routes/qutils.py
+++ b/mxcube3/routes/qutils.py
@@ -227,6 +227,11 @@ def _handle_dc(sample_id, node):
     queueID = node._node_id
     enabled, state = get_node_state(queueID)
 
+    try:
+        limsres = mxcube.rest_lims.get_dc(node.id)
+    except:
+        limsres = ''
+
     res = {"label": "Data Collection",
            "type": "DataCollection",
            "parameters": parameters,
@@ -235,7 +240,7 @@ def _handle_dc(sample_id, node):
            "queueID": queueID,
            "checked": enabled,
            "state": state,
-           "limstResultData": mxcube.rest_lims.get_dc(node.id),
+           "limstResultData": limsres,
            }
 
     return res

--- a/mxcube3/routes/signals.py
+++ b/mxcube3/routes/signals.py
@@ -218,11 +218,15 @@ def collect_oscillation_started(*args):
 
 
 def collect_oscillation_failed(owner, status, state, lims_id, osc_id, params=None):
+    try:
+        limsres = mxcube.rest_lims.get_dc(lims_id)
+    except:
+        limsres = ''
     msg = {'Signal': 'collectOscillationFailed',
            'Message': task_signals['collectOscillationFailed'],
-           'taskIndex' : last_queue_node()['idx'] ,
+           'taskIndex': last_queue_node()['idx'],
            'sample': last_queue_node()['sample'],
-           'limstResultData': mxcube.rest_lims.get_dc(lims_id),
+           'limstResultData': limsres,
            'state': get_signal_result('collectOscillationFailed'),
            'progress': 100}
     logging.getLogger('HWR').debug('[TASK CALLBACK]   ' + str(msg))
@@ -234,12 +238,15 @@ def collect_oscillation_failed(owner, status, state, lims_id, osc_id, params=Non
 
 def collect_oscillation_finished(owner, status, state, lims_id, osc_id, params):
     qutils.enable_entry(last_queue_node()['queue_id'], False)
-    
+    try:
+        limsres = mxcube.rest_lims.get_dc(lims_id)
+    except:
+        limsres = ''
     msg = {'Signal': 'collectOscillationFinished',
            'Message': task_signals['collectOscillationFinished'],
-           'taskIndex': last_queue_node()['idx'] ,
+           'taskIndex': last_queue_node()['idx'],
            'sample': last_queue_node()['sample'],
-           'limsResultData': mxcube.rest_lims.get_dc(lims_id),
+           'limsResultData': limsres,
            'state': 2,
            'progress': 100}
     logging.getLogger('HWR').debug('[TASK CALLBACK] ' + str(msg))

--- a/mxcube3/ui/components/SampleQueue/CurrentTree.js
+++ b/mxcube3/ui/components/SampleQueue/CurrentTree.js
@@ -36,7 +36,8 @@ export default class CurrentTree extends React.Component {
 
   nextSample() {
     if (this.props.todoList[0]) {
-      this.props.runSample(this.props.todoList[0]);
+        this.props.mount(this.props.sampleList[this.props.todoList[0]]);
+        this.props.runSample(this.props.todoList[0]);
     }
   }
 

--- a/mxcube3/ui/components/SampleQueue/CurrentTree.js
+++ b/mxcube3/ui/components/SampleQueue/CurrentTree.js
@@ -36,8 +36,9 @@ export default class CurrentTree extends React.Component {
 
   nextSample() {
     if (this.props.todoList[0]) {
-        this.props.mount(this.props.sampleList[this.props.todoList[0]]);
-        this.props.runSample(this.props.todoList[0]);
+      this.props.mount(this.props.sampleList[this.props.todoList[0]]);
+      // TODO: discuss behaviour and logic a bit more
+      // this.props.runSample(this.props.todoList[0]);
     }
   }
 

--- a/mxcube3/ui/components/SampleQueue/QueueControl.js
+++ b/mxcube3/ui/components/SampleQueue/QueueControl.js
@@ -36,7 +36,7 @@ export default class QueueControl extends React.Component {
         bsSize="sm"
         onClick={option.action}
         key={option.key}
-      > 
+      >
         {option.text}
       </Button>
     );

--- a/mxcube3/ui/components/SampleQueue/TaskItem.js
+++ b/mxcube3/ui/components/SampleQueue/TaskItem.js
@@ -157,10 +157,10 @@ export default class TaskItem extends Component {
 
     let typePrefix = '';
 
-    if (data.type === 'DataCollection' || data.type === 'Characterisation') {
-      typePrefix = 'P';
-    } else {
+    if (data.parameters.helical) {
       typePrefix = 'L';
+    } else {
+      typePrefix = 'P';
     }
 
     let delTaskCSS = {
@@ -170,7 +170,6 @@ export default class TaskItem extends Component {
       paddingLeft: '10px',
       paddingRight: '10px'
     };
-
     const element = (
       <div className="node node-sample" style={{ opacity }}>
             <div className={taskCSS} style={{ display: 'flex' }} onClick={this.collapseTask} >

--- a/mxcube3/ui/components/SampleView/ContextMenu.js
+++ b/mxcube3/ui/components/SampleView/ContextMenu.js
@@ -40,13 +40,22 @@ export default class ContextMenu extends React.Component {
 
   showModal(modalName) {
     const { sampleID, defaultParameters, shape, sampleData } = this.props;
+    let typePrefix = '';
+    if (modalName === 'Characterisation') {
+      typePrefix = 'c-';
+    } else if (modalName === 'DataCollection') {
+      typePrefix = 'd-';
+    } else if (modalName === 'Helical') {
+      typePrefix = 'l-';
+    }
+
     this.props.showForm(
       modalName,
       [sampleID],
       { parameters:
         { path: sampleData.sampleName,
           ...defaultParameters[modalName.toLowerCase()],
-          prefix: sampleData.defaultPrefix
+          prefix: typePrefix + sampleData.defaultPrefix
         }
       },
       shape.id

--- a/mxcube3/ui/components/Tasks/Characterisation.js
+++ b/mxcube3/ui/components/Tasks/Characterisation.js
@@ -431,7 +431,6 @@ state => ({ // mapStateToProps
   initialValues: {
     ...state.taskForm.taskData.parameters,
     beam_size: state.sampleview.currentAperture,
-    path: state.login.loginInfo.loginRes.Proposal.code
   } // will pull state into form's initialValues
 }))(Characterisation);
 

--- a/mxcube3/ui/containers/SampleQueueContainer.js
+++ b/mxcube3/ui/containers/SampleQueueContainer.js
@@ -154,6 +154,7 @@ export default class SampleQueueContainer extends React.Component {
                   stop={sendStopQueue}
                   showForm={showForm}
                   unmount={sendUnmountSample}
+                  mount={sendMountSample}
                   queueStatus={queueStatus}
                   rootPath={rootPath}
                   collapseTask={collapseTask}

--- a/mxcube3/ui/reducers/queue.js
+++ b/mxcube3/ui/reducers/queue.js
@@ -78,7 +78,7 @@ export default (state = initialState, action) => {
       {
         return {
           ...state,
-          rootPath: action.data.rootPath,
+          rootPath: action.data.beamlineSetup.path,
           queue: Object.keys(action.data.queue.queue),
           autoMountNext: action.data.queue.autoMountNext,
           current: { sampleID: action.data.queue.loaded,


### PR DESCRIPTION
a collection of small fixes here and there while we are testing in the beamline.

WIP because I guess more will come.

* in the queue state retrieval `sample_order` was not properly pop-ed
* missing `get_dc` if rest lims not available (this is an old friend)
* the prefix changed to {'d-', 'c-', 'l-'}name-acr based on collection type
* the root path supplied to the task was lost
* In the current tree clicking on 'next sample' was not mounting the sample, only running it
   * linked to that: it is a bit confusing that if you click 'next sample' it will start running that one no matter if you have run the queue first. This pr looks that it fixes the issue for us but I am not sure if it breaks something else (gonna work on this more, perhaps a flag that tells if the queue is already running?)
* Solving #468