### PR TITLE
Save mounted sample on logout

### DIFF
--- a/mxcube3/routes/Login.py
+++ b/mxcube3/routes/Login.py
@@ -101,6 +101,10 @@ def signout():
     mxcube.queue = qutils.new_queue()
     mxcube.shapes.clear_all()
 
+    if mxcube.CURRENTLY_MOUNTED_SAMPLE_IS_MANUAL:
+        mxcube.CURRENTLY_MOUNTED_SAMPLE = ''
+        mxcube.CURRENTLY_MOUNTED_SAMPLE_IS_MANUAL = False
+
     LOGGED_IN_USER = None
     if remote_access.is_master(session.sid):
         state_storage.flush()

--- a/mxcube3/routes/Login.py
+++ b/mxcube3/routes/Login.py
@@ -102,7 +102,7 @@ def signout():
     mxcube.shapes.clear_all()
 
     if mxcube.CURRENTLY_MOUNTED_SAMPLE:
-        if mxcube.CURRENTLY_MOUNTED_SAMPLE_DATA['location'] == 'Manual':
+        if mxcube.CURRENTLY_MOUNTED_SAMPLE.get('location', '') == 'Manual':
             mxcube.CURRENTLY_MOUNTED_SAMPLE = ''
 
     LOGGED_IN_USER = None

--- a/mxcube3/routes/Login.py
+++ b/mxcube3/routes/Login.py
@@ -101,9 +101,9 @@ def signout():
     mxcube.queue = qutils.new_queue()
     mxcube.shapes.clear_all()
 
-    if mxcube.CURRENTLY_MOUNTED_SAMPLE_IS_MANUAL:
-        mxcube.CURRENTLY_MOUNTED_SAMPLE = ''
-        mxcube.CURRENTLY_MOUNTED_SAMPLE_IS_MANUAL = False
+    if mxcube.CURRENTLY_MOUNTED_SAMPLE:
+        if mxcube.CURRENTLY_MOUNTED_SAMPLE_DATA['location'] == 'Manual':
+            mxcube.CURRENTLY_MOUNTED_SAMPLE = ''
 
     LOGGED_IN_USER = None
     if remote_access.is_master(session.sid):

--- a/mxcube3/routes/SampleCentring.py
+++ b/mxcube3/routes/SampleCentring.py
@@ -660,7 +660,7 @@ def wait_for_centring_finishes(*args, **kwargs):
 
     # we do not send/save any centring data if there is no sample
     # to avoid the 2d centring when no sample is mounted
-    if scutils.get_current_sample() == '':
+    if scutils.get_current_sample().get('sampleID', '') == '':
         return
     try:
         motor_positions = mxcube.diffractometer.centringStatus["motors"]

--- a/mxcube3/routes/SampleChanger.py
+++ b/mxcube3/routes/SampleChanger.py
@@ -74,7 +74,7 @@ def get_samples_list():
         if s.isLoaded():
             state = SAMPLE_MOUNTED
         elif s.hasBeenLoaded():
-            state.COLLECTED
+            state = COLLECTED
         else:
             state = UNCOLLECTED
         sample_dm = s.getID() or ""

--- a/mxcube3/routes/SampleChanger.py
+++ b/mxcube3/routes/SampleChanger.py
@@ -144,13 +144,13 @@ def mount_sample(loc):
 @mxcube.route("/mxcube/api/v0.1/sample_changer/unmount/<loc>", methods=['GET'])
 def unmount_sample(loc):
     mxcube.sample_changer.unload(loc, wait=True)
-    set_current_sample('')
+    set_current_sample(None)
     return jsonify(get_sc_contents())
 
 @mxcube.route("/mxcube/api/v0.1/sample_changer/unmount_current/", methods=['GET'])
 def unmount_current():
     mxcube.sample_changer.unload(None, wait=True)
-    set_current_sample('')
+    set_current_sample(None)
     return jsonify(get_sc_contents())
 
 @mxcube.route("/mxcube/api/v0.1/sample_changer/mount", methods=["POST"])

--- a/mxcube3/routes/qutils.py
+++ b/mxcube3/routes/qutils.py
@@ -257,13 +257,13 @@ def get_queue_state():
     # in case the user logged out without unloading a sample
     # we populate the queue with that sample
     if not queue and mxcube.CURRENTLY_MOUNTED_SAMPLE:
-        add_sample(mxcube.CURRENTLY_MOUNTED_SAMPLE, mxcube.CURRENTLY_MOUNTED_SAMPLE_DATA)
+        add_sample(mxcube.CURRENTLY_MOUNTED_SAMPLE.get('sampleID'), mxcube.CURRENTLY_MOUNTED_SAMPLE_DATA)
         queue = queue_to_dict()
     
     if queue:
         queue.pop("sample_order")
 
