### PR TITLE
Issue 485 - Sample Grid: replace 'mount and collect' icon with right-click

### DIFF
--- a/mxcube3/ui/components/SampleGrid/SampleGridItem.jsx
+++ b/mxcube3/ui/components/SampleGrid/SampleGridItem.jsx
@@ -106,20 +106,6 @@ export class SampleGridItem extends React.Component {
       </OverlayTrigger>
      );
 
-    const collectButton = (
-      <OverlayTrigger
-        placement="top"
-        overlay={(<Tooltip id="mount-and-collect" >Mount and collect THIS sample now</Tooltip>)}
-      >
-        <button
-          className="samples-grid-item-button"
-          onClick={ () => { location.href = '#/datacollection'; } }
-        >
-          <i className="glyphicon glyphicon-screenshot" />
-        </button>
-      </OverlayTrigger>
-    );
-
     let content = (
       <div className="samples-item-controls-container">
       {pickButton}
@@ -131,7 +117,6 @@ export class SampleGridItem extends React.Component {
         <div className="samples-item-controls-container">
           {pickButton}
           {moveButton}
-          {collectButton}
         </div>
       );
     }

--- a/mxcube3/ui/containers/SampleGridContainer.jsx
+++ b/mxcube3/ui/containers/SampleGridContainer.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { withRouter } from 'react-router';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { Glyphicon, MenuItem } from 'react-bootstrap';
@@ -16,7 +17,7 @@ import { toggleMovableAction,
          selectSamplesAction,
          setSampleOrderAction } from '../actions/sampleGrid';
 
-import { deleteTask } from '../actions/queue';
+import { deleteTask, sendMountSample } from '../actions/queue';
 
 import { showTaskForm } from '../actions/taskForm';
 
@@ -61,6 +62,7 @@ class SampleGridContainer extends React.Component {
     this.state = { sampleItems: this.getSampleItems(props) };
     this.sampleItems = this.getSampleItems(props);
     this.workflowMenuOptions = this.workflowMenuOptions.bind(this);
+    this.mountAndCollect = this.mountAndCollect.bind(this);
   }
 
 
@@ -661,6 +663,25 @@ class SampleGridContainer extends React.Component {
   }
 
 
+  mountAndCollect() {
+    let sampleData = null;
+
+    // If several samples selected mount the first one and add the others to the queue
+    this.props.order.some((sampleID) => {
+      if (this.props.selected[sampleID]) {
+        sampleData = this.props.sampleList[sampleID];
+      }
+      return this.props.selected[sampleID] === true;
+    });
+
+    if (sampleData) {
+      this.props.sendMountSample(sampleData);
+      this.props.addSelectedSamplesToQueue();
+      this.props.router.push('datacollection');
+    }
+  }
+
+
   render() {
     this.sampleItems = this.getSampleItems(this.props);
 
@@ -674,6 +695,9 @@ class SampleGridContainer extends React.Component {
         <ul id="contextMenu" style={{ display: 'none' }} className="dropdown-menu" role="menu">
           <MenuItem eventKey="1" onClick={this.props.addSelectedSamplesToQueue}>
             <span><Glyphicon glyph="unchecked" /> En-queue Sample </span>
+          </MenuItem>
+          <MenuItem eventKey="2" onClick={this.mountAndCollect}>
+            <span><Glyphicon glyph="screenshot" /> Mount and collect</span>
           </MenuItem>
           <MenuItem divider />
           <MenuItem header> <span><Glyphicon glyph="plus" /> Add </span></MenuItem>
@@ -737,10 +761,13 @@ function mapDispatchToProps(dispatch) {
     setSampleOrderAction: (order) => dispatch(setSampleOrderAction(order)),
     showTaskParametersForm: bindActionCreators(showTaskForm, dispatch),
     deleteTask: bindActionCreators(deleteTask, dispatch),
+    sendMountSample: bindActionCreators(sendMountSample, dispatch),
     toggleMovableAction: (key) => dispatch(toggleMovableAction(key)),
     selectSamples: (keys, selected) => dispatch(selectSamplesAction(keys, selected)),
   };
 }
+
+SampleGridContainer = withRouter(SampleGridContainer);
 
 export default connect(
   mapStateToProps,

--- a/mxcube3/ui/containers/SampleQueueContainer.js
+++ b/mxcube3/ui/containers/SampleQueueContainer.js
@@ -148,7 +148,7 @@ export default class SampleQueueContainer extends React.Component {
                       { current.sampleID ? `Sample: ${sampleName} ${proteinAcronym}` : 'Current'}
                     </b>
                   </NavItem>
-                  <NavItem eventKey={'todo'}><b>Upcoming</b></NavItem>
+                  <NavItem eventKey={'todo'}><b>Upcoming ({todo.length})</b></NavItem>
                 </Nav>
                 {loading ?
                   <div className="center-in-box">


### PR DESCRIPTION
Hi !

Fix for issue #485 Sample Grid: replace 'mount and collect' icon with right-click

Right clicking and selecting mount and collect adds the selected samples to the queue
and mounts the first one (if several samples where selected).

Marcus