### PR TITLE
Login fix

### DIFF
--- a/mxcube3/routes/Login.py
+++ b/mxcube3/routes/Login.py
@@ -166,15 +166,18 @@ def loginInfo():
 
     if res["loginType"].lower() != 'user' and login_info:
         # autoselect proposal
+
         limsutils.select_proposal(LOGGED_IN_USER)
         res["selectedProposal"] = LOGGED_IN_USER
         logging.getLogger('user_log').info('[LIMS] Proposal autoselected.')
 
 
     # Get all the files in the root data dir for this user
-    if not mxcube.INITIAL_FILE_LIST:
+    root_path = mxcube.session.get_base_image_directory()
+
+    if not mxcube.INITIAL_FILE_LIST and os.path.isdir(root_path):
         ftype = mxcube.beamline.detector_hwobj.getProperty('file_suffix')
-        root_path = mxcube.session.get_base_image_directory()
+
         mxcube.INITIAL_FILE_LIST = scantree(root_path, [ftype])
 
     return jsonify(res)

--- a/mxcube3/routes/limsutils.py
+++ b/mxcube3/routes/limsutils.py
@@ -166,7 +166,7 @@ def lims_login(loginID, password):
         for prop in session['proposal_list']:
             # if len(prop['Session']) == 0:
             todays_session = mxcube.db_connection.get_todays_session(prop)
-            prop['Session'] = [todays_session]
+            prop['Session'] = [todays_session['session']]
             # elif not prop['Session'][0]['scheduled']:
             #     todays_session = mxcube.db_connection.get_todays_session(prop)
             #     prop['Session'] = [todays_session]

--- a/mxcube3/routes/limsutils.py
+++ b/mxcube3/routes/limsutils.py
@@ -214,12 +214,8 @@ def get_proposal_info(proposal):
 
 
 def select_proposal(proposal):
-    if not proposal.lower().startswith('mx'):
-	aux_prop = "{}{}".format('mx', proposal)
-    else:
-	aux_prop = proposal
-    
-    proposal_info = get_proposal_info(aux_prop)
+    proposal_info = get_proposal_info(proposal)
+
     logging.getLogger('HWR').info("[LIMS] Selecting proposal: %s" % proposal)
     logging.getLogger('HWR').info("[LIMS] Proposal info: %s" % proposal_info)
     if mxcube.db_connection.loginType.lower() == 'user' and 'Commissioning' in proposal_info['Proposal']['title']:
@@ -230,7 +226,7 @@ def select_proposal(proposal):
     if proposal_info:
         mxcube.session.proposal_code = proposal_info.get('Proposal').get('code', '')
         mxcube.session.proposal_number = proposal_info.get('Proposal').get('number', '')
-        mxcube.session.session_id = proposal_info.get('Session')[0].get('session').get('sessionId')
+        mxcube.session.session_id = proposal_info.get('Session')[0].get('sessionId')
 
         if hasattr(mxcube.session, 'prepare_directories'):
             try:

--- a/mxcube3/ui/components/Login/SelectProposal.js
+++ b/mxcube3/ui/components/Login/SelectProposal.js
@@ -38,7 +38,7 @@ class SelectProposal extends React.Component {
     const proposals = this.props.data.proposalList.map((prop) => ({
       Number: prop.Proposal.code + prop.Proposal.number,
       Person: prop.Person.familyName,
-      Session: prop.Session[0].session.startDate.split(' ')[0]
+      Session: prop.Session[0].startDate.split(' ')[0]
     }));
 
     return (


### PR DESCRIPTION
Hi,

Fixes to login introduced by select proposal PR, two main issues,

 - We cant categorically add mx like it was done in select_proposal.
 - The session ID is accessed directly on the session and not through session.session (which normally should not exist, do you have this structure or was it a mistake ?)

Marcus