### PR TITLE
Fixed import and improved login routine

### DIFF
--- a/mxcube3/routes/Queue.py
+++ b/mxcube3/routes/Queue.py
@@ -58,9 +58,6 @@ def queue_stop():
               200: On success
               409: Queue could not be stopped
     """
-    import pdb
-    pdb.set_trace()
-
     if mxcube.queue.queue_hwobj._root_task is not None:
         mxcube.queue.queue_hwobj.stop()
     else:

--- a/mxcube3/routes/Utils.py
+++ b/mxcube3/routes/Utils.py
@@ -188,7 +188,7 @@ def _snapshot_received(data):
 
 def _do_take_snapshot(filename):
     SNAPSHOT_RECEIVED.clear()
-    rid = loginutils.get_operator["socketio_sid"]
+    rid = loginutils.get_operator()["socketio_sid"]
 
     socketio.emit("take_xtal_snapshot", namespace="/hwr", room=rid, callback=_snapshot_received)
 

--- a/mxcube3/routes/beamlineutils.py
+++ b/mxcube3/routes/beamlineutils.py
@@ -46,10 +46,12 @@ def get_aperture():
 
 
 def get_beam_definer():
-    if hasattr(mxcube.beamline.getObjectByRole("beam_info"), "beam_definer_hwobj"):
-        bd = mxcube.beamline.getObjectByRole("beam_info").beam_definer_hwobj
+    beam_info = mxcube.beamline.getObjectByRole("beam_info") 
+
+    if hasattr(beam_info, "beam_definer_hwobj") and beam_info.beam_definer_hwobj:
+        bd = beam_info.beam_definer_hwobj
     else:
-        bd = mxcube.beamline.getObjectByRole("beam_info").aperture_hwobj
+        bd = beam_info.aperture_hwobj
 
     return bd
 

--- a/mxcube3/routes/loginutils.py
+++ b/mxcube3/routes/loginutils.py
@@ -69,8 +69,14 @@ def is_operator(sid):
     return user and user["sid"] == sid
 
 
-def logged_in_users():
-    return [user["loginID"] for user in mxcube.USERS.itervalues()]
+def logged_in_users(exclude_inhouse=False):
+    users = [user["loginID"] for user in mxcube.USERS.itervalues()]
+
+    if exclude_inhouse:
+        ih_users =["%s%s"% (p, c) for (p, c) in mxcube.session.in_house_users]
+        users = [user for user in users if user not in ih_users]
+
+    return users
 
 
 def set_operator(sid):

--- a/mxcube3/routes/loginutils.py
+++ b/mxcube3/routes/loginutils.py
@@ -159,4 +159,7 @@ def remote_addr():
 
 
 def is_local_host():
-    return remote_addr() in socket.gethostbyname_ex(socket.gethostname())[2]
+    localhost_list = socket.gethostbyname_ex(socket.gethostname())[2]
+    localhost_list.append("127.0.0.1")
+
+    return remote_addr() in localhost_list

--- a/mxcube3/routes/signals.py
+++ b/mxcube3/routes/signals.py
@@ -10,7 +10,7 @@ from mxcube3.routes import Utils
 from mxcube3.routes import qutils
 from mxcube3.routes import scutils
 from mxcube3.routes import limsutils
-from mxcube3.routes.remote_access import safe_emit
+from mxcube3.routes.loginutils import safe_emit
 
 from sample_changer.GenericSampleChanger import SampleChangerState
 from sample_changer.Container import Pin

--- a/mxcube3/ui/components/RemoteAccess/RequestControlForm.jsx
+++ b/mxcube3/ui/components/RemoteAccess/RequestControlForm.jsx
@@ -23,7 +23,9 @@ class RequestControlForm extends React.Component {
                      <Button onClick={this.takeControlOnClick}>Take control</Button>
                    </span>);
 
-    if (!this.props.login.loginInfo.loginRes.Session.is_inhouse) {
+    const loginRes = this.props.login.loginInfo.loginRes;
+
+    if (loginRes && !loginRes.Session.is_inhouse) {
       content = null;
     }
 

--- a/mxcube3/ui/components/RemoteAccess/UserList.jsx
+++ b/mxcube3/ui/components/RemoteAccess/UserList.jsx
@@ -24,7 +24,7 @@ class UserList extends React.Component {
                </Button>
              </div>)
             :
-            null
+            (<div className="col-xs-4"><span>&nbsp;</span></div>)
           }
         </div>
       ));

--- a/mxcube3/ui/containers/RemoteAccessContainer.jsx
+++ b/mxcube3/ui/containers/RemoteAccessContainer.jsx
@@ -27,7 +27,10 @@ export class RemoteAccessContainer extends React.Component {
                      </Panel>
                    </div>);
 
-    if (!this.props.login.loginInfo.loginRes.Session.is_inhouse) {
+
+    const loginRes = this.props.login.loginInfo.loginRes;
+
+    if (loginRes && !loginRes.Session.is_inhouse) {
       content = null;
     }
 


### PR DESCRIPTION
Hi,

While testing on the beamline I noticed that I forgot to commit a changed import. We also refined the remote access login routine. So now we are using the following protocol:

A user (non in-house accounts) can login remotely:

- IFF no other account is already using the beamline, there is a valid session and remote access is enabled

In-house users can only login from the local control computer
-   They can give and take control by force as well as enable/disable remote access

Both in-house and normal users can login from the local control computer to for instance create a session

Marcus