### PR TITLE
Reset session

### DIFF
--- a/mxcube3/ui/actions/login.js
+++ b/mxcube3/ui/actions/login.js
@@ -1,6 +1,6 @@
 import fetch from 'isomorphic-fetch';
 import { showErrorPanel, setLoading, getInitialState } from './general';
-import { sendClearQueue } from './queue';
+import { sendClearQueue, clearAll } from './queue';
 import { setMaster } from './remoteAccess';
 import { browserHistory } from 'react-router';
 
@@ -76,6 +76,7 @@ export function doSignOut() {
     }).then(() => {
       dispatch(signOut());
       dispatch(sendClearQueue());
+      dispatch(clearAll());
       browserHistory.push('/login');
     });
   };

--- a/mxcube3/ui/actions/queue.js
+++ b/mxcube3/ui/actions/queue.js
@@ -1,7 +1,7 @@
 import fetch from 'isomorphic-fetch';
 import { showErrorPanel } from './general';
 import { sendAbortCentring } from './sampleview';
-import { selectSamplesAction } from '../actions/sampleGrid';
+import { selectSamplesAction, clearSampleGrid } from '../actions/sampleGrid';
 import { TASK_UNCOLLECTED } from '../constants';
 
 export function queueLoading(loading) {
@@ -121,7 +121,8 @@ export function sendClearQueue(clearQueueOnly = false) {
         if (clearQueueOnly) {
           dispatch(clearQueue());
         } else {
-          dispatch(clearAll());
+          dispatch(clearQueue());
+          dispatch(clearSampleGrid());
         }
       }
     });

--- a/mxcube3/ui/actions/sampleGrid.js
+++ b/mxcube3/ui/actions/sampleGrid.js
@@ -7,6 +7,11 @@ export function updateSampleList(sampleList, order) {
 }
 
 
+export function clearSampleGrid() {
+  return { type: 'CLEAR_SAMPLE_GRID' };
+}
+
+
 export function addSamplesToList(samplesData) {
   return function (dispatch, getState) {
     // find last manually mounted sample id

--- a/mxcube3/ui/components/MXNavbar/MXNavbar.jsx
+++ b/mxcube3/ui/components/MXNavbar/MXNavbar.jsx
@@ -34,7 +34,6 @@ export default class MXNavbar extends React.Component {
           </LinkContainer>
         </Nav>
         <Nav pullRight>
-          <NavItem eventKey={5} onClick={this.props.reset}>Reset session</NavItem>
           <LinkContainer to="/remoteaccess">
             <NavItem eventKey={6}>
               <span style={ raStyle } className="fa fa-lg fa-universal-access" />

--- a/mxcube3/ui/components/SampleView/PhaseInput.js
+++ b/mxcube3/ui/components/SampleView/PhaseInput.js
@@ -19,16 +19,15 @@ export default class PhaseInput extends React.Component {
         className="form-control input-sm"
         onChange={this.sendPhase}
       >
-        {this.props.phaseList.map((option) =>
-          (<option 
-            key={option} 
+        {this.props.phaseList.map((option) => (
+          <option
+            key={option}
             value={option}
-            selected={this.props.phase===option}
-           >
-            {option}
-           </option>
-          )
-        )}
+            selected={this.props.phase === option}
+          >
+           {option}
+          </option>
+         ))}
       </select>
       );
   }

--- a/mxcube3/ui/containers/MXNavbarContainer.js
+++ b/mxcube3/ui/containers/MXNavbarContainer.js
@@ -1,9 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import MXNavbar from '../components/MXNavbar/MXNavbar';
 import { doSignOut } from '../actions/login';
-import { sendClearQueue } from '../actions/queue';
 
 class MXNavbarContainer extends React.Component {
 
@@ -15,7 +13,6 @@ class MXNavbarContainer extends React.Component {
           loggedIn={this.props.loggedIn}
           location={this.props.location}
           setAutomatic={this.props.setAutomatic}
-          reset={this.props.reset}
           remoteAccessMaster={this.props.remoteAccessMaster}
         />
     );
@@ -33,8 +30,7 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    signOut: () => dispatch(doSignOut()),
-    reset: bindActionCreators(sendClearQueue, dispatch)
+    signOut: () => dispatch(doSignOut())
   };
 }
 

--- a/mxcube3/ui/reducers/sampleGrid.js
+++ b/mxcube3/ui/reducers/sampleGrid.js
@@ -226,6 +226,9 @@ export default (state = INITIAL_STATE, action) => {
 
       return { ...state, sampleList };
     }
+    case 'CLEAR_SAMPLE_GRID': {
+      return Object.assign({}, state, { ...INITIAL_STATE });
+    }
     case 'CLEAR_ALL': {
       return Object.assign({}, state, { ...INITIAL_STATE });
     }

--- a/mxcube3/ui/reducers/sampleGrid.js
+++ b/mxcube3/ui/reducers/sampleGrid.js
@@ -19,7 +19,6 @@ const INITIAL_STATE = { selected: {},
                         sampleList: {},
                         order: [],
                         moving: {},
-                        contextMenu: {},
                         filterOptions: { text: '',
                                          inQueue: false,
                                          notInQueue: false,
@@ -205,11 +204,6 @@ export default (state = INITIAL_STATE, action) => {
       const selected = Object.assign({}, state.selected);
       selected[action.sampleID] = (!state.selected[action.sampleID]);
       return Object.assign({}, state, { selected });
-    }
-    case 'SAMPLE_GRID_CONTEXT_MENU': {
-      return Object.assign({}, state, { contextMenu: { x: action.x,
-                                                       y: action.y,
-                                                       show: action.show } });
     }
     case 'FILTER_SAMPLE_LIST': {
       const filterOptions = Object.assign({}, state.filterOptions, action.filterOptions);

--- a/mxcube3/ui/reducers/sampleview.js
+++ b/mxcube3/ui/reducers/sampleview.js
@@ -171,6 +171,16 @@ export default (state = initialState, action) => {
                                gridCount: 0 }
          );
       }
+    case 'CLEAR_QUEUE':
+      {
+        return Object.assign({}, state,
+                             { lines: [],
+                               distancePoints: [],
+                               clickCentringPoints: [],
+                               gridList: [],
+                               gridCount: 0 }
+         );
+      }
     case 'SET_INITIAL_STATE':
       {
         return {


### PR DESCRIPTION
Hey,

- Removed the reset session from navbar

- Clear sample grid now only clears the sample grid content, the queue (including current sample), also   clearing shapes since we are clearing current sample. Its at the moment not clear if its good idea to clear
the current sample (and shapes), alltough it seems intuitive to the user.

- Clearing all on logout so we can always achieve the old session reset by logging out.

- Two other completely unrelated fixes,  updated sub modules and fixed linting

Marcus
