### PR TITLE
Preliminary Workflow integration

### DIFF
--- a/mxcube3/__init__.py
+++ b/mxcube3/__init__.py
@@ -96,7 +96,7 @@ if not app.debug or os.environ.get("WERKZEUG_RUN_MAIN") == "true":
     ### Importing all REST-routes
     from routes import (Main, Login, Beamline, Collection, Mockups, Utils,
                         SampleCentring, SampleChanger, Diffractometer, Queue,
-                        lims, qutils)
+                        lims, qutils, workflow)
 
     ### Install server-side UI state storage
     from mxcube3 import state_storage
@@ -105,6 +105,7 @@ if not app.debug or os.environ.get("WERKZEUG_RUN_MAIN") == "true":
         app.beamline = hwr.getHardwareObject(cmdline_options.beamline_setup)
         app.session = app.beamline.getObjectByRole("session")
         app.collect = app.beamline.getObjectByRole("collect")
+        app.workflow = app.beamline.getObjectByRole("workflow")
 
         Utils.enable_snapshots(app.collect)
 
@@ -125,6 +126,7 @@ if not app.debug or os.environ.get("WERKZEUG_RUN_MAIN") == "true":
         app.CURRENTLY_MOUNTED_SAMPLE = ''
         app.AUTO_MOUNT_SAMPLE = False
         app.AUTO_LOOP_CENTER = False
+        app.CURRENT_WORKFLOW = None
 
         try:
             SampleCentring.init_signals()

--- a/mxcube3/__init__.py
+++ b/mxcube3/__init__.py
@@ -127,7 +127,6 @@ if not app.debug or os.environ.get("WERKZEUG_RUN_MAIN") == "true":
         app.CURRENTLY_MOUNTED_SAMPLE = ''
         app.AUTO_MOUNT_SAMPLE = False
         app.AUTO_LOOP_CENTER = False
-        app.CURRENT_WORKFLOW = None
 
         try:
             SampleCentring.init_signals()

--- a/mxcube3/__init__.py
+++ b/mxcube3/__init__.py
@@ -103,6 +103,7 @@ if not app.debug or os.environ.get("WERKZEUG_RUN_MAIN") == "true":
 
     def complete_initialization(app):
         app.beamline = hwr.getHardwareObject(cmdline_options.beamline_setup)
+        app.xml_rpc_server = hwr.getHardwareObject('xml-rpc-server')
         app.session = app.beamline.getObjectByRole("session")
         app.collect = app.beamline.getObjectByRole("collect")
         app.workflow = app.beamline.getObjectByRole("workflow")

--- a/mxcube3/ho_mediators/beamline_setup.py
+++ b/mxcube3/ho_mediators/beamline_setup.py
@@ -33,6 +33,13 @@ class _BeamlineSetupMediator(object):
         self._bl = beamline_setup
         self._ho_dict = {}
 
+        workflow = self.getObjectByRole("workflow")
+
+        if workflow:
+            workflow.connect('parametersNeeded', self.wf_parameters_needed)
+
+    def wf_parameters_needed(params):
+        socketio.emit("workflowParametersDialog", params, namespace="/hwr")
 
     def getObjectByRole(self, name):
         try:

--- a/mxcube3/routes/workflow.py
+++ b/mxcube3/routes/workflow.py
@@ -8,7 +8,13 @@ def workflow():
     workflows = {}
 
     for wf in mxcube.workflow.get_available_workflows():
-        workflows[wf["name"]] = wf
+        # Rename name and path to wfname and wfpath in order to avoid name
+        # clashes
+        wf["wfname"] = wf.pop("name")
+        wf["wfpath"] = wf.pop("path")
+
+        workflows[wf["wfname"]] = wf
+
     
     return jsonify({"workflows": workflows})
 

--- a/mxcube3/routes/workflow.py
+++ b/mxcube3/routes/workflow.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from mxcube3 import socketio
 from mxcube3 import app as mxcube
 from flask import Response, jsonify, request
 
@@ -19,26 +20,31 @@ def workflow():
     return jsonify({"workflows": workflows})
 
 
-
-@mxcube.route("/mxcube/api/v0.1/workflow/start", methods=['POST'])
-def workflow_start():
-    data = request.get_json()
-
-    try:
-         mxcube.workflow.start(data["path"])
-         mxcube.CURRENT_WORKFLOW = data
-    except:
-        return Response(status=409)
-    else:
-        return Response(status=200)
-
-
-@mxcube.route("/mxcube/api/v0.1/workflow/stop", methods=['POST'])
-def workflow_stop():
-    try:
-         mxcube.CURRENT_WORKFLOW = None
-         mxcube.workflow.abort()
-    except:
-        return Response(status=409)
-    else:
-        return Response(status=200)
+@mxcube.route("/mxcube/api/v0.1/workflow/dialog/<wf>", methods=['GET'])
+def workflow_dialog(wf):
+    dialog = {
+        "properties": {
+            "name": {
+                "title":"Task name",
+                "type":"string",
+                "minLength": 2
+                },
+            "description": {
+                "title":"Description",
+                "type":"string",
+                "widget":"textarea"
+                },
+            "dueTo": {
+                "title":"Due to",
+                "type":"string",
+                "widget":"compatible-datetime",
+                "format":"date-time"
+                }
+            },
+        "required":["name"],
+        "dialogName": "Trouble shooting !"
+        }
+    
+    socketio.emit("workflowParametersDialog", dialog, namespace="/hwr")
+    
+    return Response(status=200)

