### PR TITLE
Run number and paths

### DIFF
--- a/mxcube3/routes/Queue.py
+++ b/mxcube3/routes/Queue.py
@@ -232,7 +232,7 @@ def queue_add_item():
 
             # Swap first "wedge task" and the actual interleaved collection
             # so that the interleaved task is the first task
-            qutils.move_task_entry(sid, interleaved_tindex, tindex_list[0])
+            qutils.swap_task_entry(sid, interleaved_tindex, tindex_list[0])
 
             # We remove the swapped wedge index from the list, (now pointing
             # at the interleaved collection) and add its new position

--- a/mxcube3/routes/Queue.py
+++ b/mxcube3/routes/Queue.py
@@ -443,6 +443,11 @@ def get_default_dc_params():
     TODO: implement as_dict in the qmo.AcquisitionParameters
     """
     acq_parameters = mxcube.beamline.get_default_acquisition_parameters()
+    ftype = mxcube.beamline.detector_hwobj.getProperty('fileSuffix')
+    ftype = ftype if ftype else '.?'
+    n = int(mxcube.session["file_info"].getProperty("precision", 4))
+    template = '`${prefix}_${position}_[RUN]_%s.%s`' % (n * '#', ftype)
+
     resp = jsonify({
         'acq_parameters': {
             'first_image': acq_parameters.first_image,
@@ -464,7 +469,8 @@ def get_default_dc_params():
             'skip_existing_images': False,
             'take_snapshots': True,
             'helical': False,
-            'mesh': False
+            'mesh': False,
+            'fileNameTemplate': template
         },
         'limits': mxcube.beamline.get_acquisition_limit_values()
     })
@@ -480,6 +486,10 @@ def get_default_char_acq_params():
     TODO: implement as_dict in the qmo.AcquisitionParameters
     """
     acq_parameters = mxcube.beamline.get_default_char_acq_parameters()
+    ftype = mxcube.beamline.detector_hwobj.getProperty('fileSuffix')
+    ftype = ftype if ftype else '.?'
+    n = int(mxcube.session["file_info"].getProperty("precision", 4))
+    template = '`${prefix}_${position}_[RUN]_%s.%s`' % (n * '#', ftype)
 
     resp = jsonify({
         'acq_parameters': {
@@ -501,6 +511,7 @@ def get_default_char_acq_params():
             'take_dark_current': True,
             'skip_existing_images': False,
             'take_snapshots': True,
+            'fileNameTemplate': template
         },
         })
 

--- a/mxcube3/routes/qutils.py
+++ b/mxcube3/routes/qutils.py
@@ -17,6 +17,7 @@ from mock import Mock
 from mxcube3 import app as mxcube
 from mxcube3 import socketio
 from . import scutils
+from . import limsutils
 
 # Important: same constants as in constants.js
 QUEUE_PAUSED = 'QueuePaused'
@@ -346,15 +347,21 @@ def _handle_sample(node):
     else:
         state = UNCOLLECTED
 
-    return {node.loc_str: {'sampleID': node.loc_str,
-                           'queueID': node._node_id,
-                           'location': location,
-                           'sampleName': node.get_name(),
-                           'proteinAcronym': node.crystals[0].protein_acronym,
-                           'type': 'Sample',
-                           'checked': enabled,
-                           'state': state,
-                           'tasks': queue_to_dict_rec(node)}}
+    sample = {node.loc_str: {'sampleID': node.loc_str,
+                             'queueID': node._node_id,
+                             'code': node.code,
+                             'location': location,
+                             'sampleName': node.get_name(),
+                             'proteinAcronym': node.crystals[0].protein_acronym,
+                             'type': 'Sample',
+                             'checked': enabled,
+                             'state': state,
+                             'tasks': queue_to_dict_rec(node)}}
+
+    sample[node.loc_str]["defaultPrefix"] = limsutils.\
+        get_default_prefix(sample[node.loc_str], False)
+
+    return sample
 
 
 def queue_to_dict_rec(node):

--- a/mxcube3/ui/actions/queueGUI.js
+++ b/mxcube3/ui/actions/queueGUI.js
@@ -6,23 +6,16 @@ export function showList(listName) {
 }
 
 