-    res = { "loaded": scutils.get_current_sample(),
+    res = { "loaded": scutils.get_current_sample().get('sampleID', ''),
             "centringMethod": mxcube.CENTRING_METHOD,
             "autoMountNext": get_auto_mount_sample(),
             "autoAddDiffPlan": mxcube.AUTO_ADD_DIFFPLAN,
@@ -1547,7 +1547,7 @@ def execute_entry_with_id(sid, tindex=None):
         # the sample task), so in order function as expected; just mount the
         # sample
         if (not len(current_queue[sid]["tasks"])) and \
-           sid != scutils.get_current_sample():
+           sid != scutils.get_current_sample().get('sampleID', ''):
 
             scutils.mount_sample_clean_up(current_queue[sid])
 
@@ -1641,7 +1641,7 @@ def set_auto_mount_sample(automount, current_sample=None):
     mxcube.AUTO_MOUNT_SAMPLE = automount
     current_queue = queue_to_dict()
 
-    sample = current_sample if current_sample else scutils.get_current_sample()
+    sample = current_sample if current_sample else scutils.get_current_sample().get('sampleID', '')
 
     # If automount next is off, that is do not mount and run next
     # sample, disable all entries except the current one

--- a/mxcube3/routes/qutils.py
+++ b/mxcube3/routes/qutils.py
@@ -819,12 +819,6 @@ def add_sample(sample_id, item):
     :param str sample_id: Sample id (often sample changer location)
     :returns: SampleQueueEntry
     """
-    if item['location'] == 'Manual':
-        mxcube.CURRENTLY_MOUNTED_SAMPLE_IS_MANUAL = True
-    else:
-        mxcube.CURRENTLY_MOUNTED_SAMPLE_IS_MANUAL = False
-        mxcube.CURRENTLY_MOUNTED_SAMPLE_DATA = item
-
     sample_model = qmo.Sample()
     sample_model.set_origin(ORIGIN_MX3)
 

--- a/mxcube3/routes/qutils.py
+++ b/mxcube3/routes/qutils.py
@@ -257,7 +257,7 @@ def get_queue_state():
     # in case the user logged out without unloading a sample
     # we populate the queue with that sample
     if not queue and mxcube.CURRENTLY_MOUNTED_SAMPLE:
-        add_sample(mxcube.CURRENTLY_MOUNTED_SAMPLE.get('sampleID'), mxcube.CURRENTLY_MOUNTED_SAMPLE_DATA)
+        add_sample(mxcube.CURRENTLY_MOUNTED_SAMPLE.get('sampleID'), mxcube.CURRENTLY_MOUNTED_SAMPLE)
         queue = queue_to_dict()
     
     if queue:

--- a/mxcube3/routes/qutils.py
+++ b/mxcube3/routes/qutils.py
@@ -253,6 +253,13 @@ def get_queue_state():
               }
     """
     queue = queue_to_dict()
+
+    # in case the user logged out without unloading a sample
+    # we populate the queue with that sample
+    if not queue and mxcube.CURRENTLY_MOUNTED_SAMPLE:
+        add_sample(mxcube.CURRENTLY_MOUNTED_SAMPLE, mxcube.CURRENTLY_MOUNTED_SAMPLE_DATA)
+        queue = queue_to_dict()
+    
     if queue:
         queue.pop("sample_order")
 
@@ -812,6 +819,12 @@ def add_sample(sample_id, item):
     :param str sample_id: Sample id (often sample changer location)
     :returns: SampleQueueEntry
     """
+    if item['location'] == 'Manual':
+        mxcube.CURRENTLY_MOUNTED_SAMPLE_IS_MANUAL = True
+    else:
+        mxcube.CURRENTLY_MOUNTED_SAMPLE_IS_MANUAL = False
+        mxcube.CURRENTLY_MOUNTED_SAMPLE_DATA = item
+
     sample_model = qmo.Sample()
     sample_model.set_origin(ORIGIN_MX3)
 

--- a/mxcube3/routes/scutils.py
+++ b/mxcube3/routes/scutils.py
@@ -8,11 +8,17 @@ from mxcube3 import app as mxcube
 from queue_entry import QueueSkippEntryException, CENTRING_METHOD
 
 
-def set_current_sample(sample_id):
-    mxcube.CURRENTLY_MOUNTED_SAMPLE = str(sample_id)
+def set_current_sample(sample):
+    mxcube.CURRENTLY_MOUNTED_SAMPLE = sample
 
 def get_current_sample():
-    return mxcube.CURRENTLY_MOUNTED_SAMPLE
+    if mxcube.CURRENTLY_MOUNTED_SAMPLE:
+        return mxcube.CURRENTLY_MOUNTED_SAMPLE
+    else:
+        return {}
+
+def get_sample_info(location):
+    return {}
 
 def set_sample_to_be_mounted(loc):
     mxcube.SAMPLE_TO_BE_MOUNTED = loc
@@ -25,7 +31,7 @@ def mount_sample(beamline_setup_hwobj,
                  centring_done_cb, async_result):
 
     logging.getLogger('user_level_log').info("Loading sample ...")
-    set_current_sample(data_model.loc_str)
+    set_current_sample(data_model)
 
     beamline_setup_hwobj.shape_history_hwobj.clear_all()
     log = logging.getLogger("user_level_log")
@@ -101,10 +107,10 @@ def mount_sample(beamline_setup_hwobj,
 
 def mount_sample_clean_up(sample):
     try:
-        msg = '[SC] mounting %s (%r)', sample['location'], sample['sampleID']
+        msg = '[SC] mounting %s (%r)' % (sample['location'], sample['sampleID'])
         logging.getLogger('HWR').info(msg)
         set_sample_to_be_mounted(sample['sampleID'])
-        set_current_sample(sample['sampleID'])
+        set_current_sample(sample)
         mxcube.CURRENTLY_MOUNTED_SAMPLE_DATA = sample
 
         if not sample['location'] == 'Manual':
@@ -113,7 +119,7 @@ def mount_sample_clean_up(sample):
         mxcube.queue.mounted_sample = sample['sampleID']
     except Exception:
         logging.getLogger('HWR').exception('[SC] sample could not be mounted')
-        set_current_sample('')
+        set_current_sample(None)
         raise
     else:
         # Clearing centered position
@@ -133,7 +139,7 @@ def unmount_sample_clean_up(sample):
         raise
     else:
         mxcube.queue.mounted_sample = ''
-        set_current_sample('')
+        set_current_sample(None)
         # Remove Centring points
 
         mxcube.shapes.clear_all()

--- a/mxcube3/routes/scutils.py
+++ b/mxcube3/routes/scutils.py
@@ -111,7 +111,6 @@ def mount_sample_clean_up(sample):
         logging.getLogger('HWR').info(msg)
         set_sample_to_be_mounted(sample['sampleID'])
         set_current_sample(sample)
-        mxcube.CURRENTLY_MOUNTED_SAMPLE_DATA = sample
 
         if not sample['location'] == 'Manual':
             mxcube.sample_changer.load(sample['sampleID'], wait=False)

--- a/mxcube3/routes/scutils.py
+++ b/mxcube3/routes/scutils.py
@@ -105,6 +105,7 @@ def mount_sample_clean_up(sample):
         logging.getLogger('HWR').info(msg)
         set_sample_to_be_mounted(sample['sampleID'])
         set_current_sample(sample['sampleID'])
+        mxcube.CURRENTLY_MOUNTED_SAMPLE_DATA = sample
 
         if not sample['location'] == 'Manual':
             mxcube.sample_changer.load(sample['sampleID'], wait=False)

--- a/mxcube3/ui/reducers/sampleGrid.js
+++ b/mxcube3/ui/reducers/sampleGrid.js
@@ -293,16 +293,18 @@ export default (state = INITIAL_STATE, action) => {
     }
     case 'SET_INITIAL_STATE': {
       const sampleList = { ...state.sampleList };
+      const order = [...state.order];
 
       for (const sampleID in action.data.queue.queue) {
         if (action.data.queue.queue.hasOwnProperty(sampleID)) {
           sampleList[sampleID] = action.data.queue.queue[sampleID];
+          order.push(sampleID);
           const pref = `${sampleList[sampleID].sampleName}-${sampleList[sampleID].proteinAcronym}`;
           sampleList[sampleID].defaultPrefix = pref;
         }
       }
 
-      return { ...state, sampleList };
+      return { ...state, sampleList, order };
     }
     case 'CLEAR_SAMPLE_GRID': {
       return Object.assign({}, state, { ...INITIAL_STATE });


### PR DESCRIPTION
On #663 

I reproduce the behaviour you describe only if I mount a sample before signing out.
this line `mxcube.CURRENTLY_MOUNTED_SAMPLE = ''` in the signout api would do the fix.

I am a bit confused with how this affects the sample changer operation. I understand that currently only a unload command clears that attribute. 

So, for the cases where `unload` is not used and a sample was mounted before logout, the user logouts, If anyone logs in again, he/she does not see anything mounted but on the sample changer page. So, no queue at all but a sample mounted.

We could send and unload together with the signout, but it will probably make any test problematic. An alternative could be to create a queue with that single sample (no tasks)