### PR TITLE
Mesh scan resuts issue 607

### DIFF
--- a/mxcube3/routes/Login.py
+++ b/mxcube3/routes/Login.py
@@ -75,6 +75,7 @@ def signout():
 
     qutils.save_queue(session)
     mxcube.queue = qutils.new_queue()
+    mxcube.shapes.clear_all()
 
     LOGGED_IN_USER = None
     if remote_access.is_master(session.sid):

--- a/mxcube3/routes/SampleCentring.py
+++ b/mxcube3/routes/SampleCentring.py
@@ -346,9 +346,12 @@ def update_shapes():
 
         # Store pixels per mm for third party software, to facilitate
         # certain calculations
-        shape_data["pixels_per_mm"] =  mxcube.diffractometer.get_pixels_per_mm()
-        shape_data["beam_pos"] = (mxcube.diffractometer.getBeamPosX(),
-                                  mxcube.diffractometer.getBeamPosY())
+
+        beam_info_dict = beam_info_dict = beamlineutils.get_beam_info()
+       
+        shape_data["pixels_per_mm"] = mxcube.diffractometer.get_pixels_per_mm()
+        shape_data["beam_pos"] = (beam_info_dict.get("position")[0],
+                                  beam_info_dict.get("position")[1])
 
         # Shape does not have any refs, create a new Centered position
         if not refs:

--- a/mxcube3/ui/components/Tasks/validate.js
+++ b/mxcube3/ui/components/Tasks/validate.js
@@ -21,7 +21,9 @@ const validate = (values, props) => {
       parseInt(values.num_images, 10) < 1) {
     errors.num_images = 'Number of images out of allowed range';
   }
-  if (values.osc_range === '' || parseFloat(values.osc_range, 10) < 0) {
+  if (values.osc_range === '' ||
+    parseInt(values.osc_range, 10) > props.acqParametersLimits.osc_range ||
+    parseFloat(values.osc_range, 10) < 0) {
     errors.osc_range = 'wrong value';
   }
   if (values.osc_start === '') {

--- a/mxcube3/ui/containers/TaskContainer.js
+++ b/mxcube3/ui/containers/TaskContainer.js
@@ -84,6 +84,7 @@ class TaskContainer extends React.Component {
         hide={this.props.hideTaskParametersForm}
         apertureList={this.props.apertureList}
         rootPath={this.props.path}
+        attributes={this.props.attributes}
       />);
     }
 
@@ -96,6 +97,7 @@ class TaskContainer extends React.Component {
         hide={this.props.hideTaskParametersForm}
         apertureList={this.props.apertureList}
         rootPath={this.props.path}
+        attributes={this.props.attributes}
       />);
     }
 
@@ -110,6 +112,7 @@ class TaskContainer extends React.Component {
         apertureList={this.props.apertureList}
         rootPath={this.props.path}
         lines={lines}
+        attributes={this.props.attributes}
       />);
     }
 
@@ -199,7 +202,8 @@ function mapStateToProps(state) {
     pointID: state.taskForm.pointID,
     apertureList: state.sampleview.apertureList,
     path: state.queue.rootPath,
-    shapes: state.shapes.shapes
+    shapes: state.shapes.shapes,
+    attributes: state.beamline.attributes
   };
 }
 


### PR DESCRIPTION
** accept first https://github.com/mxcube/mxcube3/pull/634 **

lets see if #607  bug is solved. Nothing was preventing from having different results for different grids, I think the issue was that the grids were not deleted on a logout, so that collisions will appear.

I cannot reproduce the issue.


![image](https://user-images.githubusercontent.com/12758327/30640458-50df0dce-9e03-11e7-97b5-c6852defb91d.png)
