### PR TITLE
Adapt support for SampleChanger / add SampleChangerMaintenance

### DIFF
--- a/mxcube3/__init__.py
+++ b/mxcube3/__init__.py
@@ -130,9 +130,11 @@ if not app.debug or os.environ.get("WERKZEUG_RUN_MAIN") == "true":
         app.db_connection = app.beamline.getObjectByRole("lims_client")
         app.empty_queue = pickle.dumps(hwr.getHardwareObject(cmdline_options.queue_model))
         app.sample_changer = app.beamline.getObjectByRole("sample_changer")
+        app.sc_maintenance = app.beamline.getObjectByRole("sample_changer_maintenance")
         app.rest_lims = app.beamline.getObjectByRole("lims_rest_client")
         app.queue = qutils.new_queue()
         app.actions = hwr.getHardwareObject(cmdline_options.beamline_actions)
+
 
         # SampleID of currently mounted sample
         app.CURRENTLY_MOUNTED_SAMPLE = ''

--- a/mxcube3/routes/scutils.py
+++ b/mxcube3/routes/scutils.py
@@ -68,16 +68,16 @@ def mount_sample(beamline_setup_hwobj,
                 if centring_method == CENTRING_METHOD.MANUAL:
                     log.warning("Manual centring used, waiting for" +\
                                 " user to center sample")
-                    dm.startCentringMethod(dm.MANUAL3CLICK_MODE)
+                    dm.start_centring_method(dm.CENTRING_METHOD_MANUAL)
                 elif centring_method == CENTRING_METHOD.LOOP:
-                    dm.startCentringMethod(dm.C3D_MODE)
+                    dm.start_centring_method(dm.CENTRING_METHOD_AUTO)
                     log.warning("Centring in progress. Please save" +\
                                 " the suggested centring or re-center")
                 elif centring_method == CENTRING_METHOD.FULLY_AUTOMATIC:
                     log.info("Centring sample, please wait.")
-                    dm.startCentringMethod(dm.C3D_MODE)
+                    dm.start_centring_method(dm.CENTRING_METHOD_AUTO)
                 else:
-                    dm.startCentringMethod(dm.MANUAL3CLICK_MODE)
+                    dm.start_centring_method(dm.CENTRING_METHOD_MANUAL)
 
                 view.setText(1, "Centring !")
                 centring_result = async_result.get()
@@ -90,6 +90,8 @@ def mount_sample(beamline_setup_hwobj,
                     else:
                         raise RuntimeError("Could not center sample")
             except:
+                import traceback
+                log.info(" centrong did not pass %s" % traceback.format_exc())
                 pass
             finally:
                 dm.disconnect("centringAccepted", centring_done_cb)

--- a/mxcube3/routes/signals.py
+++ b/mxcube3/routes/signals.py
@@ -501,3 +501,10 @@ def safety_shutter_state_changed(values):
         socketio.emit("beamline_value_change", data, namespace="/hwr")
     except Exception:
         logging.getLogger("HWR").error('error sending message: %s' + str(data))
+
+def mach_info_changed(values):
+    try:
+        socketio.emit("mach_info_changed", values, namespace="/hwr")
+    except Exception:
+        logging.getLogger("HWR").error('error sending message: %s' + str(msg))
+

--- a/mxcube3/routes/signals.py
+++ b/mxcube3/routes/signals.py
@@ -1,6 +1,7 @@
 import logging
 
 import queue_model_objects_v1 as qmo
+import json
 
 from mxcube3 import socketio
 from mxcube3 import app as mxcube
@@ -99,33 +100,58 @@ def sc_state_changed(*args):
     known_location = scutils.get_current_sample()
     location = known_location if known_location else sc_location
 
-    if location:
-        if new_state == SampleChangerState.Moving and ( old_state == None or
-           SampleChangerState.Ready ):
-            msg = {'signal': 'loadingSample',
-                   'location': location,
-                   'message': 'Please wait, operating sample changer'}
+    if new_state == SampleChangerState.Moving:
+        msg = {'signal': 'operatingSampleChanger',
+               'location': '',
+               'message': 'Please wait, operating sample changer'}
 
-        elif new_state == SampleChangerState.Loading:
-            msg = {'signal': 'loadingSample',
-                   'location': location,
-                   'message': 'Please wait, Loading sample %s' % location}
+    elif new_state in [SampleChangerState.Loading, SampleChangerState.Unloading]:
+        if new_state == SampleChangerState.Loading:
+            message = 'Please wait, Loading sample %s' % location
+        elif new_state == SampleChangerState.Unloading:
+            message = 'Please wait, Unloading sample' 
 
-        elif new_state == SampleChangerState.Unloading and location:
-            msg = {'signal': 'loadingSample',
-                   'location': location,
-                   'message': 'Please wait, Unloading sample %s' % location}
+        msg = {'signal': 'loadingSample',
+               'location': location,
+               'message': message}
 
-        elif new_state == SampleChangerState.Ready and (old_state == None or
-             old_state == SampleChangerState.Loading or
-             old_state == SampleChangerState.Moving):
-
+    else:
+        # make sure operation is finished in any other case
+        if location: 
             msg = {'signal': 'loadReady', 'location': location}
             scutils.set_current_sample(location)
+        msg = {'signal': 'loadReady', 'location': ''}
+    
+    if msg:
+        logging.getLogger("HWR").info('emitting sc state changed: ' + str(msg))
+        socketio.emit('sc', msg, namespace='/hwr')
+   
+    # emit also brut sample changer state for those interested
+    state_str = SampleChangerState.STATE_DESC.get(new_state, "Unknown").upper()
+    socketio.emit('sc_state', state_str, namespace='/hwr')
 
-        if msg:
-            socketio.emit('sc', msg, namespace='/hwr')
+def loaded_sample_changed(sample):
+    if sample is not None:
+        address = sample.getAddress()
+        barcode = sample.getID()
+    else:
+        address = ''
 
+    logging.getLogger("HWR").info('loaded sample changed now is: ' + address)
+
+    try:
+        socketio.emit("loaded_sample_changed", {'address': address, 'barcode': barcode}, namespace="/hwr")
+    except Exception, msg:
+        logging.getLogger("HWR").error('error setting loaded sample: %s' + str(msg))
+
+def sc_contents_update():
+    socketio.emit("sc_contents_update")
+
+def sc_maintenance_update(state_list, cmd_state, message):
+    try:
+        socketio.emit("sc_maintenance_update", {'state': json.dumps(state_list), 'commands_state': json.dumps(cmd_state), 'message': message}, namespace="/hwr")
+    except Exception,msg:
+        logging.getLogger("HWR").error('error sending message: %s' + str(msg))
 
 def centring_started(method, *args):
     usr_msg = 'Using 3-click centring, please click the position on '

--- a/mxcube3/ui/actions/general.js
+++ b/mxcube3/ui/actions/general.js
@@ -165,6 +165,38 @@ export function getInitialState() {
         'Content-type': 'application/json'
       }
     });
