### PR TITLE
UX Fixes

### DIFF
--- a/mxcube3/ui/components/SampleGrid/SampleGrid.css
+++ b/mxcube3/ui/components/SampleGrid/SampleGrid.css
@@ -124,6 +124,10 @@
   border: 1px solid Transparent;
 }
 
+button[disabled] {
+  opacity: 0.2;
+}
+
 .samples-grid-item-button:hover {
   border: 1px solid #888;
 }

--- a/mxcube3/ui/components/SampleGrid/SampleGrid.css
+++ b/mxcube3/ui/components/SampleGrid/SampleGrid.css
@@ -177,11 +177,9 @@ button[disabled] {
 
 
 .samples-grid-item-selected {
-    border: 2px dashed #337ab7 !important;
+    border: 2px dashed #616161 !important;
     padding: 4px;
 }
-
-
 
 .btn-link {
     color: #333 !important;

--- a/mxcube3/ui/components/SampleGrid/SampleGridItem.jsx
+++ b/mxcube3/ui/components/SampleGrid/SampleGridItem.jsx
@@ -78,6 +78,7 @@ export class SampleGridItem extends React.Component {
         overlay={(<Tooltip id="pick-sample">Pick/Unpick sample for collect</Tooltip>)}
       >
         <button
+          disabled={this.props.current}
           className="samples-grid-item-button"
           onClick={this.pickButtonOnClick}
           onMouseUp={this.pickButtonMouseUp}

--- a/mxcube3/ui/components/SampleView/SampleControls.js
+++ b/mxcube3/ui/components/SampleView/SampleControls.js
@@ -30,6 +30,11 @@ export default class SampleControls extends React.Component {
   }
 
   toggleDrawGrid() {
+    // Cancel click centering before draw grid is started
+    if (this.props.clickCentring) {
+      this.props.sampleActions.sendAbortCentring();
+    }
+
     this.props.sampleActions.toggleDrawGrid();
   }
 
@@ -55,6 +60,12 @@ export default class SampleControls extends React.Component {
   toggleCentring() {
     const { sendStartClickCentring, sendAbortCentring } = this.props.sampleActions;
     const { clickCentring } = this.props;
+
+    // If draw grid tool enabled, disable it before starting centering
+    if (this.props.drawGrid) {
+      this.props.sampleActions.toggleDrawGrid();
+    }
+
     if (clickCentring) {
       sendAbortCentring();
     } else {

--- a/mxcube3/ui/containers/SampleGridContainer.jsx
+++ b/mxcube3/ui/containers/SampleGridContainer.jsx
@@ -507,6 +507,7 @@ class SampleGridContainer extends React.Component {
    */
   sampleItemPickButtonOnClickHandler(e, sampleID) {
     e.stopPropagation();
+
     // Is sample already in the set of selected samples, add all those samples
     // to queue
     if (this.sampleItemIsSelected(sampleID)) {

--- a/mxcube3/ui/containers/SampleGridViewContainer.jsx
+++ b/mxcube3/ui/containers/SampleGridViewContainer.jsx
@@ -329,7 +329,10 @@ class SampleGridViewContainer extends React.Component {
     const samplesToRemove = [];
     for (const sampleID of sampleIDList) {
       if (this.inQueue(sampleID)) {
-        samplesToRemove.push(sampleID);
+        // Do not remove currently mounted sample
+        if (this.props.queue.current.sampleID !== sampleID) {
+          samplesToRemove.push(sampleID);
+        }
       } else {
         samples.push(sampleID);
       }


### PR DESCRIPTION
Hi,

  Three (together with the HR PR #136) smaller UX fixes
     -  The mounted sample cannot be removed from the queue once en-queued (unmounted needed)
     -  Dark grey border instead of blue for selected samples
     -  Points are named Point-n instead of Pn (could be confused with space groups)

Cheers,
Marcus