--- a/mxcube3/routes/workflow.py
+++ b/mxcube3/routes/workflow.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from mxcube3 import app as mxcube
+from flask import Response, jsonify, request
+
+
+@mxcube.route("/mxcube/api/v0.1/workflow", methods=['GET'])
+def workflow():
+    workflows = {}
+
+    for wf in mxcube.workflow.get_available_workflows():
+        workflows[wf["name"]] = wf
+    
+    return jsonify({"workflows": workflows})
+
+
+
+@mxcube.route("/mxcube/api/v0.1/workflow/start", methods=['POST'])
+def workflow_start():
+    data = request.get_json()
+
+    try:
+         mxcube.workflow.start(data["path"])
+         mxcube.CURRENT_WORKFLOW = data
+    except:
+        return Response(status=409)
+    else:
+        return Response(status=200)
+
+
+@mxcube.route("/mxcube/api/v0.1/workflow/stop", methods=['POST'])
+def workflow_stop():
+    try:
+         mxcube.CURRENT_WORKFLOW = None
+         mxcube.workflow.abort()
+    except:
+        return Response(status=409)
+    else:
+        return Response(status=200)

--- a/mxcube3/routes/workflow.py
+++ b/mxcube3/routes/workflow.py
@@ -20,6 +20,7 @@ def workflow():
     return jsonify({"workflows": workflows})
 
 
+# This route is only for testing
 @mxcube.route("/mxcube/api/v0.1/workflow/dialog/<wf>", methods=['GET'])
 def workflow_dialog(wf):
     dialog = {

--- a/mxcube3/ui/actions/general.js
+++ b/mxcube3/ui/actions/general.js
@@ -157,6 +157,14 @@ export function getInitialState() {
         'Content-type': 'application/json'
       }
     });