-export function collapseSample(sampleID) {
+export function collapseItem(queueID) {
   return {
-    type: 'COLLAPSE_SAMPLE', sampleID
+    type: 'COLLAPSE_ITEM', queueID
   };
 }
 
 
-export function collapseTask(sampleID, taskIndex) {
+export function selectItem(queueID) {
   return {
-    type: 'COLLAPSE_TASK', sampleID, taskIndex
-  };
-}
-
-
-export function selectTask(sampleID, taskIndex) {
-  return {
-    type: 'SELECT_TASK', sampleID, taskIndex
+    type: 'SELECT_ITEM', queueID
   };
 }
 

--- a/mxcube3/ui/components/SampleGrid/TaskItem.jsx
+++ b/mxcube3/ui/components/SampleGrid/TaskItem.jsx
@@ -38,8 +38,7 @@ export class TaskItem extends React.Component {
 
   summary() {
     const task = this.props.taskData;
-    let filePath = `${this.props.rootPath}/${task.parameters.subdir}/${task.parameters.prefix}`;
-    filePath += `_${task.parameters.run_number}_xxxx.cbf`;
+    let filePath = this.props.taskData.parameters.fullPath;
     return (
       <div>
         <div className="row">

--- a/mxcube3/ui/components/SampleQueue/CurrentTree.js
+++ b/mxcube3/ui/components/SampleQueue/CurrentTree.js
@@ -10,18 +10,17 @@ export default class CurrentTree extends React.Component {
     super(props);
     this.moveCard = this.moveCard.bind(this);
     this.taskHeaderOnClickHandler = this.taskHeaderOnClickHandler.bind(this);
-    this.selectTask = this.selectTask.bind(this);
     this.showInterleavedDialog = this.showInterleavedDialog.bind(this);
     this.interleavedAvailable = this.interleavedAvailable.bind(this);
   }
 
   interleavedAvailable() {
     let available = false;
-    const taskList = this.props.mounted ? this.props.displayData[this.props.mounted].tasks : [];
+    const taskList = this.props.mounted ? this.props.sampleList[this.props.mounted].tasks : [];
     const selectedTasks = [];
 
     taskList.forEach((task, taskIdx) => {
-      if (task.selected) {
+      if (this.props.displayData[task.queueID].selected) {
         const tData = this.props.sampleList[this.props.mounted].tasks[parseInt(taskIdx, 10)];
 
         if (tData) {
@@ -48,10 +47,11 @@ export default class CurrentTree extends React.Component {
   }
 
   taskHeaderOnClickHandler(e, index) {
+    const task = this.props.sampleList[this.props.mounted].tasks[index];
     if (!e.ctrlKey) {
-      this.props.collapseTask(this.props.mounted, index);
+      this.props.collapseItem(task.queueID);
     } else {
-      this.selectTask(index);
+      this.props.selectItem(task.queueID);
     }
   }
 
@@ -59,8 +59,8 @@ export default class CurrentTree extends React.Component {
     const wedges = [];
     const taskIndexList = [];
 
-    Object.values(this.props.displayData[this.props.mounted].tasks).forEach((task, taskIdx) => {
-      if (task.selected) {
+    Object.values(this.props.sampleList[this.props.mounted].tasks).forEach((task, taskIdx) => {
+      if (this.props.displayData[task.queueID].selected) {
         wedges.push(this.props.sampleList[this.props.mounted].tasks[parseInt(taskIdx, 10)]);
         taskIndexList.push(taskIdx);
       }
@@ -70,10 +70,6 @@ export default class CurrentTree extends React.Component {
                         [this.props.mounted],
                         { parameters: { taskIndexList, wedges } },
                         -1);
-  }
-
-  selectTask(index) {
-    this.props.selectTask(this.props.mounted, index);
   }
 
   render() {
@@ -93,32 +89,22 @@ export default class CurrentTree extends React.Component {
         <ContextMenuTrigger id="currentSampleQueueContextMenu">
         <div style={{ top: 'initial' }} className="list-body">
             {sampleTasks.map((taskData, i) => {
-              let runNumber = null;
-
-              if (taskData.type === 'Interleaved') {
-                runNumber = taskData.parameters.wedges[0].parameters.run_number;
-              } else {
-                runNumber = taskData.parameters.run_number;
-              }
-
-              const key = taskData.label + runNumber;
-
               const task =
                 (<TaskItem
-                  key={key}
+                  key={taskData.queueID}
                   index={i}
-                  id={key}
+                  id={taskData.queueID}
                   data={taskData}
                   moveCard={this.moveCard}
                   deleteTask={this.props.deleteTask}
                   sampleId={sampleData.sampleID}
-                  selected={this.props.displayData[taskData.sampleID].tasks[i].selected}
+                  selected={this.props.displayData[taskData.queueID].selected}
                   checked={this.props.checked}
                   toggleChecked={this.props.toggleCheckBox}
                   rootPath={this.props.rootPath}
                   taskHeaderOnClickHandler={this.taskHeaderOnClickHandler}
                   state={this.props.sampleList[taskData.sampleID].tasks[i].state}
-                  show={this.props.displayData[taskData.sampleID].tasks[i].collapsed}
+                  show={this.props.displayData[taskData.queueID].collapsed}
                   moveTask={this.props.moveTask}
                   showForm={this.props.showForm}
                 />);

--- a/mxcube3/ui/components/SampleQueue/CurrentTree.js
+++ b/mxcube3/ui/components/SampleQueue/CurrentTree.js
@@ -101,7 +101,6 @@ export default class CurrentTree extends React.Component {
                   selected={this.props.displayData[taskData.queueID].selected}
                   checked={this.props.checked}
                   toggleChecked={this.props.toggleCheckBox}
-                  rootPath={this.props.rootPath}
                   taskHeaderOnClickHandler={this.taskHeaderOnClickHandler}
                   state={this.props.sampleList[taskData.sampleID].tasks[i].state}
                   show={this.props.displayData[taskData.queueID].collapsed}

--- a/mxcube3/ui/components/SampleQueue/TaskItem.jsx
+++ b/mxcube3/ui/components/SampleQueue/TaskItem.jsx
@@ -163,7 +163,7 @@ export default class TaskItem extends Component {
 
   wedgePath(wedge) {
     const parameters = wedge.parameters;
-    const value = `./${parameters.subdir}/${parameters.prefix}-${parameters.run_number}`;
+    const value = parameters.fileName;
     const path = parameters.path ? parameters.path : '';
 
     return (

--- a/mxcube3/ui/components/Tasks/Helical.js
+++ b/mxcube3/ui/components/Tasks/Helical.js
@@ -36,7 +36,6 @@ class Helical extends React.Component {
       label: 'Helical',
       helical: true,
       shape: this.props.pointID,
-      suffix: this.props.suffix
     };
 
     // Form gives us all parameter values in strings so we need to transform numbers back
@@ -52,7 +51,6 @@ class Helical extends React.Component {
       'label',
       'helical',
       'shape',
-      'suffix'
     ];
 
     this.props.addTask(parameters, stringFields, runNow);
@@ -76,10 +74,18 @@ class Helical extends React.Component {
             <Row>
               <Col xs={8}>
                 <InputField propName="prefix" label="Prefix" col1="6" col2="6" />
-              </Col>
-              <Col xs={4}>
-                <InputField propName="run_number" disabled label="Run number" col1="4" col2="8" />
-              </Col>
+            </Col>
+            {this.props.taskData.sampleID ?
+              (<Col xs={4}>
+                 <InputField
+                   propName="run_number"
+                   disabled
+                   label="Run number"
+                   col1="4"
+                   col2="8"
+                 />
+               </Col>)
+             : null}
             </Row>
             <StaticField label="Filename" data={this.props.filename} />
           </Form>
@@ -158,16 +164,30 @@ const selector = formValueSelector('helical');
 
 Helical = connect(state => {
   const subdir = selector(state, 'subdir');
-  const prefix = selector(state, 'prefix');
-  const runNumber = selector(state, 'run_number');
-  const fileSuffix = state.taskForm.fileSuffix === 'h5' ? '_master.h5' : '.cbf';
-  const position = state.taskForm.pointID === '' ? 'LX' : state.taskForm.pointID;
+  let fname = '';
 
+  if (state.taskForm.taskData.sampleID) {
+    fname = state.taskForm.taskData.parameters.fileName;
+  } else {
+    // Try to call eval on the file name template, just return the template
+    // itself if it fails. Disable eslint since prefix and runNumber are unused
+    // by the rest of the code, but possible used in the template. All variables
+    // that are to be used in the template should be defined in the try.
+    try {
+      /*eslint-disable */
+      const prefix = selector(state, 'prefix');
+      const position = state.taskForm.pointID === '' ? 'LX' : state.taskForm.pointID;
+
+      fname = eval(state.taskForm.taskData.parameters.fileNameTemplate);
+      /*eslint-enable */
+    } catch (e) {
+      fname = state.taskForm.taskData.parameters.fileNameTemplate;
+    }
+  }
   return {
     path: `${state.queue.rootPath}/${subdir}`,
-    filename: `${prefix}_${position}_${runNumber}${fileSuffix}`,
+    filename: fname,
     acqParametersLimits: state.taskForm.acqParametersLimits,
-    suffix: fileSuffix,
     initialValues: {
       ...state.taskForm.taskData.parameters,
       beam_size: state.sampleview.currentAperture,

--- a/mxcube3/ui/components/Tasks/Interleaved.jsx
+++ b/mxcube3/ui/components/Tasks/Interleaved.jsx
@@ -146,8 +146,7 @@ class Interleaved extends React.Component {
               </thead>
               <tbody>
             {this.props.wedges.map((task, i) => {
-              const p = task.parameters;
-              const filename = `${p.prefix}_${p.run_number}.${this.props.suffix}`;
+              const filename = task.parameters.fileName;
 
               return (
                 <tr style={{ backgroundColor: wedgeColorTable[i] }}>

--- a/mxcube3/ui/components/Tasks/Interleaved.jsx
+++ b/mxcube3/ui/components/Tasks/Interleaved.jsx
@@ -141,7 +141,7 @@ class Interleaved extends React.Component {
               <thead>
                 <tr>
                   <th>Wedge </th>
-                  <th>Path </th>
+                  <th width="0">Path </th>
                 </tr>
               </thead>
               <tbody>

--- a/mxcube3/ui/components/Tasks/Mesh.js
+++ b/mxcube3/ui/components/Tasks/Mesh.js
@@ -37,7 +37,6 @@ class Mesh extends React.Component {
       mesh: true,
       helical: false,
       shape: this.props.pointID,
-      suffix: this.props.suffix
     };
 
     // Form gives us all parameter values in strings so we need to transform numbers back
@@ -54,7 +53,6 @@ class Mesh extends React.Component {
       'label',
       'mesh',
       'shape',
-      'suffix'
     ];
 
     this.props.addTask(parameters, stringFields, runNow);
@@ -78,10 +76,18 @@ class Mesh extends React.Component {
             <Row>
               <Col xs={8}>
                 <InputField propName="prefix" label="Prefix" col1="6" col2="6" />
-              </Col>
-              <Col xs={4}>
-                <InputField propName="run_number" disabled label="Run number" col1="4" col2="8" />
-              </Col>
+            </Col>
+            {this.props.taskData.sampleID ?
+              (<Col xs={4}>
+                <InputField
+                  propName="run_number"
+                  disabled
+                  label="Run number"
+                  col1="4"
+                  col2="8"
+                />
+              </Col>)
+            : null}
             </Row>
             <StaticField label="Filename" data={this.props.filename} />
           </Form>
@@ -160,16 +166,32 @@ const selector = formValueSelector('helical');
 
 Mesh = connect(state => {
   const subdir = selector(state, 'subdir');
-  const prefix = selector(state, 'prefix');
-  const runNumber = selector(state, 'run_number');
-  const fileSuffix = state.taskForm.fileSuffix === 'h5' ? '_master.h5' : 'cbf';
-  const position = state.taskForm.pointID === '' ? 'GX' : state.taskForm.pointID;
+
+  let fname = '';
+
+  if (state.taskForm.taskData.sampleID) {
+    fname = state.taskForm.taskData.parameters.fileName;
+  } else {
+    // Try to call eval on the file name template, just return the template
+    // itself if it fails. Disable eslint since prefix and runNumber are unused
+    // by the rest of the code, but possible used in the template. All variables
+    // that are to be used in the template should be defined in the try.
+    try {
+      /*eslint-disable */
+      const prefix = selector(state, 'prefix');
+      const position = state.taskForm.pointID === '' ? 'GX' : state.taskForm.pointID;
+
+      fname = eval(state.taskForm.taskData.parameters.fileNameTemplate);
+      /*eslint-enable */
+    } catch (e) {
+      fname = state.taskForm.taskData.parameters.fileNameTemplate;
+    }
+  }
 
   return {
     path: `${state.queue.rootPath}/${subdir}`,
-    filename: `${prefix}_${position}_${runNumber}${fileSuffix}`,
+    filename: fname,
     acqParametersLimits: state.taskForm.acqParametersLimits,
-    suffix: fileSuffix,
     initialValues: {
       ...state.taskForm.taskData.parameters,
       beam_size: state.sampleview.currentAperture,

--- a/mxcube3/ui/components/Tasks/Workflow.jsx
+++ b/mxcube3/ui/components/Tasks/Workflow.jsx
@@ -68,9 +68,17 @@ class Workflow extends React.Component {
               <Col xs={8}>
                 <InputField propName="prefix" label="Prefix" col1="6" col2="6" />
               </Col>
-              <Col xs={4}>
-                <InputField propName="run_number" disabled label="Run number" col1="4" col2="8" />
-              </Col>
+              {this.props.taskData.sampleID ?
+                (<Col xs={4}>
+                  <InputField
+                    propName="run_number"
+                    disabled
+                    label="Run number"
+                    col1="4"
+                    col2="8"
+                  />
+                </Col>)
+              : null}
             </Row>
           </Form>
        </Modal.Body>
@@ -105,8 +113,6 @@ const selector = formValueSelector('workflow');
 
 Workflow = connect(state => {
   const subdir = selector(state, 'subdir');
-  const prefix = selector(state, 'prefix');
-  const runNumber = selector(state, 'run_number');
   const fileSuffix = state.taskForm.fileSuffix === 'h5' ? '_master.h5' : 'cbf';
   let position = state.taskForm.pointID === '' ? 'PX' : state.taskForm.pointID;
   if (typeof position === 'object') {
@@ -114,9 +120,30 @@ Workflow = connect(state => {
     position = `[${vals}]`;
   }
 
+  let fname = '';
+
+  if (state.taskForm.taskData.sampleID) {
+    fname = state.taskForm.taskData.parameters.fileName;
+  } else {
+    // Try to call eval on the file name template, just return the template
+    // itself if it fails. Disable eslint since prefix and runNumber are unused
+    // by the rest of the code, but possible used in the template. All variables
+    // that are to be used in the template should be defined in the try.
+    try {
+      /*eslint-disable */
+      const prefix = selector(state, 'prefix');
+      const position = state.taskForm.pointID === '' ? 'GX' : state.taskForm.pointID;
+
+      fname = eval(state.taskForm.taskData.parameters.fileNameTemplate);
+      /*eslint-enable */
+    } catch (e) {
+      fname = state.taskForm.taskData.parameters.fileNameTemplate;
+    }
+  }
+
   return {
     path: `${state.queue.rootPath}/${subdir}`,
-    filename: `${prefix}_${position}_${runNumber}${fileSuffix}`,
+    filename: fname,
     wfname: state.taskForm.taskData.parameters.wfname,
     acqParametersLimits: state.taskForm.acqParametersLimits,
     suffix: fileSuffix,

--- a/mxcube3/ui/containers/SampleGridContainer.jsx
+++ b/mxcube3/ui/containers/SampleGridContainer.jsx
@@ -248,7 +248,6 @@ class SampleGridContainer extends React.Component {
                   deleteButtonOnClick={this.taskItemDeleteButtonOnClickHandler}
                   taskData={taskData}
                   taskIndex={i}
-                  rootPath={props.queue.rootPath}
                 />))
               }
             </SampleGridItem>

--- a/mxcube3/ui/containers/SampleGridContainer.jsx
+++ b/mxcube3/ui/containers/SampleGridContainer.jsx
@@ -215,8 +215,7 @@ class SampleGridContainer extends React.Component {
 
     const orderedList = [];
     props.order.forEach(key => {
-      const sampleID = props.sampleList[key].sampleID;
-      if (props.queue.queue.includes(sampleID)) {
+      if (props.queue.queue.includes(key)) {
         orderedList.push(key);
       }
     });

--- a/mxcube3/ui/containers/SampleQueueContainer.js
+++ b/mxcube3/ui/containers/SampleQueueContainer.js
@@ -88,10 +88,9 @@ export default class SampleQueueContainer extends React.Component {
       sendRunSample,
     } = this.props.queueActions;
     const {
-      collapseTask,
-      collapseSample,
+      collapseItem,
       showConfirmCollectDialog,
-      selectTask
+      selectItem
     } = this.props.queueGUIActions;
 
     // go through the queue, check if sample has been collected or not
@@ -173,8 +172,8 @@ export default class SampleQueueContainer extends React.Component {
                   unmount={sendUnmountSample}
                   queueStatus={queueStatus}
                   rootPath={rootPath}
-                  collapseTask={collapseTask}
-                  selectTask={selectTask}
+                  collapseItem={collapseItem}
+                  selectItem={selectItem}
                   displayData={displayData}
                   runSample={sendRunSample}
                   todoList={todo}
@@ -185,7 +184,7 @@ export default class SampleQueueContainer extends React.Component {
                   list={todo}
                   queue={queue}
                   sampleList={sampleList}
-                  collapseSample={collapseSample}
+                  collapseItem={collapseItem}
                   displayData={displayData}
                   mount={sendMountSample}
                   showForm={showForm}

--- a/mxcube3/ui/reducers/queue.js
+++ b/mxcube3/ui/reducers/queue.js
@@ -11,9 +11,7 @@ const initialState = {
 export default (state = initialState, action) => {
   switch (action.type) {
     case 'SET_QUEUE': {
-      const queue = {};
-      action.queue.forEach(sample => { queue[sample.sampleID] = sample; });
-      return Object.assign({}, initialState, { queue });
+      return Object.assign({}, { ...state, queue: Object.keys(action.queue) });
     }
     case 'CLEAR_QUEUE': {
       return Object.assign({}, state, { queue: initialState.queue,

--- a/mxcube3/ui/reducers/queueGUI.js
+++ b/mxcube3/ui/reducers/queueGUI.js
@@ -12,11 +12,47 @@ const initialState = {
 
 export default (state = initialState, action) => {
   switch (action.type) {
-    case 'redux-form/CHANGE':
+    case 'redux-form/CHANGE': {
       if (action.form === 'search-sample') {
         return Object.assign({}, state, { searchString: action.value });
       }
+
       return state;
+    }
+    case 'SET_QUEUE': {
+      const displayData = { ...state.displayData };
+      const existingNodes = Object.keys(state.displayData);
+      const sourceNodes = [];
+      const newNodes = [];
+
+      for (const sampleID in action.queue) {
+        if (action.queue.hasOwnProperty(sampleID)) {
+          action.queue[sampleID].tasks.forEach((task) => {
+            if (existingNodes.indexOf(task.queueID.toString()) === -1) {
+              newNodes.push(task.queueID.toString());
+              displayData[task.queueID] = { collapsed: false,
+                                            selected: false,
+                                            progress: 0 };
+            }
+            sourceNodes.push(task.queueID.toString());
+          });
+        }
+      }
+
+      const nodesToBeRemoved = [];
+
+      existingNodes.forEach((node) => {
+        if (sourceNodes.indexOf(node) === -1) {
+          nodesToBeRemoved.push(node);
+        }
+      });
+
+      nodesToBeRemoved.forEach((nodeID) => {
+        delete displayData[nodeID];
+      });
+
+      return { ...state, displayData };
+    }
     case 'ADD_TASKS': {
       const displayData = { ...state.displayData };
 
@@ -32,53 +68,25 @@ export default (state = initialState, action) => {
     case 'ADD_TASK_RESULT': {
       const displayData = {
         ...state.displayData,
-        [action.sampleID]: {
-          ...state.displayData[action.sampleID],
-          tasks: [
-            ...state.displayData[action.sampleID].tasks.slice(0, action.taskIndex),
-            {
-              ...state.displayData[action.sampleID].tasks[action.taskIndex],
-              progress: action.progress
-            },
-            ...state.displayData[action.sampleID].tasks.slice(action.taskIndex + 1)
-          ]
-        }
+        [action.queueID]: {
+          ...state.displayData[action.queueID], progress: action.progress }
       };
 
       return Object.assign({}, state, { displayData });
     }
 
     case 'ADD_SAMPLES_TO_QUEUE': {
-      const samplesData = {};
+      const displayData = { ...state.displayData };
       action.samplesData.forEach((sample) => {
-        samplesData[sample.sampleID] = { collapsed: false, tasks: sample.tasks.map(() => {
-          const task = { collapsed: false };
-          return task;
-        }) };
+        displayData[sample.queueID] = { collpased: false,
+                                        selected: false,
+                                        progress: 0 };
       });
 
-      return Object.assign({}, state, { displayData: { ...state.displayData, ...samplesData } });
-    }
-
-    case 'REMOVE_SAMPLE_FROM_QUEUE':
-      return Object.assign({}, state, { displayData: omit(state.displayData, action.sampleID) });
-
-    case 'REMOVE_TASK': {
-      const displayData = {
-        ...state.displayData,
-        [action.sampleID]: {
-          ...state.displayData[action.sampleID],
-          tasks: [...state.displayData[action.sampleID].tasks.slice(0, action.taskIndex),
-                  ...state.displayData[action.sampleID].tasks.slice(action.taskIndex + 1)]
-        }
-      };
       return Object.assign({}, state, { displayData });
     }
-    case 'COLLAPSE_SAMPLE': {
-      const displayData = Object.assign({}, state.displayData);
-      displayData[action.sampleID].collapsed ^= true;
-
-      return { ...state, displayData };
+    case 'REMOVE_TASK': {
+      return Object.assign({}, state, { displayData: omit(state.displayData, action.queueID) });
     }
     case 'QUEUE_LOADING': {
       return { ...state, loading: action.loading };
@@ -95,27 +103,15 @@ export default (state = initialState, action) => {
     case 'SHOW_CONFIRM_COLLECT_DIALOG': {
       return { ...state, showConfirmCollectDialog: action.show };
     }
-    // Toggle task collapse flag
-    case 'COLLAPSE_TASK': {
+    case 'COLLAPSE_ITEM': {
       const displayData = Object.assign({}, state.displayData);
-      displayData[action.sampleID].tasks[action.taskIndex].collapsed ^= true;
+      displayData[action.queueID].collapsed ^= true;
 
       return { ...state, displayData };
     }
-    case 'SELECT_TASK': {
+    case 'SELECT_ITEM': {
       const displayData = Object.assign({}, state.displayData);
-      displayData[action.sampleID].tasks[action.taskIndex].selected ^= true;
-
-      return { ...state, displayData };
-    }
-    case 'CHANGE_TASK_ORDER': {
-      const displayData = Object.assign({}, state.displayData);
-
-      const task = state.displayData[action.sampleId].tasks[action.oldIndex];
-      const tempTask = displayData[action.sampleId].tasks[action.newIndex];
-
-      displayData[action.sampleId].tasks[action.newIndex] = task;
-      displayData[action.sampleId].tasks[action.oldIndex] = tempTask;
+      displayData[action.queueID].selected ^= true;
 
       return { ...state, displayData };
     }

--- a/mxcube3/ui/reducers/sampleGrid.js
+++ b/mxcube3/ui/reducers/sampleGrid.js
@@ -28,6 +28,9 @@ const INITIAL_STATE = { selected: {},
 
 export default (state = INITIAL_STATE, action) => {
   switch (action.type) {
+    case 'SET_QUEUE': {
+      return { ...state, sampleList: Object.assign(state.sampleList, action.queue) };
+    }
     // Set the list of samples (sampleList), clearing any existing list
     case 'UPDATE_SAMPLE_LIST': {
       const sampleList = { ...state.sampleList };

--- a/mxcube3/ui/reducers/taskForm.js
+++ b/mxcube3/ui/reducers/taskForm.js
@@ -34,8 +34,7 @@ export default (state = initialState, action) => {
         }
         return { ...state, defaultParameters:
                  { ...state.defaultParameters, [type]: {
-                   ...action.tasks[0].parameters, run_number:
-                   state.defaultParameters[type].run_number + action.tasks.length
+                   ...action.tasks[0].parameters
                  }
                }
              };
@@ -47,8 +46,7 @@ export default (state = initialState, action) => {
           defaultParameters: {
             ...state.defaultParameters,
             [action.taskData.parameters.type.toLowerCase()]: {
-              ...action.taskData.parameters, run_number:
-             state.defaultParameters[action.taskData.parameters.type.toLowerCase()].run_number
+              ...action.taskData.parameters
             }
           }
         };
@@ -58,12 +56,12 @@ export default (state = initialState, action) => {
         return {
           ...state,
           defaultParameters: {
-            datacollection: { ...state.defaultParameters.datacollection, run_number: 1 },
-            characterisation: { ...state.defaultParameters.characterisation, run_number: 1 },
-            helical: { ...state.defaultParameters.helical, run_number: 1 },
-            mesh: { ...state.defaultParameters.mesh, run_number: 1 },
-            workflow: { ...state.defaultParameters.workflow, run_number: 1 },
-            interleaved: { ...state.defaultParameters.interleaved, run_number: 1 }
+            datacollection: { ...state.defaultParameters.datacollection },
+            characterisation: { ...state.defaultParameters.characterisation },
+            helical: { ...state.defaultParameters.helical },
+            mesh: { ...state.defaultParameters.mesh },
+            workflow: { ...state.defaultParameters.workflow },
+            interleaved: { ...state.defaultParameters.interleaved }
           }
         };
       }
@@ -77,27 +75,21 @@ export default (state = initialState, action) => {
           ...state,
           defaultParameters: {
             datacollection: {
-              run_number: 1,
               ...action.data.dcParameters,
               ...state.defaultParameters.datacollection },
             characterisation: {
-              run_number: 1,
               ...action.data.charParameters,
               ...state.defaultParameters.characterisation },
             helical: {
-              run_number: 1,
               ...action.data.dcParameters,
               ...state.defaultParameters.helical },
             mesh: {
-              run_number: 1,
               ...action.data.dcParameters,
               ...state.defaultParameters.mesh },
             workflow: {
-              run_number: 1,
               ...action.data.dcParameters,
               ...state.defaultParameters.workflow },
             interleaved: {
-              run_number: 1,
               ...state.defaultParameters.interleaved }
           },
           acqParametersLimits: { ...action.data.acqParametersLimits },

--- a/test/HardwareObjectsMockup.xml/session.xml
+++ b/test/HardwareObjectsMockup.xml/session.xml
@@ -51,6 +51,7 @@
    <processed_data_folder_name>PROCESSED_DATA</processed_data_folder_name>
    <archive_base_directory>/tmp</archive_base_directory>
    <archive_folder>pyarch</archive_folder>
+   <precission>4</precission>
   </file_info>
 
 </object>


### PR DESCRIPTION
Dear all,

** NOTE PLEASE MERGE #590 first **

Now using run numbers and file paths entirely given by the server. This means that there should be no run number calculations or other manipulation of the run number performed on the client. The same goes for paths and file names (including file extensions), any manipulation to paths should be solely for display (if really necessary)

We need to implement the shape part of the prefix in the PathTemplate object that you guys wanted, this will otherwise be ignored. It remains to be done but its has you understand a part of the HardwareRepository that needs to be updated.

There is a attempt to a file name template that are thought to per site configurable, we will see if we keep
that or if we do something simpler.

Cheers,
Marcus
