### PR TITLE
Grid UI

### DIFF
--- a/mxcube3/ui/actions/sampleview.js
+++ b/mxcube3/ui/actions/sampleview.js
@@ -79,7 +79,6 @@ export function addCentringPoint(x, y) {
   };
 }
 
-
 export function addLine(p1, p2) {
   return {
     type: 'ADD_LINE', p1, p2
@@ -138,6 +137,33 @@ export function toggleCinema() {
   return {
     type: 'TOOGLE_CINEMA'
   };
+}
+
+export function toggleDrawGrid() {
+  return { type: 'DRAW_GRID' };
+}
+
+export function addGridAction(gridData) {
+  return { type: 'ADD_GRID', gridData };
+}
+
+export function addGrid(gridData) {
+  return function (dispatch, getState) {
+    const { sampleview } = getState();
+    dispatch(addGridAction({ ...gridData, id: sampleview.gridCount }));
+  };
+}
+
+export function deleteGrid(id) {
+  return { type: 'DELETE_GRID', id };
+}
+
+export function selectGrid(id) {
+  return { type: 'SELECT_GRID', id };
+}
+
+export function updateGrid(gridData) {
+  return { type: 'UPDATE_GRID', gridData };
 }
 
 export function sendStartClickCentring() {

--- a/mxcube3/ui/components/SampleView/ContextMenu.js
+++ b/mxcube3/ui/components/SampleView/ContextMenu.js
@@ -4,6 +4,9 @@ export default class ContextMenu extends React.Component {
 
   constructor(props) {
     super(props);
+    this.toggleDrawGrid = this.toggleDrawGrid.bind(this);
+    this.deleteGrid = this.deleteGrid.bind(this);
+
     this.state = {
       options: {
         SAVED: [
@@ -20,11 +23,18 @@ export default class ContextMenu extends React.Component {
         { text: 'Add Helical Scan', action: () => this.createLine(), key: 1 }
         ],
         LINE: [
-        { text: 'Delete Line', action: () => this.removeLine(), key: 2 }
+        { text: 'Delete Line', action: () => this.removeLine(), key: 1 }
+        ],
+        GridGroup: [
+          { text: 'Save Grid', action: () => this.saveGrid(), key: 1 }
+        ],
+        GridGroupSaved: [
+          { text: 'Delete', action: () => this.deleteGrid(), key: 1 }
         ],
         NONE: [
-        { text: 'Go To Beam', action: () => this.goToBeam(), key: 1 },
-        { text: 'Measure Distance', action: () => this.measureDistance(), key: 2 }
+          { text: 'Go To Beam', action: () => this.goToBeam(), key: 1 },
+          { text: 'Measure Distance', action: () => this.measureDistance(), key: 2 },
+          { text: 'Draw Grid', action: () => this.toggleDrawGrid(), key: 3 }
         ]
       }
     };
@@ -89,6 +99,22 @@ export default class ContextMenu extends React.Component {
     this.props.sampleActions.measureDistance(true);
   }
 
+  toggleDrawGrid() {
+    this.props.sampleActions.showContextMenu(false);
+    this.props.sampleActions.toggleDrawGrid();
+  }
+
+  deleteGrid() {
+    this.props.sampleActions.showContextMenu(false);
+    this.props.sampleActions.deleteGrid(this.props.shape.obj.id);
+  }
+
+  saveGrid() {
+    this.props.sampleActions.showContextMenu(false);
+    this.props.sampleActions.addGrid(this.props.shape.gridData);
+    this.props.sampleActions.toggleDrawGrid();
+  }
+
   createLine() {
     const { shape } = this.props;
     this.props.sampleActions.showContextMenu(false);
@@ -100,6 +126,7 @@ export default class ContextMenu extends React.Component {
     this.props.sampleActions.showContextMenu(false);
     this.props.sampleActions.deleteLine(this.props.shape.id);
   }
+
   hideContextMenu() {
     document.getElementById('contextMenu').style.display = 'none';
   }

--- a/mxcube3/ui/components/SampleView/DrawGridPlugin.js
+++ b/mxcube3/ui/components/SampleView/DrawGridPlugin.js
@@ -1,0 +1,373 @@
+import 'fabric';
+const fabric = window.fabric;
+
+/**
+ * Fabric Shape for drawing grid (defined by GridData)
+ */
+const GridGroup = fabric.util.createClass(fabric.Group, {
+  type: 'GridGroup',
+
+  initialize(objects, options = {}) {
+    this.callSuper('initialize', objects, options);
+    this.id = options.id;
+  }
+});
+
+
+/**
+ * GridData object defines a grid
+ *
+ * @return {GridData} GridData object
+ */
+function _GridData() {
+  return { top: null, left: null,
+           width: null, height: null,
+           cellWidth: null, cellHeight: null,
+           cellVSpace: 0, cellHSpace: 0,
+           numCols: null, numRows: null,
+           label: 'Grid', cellCountFun: 'zig-zag',
+           selected: false, id: null };
+}
+
+
+export default class DrawGridPlugin {
+  constructor() {
+    this.startDrawing = this.startDrawing.bind(this);
+    this.update = this.update.bind(this);
+    this.endDrawing = this.endDrawing.bind(this);
+    this.repaint = this.repaint.bind(this);
+    this.currentGridData = this.currentGridData.bind(this);
+    this.currentShape = this.currentShape.bind(this);
+    this.setCellSize = this.setCellSize.bind(this);
+    this.shapeFromGridData = this.shapeFromGridData.bind(this);
+    this.reset = this.reset.bind(this);
+    this.snapToGrid = true;
+
+    this.drawing = false;
+    this.shapeGroup = null;
+    this.gridData = _GridData();
+  }
+
+  /**
+   * Sets cell size of current grid
+   *
+   * @param {float} cellWidth
+   * @param {float} cellHeight
+   */
+  setCellSize(cellWidth, cellHeight) {
+    this.gridData.cellWidth = cellWidth;
+    this.gridData.cellHeight = cellHeight;
+  }
+
+
+  /**
+   * Sets cell spacing, of an arbitrary grid (specified by a GridData object)
+   *
+   * @param {GridData} gd - GridData object
+   * @param {boolean} snapToGrid - True if grid is defined by whole cells,
+   *                               false if fractions of a cell is allowed
+   * @param {float} hSpace - horizontal space
+   * @param {float} VSpace - vertical space
+   */
+  setCellSpace(gd, snapToGrid, hSpace, vSpace) {
+    const gridData = { ...gd };
+
+    if (vSpace !== null && !isNaN(vSpace)) { gridData.cellVSpace = vSpace; }
+    if (hSpace !== null && !isNaN(hSpace)) { gridData.cellHSpace = hSpace; }
+
+    if (snapToGrid) {
+      const cellTW = gridData.cellWidth + gridData.cellHSpace;
+      const cellTH = gridData.cellHeight + gridData.cellVSpace;
+
+      gridData.width = gridData.numCols * cellTW;
+      gridData.height = gridData.numRows * cellTH;
+    }
+
+    return gridData;
+  }
+
+
+  /**
+   * Sets cell spacing for current grid
+   *
+   * @param {float} hSpace
+   * @param {float} vSpace
+   */
+  setCurrentCellSpace(hSpace, vSpace) {
+    this.gridData = this.setCellSpace(this.gridData, this.snapToGrid, hSpace, vSpace);
+  }
+
+
+  /**
+   * Sart drawing grid
+   *
+   * @param {Object} options
+   * @param {FabricCanvas} canvas
+   * @param {boolean} snapToGrid - True if grid is defined by whole cells,
+   *                               false if fractions of a cell is allowed
+   */
+  startDrawing(options, canvas, snapToGrid = true) {
+    if (!canvas.getActiveObject() && !this.drawing) {
+      this.snapToGrid = snapToGrid;
+      this.drawing = true;
+      this.gridData.top = options.e.layerY;
+      this.gridData.left = options.e.layerX;
+    }
+  }
+
+
+  /**
+   * Updates current grid while drawing
+   *
+   * @param {FabricCanvas} canvas
+   * @param {float} x - bottom x coordinate of grid, (mouse x position)
+   * @param {float} y - bottom y coordinate of grid, (mouse y position)
+   */
+  update(canvas, x, y) {
+    const validPosition = x > this.gridData.left && y > this.gridData.top;
+    const draw = this.drawing && validPosition;
+    const cellTW = this.gridData.cellWidth + this.gridData.cellHSpace;
+    const cellTH = this.gridData.cellHeight + this.gridData.cellVSpace;
+
+    let width = Math.abs(x - this.gridData.left);
+    let height = Math.abs(y - this.gridData.top);
+
+    const numCols = Math.ceil(width / this.gridData.cellWidth);
+    const numRows = Math.ceil(height / this.gridData.cellHeight);
+
+    if (this.snapToGrid) {
+      width = numCols * cellTW;
+      height = numRows * cellTH;
+    }
+
+    if (draw) {
+      this.gridData.width = width;
+      this.gridData.height = height;
+      this.gridData.numCols = numCols;
+      this.gridData.numRows = numRows;
+
+      this.repaint(canvas);
+    }
+  }
+
+
+  /**
+   * Repaint current grid
+   *
+   * @param {FabricCanvas} canvas
+   */
+  repaint(canvas) {
+    const shape = this.shapeFromGridData(this.gridData);
+
+    if (this.shapeGroup) {
+      canvas.remove(this.shapeGroup);
+    }
+
+    this.shapeGroup = shape.shapeGroup;
+    this.gridData = shape.gridData;
+    canvas.add(this.shapeGroup);
+
+    canvas.renderAll();
+  }
+
+
+  /**
+   * Creates a Fabric GridGroup shape from a GridData object
+   *
+   * @param {GridData} gd
+   * @return {Object} {shapeGroup, gridData}
+   */
+  shapeFromGridData(gd) {
+    const gridData = { ...gd };
+    const shapes = [];
+    const cellWidth = gridData.cellWidth;
+    const cellHeight = gridData.cellHeight;
+
+    const cellTW = cellWidth + gridData.cellHSpace;
+    const cellTH = cellHeight + gridData.cellVSpace;
+
+    const color = gridData.selected ? 'rgba(0,255,0,1)' : 'rgba(0,0,100,0.8)';
+    const strokeArray = gridData.selected ? [] : [5, 5];
+
+
+    if (cellWidth > 0 && cellHeight > 0) {
+      for (let nw = 1; nw < gridData.numCols; nw++) {
+        shapes.push(new fabric.Line(
+          [gridData.left + cellTW * nw, gridData.top,
+           gridData.left + cellTW * nw, gridData.top + gridData.height],
+          {
+            strokeDashArray: strokeArray,
+            stroke: color,
+            hasControls: false,
+            selectable: false
+          }));
+      }
+
+      for (let nh = 1; nh < gridData.numRows; nh++) {
+        shapes.push(new fabric.Line(
+          [gridData.left, gridData.top + (cellTH) * nh,
+           gridData.left + gridData.width, gridData.top + (cellTH) * nh],
+          {
+            strokeDashArray: strokeArray,
+            stroke: color,
+            hasControls: false,
+            selectable: false
+          }));
+      }
+
+      for (let nw = 0; nw < gridData.numCols; nw++) {
+        for (let nh = 0; nh < gridData.numRows; nh++) {
+          shapes.push(new fabric.Ellipse({
+            left: gridData.left + gridData.cellHSpace / 2 + (cellTW) * nw,
+            top: gridData.top + gridData.cellVSpace / 2 + (cellTH) * nh,
+            width: cellWidth,
+            height: cellHeight,
+            fill: 'rgba(0,0,100,0.2)',
+            stroke: 'rgba(0,0,0,0)',
+            hasControls: false,
+            selectable: false,
+            originX: 'left',
+            originY: 'top',
+            rx: cellWidth / 2,
+            ry: cellHeight / 2
+          }));
+
+          const cellCount = this.countCells(gridData.cellCountFun, nw, nh,
+                                            gridData.numRows, gridData.numCols);
+
+          shapes.push(new fabric.Text(cellCount, {
+            left: gridData.left + gridData.cellHSpace / 2 + (cellTW) * nw + cellWidth / 2,
+            top: gridData.top + gridData.cellVSpace / 2 + (cellTH) * nh + cellHeight / 2,
+            originX: 'center',
+            originY: 'center',
+            fill: 'rgba(0, 0, 200, 1)',
+            fontFamily: 'Helvetica',
+            fontSize: 18
+          }));
+        }
+      }
+    }
+
+    shapes.push(new fabric.Rect({
+      left: gridData.left,
+      top: gridData.top,
+      width: gridData.width,
+      height: gridData.height,
+      fill: 'rgba(0,0,0,0)',
+      strokeDashArray: strokeArray,
+      stroke: color,
+      hasControls: false,
+      selectable: true,
+      hoverCursor: 'pointer'
+    }));
+
+    if (gridData.label) {
+      shapes.push(new fabric.Text(gridData.label, {
+        left: gridData.left + gridData.width,
+        top: gridData.top - 20,
+        fill: color,
+        fontFamily: 'Helvetica',
+        fontSize: 18
+      }));
+    }
+
+    const shapeGroup = new GridGroup(shapes, {
+      hasBorders: false,
+      hasControls: false,
+      selectable: true,
+      lockMovementX: true,
+      lockMovementY: true,
+      lockScalingX: true,
+      lockScalingY: true,
+      lockRotatio: true,
+      hoverCursor: 'pointer',
+      id: gd.id
+    });
+
+    return { shapeGroup, gridData };
+  }
+
+
+  /**
+   * Ends drawing
+   */
+  endDrawing() {
+    if (this.drawing) {
+      this.drawing = false;
+    }
+  }
+
+
+  /**
+   * Reset current grid, used to clear current grid.
+   */
+  reset() {
+    this.drawing = false;
+    this.shapeGroup = null;
+    this.gridData = _GridData();
+  }
+
+  /**
+   * Returns current GridGroup shape
+   * @return {GridGroup}
+   */
+  currentShape() {
+    return this.shapeGroup;
+  }
+
+
+  /**
+   * Returns current GridData object
+   * @return {GridData}
+   */
+  currentGridData() {
+    return this.gridData;
+  }
+
+
+  /**
+   * Maps cell at (currentRow, currentCol) in a grid with total number of rows
+   * and columns (numRows, numCols) to a index. The mapping function used is
+   * given by mode.
+   *
+   * @param {String} mode - method to use one of ['zig-zag', 'left-to-right']
+   * @param {Number} currentRow - Row currently at
+   * @param {Number} currentCol - Column currently at
+   * @param {Number} numRows - Total numver of rows in grid
+   * @param {Number} numCols - Total number of columns in grid
+   *
+   * @return {String} - index
+   */
+  countCells(mode, currentRow, currentCol, numRows, numCols) {
+    let count = '';
+
+    if (mode === 'zig-zag') {
+      count = this.zigZagCellCount(currentRow, currentCol, numRows, numCols);
+    } else {
+      count = this.leftRightCellCount(currentRow, currentCol, numRows, numCols);
+    }
+
+    return count.toString();
+  }
+
+
+  /**
+   * zig-zag indexing of cells (see countCells for doc)
+   */
+  zigZagCellCount(currentRow, currentCol, numRows, numCols) {
+    let cellCount = (currentRow + 1) + currentCol * numCols;
+
+    if (currentCol % 2 !== 0) {
+      cellCount = numCols * (currentCol + 1) - currentRow;
+    }
+
+    return cellCount;
+  }
+
+  /**
+   * left-to-right indexing of cells (see countCells for doc)
+   */
+  leftRightCellCount(currentRow, currentCol, numRows, numCols) {
+    return (currentRow + 1) + currentCol * numCols;
+  }
+}

--- a/mxcube3/ui/components/SampleView/SampleControls.js
+++ b/mxcube3/ui/components/SampleView/SampleControls.js
@@ -146,16 +146,6 @@ export default class SampleControls extends React.Component {
           <Button
             type="button"
             data-toggle="tooltip"
-            title="Start auto centring"
-            className="fa fa-arrows sample-controll"
-            onClick={this.props.sampleActions.sendStartAutoCentring}
-          />
-          <span className="sample-controll-label">Auto-Centring</span>
-          </li>
-          <li>
-          <Button
-            type="button"
-            data-toggle="tooltip"
             title="Start 3-click Centring"
             className="fa fa-circle-o-notch sample-controll"
             onClick={this.toggleCentring}

--- a/mxcube3/ui/components/SampleView/SampleControls.js
+++ b/mxcube3/ui/components/SampleView/SampleControls.js
@@ -20,6 +20,7 @@ export default class SampleControls extends React.Component {
     this.toggleFrontLight = this.toggleLight.bind(this, 'FrontLight');
     this.toggleBackLight = this.toggleLight.bind(this, 'BackLight');
     this.toggleCentring = this.toggleCentring.bind(this);
+    this.toggleDrawGrid = this.toggleDrawGrid.bind(this);
   }
 
   componentDidMount() {
@@ -45,6 +46,10 @@ export default class SampleControls extends React.Component {
 
   setApertureSize(option) {
     this.props.sampleActions.sendChangeAperture(option.target.value);
+  }
+
+  toggleDrawGrid() {
+    this.props.sampleActions.toggleDrawGrid();
   }
 
   doTakeSnapshot() {
@@ -141,6 +146,17 @@ export default class SampleControls extends React.Component {
             download
           />
           <span className="sample-controll-label">Snapshot</span>
+          </li>
+          <li>
+          <Button
+            type="button"
+            data-toggle="tooltip"
+            title="Draw grid"
+            className="fa fa-th sample-controll"
+            onClick={this.toggleDrawGrid}
+            active={this.props.drawGrid}
+          />
+          <span className="sample-controll-label">Draw grid</span>
           </li>
           <li>
           <Button

--- a/mxcube3/ui/containers/BeamlineSetupContainer.jsx
+++ b/mxcube3/ui/containers/BeamlineSetupContainer.jsx
@@ -3,7 +3,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { Row, Col } from 'react-bootstrap';
 import PopInput from '../components/PopInput/PopInput';
-import BeamlineActions from './BeamlineActionsContainer';
+import BeamlineActions from '../components/BeamlineActions/BeamlineActions';
 import InOutSwitch2 from '../components/InOutSwitch2/InOutSwitch2';
 import MachInfo from '../components/MachInfo/MachInfo';
 import CryoInput from '../components/Cryo/CryoInput';

--- a/mxcube3/ui/reducers/sampleview.js
+++ b/mxcube3/ui/reducers/sampleview.js
@@ -24,7 +24,11 @@ const initialState = {
   beamShape: 'elipse',
   beamSize: { x: 0, y: 0 },
   cinema: false,
-  phaseList: []
+  phaseList: [],
+  drawGrid: false,
+  gridList: [],
+  gridCount: 0,
+  selectedGrids: []
 };
 
 export default (state = initialState, action) => {
@@ -60,6 +64,46 @@ export default (state = initialState, action) => {
     case 'ADD_LINE':
       {
         return { ...state, lines: [...state.lines, { p1: action.p1, p2: action.p2 }] };
+      }
+    case 'DRAW_GRID':
+      {
+        let selectedGrids = state.selectedGrids;
+        if (!state.drawGrid) { selectedGrids = []; }
+
+        return { ...state, drawGrid: !state.drawGrid, selectedGrids };
+      }
+    case 'ADD_GRID':
+      {
+        return { ...state,
+                 gridList: [...state.gridList, action.gridData],
+                 gridCount: state.gridCount + 1,
+                 selectedGrids: [action.gridData.id]
+               };
+      }
+    case 'DELETE_GRID':
+      {
+        return { ...state,
+                 gridList: state.gridList.filter((gridData) => (gridData.id !== action.id))
+        };
+      }
+    case 'SELECT_GRID':
+      {
+        return { ...state, selectedGrids: [action.id] };
+      }
+
+    case 'UPDATE_GRID':
+      {
+        const gridList = state.gridList.map((gridData) => {
+          let gd = gridData;
+
+          if (gridData.id === action.gridData.id) {
+            gd = { ...action.gridData };
+          }
+
+          return gd;
+        });
+
+        return { ...state, gridList };
       }
     case 'MEASURE_DISTANCE':
       {
@@ -119,10 +163,13 @@ export default (state = initialState, action) => {
       }
     case 'CLEAR_ALL':
       {
-        return Object.assign({},
-          state,
-          { lines: [], distancePoints: [], clickCentringPoints: [] }
-        );
+        return Object.assign({}, state,
+                             { lines: [],
+                               distancePoints: [],
+                               clickCentringPoints: [],
+                               gridList: [],
+                               gridCount: 0 }
+         );
       }
     case 'SET_INITIAL_STATE':
       {


### PR DESCRIPTION
Hey,

Preliminary version of the grid UI, implements #403 

Its now possible to: 
 - Delete and save grids
 - Several grids supported
 - Define cell spacing or overlap (negative spacing)

The cell counting is by default done in "zig-zag" mode but is configurable and other methods can be added, methods currently available is "left-to-right" or "zig-zag"

A grid is: 
- Drawn either from the context menu or the video toolbar (the later will probably be removed).
- Saved or Deleted from the context menu
- Cell spacing is defined in the form that appears above the grid, (which probably will be moved into the
  context menu)

Marcus