### PR TITLE
Issue 517 sample naming and 521

### DIFF
--- a/mxcube3/ui/components/SampleQueue/CurrentTree.js
+++ b/mxcube3/ui/components/SampleQueue/CurrentTree.js
@@ -66,10 +66,14 @@ export default class CurrentTree extends React.Component {
     let sampleData = {};
     let sampleTasks = [];
     let queueOptions = [];
+    let sampleName = '';
+    let proteinAcronym = '';
 
     if (sampleId) {
       sampleData = this.props.sampleList[sampleId];
       sampleTasks = sampleData ? this.props.sampleList[sampleId].tasks : [];
+      sampleName = sampleData ? sampleData.sampleName : undefined;
+      proteinAcronym = sampleData ? sampleData.proteinAcronym : undefined;
 
       if (this.props.todoList.length === 0 && this.props.queueStatus === QUEUE_STOPPED) {
         queueOptions = this.state.options.LastSample;
@@ -82,11 +86,6 @@ export default class CurrentTree extends React.Component {
     }
 
     if (! this.props.show) { return <div />; }
-
-    const {
-      sampleName,
-      proteinAcronym
-    } = sampleData;
 
     return (
       <div>

--- a/mxcube3/ui/components/SampleQueue/CurrentTree.js
+++ b/mxcube3/ui/components/SampleQueue/CurrentTree.js
@@ -69,7 +69,7 @@ export default class CurrentTree extends React.Component {
 
     if (sampleId) {
       sampleData = this.props.sampleList[sampleId];
-      sampleTasks = this.props.sampleList[sampleId].tasks;
+      sampleTasks = sampleData ? this.props.sampleList[sampleId].tasks : [];
 
       if (this.props.todoList.length === 0 && this.props.queueStatus === QUEUE_STOPPED) {
         queueOptions = this.state.options.LastSample;
@@ -91,7 +91,7 @@ export default class CurrentTree extends React.Component {
     return (
       <div>
           <div className="list-head">
-              <p className="queue-root" onClick={this.collapse}>
+              <p className="queue-root">
                 { sampleId ? `Sample: ${sampleName} (${proteinAcronym})` : 'No Sample Mounted'}
                 {queueOptions.map((option) => this.renderOptions(option))}
               </p>

--- a/mxcube3/ui/components/SampleQueue/TaskItem.js
+++ b/mxcube3/ui/components/SampleQueue/TaskItem.js
@@ -184,6 +184,8 @@ export default class TaskItem extends Component {
                 <label className="col-sm-12">File path:</label>
                 <div className="col-sm-12" style={{ display: 'flex' }} >
                   <FormControl
+                    onMouseEnter={() => this.setState({ overInput: true }) }
+                    onMouseLeave={() => this.setState({ overInput: false }) }
                     readOnly
                     type="text"
                     defaultValue={value}

--- a/mxcube3/ui/components/SampleQueue/app.less
+++ b/mxcube3/ui/components/SampleQueue/app.less
@@ -132,6 +132,7 @@
   font-size: 1em;
   margin: 10px;
   line-height: 33px;
+  user-select: text;
 }
 
 .current-sample-controls{

--- a/mxcube3/ui/components/Tasks/Characterisation.js
+++ b/mxcube3/ui/components/Tasks/Characterisation.js
@@ -77,7 +77,7 @@ class Characterisation extends React.Component {
                   <InputField propName="prefix" label="Prefix" col1="6" col2="6" />
                 </Col>
                 <Col xs={4}>
-                  <InputField propName="run_number" label="Run number" col1="4" col2="8" />
+                  <InputField propName="run_number" disabled label="Run number" col1="4" col2="8" />
                 </Col>
               </Row>
             </Form>

--- a/mxcube3/ui/components/Tasks/Characterisation.js
+++ b/mxcube3/ui/components/Tasks/Characterisation.js
@@ -188,7 +188,7 @@ Characterisation = connect(state => {
   const prefix = selector(state, 'prefix');
   const runNumber = selector(state, 'run_number');
   const fileSuffix = state.taskForm.fileSuffix === 'h5' ? '_master.h5' : '_????.cbf';
-  const position = state.taskForm.pointID ? state.taskForm.pointID : 'PX';
+  const position = state.taskForm.pointID === '' ? state.taskForm.pointID : 'PX';
 
   return {
     path: `${state.queue.rootPath}/${subdir}`,

--- a/mxcube3/ui/components/Tasks/Characterisation.js
+++ b/mxcube3/ui/components/Tasks/Characterisation.js
@@ -188,10 +188,11 @@ Characterisation = connect(state => {
   const prefix = selector(state, 'prefix');
   const runNumber = selector(state, 'run_number');
   const fileSuffix = state.taskForm.fileSuffix === 'h5' ? '_master.h5' : '_????.cbf';
+  const position = state.taskForm.pointID ? state.taskForm.pointID : 'PX';
 
   return {
     path: `${state.queue.rootPath}/${subdir}`,
-    filename: `ref-${prefix}_${runNumber}${fileSuffix}`,
+    filename: `${prefix}_${position}_${runNumber}${fileSuffix}`,
     acqParametersLimits: state.taskForm.acqParametersLimits,
     initialValues: {
       ...state.taskForm.taskData.parameters,

--- a/mxcube3/ui/components/Tasks/DataCollection.js
+++ b/mxcube3/ui/components/Tasks/DataCollection.js
@@ -57,6 +57,8 @@ class DataCollection extends React.Component {
   }
 
   render() {
+    console.log(this.props);
+    console.log(this.props.taskData.parameters.shape);
     return (<Modal show={this.props.show} onHide={this.props.hide}>
         <Modal.Header closeButton>
           <Modal.Title>Standard Data Collection</Modal.Title>
@@ -159,10 +161,11 @@ DataCollection = connect(state => {
   const prefix = selector(state, 'prefix');
   const runNumber = selector(state, 'run_number');
   const fileSuffix = state.taskForm.fileSuffix === 'h5' ? '_master.h5' : '_????.cbf';
+  const position = state.taskForm.pointID ? state.taskForm.pointID : 'PX';
 
   return {
     path: `${state.queue.rootPath}/${subdir}`,
-    filename: `${prefix}_${runNumber}${fileSuffix}`,
+    filename: `${prefix}_${position}_${runNumber}${fileSuffix}`,
     acqParametersLimits: state.taskForm.acqParametersLimits,
     initialValues: {
       ...state.taskForm.taskData.parameters,

--- a/mxcube3/ui/components/Tasks/DataCollection.js
+++ b/mxcube3/ui/components/Tasks/DataCollection.js
@@ -76,7 +76,7 @@ class DataCollection extends React.Component {
                 <InputField propName="prefix" label="Prefix" col1="6" col2="6" />
               </Col>
               <Col xs={4}>
-                <InputField propName="run_number" label="Run number" col1="4" col2="8" />
+                <InputField propName="run_number" disabled label="Run number" col1="4" col2="8" />
               </Col>
             </Row>
           </Form>

--- a/mxcube3/ui/components/Tasks/DataCollection.js
+++ b/mxcube3/ui/components/Tasks/DataCollection.js
@@ -57,8 +57,6 @@ class DataCollection extends React.Component {
   }
 
   render() {
-    console.log(this.props);
-    console.log(this.props.taskData.parameters.shape);
     return (<Modal show={this.props.show} onHide={this.props.hide}>
         <Modal.Header closeButton>
           <Modal.Title>Standard Data Collection</Modal.Title>
@@ -161,7 +159,7 @@ DataCollection = connect(state => {
   const prefix = selector(state, 'prefix');
   const runNumber = selector(state, 'run_number');
   const fileSuffix = state.taskForm.fileSuffix === 'h5' ? '_master.h5' : '_????.cbf';
-  const position = state.taskForm.pointID ? state.taskForm.pointID : 'PX';
+  const position = state.taskForm.pointID === '' ? state.taskForm.pointID : 'PX';
 
   return {
     path: `${state.queue.rootPath}/${subdir}`,

--- a/mxcube3/ui/components/Tasks/Helical.js
+++ b/mxcube3/ui/components/Tasks/Helical.js
@@ -57,8 +57,6 @@ class Helical extends React.Component {
   }
 
   render() {
-    console.log(this.props);
-    console.log(this.props.taskData.parameters.shape);
     return (<Modal show={this.props.show} onHide={this.props.hide}>
         <Modal.Header closeButton>
           <Modal.Title>Helical Data Collection</Modal.Title>
@@ -160,7 +158,7 @@ Helical = connect(state => {
   const prefix = selector(state, 'prefix');
   const runNumber = selector(state, 'run_number');
   const fileSuffix = state.taskForm.fileSuffix === 'h5' ? '_master.h5' : '_????.cbf';
-  const position = state.taskForm.pointID ? state.taskForm.pointID : 'LX';
+  const position = state.taskForm.pointID === '' ? state.taskForm.pointID : 'LX';
 
   return {
     path: `${state.queue.rootPath}/${subdir}`,

--- a/mxcube3/ui/components/Tasks/Helical.js
+++ b/mxcube3/ui/components/Tasks/Helical.js
@@ -75,7 +75,7 @@ class Helical extends React.Component {
                 <InputField propName="prefix" label="Prefix" col1="6" col2="6" />
               </Col>
               <Col xs={4}>
-                <InputField propName="run_number" label="Run number" col1="4" col2="8" />
+                <InputField propName="run_number" disabled label="Run number" col1="4" col2="8" />
               </Col>
             </Row>
             <StaticField label="Filename" data={this.props.filename} />

--- a/mxcube3/ui/components/Tasks/Helical.js
+++ b/mxcube3/ui/components/Tasks/Helical.js
@@ -57,6 +57,8 @@ class Helical extends React.Component {
   }
 
   render() {
+    console.log(this.props);
+    console.log(this.props.taskData.parameters.shape);
     return (<Modal show={this.props.show} onHide={this.props.hide}>
         <Modal.Header closeButton>
           <Modal.Title>Helical Data Collection</Modal.Title>
@@ -158,10 +160,11 @@ Helical = connect(state => {
   const prefix = selector(state, 'prefix');
   const runNumber = selector(state, 'run_number');
   const fileSuffix = state.taskForm.fileSuffix === 'h5' ? '_master.h5' : '_????.cbf';
+  const position = state.taskForm.pointID ? state.taskForm.pointID : 'LX';
 
   return {
     path: `${state.queue.rootPath}/${subdir}`,
-    filename: `${prefix}_${runNumber}${fileSuffix}`,
+    filename: `${prefix}_${position}_${runNumber}${fileSuffix}`,
     acqParametersLimits: state.taskForm.acqParametersLimits,
     initialValues: {
       ...state.taskForm.taskData.parameters,

--- a/mxcube3/ui/components/Tasks/Mesh.js
+++ b/mxcube3/ui/components/Tasks/Mesh.js
@@ -160,7 +160,7 @@ Mesh = connect(state => {
   const prefix = selector(state, 'prefix');
   const runNumber = selector(state, 'run_number');
   const fileSuffix = state.taskForm.fileSuffix === 'h5' ? '_master.h5' : '_????.cbf';
-  const position = state.taskForm.pointID ? state.taskForm.pointID : 'PX';
+  const position = state.taskForm.pointID === '' ? state.taskForm.pointID : 'PX';
 
   return {
     path: `${state.queue.rootPath}/${subdir}`,

--- a/mxcube3/ui/components/Tasks/Mesh.js
+++ b/mxcube3/ui/components/Tasks/Mesh.js
@@ -160,7 +160,7 @@ Mesh = connect(state => {
   const prefix = selector(state, 'prefix');
   const runNumber = selector(state, 'run_number');
   const fileSuffix = state.taskForm.fileSuffix === 'h5' ? '_master.h5' : '_????.cbf';
-  const position = state.taskForm.pointID === '' ? state.taskForm.pointID : 'PX';
+  const position = state.taskForm.pointID === '' ? state.taskForm.pointID : 'GX';
 
   return {
     path: `${state.queue.rootPath}/${subdir}`,

--- a/mxcube3/ui/components/Tasks/Mesh.js
+++ b/mxcube3/ui/components/Tasks/Mesh.js
@@ -160,10 +160,11 @@ Mesh = connect(state => {
   const prefix = selector(state, 'prefix');
   const runNumber = selector(state, 'run_number');
   const fileSuffix = state.taskForm.fileSuffix === 'h5' ? '_master.h5' : '_????.cbf';
+  const position = state.taskForm.pointID ? state.taskForm.pointID : 'PX';
 
   return {
     path: `${state.queue.rootPath}/${subdir}`,
-    filename: `${prefix}_${runNumber}${fileSuffix}`,
+    filename: `${prefix}_${position}_${runNumber}${fileSuffix}`,
     acqParametersLimits: state.taskForm.acqParametersLimits,
     initialValues: {
       ...state.taskForm.taskData.parameters,

--- a/mxcube3/ui/components/Tasks/Mesh.js
+++ b/mxcube3/ui/components/Tasks/Mesh.js
@@ -77,7 +77,7 @@ class Mesh extends React.Component {
                 <InputField propName="prefix" label="Prefix" col1="6" col2="6" />
               </Col>
               <Col xs={4}>
-                <InputField propName="run_number" label="Run number" col1="4" col2="8" />
+                <InputField propName="run_number" disabled label="Run number" col1="4" col2="8" />
               </Col>
             </Row>
             <StaticField label="Filename" data={this.props.filename} />

--- a/mxcube3/ui/components/Tasks/Workflow.jsx
+++ b/mxcube3/ui/components/Tasks/Workflow.jsx
@@ -67,7 +67,7 @@ class Workflow extends React.Component {
                 <InputField propName="prefix" label="Prefix" col1="6" col2="6" />
               </Col>
               <Col xs={4}>
-                <InputField propName="run_number" label="Run number" col1="4" col2="8" />
+                <InputField propName="run_number" disabled label="Run number" col1="4" col2="8" />
               </Col>
             </Row>
           </Form>

--- a/mxcube3/ui/components/Tasks/Workflow.jsx
+++ b/mxcube3/ui/components/Tasks/Workflow.jsx
@@ -106,10 +106,11 @@ Workflow = connect(state => {
   const prefix = selector(state, 'prefix');
   const runNumber = selector(state, 'run_number');
   const fileSuffix = state.taskForm.fileSuffix === 'h5' ? '_master.h5' : '_????.cbf';
+  const position = state.taskForm.pointID ? state.taskForm.pointID : 'PX';
 
   return {
     path: `${state.queue.rootPath}/${subdir}`,
-    filename: `${prefix}_${runNumber}${fileSuffix}`,
+    filename: `${prefix}_${position}_${runNumber}${fileSuffix}`,
     wfname: state.taskForm.taskData.parameters.wfname,
     acqParametersLimits: state.taskForm.acqParametersLimits,
     initialValues: {

--- a/mxcube3/ui/components/Tasks/Workflow.jsx
+++ b/mxcube3/ui/components/Tasks/Workflow.jsx
@@ -106,7 +106,7 @@ Workflow = connect(state => {
   const prefix = selector(state, 'prefix');
   const runNumber = selector(state, 'run_number');
   const fileSuffix = state.taskForm.fileSuffix === 'h5' ? '_master.h5' : '_????.cbf';
-  const position = state.taskForm.pointID ? state.taskForm.pointID : 'PX';
+  const position = state.taskForm.pointID === '' ? state.taskForm.pointID : 'PX';
 
   return {
     path: `${state.queue.rootPath}/${subdir}`,

--- a/mxcube3/ui/reducers/sampleGrid.js
+++ b/mxcube3/ui/reducers/sampleGrid.js
@@ -225,6 +225,8 @@ export default (state = INITIAL_STATE, action) => {
       for (const sampleID in action.data.queue.queue) {
         if (action.data.queue.queue.hasOwnProperty(sampleID)) {
           sampleList[sampleID] = action.data.queue.queue[sampleID];
+          const pref = `${sampleList[sampleID].sampleName}-${sampleList[sampleID].proteinAcronym}`;
+          sampleList[sampleID].defaultPrefix = pref;
         }
       }
 


### PR DESCRIPTION
* solving #517 
  * Cannot select the sample name string displayed in the current queue
  * Naming convention: <sample_name><position_name><run_number>_xxxx.<file_type>
* solving #521: without removing drag&drop
* also a but where `defaultPrefix` was lost after a page refresh
----
* Not done: rename a sample in # 517
