### PR TITLE
Plotting - closes #560

### DIFF
--- a/mxcube3/__init__.py
+++ b/mxcube3/__init__.py
@@ -43,6 +43,11 @@ opt_parser.add_option("-v", "--video-device",
                       dest="video_device",
                       help="Video device, defaults to /dev/video0",
                       default='/dev/video0')
+opt_parser.add_option("-p", "--plotting",
+                      dest="plotting",
+                      help="Plotting HWR file, defaults to /plotting",
+                      default='/plotting')
+
 
 cmdline_options, args = opt_parser.parse_args()
 
@@ -136,12 +141,12 @@ if not app.debug or os.environ.get("WERKZEUG_RUN_MAIN") == "true":
         app.rest_lims = app.beamline.getObjectByRole("lims_rest_client")
         app.queue = qutils.new_queue()
         app.actions = hwr.getHardwareObject(cmdline_options.beamline_actions)
+        app.plotting = hwr.getHardwareObject(cmdline_options.plotting)
 
         # SampleID of currently mounted sample
         app.CURRENTLY_MOUNTED_SAMPLE = ''
         app.AUTO_MOUNT_SAMPLE = False
         app.AUTO_LOOP_CENTER = False
-
 
         # set up streaming
         from mxcube3.video import streaming

--- a/mxcube3/routes/Beamline.py
+++ b/mxcube3/routes/Beamline.py
@@ -45,6 +45,13 @@ def init_signals():
     except Exception, ex:
         logging.getLogger('HWR').error("error loading safety_shutter hwo: %s" % str(ex))
 
+    try:
+        mxcube.plotting.connect(mxcube.plotting, 'new_plot', signals.new_plot)
+        mxcube.plotting.connect(mxcube.plotting, 'plot_data', signals.plot_data)
+        mxcube.plotting.connect(mxcube.plotting, 'plot_end', signals.plot_end)
+    except Exception, ex:
+        logging.getLogger('HWR').error("error loading plotting hwo: %s" % str(ex))
+
 
 @mxcube.route("/mxcube/api/v0.1/beamline", methods=['GET'])
 def beamline_get_all_attributes():

--- a/mxcube3/routes/signals.py
+++ b/mxcube3/routes/signals.py
@@ -475,6 +475,7 @@ def beamline_action_failed(name):
     else:
         logging.getLogger('user_level_log').error('Action %s failed !', name)
 
+
 def safety_shutter_state_changed(values):
     ho = BeamlineSetupMediator(mxcube.beamline).getObjectByRole("safety_shutter")
     data = ho.dict_repr()
@@ -482,4 +483,33 @@ def safety_shutter_state_changed(values):
         socketio.emit("beamline_value_change", data, namespace="/hwr")
     except Exception:
         logging.getLogger("HWR").error('error sending message: %s', data)
+
+
+def new_plot(plot_info):
+    try:
+        socketio.emit("new_plot", plot_info, namespace="/hwr")
+    except Exception:
+        logging.getLogger("HWR").error('error sending new_plot message: %s', plot_info)
+
+
+@Utils.RateLimited(1)
+def plot_data(data, last_index=[0], **kwargs):
+    data_data = data["data"]
+    if last_index[0] > len(data_data):
+      last_index = [0]
+
+    data["data"] = data_data[last_index[0]:]
+
+    try:
+        socketio.emit("plot_data", data, namespace="/hwr")
+    except Exception:
+        logging.getLogger("HWR").exception('error sending plot_data message for plot %s', data['id'])
+    else:    
+        last_index[0] += len(data_data)
+
+def plot_end(data):
+    try:
+        socketio.emit("plot_end", data, namespace="/hwr")
+    except Exception:
+        logging.getLogger("HWR").error('error sending plot_end message for plot %s', data['id'])
 

--- a/mxcube3/ui/actions/beamlineActions.js
+++ b/mxcube3/ui/actions/beamlineActions.js
@@ -56,3 +56,14 @@ export function stopAction(cmdName) {
   };
 }
 
