### PR TITLE
Minor fixes - task addtion from grid

### DIFF
--- a/mxcube3/routes/qutils.py
+++ b/mxcube3/routes/qutils.py
@@ -632,7 +632,7 @@ def add_sample(sample_id, item):
     return sample_model._node_id
 
 
-def set_dc_params(model, entry, task_data):
+def set_dc_params(model, entry, task_data, sample_model):
     """
     Helper method that sets the data collection parameters for a DataCollection.
 
@@ -651,7 +651,12 @@ def set_dc_params(model, entry, task_data):
     acq.path_template.suffix = ftype
     acq.path_template.precision = '0' + str(mxcube.session["file_info"].\
         getProperty("precision", 4))
-    acq.path_template.base_prefix = params['prefix']
+
+    if params['prefix']:
+        acq.path_template.base_prefix = params['prefix']
+    else:
+        acq.path_template.base_prefix = mxcube.session.\
+            get_default_prefix(sample_model, False)
 
     full_path = os.path.join(mxcube.session.get_base_image_directory(),
                              params.get('subdir', ''))
@@ -754,7 +759,7 @@ def set_wf_params(model, entry, task_data, sample_model):
     entry.set_enabled(task_data['checked'])
 
 
-def set_char_params(model, entry, task_data):
+def set_char_params(model, entry, task_data, sample_model):
     """
     Helper method that sets the characterisation parameters for a
     Characterisation.
@@ -844,7 +849,7 @@ def add_characterisation(node_id, task):
     char_entry = qe.CharacterisationGroupQueueEntry(Mock(), char_model)
     char_entry.queue_model_hwobj = mxcube.queue
     # Set the characterisation and reference collection parameters
-    set_char_params(char_model, char_entry, task)
+    set_char_params(char_model, char_entry, task, sample_model)
 
     # A characterisation has two TaskGroups one for the characterisation itself
     # and its reference collection and one for the resulting diffraction plans.
@@ -878,7 +883,7 @@ def add_data_collection(node_id, task):
     """
     sample_model, sample_entry = get_entry(node_id)
     dc_model, dc_entry = _create_dc(task)
-    set_dc_params(dc_model, dc_entry, task)
+    set_dc_params(dc_model, dc_entry, task, sample_model)
 
     pt = dc_model.acquisitions[0].path_template
 
@@ -963,7 +968,7 @@ def add_interleaved(node_id, task):
     for wedge in task['parameters']['wedges']:
         wc = wc + 1
         dc_model, dc_entry = _create_dc(wedge)
-        set_dc_params(dc_model, dc_entry, wedge)
+        set_dc_params(dc_model, dc_entry, wedge, sample_model)
         dc_model.acquisitions[0].path_template.wedge_prefix = "wedge-%s" % wc
         mxcube.queue.add_child(group_model, dc_model)
         group_entry.enqueue(dc_entry)

--- a/mxcube3/ui/components/SampleQueue/QueueControl.js
+++ b/mxcube3/ui/components/SampleQueue/QueueControl.js
@@ -30,7 +30,7 @@ export default class QueueControl extends React.Component {
           { text: 'Pause', class: 'btn-warning', action: this.props.pause, key: 2 },
         ],
         [QUEUE_STOPPED]: [
-          { text: 'Skip to next Sample', class: 'btn-primary', action: this.nextSample, key: 2 }
+          { text: 'Mount Next Sample', class: 'btn-primary', action: this.nextSample, key: 2 }
         ],
         [QUEUE_PAUSED]: [
           { text: 'Unpause', class: 'btn-success', action: this.props.unpause, key: 2 }

--- a/mxcube3/ui/components/SampleQueue/TaskItem.jsx
+++ b/mxcube3/ui/components/SampleQueue/TaskItem.jsx
@@ -81,7 +81,7 @@ export default class TaskItem extends Component {
     let res = '';
 
     wedges.forEach((wedge) => {
-      if (res.indexOf(`${wedge.parameters.shape}`) < 0) {
+      if ((wedge.parameters.shape !== -1) && res.indexOf(`${wedge.parameters.shape}`) < 0) {
         res += `${wedge.parameters.shape} `;
       }
     });

--- a/mxcube3/ui/containers/SampleGridViewContainer.jsx
+++ b/mxcube3/ui/containers/SampleGridViewContainer.jsx
@@ -168,7 +168,7 @@ class SampleGridViewContainer extends React.Component {
   showTaskForm(formName, extraParams = {}) {
     let prefix = '';
     let path = '';
-    let subdir = ''
+    const subdir = '';
 
     if (Object.keys(this.props.selected).length === 1) {
       prefix = this.props.sampleList[Object.keys(this.props.selected)[0]].defaultPrefix;

--- a/mxcube3/ui/containers/SampleGridViewContainer.jsx
+++ b/mxcube3/ui/containers/SampleGridViewContainer.jsx
@@ -168,6 +168,7 @@ class SampleGridViewContainer extends React.Component {
   showTaskForm(formName, extraParams = {}) {
     let prefix = '';
     let path = '';
+    let subdir = ''
 
     if (Object.keys(this.props.selected).length === 1) {
       prefix = this.props.sampleList[Object.keys(this.props.selected)[0]].defaultPrefix;
@@ -178,7 +179,8 @@ class SampleGridViewContainer extends React.Component {
       ...this.props.defaultParameters[formName.toLowerCase()],
       ...extraParams,
       prefix,
-      path } };
+      path,
+      subdir } };
 
     const selected = [];
 


### PR DESCRIPTION
Hi,

Some minor fixes for when adding tasks from the sample grid;

  - Point id label was -1 if no point, displaying empty string instead
  - Using default prefix when tasks are added to multiple samples, or no prefix is given.
  - Making sure that subdir is not initialized as undefined

Marcus