+    const loadedSample = fetch('mxcube/api/v0.1/sample_changer/loaded_sample', {
+      method: 'GET',
+      credentials: 'include',
+      headers: {
+        Accept: 'application/json',
+        'Content-type': 'application/json'
+      }
+    });
+    const sampleChangerState = fetch('mxcube/api/v0.1/sample_changer/state', {
+      method: 'GET',
+      credentials: 'include',
+      headers: {
+        Accept: 'application/json',
+        'Content-type': 'application/json'
+      }
+    });
+    const sampleChangerCommands = fetch('mxcube/api/v0.1/sample_changer/get_maintenance_cmds', {
+      method: 'GET',
+      credentials: 'include',
+      headers: {
+        Accept: 'application/json',
+        'Content-type': 'application/json'
+      }
+    });
+    const sampleChangerGlobalState = fetch('mxcube/api/v0.1/sample_changer/get_global_state', {
+      method: 'GET',
+      credentials: 'include',
+      headers: {
+        Accept: 'application/json',
+        'Content-type': 'application/json'
+      }
+    });
     const observers = fetch('mxcube/api/v0.1/login/observers', {
       method: 'GET',
       credentials: 'include',
@@ -201,9 +233,23 @@ export function getInitialState() {
       sampleChangerContents.then(parse).then(json => {
         state.sampleChangerContents = json;
       }).catch(notify),
+      loadedSample.then(parse).then(json => {
+        state.loadedSample = json;
+      }).catch(notify),
+      sampleChangerState.then(parse).then(json => {
+        state.sampleChangerState = json;
+      }).catch(notify),
+      sampleChangerCommands.then(parse).then(json => {
+        state.sampleChangerCommands = json;
+      }).catch(notify),
+      sampleChangerGlobalState.then(parse).then(json => {
+        state.sampleChangerGlobalState = json;
+      }).catch(notify),
       observers.then(parse).then(json => { state.remoteAccess = json.data; }).catch(notify),
       workflow.then(parse).then(json => { state.workflow = json; }).catch(notify)
     ];
+
+    console.log('init-state', state.sampleChangerState);
 
     Promise.all(pchains).then(() => {
       dispatch(setInitialState(state));

--- a/mxcube3/ui/actions/sampleChanger.js
+++ b/mxcube3/ui/actions/sampleChanger.js
@@ -1,11 +1,28 @@
 import fetch from 'isomorphic-fetch';
+import { showErrorPanel } from './general';
 
 export function setContents(contents) {
   return { type: 'SET_SC_CONTENTS', data: { sampleChangerContents: contents } };
 }
 
-export function setState(state) {
+export function setSCState(state) {
   return { type: 'SET_SC_STATE', state };
+}
+
+export function setLoadedSample(data) {
+  return { type: 'SET_LOADED_SAMPLE', data };
+}
+
+export function setSCGlobalState(data) {
+  return { type: 'SET_SC_GLOBAL_STATE', data };
+}
+
+export function updateSCContents(data) {
+  return { type: 'UPDATE_SC_CONTENTS', data };
+}
+
+export function setSCCommandResponse(response) {
+  return { type: 'SET_SC_RESPONSE', response };
 }
 
 export function refresh() {
@@ -19,18 +36,34 @@ export function refresh() {
       credentials: 'include'
     }).then(response => {
       if (response.status >= 400) {
-        dispatch(setState('ERROR'));
+        // dispatch(setSCState('ERROR'));
         throw new Error('Error refreshing sample changer contents');
       }
 
       response.json().then(contents => { dispatch(setContents(contents)); });
+    });
+
+    fetch('mxcube/api/v0.1/sample_changer/loaded_sample', {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        'Content-type': 'application/json'
+      },
+      credentials: 'include'
+    }).then(response => {
+      if (response.status >= 400) {
+        // dispatch(setSCState('ERROR'));
+        throw new Error('Error refreshing sample changer contents');
+      }
+
+      response.json().then(loadedSample => { dispatch(setLoadedSample(loadedSample)); });
     });
   };
 }
 
 export function select(address) {
   return function (dispatch) {
-    dispatch(setState('MOVING'));
+    // dispatch(setSCState('MOVING'));
 
     fetch(`mxcube/api/v0.1/sample_changer/select/${address}`, {
       method: 'GET',
@@ -41,20 +74,20 @@ export function select(address) {
       credentials: 'include'
     }).then(response => {
       if (response.status >= 400) {
-        dispatch(setState('ERROR'));
+        // dispatch(setSCState('ERROR'));
         throw new Error(`Error while selecting sample changer container @ ${address}`);
       }
 
       response.json().then(contents => { dispatch(setContents(contents)); });
 
-      dispatch(setState('READY'));
+      // dispatch(setSCState('READY'));
     });
   };
 }
 
 export function scan(address) {
   return function (dispatch) {
-    dispatch(setState('MOVING'));
+    // dispatch(setSCState('MOVING'));
 
     fetch(`mxcube/api/v0.1/sample_changer/scan/${address}`, {
       method: 'GET',
@@ -65,20 +98,20 @@ export function scan(address) {
       credentials: 'include'
     }).then(response => {
       if (response.status >= 400) {
-        dispatch(setState('ERROR'));
+        // dispatch(setSCState('ERROR'));
         throw new Error(`Error while scanning sample changer @ ${address}`);
       }
 
       response.json().then(contents => { dispatch(setContents(contents)); });
 
-      dispatch(setState('READY'));
+      // dispatch(setSCState('READY'));
     });
   };
 }
 
 export function loadSample(address) {
   return function (dispatch) {
-    dispatch(setState('MOVING'));
+    // dispatch(setSCState('MOVING'));
 
     fetch(`mxcube/api/v0.1/sample_changer/mount/${address}`, {
       method: 'GET',
@@ -89,22 +122,29 @@ export function loadSample(address) {
       credentials: 'include'
     }).then(response => {
       if (response.status >= 400) {
-        dispatch(setState('ERROR'));
+        // dispatch(setSCState('ERROR'));
         throw new Error(`Error while  sample loading sample @ ${address}`);
       }
 
       response.json().then(contents => { dispatch(setContents(contents)); });
 
-      dispatch(setState('READY'));
+      // dispatch(setSCState('READY'));
     });
   };
 }
 
 export function unloadSample(address) {
-  return function (dispatch) {
-    dispatch(setState('MOVING'));
+  let url = '';
 
-    fetch(`mxcube/api/v0.1/sample_changer/unmount/${address}`, {
+  if (address) {
+    url = `mxcube/api/v0.1/sample_changer/unmount/${address}`;
+  } else {
+    url = 'mxcube/api/v0.1/sample_changer/unmount_current';
+  }
+  return function (dispatch) {
+    // dispatch(setSCState('MOVING'));
+
+    fetch(url, {
       method: 'GET',
       headers: {
         Accept: 'application/json',
@@ -113,13 +153,49 @@ export function unloadSample(address) {
       credentials: 'include'
     }).then(response => {
       if (response.status >= 400) {
-        dispatch(setState('ERROR'));
+        // dispatch(setSCState('ERROR'));
         throw new Error(`Error while  sample unloading sample @ ${address}`);
       }
 
       response.json().then(contents => { dispatch(setContents(contents)); });
 
-      dispatch(setState('READY'));
+      // dispatch(setSCState('READY'));
+    });
+  };
+}
+
+export function abort() {
+  return function (dispatch) {
+    fetch('mxcube/api/v0.1/sample_changer/send_command/abort', {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        'Content-type': 'application/json'
+      },
+      credentials: 'include'
+    }).then(response => {
+      if (response.status < 400) {
+        dispatch(showErrorPanel(true, 'action aborted'));
+      }
+    });
+  };
+}
+
+export function sendCommand(cmdparts) {
+  return function (dispatch) {
+    fetch(`mxcube/api/v0.1/sample_changer/send_command/${cmdparts}`, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        'Content-type': 'application/json'
+      },
+      credentials: 'include'
+    }).then(response => {
+      if (response.status >= 400) {
+        dispatch(showErrorPanel(true, response.headers.get('message')));
+        throw new Error(`Error while  sending command @ ${cmdparts}`);
+      }
+      response.json().then(answer => { dispatch(setSCCommandResponse(answer)); });
     });
   };
 }

--- a/mxcube3/ui/components/SampleChanger/SampleChanger.css
+++ b/mxcube3/ui/components/SampleChanger/SampleChanger.css
@@ -45,3 +45,21 @@
 .custom-btn-color:hover {
   color: hsl(0,0%,0%) !important;
 }
+
+.scMessage {
+  background-color: white;
+  color: blue;
+  text-weight: bold;
+  font-size: 16px;
+  align: center;
+}
+
+.abortButton {
+  background-color: #ffdddd;
+  font-weight: bold;
+}
+
+.actionHeader {
+  background-color: #eeeeee;
+  text-align: center;
+}

--- a/mxcube3/ui/components/SampleChanger/SampleChanger.js
+++ b/mxcube3/ui/components/SampleChanger/SampleChanger.js
@@ -11,9 +11,11 @@ export class SampleChangerTree extends React.Component {
     let titleBackground;
 
     if (this.props.state === 'READY') {
-      titleBackground = 'default';
+      titleBackground = 'success';
     } else if (this.props.state === 'MOVING') {
       titleBackground = 'warning';
+    } else if (this.props.state === 'DISABLED') {
+      titleBackground = 'default';
     } else {
       titleBackground = 'danger';
     }
@@ -171,6 +173,8 @@ export default class SampleChanger extends React.Component {
     super(props);
     this.buildTree = this.buildTree.bind(this);
     this.scan = this.scan.bind(this);
+    this.unload = this.unload.bind(this);
+    this.abort = this.abort.bind(this);
   }
 
 
@@ -178,6 +182,13 @@ export default class SampleChanger extends React.Component {
     this.props.scan('');
   }
 
+  unload() {
+    this.props.unload('');
+  }
+
+  abort() {
+    this.props.abort();
+  }
 
   buildTree(node, root) {
     if (node.children) {
@@ -206,27 +217,50 @@ export default class SampleChanger extends React.Component {
                                  unload: this.props.unload });
   }
 
+  // display some buttons depending on available features
   render() {
     const nodes = this.buildTree(this.props.contents, true);
+    let current = '';
+    let abortButton = '';
+
+    if (this.props.loadedSample.address) {
+      current = (<div style={{ marginTop: '1em' }}>
+                        Currently loaded: {this.props.loadedSample.address}
+                        <span style={{ marginRight: '1em' }} />
+                         ( {this.props.loadedSample.barcode} )
+                        <span style={{ marginRight: '1em' }} />
+                        <Button bsStyle="default" onClick={this.unload}>
+                         <Glyphicon glyph="save" /> Unload
+                        </Button>
+                      </div>
+                     );
+    } else {
+      current = (<div style={{ marginTop: '1em', marginBottom: '1em' }} />);
+    }
+
+    if (this.props.state === 'MOVING') {
+      abortButton = (<Button bsStyle="default" className="abortButton" onClick={this.abort}>
+                 <Glyphicon glyph="stop" /> Abort
+               </Button>
+              );
+    } else {
+      abortButton = '';
+    }
+
     return (
-      <div style={{ marginTop: '1em' }}>
-        <SampleChangerTree
-          title={`Sample Changer (${this.props.state})`}
-          state={this.props.state}
-        >
-          <div>
-            <Button bsStyle="default" onClick={this.props.refresh}>
-               <Glyphicon glyph="refresh" /> Refresh
-            </Button>
-            <span style={{ marginLeft: '1em' }} />
-            <Button bsStyle="default" onClick={this.scan}>
-              <Glyphicon glyph="qrcode" /> Scan all containers
-            </Button>
-            <div style={{ marginBottom: '1em' }} />
-            {nodes}
-          </div>
-        </SampleChangerTree>
-      </div>
+       <Panel header="Contents">
+         <Button bsStyle="default" onClick={this.props.refresh}>
+            <Glyphicon glyph="refresh" /> Refresh
+         </Button>
+         <span style={{ marginLeft: '1em' }} />
+         <Button bsStyle="default" onClick={this.scan}>
+            <Glyphicon glyph="qrcode" /> Scan all containers
+         </Button>
+         <span style={{ marginLeft: '1em' }}>{abortButton}</span>
+         {current}
+         <div style={{ marginBottom: '1em' }} />
+         {nodes}
+       </Panel>
     );
   }
 }

--- a/mxcube3/ui/components/SampleChanger/SampleChangerMaintenance.js
+++ b/mxcube3/ui/components/SampleChanger/SampleChangerMaintenance.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import { Button, ButtonGroup, Panel } from 'react-bootstrap';
+
+import './SampleChanger.css';
+import '../context-menu-style.css';
+/* eslint-disable react/no-multi-comp */
+
+export class SampleChangerActionButton extends React.Component {
+  constructor(props) {
+    super(props);
+    this.buttonClicked = this.buttonClicked.bind(this);
+  }
+
+  buttonClicked() {
+    this.props.send_command(this.props.cmd);
+  }
+
+  render() {
+    let disabled;
+
+    if (this.props.enabled === true) {
+      disabled = false;
+    } else {
+      disabled = true;
+    }
+
+    return (
+        <Button bsStyle="default" disabled={disabled}
+          onClick={() => this.props.send_command(this.props.cmd)}
+        >
+          {this.props.label}
+        </Button>
+    );
+  }
+}
+
+export class SampleChangerActionGroup extends React.Component {
+  render() {
+    return (
+      // <Well>
+         // <div>{this.props.name}</div>
+         // <ButtonGroup>{this.props.buttons}</ButtonGroup>
+      // <Well>
+      <Panel header={this.props.name}>
+         <ButtonGroup>{this.props.buttons}</ButtonGroup>
+      </Panel>
+    );
+  }
+}
+
+export default class SampleChangerMaintenance extends React.Component {
+  buildActionButton(cmdinfo) {
+    return React.createElement(SampleChangerActionButton,
+                               { label: cmdinfo[1],
+                                 cmd: cmdinfo[0],
+                                 enabled: this.props.commands_state[cmdinfo[0]],
+                                 send_command: this.props.send_command,
+                               }
+                              );
+  }
+
+  buildActionGroup(grpinfo) {
+    const butgrp = [];
+
+    for (const cmdinfo of grpinfo[1]) {
+      butgrp.push(this.buildActionButton(cmdinfo));
+    }
+
+    return React.createElement(SampleChangerActionGroup,
+                               { name: grpinfo[0],
+                                 buttons: butgrp }
+                              );
+  }
+
+  render() {
+    const groups = [];
+    let msg = '';
+
+    for (const cmdgrp of this.props.commands.cmds) {
+      groups.push(this.buildActionGroup(cmdgrp));
+    }
+
+    if (this.props.message !== '') {
+      msg = this.props.message;
+    }
+
+    return (
+       <div>
+       <Panel className="actionHeader">
+       <span>Commands</span>
+       </Panel>
+       { groups }
+       <Panel>
+       <span className="scMessage">{ msg }</span>
+       </Panel>
+       </div>
+    );
+  }
+}
+

--- a/mxcube3/ui/components/SampleChanger/SampleChangerState.js
+++ b/mxcube3/ui/components/SampleChanger/SampleChangerState.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Panel, } from 'react-bootstrap';
+
+import './SampleChanger.css';
+import '../context-menu-style.css';
+/* eslint-disable react/no-multi-comp */
+
+export default class SampleChangerState extends React.Component {
+
+  render() {
+    let titleBackground;
+    let title;
+
+    if (this.props.state === 'READY') {
+      titleBackground = 'success';
+    } else if (this.props.state === 'MOVING') {
+      titleBackground = 'warning';
+    } else if (this.props.state === 'DISABLED') {
+      titleBackground = 'danger';
+    } else {
+      titleBackground = 'danger';
+    }
+
+    title = `Sample changer (${this.props.state})`;
+
+    return (
+      <Panel style={{ marginTop: '0.5em' }} header={title} bsStyle={titleBackground} />
+    );
+  }
+}
+

--- a/mxcube3/ui/containers/SampleChangerContainer.jsx
+++ b/mxcube3/ui/containers/SampleChangerContainer.jsx
@@ -1,29 +1,62 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { select, loadSample, unloadSample, scan,
+import { select, loadSample, unloadSample, scan, abort, sendCommand,
 refresh } from '../actions/sampleChanger';
 
 import SampleChanger from '../components/SampleChanger/SampleChanger';
+import SampleChangerState from '../components/SampleChanger/SampleChangerState';
+import SampleChangerMaintenance from '../components/SampleChanger/SampleChangerMaintenance';
 
 class SampleChangerContainer extends React.Component {
   render() {
-    return (<SampleChanger
-      state={this.props.state}
-      select={this.props.select}
-      load={this.props.loadSample}
-      unload={this.props.unloadSample}
-      scan={this.props.scan}
-      contents={this.props.contents}
-      refresh={this.props.refresh}
-    />);
+    return (<div className="row">
+      <div className="col-xs-12" style={{ marginTop: '1em' }}>
+          <div className="row">
+           <div className="col-xs-12" style={{ marginTop: '1em' }}>
+            <SampleChangerState
+              state={this.props.state}
+            />
+           </div>
+          </div>
+          <div className="row">
+           <div className="col-xs-6">
+             <SampleChanger
+               state={this.props.state}
+               loadedSample={this.props.loadedSample}
+               select={this.props.select}
+               load={this.props.loadSample}
+               unload={this.props.unloadSample}
+               abort={this.props.abort}
+               scan={this.props.scan}
+               contents={this.props.contents}
+               refresh={this.props.refresh}
+             />
+           </div>
+           <div className="col-xs-6">
+             <SampleChangerMaintenance
+               commands={this.props.commands}
+               global_state={this.props.global_state}
+               commands_state={this.props.commands_state}
+               message={this.props.message}
+               send_command={this.props.sendCommand}
+             />
+           </div>
+          </div>
+      </div>
+      </div>);
   }
 }
 
 function mapStateToProps(state) {
   return {
     contents: state.sampleChanger.contents,
-    state: state.sampleChanger.state
+    state: state.sampleChanger.state,
+    loadedSample: state.sampleChanger.loadedSample,
+    commands: state.sampleChangerMaintenance.commands,
+    commands_state: state.sampleChangerMaintenance.commands_state,
+    global_state: state.sampleChangerMaintenance.global_state,
+    message: state.sampleChangerMaintenance.message
   };
 }
 
@@ -33,7 +66,9 @@ function mapDispatchToProps(dispatch) {
     loadSample: (address) => dispatch(loadSample(address)),
     unloadSample: (address) => dispatch(unloadSample(address)),
     scan: (container) => dispatch(scan(container)),
-    refresh: () => dispatch(refresh())
+    refresh: () => dispatch(refresh()),
+    abort: () => dispatch(abort()),
+    sendCommand: (cmd) => dispatch(sendCommand(cmd))
   };
 }
 

--- a/mxcube3/ui/reducers/index.js
+++ b/mxcube3/ui/reducers/index.js
@@ -4,6 +4,7 @@ import queue from './queue';
 import queueGUI from './queueGUI';
 import sampleGrid from './sampleGrid';
 import sampleChanger from './sampleChanger';
+import sampleChangerMaintenance from './sampleChangerMaintenance';
 import taskForm from './taskForm';
 import sampleview from './sampleview';
 import general from './general';
@@ -21,6 +22,7 @@ const mxcubeReducer = combineReducers({
   queue,
   sampleGrid,
   sampleChanger,
+  sampleChangerMaintenance,
   taskForm,
   sampleview,
   logger,

--- a/mxcube3/ui/reducers/sampleChanger.js
+++ b/mxcube3/ui/reducers/sampleChanger.js
@@ -1,10 +1,20 @@
-const INITIAL_STATE = { contents: {}, state: 'READY' };
+const INITIAL_STATE = { contents: {}, state: 'READY', loadedSample: {} };
 
 export default (state = INITIAL_STATE, action) => {
   switch (action.type) {
-    case 'SET_SC_CONTENTS':
-    case 'SET_INITIAL_STATE': {
+    case 'SET_SC_CONTENTS': {
       return { ...state, contents: action.data.sampleChangerContents };
+    }
+    case 'SET_INITIAL_STATE': {
+      return { ...state,
+         state: action.data.sampleChangerState.state,
+         contents: action.data.sampleChangerContents,
+         loadedSample: action.data.loadedSample,
+      };
+    }
+    case 'SET_LOADED_SAMPLE': {
+      return { ...state,
+               loadedSample: action.data };
     }
     case 'SET_SC_STATE': {
       return { ...state, state: action.state };

--- a/mxcube3/ui/reducers/sampleChangerMaintenance.js
+++ b/mxcube3/ui/reducers/sampleChangerMaintenance.js
@@ -1,0 +1,28 @@
+
+const INITIAL_STATE = { global_state: {}, commands: {}, commands_state: {}, message: '' };
+
+export default (state = INITIAL_STATE, action) => {
+  switch (action.type) {
+    case 'SET_INITIAL_STATE': {
+      console.log('sc_maint', action.data.sampleChangerGlobalState);
+      return {
+        ...state,
+        commands: action.data.sampleChangerCommands,
+        global_state: action.data.sampleChangerGlobalState.state,
+        commands_state: action.data.sampleChangerGlobalState.commands_state,
+        message: action.data.sampleChangerGlobalState.message,
+      };
+    }
+    case 'SET_SC_GLOBAL_STATE': {
+      return {
+        ...state,
+        global_state: JSON.parse(action.data.state),
+        commands_state: JSON.parse(action.data.commands_state),
+        message: action.data.message
+      };
+    }
+    default: {
+      return state;
+    }
+  }
+};

--- a/mxcube3/ui/serverIO.js
+++ b/mxcube3/ui/serverIO.js
@@ -27,6 +27,11 @@ import { showWorkflowParametersDialog } from './actions/workflow';
 
 import { setObservers, setMaster, requestControlAction } from './actions/remoteAccess';
 
+import { setSCState,
+         setLoadedSample,
+         setSCGlobalState,
+         updateSCContents } from './actions/sampleChanger';
+
 
 class ServerIO {
 
@@ -154,6 +159,11 @@ class ServerIO {
     });
 
     this.hwrSocket.on('sc', (record) => {
+      this.dispatch(setLoading((record.signal === 'operatingSampleChanger'),
+                               'Sample changer in operation',
+                               record.message, true, () => (this.dispatch(sendStopQueue()))));
+                               // record.message, true, () => (this.dispatch(abortSC()))));
+
       this.dispatch(setLoading((record.signal === 'loadingSample' ||
                                 record.signal === 'loadedSample'),
                                `Loading sample ${record.location}`,
@@ -223,6 +233,22 @@ class ServerIO {
 
     this.hwrSocket.on('beamline_action', (data) => {
       this.dispatch(setActionState(data.name, data.state));
+    });
+
+    this.hwrSocket.on('sc_state', (state) => {
+      this.dispatch(setSCState(state));
+    });
+
+    this.hwrSocket.on('loaded_sample_changed', (data) => {
+      this.dispatch(setLoadedSample(data));
+    });
+
+    this.hwrSocket.on('sc_maintenance_update', (data) => {
+      this.dispatch(setSCGlobalState(data));
+    });
+
+    this.hwrSocket.on('sc_contents_update', () => {
+      this.dispatch(updateSCContents());
     });
   }
 }


### PR DESCRIPTION
A wiki page explains all the changes proposed by this PR. 

The PR is mostly related with SampleChanger in mxcube3 but contains also another two small commits.
(1)- fix for mach_info_updated()  that had been lost 
(2)- change method names in "scutils" to use those of the GenericDiffractometer rather than old method names.

(3)- Bigger commit with all the changes related with SampleChanger support. [see wiki for this]

@meguiraun 