+export function newPlot(plotInfo) {
+  return { type: 'NEW_PLOT', plotInfo };
+}
+
+export function plotData(plotId, data, fullDataSet) {
+  return { type: 'PLOT_DATA', id: plotId, data, fullDataSet };
+}
+
+export function plotEnd(plotId) {
+  return { type: 'PLOT_END', id: plotId };
+}

--- a/mxcube3/ui/components/Plot1D.jsx
+++ b/mxcube3/ui/components/Plot1D.jsx
@@ -44,8 +44,8 @@ class Plot1D extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.state.plotId != null) {
-      if (this.props.autoNext) {
+    if (this.props.autoNext) {
+      if (this.state.plotId != null) {
         if (nextProps.lastPlotId != this.state.plotId) {
           const currentPlotInfo = nextProps.plotsInfo[this.state.plotId];
           if (currentPlotInfo.end) {
@@ -53,30 +53,32 @@ class Plot1D extends React.Component {
             this.setPlot(nextProps.lastPlotId);
           } 
         }
-      }
-    } else {
-      const plotId = nextProps.lastPlotId;
-      const plotInfo = nextProps.plotsInfo[plotId];
+      } else {
+        const plotId = nextProps.lastPlotId;
+        const plotInfo = nextProps.plotsInfo[plotId];
       
-      if (plotInfo.end) {
-        // do not display an old plot
-        return;
-      }
+        if (plotInfo.end) {
+          // do not display an old plot
+          return;
+        }
 
-      this.setPlot(plotId);
+        this.setPlot(plotId);
+      }
     }
   }
 
   componentWillUpdate(nextProps, nextState) {
     const plotId = nextState.plotId;
-    const plotInfo = nextProps.plotsInfo[plotId];
-    const plotData = nextProps.plotsData[plotId];
+    if (plotId) {
+      const plotInfo = nextProps.plotsInfo[plotId];
+      const plotData = nextProps.plotsData[plotId];
 
-    if (this.dygraph) {
-      this.dygraph.updateOptions({ file: plotData });
-    } else { 
-      this.dygraph = new Dygraph(this.dygraph_div, plotData, { title: plotInfo.title, 
+      if (this.dygraph) {
+        this.dygraph.updateOptions({ file: plotData });
+      } else { 
+        this.dygraph = new Dygraph(this.dygraph_div, plotData, { title: plotInfo.title, 
                                                                labels: plotInfo.labels });
+      }
     }
   }
 

--- a/mxcube3/ui/components/Plot1D.jsx
+++ b/mxcube3/ui/components/Plot1D.jsx
@@ -7,8 +7,8 @@ class Plot1D extends React.Component {
   constructor(props) {
     super(props);
 
-    this.setPlot = this.setPlot.bind(this);
     this.clearPlot = this.clearPlot.bind(this);
+    this.setPlot = this.setPlot.bind(this);
 
     this.dygraph = null;
     this.state = { plotId: null };
@@ -20,43 +20,20 @@ class Plot1D extends React.Component {
     }
   }
 
-  clearPlot() {
-    if (this.dygraph) {
-      this.dygraph.destroy();
-    }
-
-    this.dygraph = null;
-  }
-
-  componentWillUnmount() {
-    this.clearPlot();
-  }
-
-  setPlot(plotId) {
-    this.clearPlot();
-
-    this.setState({ plotId });
-
-    if (this.props.displayedPlotCallback) {
-      // tell parent we are displaying this plot
-      this.props.displayedPlotCallback(plotId);
-    }
-  }
-
   componentWillReceiveProps(nextProps) {
     if (this.props.autoNext) {
-      if (this.state.plotId != null) {
-        if (nextProps.lastPlotId != this.state.plotId) {
+      if (this.state.plotId !== null) {
+        if (nextProps.lastPlotId !== this.state.plotId) {
           const currentPlotInfo = nextProps.plotsInfo[this.state.plotId];
           if (currentPlotInfo.end) {
             // display next plot
             this.setPlot(nextProps.lastPlotId);
-          } 
+          }
         }
       } else {
         const plotId = nextProps.lastPlotId;
         const plotInfo = nextProps.plotsInfo[plotId];
-      
+
         if (plotInfo.end) {
           // do not display an old plot
           return;
@@ -75,11 +52,34 @@ class Plot1D extends React.Component {
 
       if (this.dygraph) {
         this.dygraph.updateOptions({ file: plotData });
-      } else { 
-        this.dygraph = new Dygraph(this.dygraph_div, plotData, { title: plotInfo.title, 
+      } else {
+        this.dygraph = new Dygraph(this.dygraph_div, plotData, { title: plotInfo.title,
                                                                labels: plotInfo.labels });
       }
     }
+  }
+
+  componentWillUnmount() {
+    this.clearPlot();
+  }
+
+  setPlot(plotId) {
+    this.clearPlot();
+
+    this.setState({ plotId });
+
+    if (this.props.displayedPlotCallback) {
+      // tell parent we are displaying this plot
+      this.props.displayedPlotCallback(plotId);
+    }
+  }
+
+  clearPlot() {
+    if (this.dygraph) {
+      this.dygraph.destroy();
+    }
+
+    this.dygraph = null;
   }
 
   render() {

--- a/mxcube3/ui/components/Plot1D.jsx
+++ b/mxcube3/ui/components/Plot1D.jsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import Dygraph from 'dygraphs';
+import 'dygraphs/dist/dygraph.min.css';
+
+class Plot1D extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.setPlot = this.setPlot.bind(this);
+    this.clearPlot = this.clearPlot.bind(this);
+
+    this.dygraph = null;
+    this.state = { plotId: null };
+  }
+
+  componentDidMount() {
+    if (this.props.plotId) {
+      this.setState({ plotId: this.props.plotId });
+    }
+  }
+
+  clearPlot() {
+    if (this.dygraph) {
+      this.dygraph.destroy();
+    }
+
+    this.dygraph = null;
+  }
+
+  componentWillUnmount() {
+    this.clearPlot();
+  }
+
+  setPlot(plotId) {
+    this.clearPlot();
+
+    this.setState({ plotId });
+
+    if (this.props.displayedPlotCallback) {
+      // tell parent we are displaying this plot
+      this.props.displayedPlotCallback(plotId);
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.state.plotId != null) {
+      if (this.props.autoNext) {
+        if (nextProps.lastPlotId != this.state.plotId) {
+          const currentPlotInfo = nextProps.plotsInfo[this.state.plotId];
+          if (currentPlotInfo.end) {
+            // display next plot
+            this.setPlot(nextProps.lastPlotId);
+          } 
+        }
+      }
+    } else {
+      const plotId = nextProps.lastPlotId;
+      const plotInfo = nextProps.plotsInfo[plotId];
+      
+      if (plotInfo.end) {
+        // do not display an old plot
+        return;
+      }
+
+      this.setPlot(plotId);
+    }
+  }
+
+  componentWillUpdate(nextProps, nextState) {
+    const plotId = nextState.plotId;
+    const plotInfo = nextProps.plotsInfo[plotId];
+    const plotData = nextProps.plotsData[plotId];
+
+    if (this.dygraph) {
+      this.dygraph.updateOptions({ file: plotData });
+    } else { 
+      this.dygraph = new Dygraph(this.dygraph_div, plotData, { title: plotInfo.title, 
+                                                               labels: plotInfo.labels });
+    }
+  }
+
+  render() {
+    return (<div ref={ (ref) => { this.dygraph_div = ref; } } />);
+  }
+}
+
+Plot1D.defaultProps = { autoNext: true, plotId: null, displayedPlotCallback: null };
+
+function mapStateToProps(state) {
+  return {
+    lastPlotId: state.beamline.lastPlotId,
+    plotsInfo: state.beamline.plotsInfo,
+    plotsData: state.beamline.plotsData
+  };
+}
+
+export default connect(
+    mapStateToProps,
+    null
+)(Plot1D);
+

--- a/mxcube3/ui/containers/BeamlineActionsContainer.jsx
+++ b/mxcube3/ui/containers/BeamlineActionsContainer.jsx
@@ -138,7 +138,9 @@ class BeamlineActionsContainer extends React.Component {
                   Run
                 </Button> }
              <hr></hr>
-             <Plot1D displayedPlotCallback={this.newPlotDisplayed} plotId={this.plotIdByAction[currentActionName]} autoNext={currentActionRunning}/>
+             <Plot1D displayedPlotCallback={this.newPlotDisplayed}
+               plotId={this.plotIdByAction[currentActionName]} autoNext={currentActionRunning}
+             />
              { this.props.currentAction.messages.length > 0 ? (<Well>
                {this.props.currentAction.messages.map(message => <p>{message.message}</p>)}
              </Well>) : '' }

--- a/mxcube3/ui/containers/BeamlineActionsContainer.jsx
+++ b/mxcube3/ui/containers/BeamlineActionsContainer.jsx
@@ -15,16 +15,20 @@ import { Row,
          Well,
          FormControl } from 'react-bootstrap';
 import BeamlineActionControl from '../components/BeamlineActions/BeamlineActionControl';
+import Plot1D from '../components/Plot1D';
 import { RUNNING } from '../constants';
 
 class BeamlineActionsContainer extends React.Component {
   constructor(props) {
     super(props);
 
+    this.plotIdByAction = {};
+
     this.startAction = this.startAction.bind(this);
     this.stopAction = this.stopAction.bind(this);
     this.showOutput = this.showOutput.bind(this);
     this.hideOutput = this.hideOutput.bind(this);
+    this.newPlotDisplayed = this.newPlotDisplayed.bind(this);
   }
 
   startAction(cmdName) {
@@ -44,6 +48,7 @@ class BeamlineActionsContainer extends React.Component {
       return false;
     });
 
+    this.plotIdByAction[this.props.currentAction.name] = null;
     this.props.startAction(cmdName, parameters);
   }
 
@@ -57,6 +62,10 @@ class BeamlineActionsContainer extends React.Component {
 
   hideOutput() {
     this.props.hideOutput(this.props.currentAction.name);
+  }
+
+  newPlotDisplayed(plotId) {
+    this.plotIdByAction[this.props.currentAction.name] = plotId;
   }
 
   render() {
@@ -129,6 +138,7 @@ class BeamlineActionsContainer extends React.Component {
                   Run
                 </Button> }
              <hr></hr>
+             <Plot1D displayedPlotCallback={this.newPlotDisplayed} plotId={this.plotIdByAction[currentActionName]} />
              { this.props.currentAction.messages.length > 0 ? (<Well>
                {this.props.currentAction.messages.map(message => <p>{message.message}</p>)}
              </Well>) : '' }

--- a/mxcube3/ui/containers/BeamlineActionsContainer.jsx
+++ b/mxcube3/ui/containers/BeamlineActionsContainer.jsx
@@ -138,7 +138,7 @@ class BeamlineActionsContainer extends React.Component {
                   Run
                 </Button> }
              <hr></hr>
-             <Plot1D displayedPlotCallback={this.newPlotDisplayed} plotId={this.plotIdByAction[currentActionName]} />
+             <Plot1D displayedPlotCallback={this.newPlotDisplayed} plotId={this.plotIdByAction[currentActionName]} autoNext={currentActionRunning}/>
              { this.props.currentAction.messages.length > 0 ? (<Well>
                {this.props.currentAction.messages.map(message => <p>{message.message}</p>)}
              </Well>) : '' }

--- a/mxcube3/ui/reducers/beamline.js
+++ b/mxcube3/ui/reducers/beamline.js
@@ -127,7 +127,10 @@ export const INITIAL_STATE = {
   zoom: 0,
   beamlineActionsList: [],
   currentBeamlineAction: { show: false, messages: [], arguments: [] },
-  motorInputDisable: false
+  motorInputDisable: false,
+  lastPlotId: null,
+  plotsInfo: {},
+  plotsData: {}
 };
 
 
@@ -271,6 +274,37 @@ export default (state = INITIAL_STATE, action) => {
         });
 
         return { ...state, beamlineActionsList, currentBeamlineAction };
+      }
+    case 'NEW_PLOT':
+      {
+        const plotId = action.plotInfo.id;
+        const plotsInfo = { ...state.plotsInfo, [plotId]: { labels: action.plotInfo.labels,
+                                                            title: action.plotInfo.title,
+                                                            end: false } };
+        const plotsData = { ...state.plotsData };
+        plotsData[plotId] = [];
+
+        return { ...state, plotsInfo, plotsData, lastPlotId: plotId };
+      }
+    case 'PLOT_DATA':
+      {
+        const plotsData = { ...state.plotsData };
+        if (action.fullDataSet) {
+          plotsData[action.id] = action.data;
+        } else {
+          const plotData = [...plotsData[action.id]];
+          plotData.push(...action.data);
+          plotsData[action.id] = plotData;
+        }
+        return { ...state, plotsData };
+      }
+    case 'PLOT_END':
+      {
+        const plotsInfo = { ...state.plotsInfo };
+        const plotInfo = plotsInfo[action.id];
+        plotInfo.end = true;
+        plotsInfo[action.id] = plotInfo;
+        return { ...state, plotsInfo };
       }
     default:
       return state;

--- a/mxcube3/ui/serverIO.js
+++ b/mxcube3/ui/serverIO.js
@@ -11,7 +11,10 @@ import {
 } from './actions/sampleview';
 import { setBeamlineAttrAction,
          setMachInfo } from './actions/beamline';
-import { setActionState } from './actions/beamlineActions';
+import { setActionState,
+         newPlot,
+         plotData,
+         plotEnd } from './actions/beamlineActions';
 import { setStatus,
          addTaskResultAction,
          addTaskAction,
@@ -223,6 +226,19 @@ class ServerIO {
 
     this.hwrSocket.on('beamline_action', (data) => {
       this.dispatch(setActionState(data.name, data.state));
+    });
+
+    this.hwrSocket.on('new_plot', (plotInfo) => {
+      this.dispatch(newPlot(plotInfo));
+    });
+
+    this.hwrSocket.on('plot_data', (data) => {
+      this.dispatch(plotData(data.id, data.data, false));
+    });
+
+    this.hwrSocket.on('plot_end', (data) => {
+      this.dispatch(plotData(data.id, data.data, true));
+      this.dispatch(plotEnd(data.id));
     });
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "bootstrap": "3.3.5",
     "classnames": "^2.2.0",
+    "dygraphs": "^2.0.0",
     "everpolate": "0.0.3",
     "font-awesome": "^4.4.0",
     "history": "1.17.x",

--- a/test/HardwareObjectsMockup.xml/plotting.xml
+++ b/test/HardwareObjectsMockup.xml/plotting.xml
@@ -1,0 +1,2 @@
+<object class="PlottingMockup"/>
+


### PR DESCRIPTION
Finally, here it is :) The first version of the plotting facility for MXCuBE 3.
It is based on Dygraphs javascript library, after the small study I made previously.

How does it work? There is a new 'plotting' hardware object, to be specified with `-p` in mxcube3-server command line (defaults to `/plotting`). Any hardware object that can emit the following signals is a plotting hardware object:
* `new_plot`, signal argument: a dictionary like `{ "title": "plot title", "labels": ["x", "y1", ..., "yn"], "id": "plot_identifier (number?)" }`
* `plot_data`, signal argument: a dictionary like `{ "id": "plot_identifier", "data": a list of lists, see below }`
    - data format is `[ [x0, y01, y02, ..., y0n], [x1, y11, ... y1n] ]`
    - data should be the whole data from the start - internally there is a rate limitation of this signal to 1 per second, and data will be sent in pieces : this is handled by the server itself
* `plot_end`, signal argument: dictionary like `{ "id": "plot_identifier", "data": the whole scan data with the right format }`

There is a new 'Plot1D' react component for the UI; when it is placed in a container, it will automatically receive plots from hardware objects and display them. It is also possible to specify which particular plot to display via the following properties:
* `autoNext`: automatically display subsequent plots (default: `true`)
* `plotId`: to specify a particular plot to be displayed
* `displayedPlotCallback`: function, useful for the parent component to know which plot is currently being displayed; the function receives the plot identifier