+    const workflow = fetch('mxcube/api/v0.1/workflow', {
+      method: 'GET',
+      credentials: 'include',
+      headers: {
+        Accept: 'application/json',
+        'Content-type': 'application/json'
+      }
+    });
 
     const pchains = [
       queue.then(parse).then(json => { state.queue = json; }).catch(notify),
@@ -174,7 +182,8 @@ export function getInitialState() {
       sampleChangerContents.then(parse).then(json => {
         state.sampleChangerContents = json;
       }).catch(notify),
-      observers.then(parse).then(json => { state.remoteAccess = json.data; }).catch(notify)
+      observers.then(parse).then(json => { state.remoteAccess = json.data; }).catch(notify),
+      workflow.then(parse).then(json => { state.workflow = json; }).catch(notify)
     ];
 
     Promise.all(pchains).then(() => {

--- a/mxcube3/ui/actions/workflow.js
+++ b/mxcube3/ui/actions/workflow.js
@@ -1,0 +1,3 @@
+export function showWorkflowParametersDialog(formData, show = true) {
+  return { type: 'SHOW_WORKFLOW_PARAMETERS_DIALOG', formData, show };
+}

--- a/mxcube3/ui/components/Main.jsx
+++ b/mxcube3/ui/components/Main.jsx
@@ -9,6 +9,7 @@ import ConnectionLostDialog from '../containers/ConnectionLostDialog';
 import ObserverDialog from './RemoteAccess/ObserverDialog';
 import PassControlDialog from './RemoteAccess/PassControlDialog';
 import ConfirmCollectDialog from '../containers/ConfirmCollectDialog';
+import WorkflowParametersDialog from '../containers/WorkflowParametersDialog';
 
 export default class Main extends React.Component {
   render() {
@@ -22,6 +23,7 @@ export default class Main extends React.Component {
         <ObserverDialog />
         <PassControlDialog />
         <ConfirmCollectDialog />
+        <WorkflowParametersDialog />
         <MXNavbarContainer location={this.props.location} />
         <Grid fluid>
             {this.props.children}

--- a/mxcube3/ui/components/SampleGrid/TaskItem.jsx
+++ b/mxcube3/ui/components/SampleGrid/TaskItem.jsx
@@ -29,6 +29,8 @@ export class TaskItem extends React.Component {
       res = 'DC';
     } else if (type === 'Characterisation') {
       res = 'C';
+    } else if (type === 'Workflow') {
+      res = 'AS';
     }
 
     return res;

--- a/mxcube3/ui/components/SampleView/ContextMenu.js
+++ b/mxcube3/ui/components/SampleView/ContextMenu.js
@@ -7,7 +7,6 @@ export default class ContextMenu extends React.Component {
     this.toggleDrawGrid = this.toggleDrawGrid.bind(this);
     this.deleteGrid = this.deleteGrid.bind(this);
     this.menuOptions = this.menuOptions.bind(this);
-    this.startWorkflow = this.startWorkflow.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -54,19 +53,19 @@ export default class ContextMenu extends React.Component {
     Object.values(this.props.workflows).forEach((wf) => {
       if (wf.requires === 'point') {
         workflowTasks.point.push({ text: wf.wfname,
-                                   action: () => this.startWorkflow(wf),
+                                   action: () => this.showModal('Workflow', wf),
                                    key: `wf-${wf.wfname}` });
       } else if (wf.requires === 'line') {
         workflowTasks.line.push({ text: wf.wfname,
-                                  action: () => this.startWorkflow(wf),
+                                  action: () => this.showModal('Workflow', wf),
                                   key: `wf-${wf.wfname}` });
       } else if (wf.requires === 'grid') {
         workflowTasks.grid.push({ text: wf.wfname,
-                                  action: () => this.startWorkflow(wf),
+                                  action: () => this.showModal('Workflow', wf),
                                   key: `wf-${wf.wfname}` });
       } else if (wf.requires === '') {
         workflowTasks.none.push({ text: wf.wfname,
-                                  action: () => this.startWorkflow(wf),
+                                  action: () => this.showModal('Workflow', wf),
                                   key: `wf-${wf.wfname}` });
       }
     });
@@ -77,12 +76,6 @@ export default class ContextMenu extends React.Component {
     options.NONE = options.NONE.concat(workflowTasks.none);
 
     return options;
-  }
-
-  startWorkflow(wf) {
-    console.log(wf);
-    this.showModal('Workflow', wf);
-    this.props.sampleActions.showContextMenu(false);
   }
 
   showModal(modalName, wf = {}) {

--- a/mxcube3/ui/components/SampleView/ContextMenu.js
+++ b/mxcube3/ui/components/SampleView/ContextMenu.js
@@ -6,37 +6,36 @@ export default class ContextMenu extends React.Component {
     super(props);
     this.toggleDrawGrid = this.toggleDrawGrid.bind(this);
     this.deleteGrid = this.deleteGrid.bind(this);
+    this.addWfMethodsToCtxMenu = this.addWfMethodsToCtxMenu.bind(this);
 
-    this.state = {
-      options: {
-        SAVED: [
+    this.options = {
+      SAVED: [
         { text: 'Add Characterisation', action: () => this.showModal('Characterisation'), key: 1 },
         { text: 'Add Datacollection', action: () => this.showModal('DataCollection'), key: 2 },
         { text: 'Go To Point', action: () => this.goToPoint(), key: 3 },
-        { text: 'Delete Point', action: () => this.removeObject(), key: 4 }
-        ],
-        TMP: [
+        { text: 'Delete Point', action: () => this.removeObject(), key: 4 },
+      ],
+      TMP: [
         { text: 'Save Point', action: () => this.savePoint(), key: 1 },
         { text: 'Delete Point', action: () => this.removeObject(), key: 2 }
-        ],
-        GROUP: [
+      ],
+      GROUP: [
         { text: 'Add Helical Scan', action: () => this.createLine(), key: 1 }
-        ],
-        LINE: [
+      ],
+      LINE: [
         { text: 'Delete Line', action: () => this.removeLine(), key: 1 }
-        ],
-        GridGroup: [
-          { text: 'Save Grid', action: () => this.saveGrid(), key: 1 }
-        ],
-        GridGroupSaved: [
-          { text: 'Delete', action: () => this.deleteGrid(), key: 1 }
-        ],
-        NONE: [
-          { text: 'Go To Beam', action: () => this.goToBeam(), key: 1 },
-          { text: 'Measure Distance', action: () => this.measureDistance(), key: 2 },
-          { text: 'Draw Grid', action: () => this.toggleDrawGrid(), key: 3 }
-        ]
-      }
+      ],
+      GridGroup: [
+        { text: 'Save Grid', action: () => this.saveGrid(), key: 1 }
+      ],
+      GridGroupSaved: [
+        { text: 'Delete', action: () => this.deleteGrid(), key: 1 }
+      ],
+      NONE: [
+        { text: 'Go To Beam', action: () => this.goToBeam(), key: 1 },
+        { text: 'Measure Distance', action: () => this.measureDistance(), key: 2 },
+        { text: 'Draw Grid', action: () => this.toggleDrawGrid(), key: 3 }
+      ]
     };
   }
 
@@ -46,6 +45,39 @@ export default class ContextMenu extends React.Component {
     } else {
       this.hideContextMenu();
     }
+  }
+
+  addWfMethodsToCtxMenu() {
+    const workflowTasks = { point: [], line: [], grid: [], none: [] };
+
+    Object.values(this.props.workflows).forEach((wf) => {
+      if (wf.requires === 'point') {
+        workflowTasks.point.push({ text: wf.name,
+                                   action: this.startWorkflow(wf),
+                                   key: `wf-${wf.name}` });
+      } else if (wf.requires === 'line') {
+        workflowTasks.line.push({ text: wf.name,
+                                  action: this.startWorkflow(wf),
+                                  key: `wf-${wf.name}` });
+      } else if (wf.requires === 'grid') {
+        workflowTasks.grid.push({ text: wf.name,
+                                  action: this.startWorkflow(wf),
+                                  key: `wf-${wf.name}` });
+      } else if (wf.requires === '') {
+        workflowTasks.none.push({ text: wf.name,
+                                  action: this.startWorkflow(wf),
+                                  key: `wf-${wf.name}` });
+      }
+    });
+
+    this.options.SAVED = this.options.SAVED.concat(workflowTasks.point);
+    this.options.LINE = this.options.LINE.concat(workflowTasks.line);
+    this.options.GridGroupSaved = this.options.GridGroupSaved.concat(workflowTasks.grid);
+    this.options.NONE = this.options.NONE.concat(workflowTasks.none);
+  }
+
+  startWorkflow(wf) {
+    console.log(wf);
   }
 
   showModal(modalName) {
@@ -138,11 +170,13 @@ export default class ContextMenu extends React.Component {
   }
 
   render() {
+    this.addWfMethodsToCtxMenu();
+
     let optionList = [];
     if (this.props.sampleID !== undefined) {
-      optionList = this.state.options[this.props.shape.type].map(this.listOptions);
+      optionList = this.options[this.props.shape.type].map(this.listOptions);
     } else {
-      optionList = this.state.options.NONE.map(this.listOptions);
+      optionList = this.options.NONE.map(this.listOptions);
     }
     return (
       <ul id="contextMenu" className="dropdown-menu" role="menu">

--- a/mxcube3/ui/components/Tasks/Workflow.jsx
+++ b/mxcube3/ui/components/Tasks/Workflow.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { reduxForm, formValueSelector } from 'redux-form';
+
 import { Modal, Button, Form, Row, Col, ButtonToolbar } from 'react-bootstrap';
 import validate from './validate';
 import { FieldsHeader, StaticField, InputField } from './fields';

--- a/mxcube3/ui/components/Tasks/Workflow.jsx
+++ b/mxcube3/ui/components/Tasks/Workflow.jsx
@@ -26,7 +26,7 @@ class Workflow extends React.Component {
     const parameters = {
       ...params,
       type: 'Workflow',
-      label: 'workflow',
+      label: params.wfname,
       point: this.props.pointID
     };
 
@@ -49,7 +49,7 @@ class Workflow extends React.Component {
   render() {
     return (<Modal show={this.props.show} onHide={this.props.hide}>
         <Modal.Header closeButton>
-          <Modal.Title>Workflow</Modal.Title>
+          <Modal.Title>{this.props.wfname}</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <FieldsHeader title="Data location" />
@@ -108,6 +108,7 @@ Workflow = connect(state => {
   return {
     path: `${state.queue.rootPath}/${subdir}`,
     filename: `${prefix}_${runNumber}.???`,
+    wfname: state.taskForm.taskData.parameters.wfname,
     motorLimits: state.beamline.motorsLimits,
     acqParametersLimits: state.taskForm.acqParametersLimits,
     initialValues: {

--- a/mxcube3/ui/components/Tasks/Workflow.jsx
+++ b/mxcube3/ui/components/Tasks/Workflow.jsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { reduxForm, formValueSelector } from 'redux-form';
+import { Modal, Button, Form, Row, Col, ButtonToolbar } from 'react-bootstrap';
+import validate from './validate';
+import { FieldsHeader, StaticField, InputField } from './fields';
+
+class Workflow extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.submitAddToQueue = this.submitAddToQueue.bind(this);
+    this.submitRunNow = this.submitRunNow.bind(this);
+    this.addToQueue = this.addToQueue.bind(this);
+  }
+
+  submitAddToQueue() {
+    this.props.handleSubmit(this.addToQueue.bind(this, false))();
+  }
+
+  submitRunNow() {
+    this.props.handleSubmit(this.addToQueue.bind(this, true))();
+  }
+
+  addToQueue(runNow, params) {
+    const parameters = {
+      ...params,
+      type: 'Workflow',
+      label: 'workflow',
+      point: this.props.pointID
+    };
+
+    // Form gives us all parameter values in strings so we need to transform numbers back
+    const stringFields = [
+      'centringMethod',
+      'prefix',
+      'subdir',
+      'type',
+      'point',
+      'label',
+      'wfname',
+      'wfpath'
+    ];
+
+    this.props.addTask(parameters, stringFields, runNow);
+    this.props.hide();
+  }
+
+  render() {
+    return (<Modal show={this.props.show} onHide={this.props.hide}>
+        <Modal.Header closeButton>
+          <Modal.Title>Workflow</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <FieldsHeader title="Data location" />
+          <Form horizontal>
+            <StaticField label="Path" data={this.props.path} />
+            <StaticField label="Filename" data={this.props.filename} />
+            <Row>
+              <Col xs={12} style={{ marginTop: '10px' }}>
+                <InputField propName="subdir" label="Subdirectory" col1="4" col2="8" />
+              </Col>
+            </Row>
+            <Row>
+              <Col xs={8}>
+                <InputField propName="prefix" label="Prefix" col1="6" col2="6" />
+              </Col>
+              <Col xs={4}>
+                <InputField propName="run_number" label="Run number" col1="4" col2="8" />
+              </Col>
+            </Row>
+          </Form>
+       </Modal.Body>
+
+       { this.props.taskData.state ? '' :
+           <Modal.Footer>
+             <ButtonToolbar className="pull-right">
+               <Button bsStyle="success"
+                 disabled={this.props.pointID === -1 || this.props.invalid}
+                 onClick={this.submitRunNow}
+               >
+                 Run Now
+               </Button>
+               <Button bsStyle="primary" disabled={this.props.invalid}
+                 onClick={this.submitAddToQueue}
+               >
+                 {this.props.taskData.sampleID ? 'Change' : 'Add to Queue'}
+               </Button>
+             </ButtonToolbar>
+           </Modal.Footer>
+       }
+      </Modal>);
+  }
+}
+
+Workflow = reduxForm({
+  form: 'workflow',
+  validate
+})(Workflow);
+
+const selector = formValueSelector('workflow');
+
+Workflow = connect(state => {
+  const subdir = selector(state, 'subdir');
+  const prefix = selector(state, 'prefix');
+  const runNumber = selector(state, 'run_number');
+
+  return {
+    path: `${state.queue.rootPath}/${subdir}`,
+    filename: `${prefix}_${runNumber}.???`,
+    motorLimits: state.beamline.motorsLimits,
+    acqParametersLimits: state.taskForm.acqParametersLimits,
+    initialValues: {
+      ...state.taskForm.taskData.parameters,
+      beam_size: state.sampleview.currentAperture
+    }
+  };
+})(Workflow);
+
+export default Workflow;
+

--- a/mxcube3/ui/containers/SampleGridContainer.jsx
+++ b/mxcube3/ui/containers/SampleGridContainer.jsx
@@ -60,6 +60,7 @@ class SampleGridContainer extends React.Component {
     this.showRubberBand = false;
     this.state = { sampleItems: this.getSampleItems(props) };
     this.sampleItems = this.getSampleItems(props);
+    this.workflowMenuOptions = this.workflowMenuOptions.bind(this);
   }
 
 
@@ -618,6 +619,50 @@ class SampleGridContainer extends React.Component {
   }
 
 
+  /**
+   * Returns menu options for workflow tasks
+   *
+   * @property {Object} workflows
+   *
+   * return {array} Array of <MenuItem>
+   */
+  workflowMenuOptions() {
+    const workflowTasks = { point: [], line: [], grid: [], samplegrid: [], none: [] };
+
+    Object.values(this.props.workflows).forEach((wf) => {
+      if (wf.requires === 'point') {
+        workflowTasks.point.push({ text: wf.wfname,
+                                   action: () => this.props.showWorkflowForm(wf),
+                                   key: `wf-${wf.wfname}` });
+      } else if (wf.requires === 'line') {
+        workflowTasks.line.push({ text: wf.wfname,
+                                  action: () => this.props.showWorkflowForm(wf),
+                                  key: `wf-${wf.wfname}` });
+      } else if (wf.requires === 'grid') {
+        workflowTasks.grid.push({ text: wf.wfname,
+                                  action: () => this.props.showWorkflowForm(wf),
+                                  key: `wf-${wf.wfname}` });
+      } else if (wf.requires === 'samplegrid') {
+        workflowTasks.samplegrid.push({ text: wf.wfname,
+                                        action: () => this.props.showWorkflowForm(wf),
+                                        key: `wf-${wf.wfname}` });
+      } else if (wf.requires === '') {
+        workflowTasks.none.push({ text: wf.wfname,
+                                  action: () => this.props.showWorkflowForm(wf),
+                                  key: `wf-${wf.wfname}` });
+      }
+    });
+
+    const menuItems = workflowTasks.samplegrid.map((wf) => (
+      <MenuItem eventKey={wf.key} onClick={wf.action}>
+        {wf.text}
+      </MenuItem>
+    ));
+
+    return menuItems;
+  }
+
+
   render() {
     this.sampleItems = this.getSampleItems(this.props);
 
@@ -640,6 +685,7 @@ class SampleGridContainer extends React.Component {
           <MenuItem eventKey="3" onClick={this.props.showCharacterisationForm}>
             Characterisation
           </MenuItem>
+          {this.workflowMenuOptions()}
           <MenuItem divider />
           <MenuItem header><span><Glyphicon glyph="minus" /> Remove </span></MenuItem>
           <MenuItem eventKey="1" onClick={this.props.removeSelectedSamples}>
@@ -678,6 +724,7 @@ class SampleGridContainer extends React.Component {
  */
 function mapStateToProps(state) {
   return {
+    workflows: state.workflow.workflows,
     queue: state.queue,
     selected: state.sampleGrid.selected,
     moving: state.sampleGrid.moving,

--- a/mxcube3/ui/containers/SampleGridViewContainer.jsx
+++ b/mxcube3/ui/containers/SampleGridViewContainer.jsx
@@ -67,6 +67,8 @@ class SampleGridViewContainer extends React.Component {
     this.clearSelectedSamples = this.clearSelectedSamples.bind(this);
     this.showCharacterisationForm = this.showTaskForm.bind(this, 'Characterisation');
     this.showDataCollectionForm = this.showTaskForm.bind(this, 'DataCollection');
+    this.showDataCollectionForm = this.showTaskForm.bind(this, 'DataCollection');
+    this.showWorkflowForm = this.showTaskForm.bind(this, 'Workflow');
     this.showAddSampleForm = this.showTaskForm.bind(this, 'AddSample');
     this.inQueue = this.inQueue.bind(this);
     this.inQueueDeleteElseAddSamples = this.inQueueDeleteElseAddSamples.bind(this);
@@ -163,7 +165,7 @@ class SampleGridViewContainer extends React.Component {
    * @property {Object} selected
    * @property {Object} sampleList
    */
-  showTaskForm(formName) {
+  showTaskForm(formName, wf = {}) {
     let prefix = '';
     let path = '';
 
@@ -174,7 +176,9 @@ class SampleGridViewContainer extends React.Component {
 
     const parameters = { parameters: {
       ...this.props.defaultParameters[formName.toLowerCase()],
-      prefix, path } };
+      ...wf,
+      prefix,
+      path } };
 
     const selected = [];
 
@@ -570,6 +574,7 @@ class SampleGridViewContainer extends React.Component {
             addSelectedSamplesToQueue={this.addSelectedSamplesToQueue}
             showCharacterisationForm={this.showCharacterisationForm}
             showDataCollectionForm={this.showDataCollectionForm}
+            showWorkflowForm={this.showWorkflowForm}
             addSamplesToQueue={this.addSamplesToQueue}
             inQueue={this.inQueue}
             inQueueDeleteElseAddSamples={this.inQueueDeleteElseAddSamples}

--- a/mxcube3/ui/containers/SampleGridViewContainer.jsx
+++ b/mxcube3/ui/containers/SampleGridViewContainer.jsx
@@ -188,7 +188,12 @@ class SampleGridViewContainer extends React.Component {
       }
     }
 
-    this.props.showTaskParametersForm(formName, selected, parameters);
+    if (formName === 'AddSample') {
+      this.props.showTaskParametersForm('AddSample');
+    }
+    else {
+      this.props.showTaskParametersForm(formName, selected, parameters);
+    }
   }
 
 

--- a/mxcube3/ui/containers/SampleViewContainer.js
+++ b/mxcube3/ui/containers/SampleViewContainer.js
@@ -45,6 +45,7 @@ class SampleViewContainer extends Component {
                   sampleData={this.props.sampleList[sampleID]}
                   defaultParameters={this.props.defaultParameters}
                   imageRatio={imageRatio}
+                  workflows={this.props.workflows}
                 />
                 <SampleImage
                   sampleActions={this.props.sampleViewActions}
@@ -73,7 +74,8 @@ function mapStateToProps(state) {
     contextMenu: state.contextMenu,
     beamline: state.beamline,
     defaultParameters: state.taskForm.defaultParameters,
-    points: state.points
+    points: state.points,
+    workflows: state.workflow.workflows
   };
 }
 

--- a/mxcube3/ui/containers/TaskContainer.js
+++ b/mxcube3/ui/containers/TaskContainer.js
@@ -5,6 +5,7 @@ import Characterisation from '../components/Tasks/Characterisation';
 import DataCollection from '../components/Tasks/DataCollection';
 import Helical from '../components/Tasks/Helical';
 import AddSample from '../components/Tasks/AddSample';
+import Workflow from '../components/Tasks/Workflow';
 import { hideTaskParametersForm, showTaskForm } from '../actions/taskForm';
 
 
@@ -104,6 +105,18 @@ class TaskContainer extends React.Component {
       />);
     }
 
+    if (this.props.showForm === 'Workflow') {
+      return (<Workflow
+        show
+        addTask={this.addTask}
+        pointID={this.props.pointID}
+        taskData={this.props.taskData}
+        hide={this.props.hideTaskParametersForm}
+        apertureList={this.props.apertureList}
+        rootPath={this.props.path}
+      />);
+    }
+
     return null;
   }
 }
@@ -132,7 +145,7 @@ function mapDispatchToProps(dispatch) {
     addTask: bindActionCreators(addTask, dispatch),
     addSamplesToList: bindActionCreators(addSamplesToList, dispatch),
     addSamplesToQueue: bindActionCreators(addSamplesToQueue, dispatch),
-    addSampleAndMount: bindActionCreators(addSampleAndMount, dispatch),
+    addSampleAndMount: bindActionCreators(addSampleAndMount, dispatch)
   };
 }
 

--- a/mxcube3/ui/containers/WorkflowParametersDialog.jsx
+++ b/mxcube3/ui/containers/WorkflowParametersDialog.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { bindActionCreators, createStore, combineReducers } from 'redux';
+import { connect, Provider } from 'react-redux';
+import { reducer as formReducer } from 'redux-form';
+import { Modal } from 'react-bootstrap';
+import Liform from 'liform-react';
+import { showWorkflowParametersDialog } from '../actions/workflow';
+
+class WorkflowParametersDialog extends React.Component {
+  constructor(props) {
+    super(props);
+    const reducer = combineReducers({ form: formReducer });
+    this.store = (window.devToolsExtension ?
+                  window.devToolsExtension()(createStore) :
+                  createStore)(reducer);
+  }
+
+  showResults(/* values */) {
+    // window.alert(`You submitted:\n\n ${JSON.stringify(values, null, 2)}`);
+    this.props.hide();
+  }
+
+  render() {
+    let form = '';
+    let formName = '';
+
+    // The Liform generates some errors when schema is empty or null so
+    // we only create it when show is true and we have a schema to use.
+    // The errors will otherwise prevent the dialog from beeing closed
+    // properly.
+    if (this.props.show && this.props.formData) {
+      form = (
+        <Provider store={this.store}>
+          <Liform schema={this.props.formData} onSubmit={this.showResults} />
+        </Provider>
+      );
+
+      formName = this.props.formData.dialogName;
+    }
+
+    return (
+      <Modal show={this.props.show} onHide={this.props.hide}>
+        <Modal.Header closeButton>
+          <Modal.Title>{formName}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <div id="form-holder">
+            {form}
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+        </Modal.Footer>
+      </Modal>);
+  }
+}
+
+
+function mapStateToProps(state) {
+  return {
+    show: state.workflow.showParametersDialog,
+    formData: state.workflow.formData
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    hide: bindActionCreators(showWorkflowParametersDialog.bind(this, null, false), dispatch),
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(WorkflowParametersDialog);

--- a/mxcube3/ui/reducers/index.js
+++ b/mxcube3/ui/reducers/index.js
@@ -12,6 +12,8 @@ import logger from './logger';
 import contextMenu from './contextMenu';
 import remoteAccess from './remoteAccess';
 import points from './points';
+import workflow from './workflow';
+
 import { reducer as formReducer } from 'redux-form';
 
 const mxcubeReducer = combineReducers({
@@ -28,6 +30,7 @@ const mxcubeReducer = combineReducers({
   contextMenu,
   points,
   queueGUI,
+  workflow,
   form: formReducer
 });
 

--- a/mxcube3/ui/reducers/taskForm.js
+++ b/mxcube3/ui/reducers/taskForm.js
@@ -81,6 +81,10 @@ export default (state = initialState, action) => {
             helical: {
               run_number: 1,
               ...action.data.dcParameters,
+              ...state.defaultParameters.helical },
+            workflow: {
+              run_number: 1,
+              ...action.data.dcParameters,
               ...state.defaultParameters.helical }
           },
           acqParametersLimits: { ...action.data.acqParametersLimits }

--- a/mxcube3/ui/reducers/workflow.js
+++ b/mxcube3/ui/reducers/workflow.js
@@ -1,0 +1,23 @@
+const initialState = {
+  workflows: [],
+  current: null
+};
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case 'SET_WORKFLOWS':
+      {
+        return Object.assign({}, state, { workflows: { ...action.workflows } });
+      }
+    case 'SET_CURRENT_WORKFLOW':
+      {
+        return Object.assign({}, state, { current: action.current });
+      }
+    case 'SET_INITIAL_STATE':
+      {
+        return { ...state, workflows: action.data.workflow.workflows };
+      }
+    default:
+      return state;
+  }
+};

--- a/mxcube3/ui/reducers/workflow.js
+++ b/mxcube3/ui/reducers/workflow.js
@@ -13,6 +13,10 @@ export default (state = initialState, action) => {
       {
         return Object.assign({}, state, { current: action.current });
       }
+    case 'SHOW_WORKFLOW_PARAMETERS_DIALOG':
+      {
+        return { ...state, formData: action.formData, showParametersDialog: action.show };
+      }
     case 'SET_INITIAL_STATE':
       {
         return { ...state, workflows: action.data.workflow.workflows };

--- a/mxcube3/ui/serverIO.js
+++ b/mxcube3/ui/serverIO.js
@@ -24,6 +24,8 @@ import { setLoading,
          addUserMessage,
          showConnectionLostDialog } from './actions/general';
 
+import { showWorkflowParametersDialog } from './actions/workflow';
+
 import { setObservers, setMaster, requestControlAction } from './actions/remoteAccess';
 
 
@@ -191,6 +193,10 @@ class ServerIO {
 
     this.hwrSocket.on('observersChanged', (data) => {
       this.dispatch(setObservers(data));
+    });
+
+    this.hwrSocket.on('workflowParametersDialog', (data) => {
+      this.dispatch(showWorkflowParametersDialog(data));
     });
 
     this.hwrSocket.on('setMaster', (data) => {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "font-awesome": "^4.4.0",
     "history": "1.17.x",
     "isomorphic-fetch": "^2.2.0",
+    "liform-react": "^0.5.15",
     "lodash": "^4.0.0",
     "react": "15.4.2",
     "react-bootstrap": "^0.30.7",

--- a/test/HardwareObjectsMockup.xml/beamline-setup.xml
+++ b/test/HardwareObjectsMockup.xml/beamline-setup.xml
@@ -20,10 +20,9 @@
   <object href="/session" role="session"/>
   <object href="/mach-info" role="mach_info"/>
 
-
-
   <!-- Software (abstract) concepts -->
   <object href="/shape-history" role="shape_history"/>
+  <object href="/ednaparams" role="workflow"/>
   <!--object href="/edna_config" role="data_analysis"/> -->
   <!--<object href="/workflow-mockup" role="workflow"/> -->
  

--- a/test/HardwareObjectsMockup.xml/ednaparams.xml
+++ b/test/HardwareObjectsMockup.xml/ednaparams.xml
@@ -25,7 +25,7 @@
   <workflow>
     <title>MXPressE</title>
     <path>MXPressE</path>
-    <requires></requires>
+    <requires>samplegrid</requires>
   </workflow>
   <workflow>
     <title>Mesh and collect</title>
@@ -40,11 +40,11 @@
   <workflow>
     <title>Distance calibration</title>
     <path>DistanceCalibration</path>
-    <requires></requires>
+    <requires>point</requires>
   </workflow>
   <workflow>
     <title>Trouble shooting</title>
     <path>TroubleShooting</path>
-    <requires></requires>
+    <requires>samplegrid</requires>
   </workflow>
 </object>

--- a/test/HardwareObjectsMockup.xml/ednaparams.xml
+++ b/test/HardwareObjectsMockup.xml/ednaparams.xml
@@ -1,0 +1,50 @@
+<object class="EdnaWorkflow" role="workflow">
+  <bes_host>mxhpc2-1705</bes_host>
+  <bes_port>8090</bes_port>
+  <object href="/session" role="session"/>
+  <workflow>
+    <title>Mesh Scan</title>
+    <path>MeshScan</path>
+    <requires>grid</requires>
+  </workflow>
+  <workflow>
+    <title>X-ray Centring</title>
+    <path>XrayCentring</path>
+    <requires>grid</requires>
+  </workflow>
+  <workflow>
+    <title>Helical characterisation</title>
+    <path>HelicalCharacterisation</path>
+    <requires>line</requires>
+  </workflow>
+  <workflow>
+    <title>Enhanced characterisation</title>
+    <path>EnhancedCharacterisation</path>
+    <requires>point</requires>
+  </workflow>
+  <workflow>
+    <title>MXPressE</title>
+    <path>MXPressE</path>
+    <requires></requires>
+  </workflow>
+  <workflow>
+    <title>Mesh and collect</title>
+    <path>MeshAndCollect</path>
+    <requires>grid</requires>
+  </workflow>
+  <workflow>
+    <title>Mesh and collect from file</title>
+    <path>MeshAndCollectFromFile</path>
+    <requires>grid</requires>
+  </workflow>
+  <workflow>
+    <title>Distance calibration</title>
+    <path>DistanceCalibration</path>
+    <requires></requires>
+  </workflow>
+  <workflow>
+    <title>Trouble shooting</title>
+    <path>TroubleShooting</path>
+    <requires></requires>
+  </workflow>
+</object>

--- a/test/HardwareObjectsMockup.xml/ednaparams.xml
+++ b/test/HardwareObjectsMockup.xml/ednaparams.xml
@@ -1,6 +1,6 @@
 <object class="EdnaWorkflow" role="workflow">
-  <bes_host>mxhpc2-1705</bes_host>
-  <bes_port>8090</bes_port>
+  <bes_host>mxcube3</bes_host>
+  <bes_port>8100</bes_port>
   <object href="/session" role="session"/>
   <workflow>
     <title>Mesh Scan</title>

--- a/test/HardwareObjectsMockup.xml/session.xml
+++ b/test/HardwareObjectsMockup.xml/session.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <object class = "Session" role = "session">  
  <synchrotron_name>ESRF</synchrotron_name>
- <endstation_name>id30a3</endstation_name>
- <beamline_name>ID30A-3</beamline_name>
+ <endstation_name>linoscarsson</endstation_name>
+ <beamline_name>linoscarsson</beamline_name>
 
   <proposals>
     <proposal>

--- a/test/HardwareObjectsMockup.xml/xml-rpc-server.xml
+++ b/test/HardwareObjectsMockup.xml/xml-rpc-server.xml
@@ -1,0 +1,20 @@
+<object class = "XMLRPCServer" role = "XMLRPCServer">
+  <all_interfaces>
+    True
+  </all_interfaces>
+ 
+  <port>
+    7171
+  </port>
+
+  <apis>
+    <api>
+     <module>Native</module>
+     <recurse>True</recurse>
+   </api>
+  </apis>
+
+  <object href="/queue" role="queue"/>
+  <object href="/queue-model" role="queue_model"/>
+  <object href="/beamline-setup" role="beamline_setup"/>
+</object>


### PR DESCRIPTION
Hey !

Preliminary integration of workflows.

Added the possibility to:
  - get a list of available workflows, (displayed where appropriate: in sample grid and sample view context menus)
  - add workflow task to queue
  - start a workflow, (like any task in the queue)
  - stop a workflow, (like any task in the queue)
  - display a configurable dialog which is displayed on the signal parametersNeeded which can be sent
     by any HO.

The workflow methods are displayed according to the requires tag in the ednaparams.xml file. The name of the file is not really important but i kept the old name for now (its just an example file)

You need to update the HardwareObjects to get a small change to the EDNAWorkflow HO in order to get this to work. "git submodule update" should be enough

Still to be done is integration of workflow results, however I prefer to do that in another PR since many workflows does not use the result part.

Marcus