### PR TITLE
Small fix for mesh

### DIFF
--- a/mxcube3/ui/components/SampleView/SampleImage.jsx
+++ b/mxcube3/ui/components/SampleView/SampleImage.jsx
@@ -421,8 +421,8 @@ export default class SampleImage extends React.Component {
     const gridForm = document.getElementById('gridForm');
 
     if (gridData) {
-      left = gridData.left;
-      top = gridData.top;
+      left = gridData.screenCoord[0];
+      top = gridData.screenCoord[1];
     } else if (this.props.selectedGrids.length === 0 && this.props.drawGrid) {
       left = this.drawGridPlugin.currentGridData().left;
       top = this.drawGridPlugin.currentGridData().top;


### PR DESCRIPTION
Hey !

left and top directly on GridData does not exist any more, using left and top coords from screenCoord array instead.

Marcus