### PR TITLE
Issue #541 and Issue #540

### DIFF
--- a/mxcube3/ui/components/SampleView/MotorControl.js
+++ b/mxcube3/ui/components/SampleView/MotorControl.js
@@ -34,6 +34,7 @@ export default class MotorControl extends React.Component {
                 decimalPoints="2"
                 state={phi.Status}
                 stop={stop}
+                disabled={this.props.motorsDisabled}
               />
             </div>
 
@@ -49,6 +50,7 @@ export default class MotorControl extends React.Component {
                 decimalPoints="2"
                 state={kappa.Status}
                 stop={stop}
+                disabled={this.props.motorsDisabled}
               />
             </div>
 
@@ -64,6 +66,7 @@ export default class MotorControl extends React.Component {
                 decimalPoints="2"
                 state={kappa_phi.Status}
                 stop={stop}
+                disabled={this.props.motorsDisabled}
               />
             </div>
 
@@ -79,6 +82,7 @@ export default class MotorControl extends React.Component {
                 decimalPoints="2"
                 state={phiy.Status}
                 stop={stop}
+                disabled={this.props.motorsDisabled}
               />
             </div>
 
@@ -94,6 +98,7 @@ export default class MotorControl extends React.Component {
                 decimalPoints="2"
                 state={phiz.Status}
                 stop={stop}
+                disabled={this.props.motorsDisabled}
               />
             </div>
 
@@ -109,6 +114,7 @@ export default class MotorControl extends React.Component {
                 decimalPoints="2"
                 state={focus.Status}
                 stop={stop}
+                disabled={this.props.motorsDisabled}
               />
             </div>
 
@@ -124,6 +130,7 @@ export default class MotorControl extends React.Component {
                 decimalPoints="2"
                 state={sampx.Status}
                 stop={stop}
+                disabled={this.props.motorsDisabled}
               />
             </div>
 
@@ -139,6 +146,7 @@ export default class MotorControl extends React.Component {
                  decimalPoints="2"
                  state={sampy.Status}
                  stop={stop}
+                 disabled={this.props.motorsDisabled}
                />
             </div>
           </div>

--- a/mxcube3/ui/components/SampleView/MotorInput.js
+++ b/mxcube3/ui/components/SampleView/MotorInput.js
@@ -134,7 +134,6 @@ export default class MotorInput extends React.Component {
                   style={{ width: '100%', height: '100%', display: 'block' }}
                   className="btn-xs motor-abort rw-widget-no-left-border"
                   bsStyle="danger"
-                  disabled={this.props.state !== 4 || this.props.disabled}
                   onClick={this.stopMotor}
                 >
                   <i className="glyphicon glyphicon-remove" />

--- a/mxcube3/ui/components/SampleView/MotorInput.js
+++ b/mxcube3/ui/components/SampleView/MotorInput.js
@@ -82,7 +82,7 @@ export default class MotorInput extends React.Component {
                 <button
                   type="button"
                   className="rw-btn"
-                  disabled={this.props.state !== 2}
+                  disabled={this.props.state !== 2 || this.props.disabled}
                   onClick={this.stepIncrement}
                 >
                   <i aria-hidden="true" className="rw-i rw-i-caret-up"></i>
@@ -90,7 +90,7 @@ export default class MotorInput extends React.Component {
                 <button
                   type="button"
                   className="rw-btn"
-                  disabled={this.props.state !== 2}
+                  disabled={this.props.state !== 2 || this.props.disabled}
                   onClick={this.stepDecrement}
                 >
                   <i aria-hidden="true" className="rw-i rw-i-caret-down"></i>
@@ -104,7 +104,7 @@ export default class MotorInput extends React.Component {
                 step={step}
                 defaultValue={valueCropped}
                 name={motorName}
-                disabled={this.props.state !== 2}
+                disabled={this.props.state !== 2 || this.props.disabled}
               />
             </div>
             <span
@@ -134,7 +134,7 @@ export default class MotorInput extends React.Component {
                   style={{ width: '100%', height: '100%', display: 'block' }}
                   className="btn-xs motor-abort rw-widget-no-left-border"
                   bsStyle="danger"
-                  disabled={this.props.state !== 4}
+                  disabled={this.props.state !== 4 || this.props.disabled}
                   onClick={this.stopMotor}
                 >
                   <i className="glyphicon glyphicon-remove" />

--- a/mxcube3/ui/components/SampleView/SampleControls.js
+++ b/mxcube3/ui/components/SampleView/SampleControls.js
@@ -127,7 +127,9 @@ export default class SampleControls extends React.Component {
         />
       <span className="sample-controll-label">Phase</span>
       </li>);
+
     const motors = this.props.motors;
+
     return (
       <div style={ { display: 'flex', position: 'absolute', width: '100%', zIndex: 1000 } } >
         <div className="sample-controlls text-center" >
@@ -208,7 +210,8 @@ export default class SampleControls extends React.Component {
                   id="zoom-control"
                   min="1" max="10"
                   step="1"
-                  defaultValue={this.props.zoom}
+                  defaultValue={motors.zoom}
+                  disabled={motors.zoom.Status !== 2}
                   onMouseUp={this.setZoom}
                   list="volsettings"
                   name="zoomSlider"
@@ -261,6 +264,7 @@ export default class SampleControls extends React.Component {
                     step="0.1"
                     min="0" max="1"
                     defaultValue={motors.BackLight.position}
+                    disabled={motors.BackLight.Status !== 2}
                     onMouseUp={(e) =>
                       this.props.sampleActions.sendMotorPosition('BackLight', e.target.value)}
                     name="backlightSlider"
@@ -294,6 +298,7 @@ export default class SampleControls extends React.Component {
                     step="0.1"
                     min="0" max="1"
                     defaultValue={motors.FrontLight.position}
+                    disabled={motors.FrontLight.Status !== 2}
                     onMouseUp={(e) =>
                       this.props.sampleActions.sendMotorPosition('FrontLight', e.target.value)}
                     name="frontLightSlider"

--- a/mxcube3/ui/containers/SampleViewContainer.js
+++ b/mxcube3/ui/containers/SampleViewContainer.js
@@ -8,6 +8,7 @@ import * as SampleViewActions from '../actions/sampleview';
 import { showTaskForm } from '../actions/taskForm';
 import BeamlineSetupContainer from './BeamlineSetupContainer';
 import SampleQueueContainer from './SampleQueueContainer';
+import { QUEUE_RUNNING } from '../constants';
 
 class SampleViewContainer extends Component {
 
@@ -28,6 +29,7 @@ class SampleViewContainer extends Component {
       }
     });
 
+
     return (
         <div className="row">
         <div className="col-xs-12">
@@ -44,6 +46,8 @@ class SampleViewContainer extends Component {
                   save={sendMotorPosition}
                   saveStep={setStepSize}
                   motors={this.props.beamline.motors}
+                  motorsDisabled={ this.props.beamline.motorInputDisable ||
+                                   this.props.queueState === QUEUE_RUNNING }
                   steps={motorSteps}
                   stop={sendStopMotor}
                 />
@@ -84,6 +88,7 @@ function mapStateToProps(state) {
   return {
     sampleList: state.sampleGrid.sampleList,
     current: state.queue.current,
+    queueState: state.queue.queueStatus,
     sampleViewState: state.sampleview,
     contextMenu: state.contextMenu,
     beamline: state.beamline,

--- a/mxcube3/ui/reducers/beamline.js
+++ b/mxcube3/ui/reducers/beamline.js
@@ -121,11 +121,13 @@ export const INITIAL_STATE = {
     BackLightSwitch: { position: 0, Status: 0 },
     FrontLightSwitch: { position: 0, Status: 0 },
     kappa: { position: 0, Status: 0 },
-    kappa_phi: { position: 0, Status: 0 }
+    kappa_phi: { position: 0, Status: 0 },
+    zoom: { position: 0, Status: 0 }
   },
   zoom: 0,
   beamlineActionsList: [],
-  currentBeamlineAction: { show: false, messages: [], arguments: [] }
+  currentBeamlineAction: { show: false, messages: [], arguments: [] },
+  motorInputDisable: false
 };
 
 
@@ -152,11 +154,14 @@ export default (state = INITIAL_STATE, action) => {
       return data;
 
     case 'SET_MOTOR_MOVING':
-      return { ...state, motors: { ...state.motors, [action.name.toLowerCase()]:
+      return { ...state,
+               motorInputDisable: true,
+               motors: { ...state.motors, [action.name.toLowerCase()]:
                                    { ...state.motors[action.name.toLowerCase()],
                                      Status: action.status
                                    }
-      } };
+                       }
+             };
 
     case 'SAVE_MOTOR_POSITIONS':
       return { ...state,
@@ -170,10 +175,12 @@ export default (state = INITIAL_STATE, action) => {
                                  }
              };
     case 'UPDATE_MOTOR_STATE':
-      return { ...state, motors: { ...state.motors, [action.name]:
+      return { ...state,
+               motorInputDisable: action.value !== 2,
+               motors: { ...state.motors, [action.name]:
                                    { position: state.motors[action.name].position,
                                      Status: action.value }
-                                 }
+                       }
              };
     case 'SET_INITIAL_STATE':
       return { ...INITIAL_STATE,


### PR DESCRIPTION
Fixes for  Issue #541 and Issue #540

 - Disabling motors while collecting, zoom and light not disabled.
 - Disabling light motor and zoom motor input when the corresponding motor is moving

I discovered that there is a "free" zoom attribute directly under the root of the beamline store, what is this for ? maybe it can be removed. Because we also have the zoom represented as a motor but it was not initialized correctly (corrected with this PR as well). Please let me know.

Also these changes rely on that the state of motors are updated correctly which is not the case for the zoom and light mockups. The rest should work fine in mockup mode.

Marcus
