### PR TITLE
[WIP] added a basic beamline webcam viewer

### DIFF
--- a/config.gui.prod.js
+++ b/config.gui.prod.js
@@ -1,4 +1,16 @@
 module.exports = {
-	phaseControl: false,
-	apertureControl: true
+	phaseControl: true,
+	apertureControl: true,
+	beamlineCameras: [{
+		url: "http://www.youtube.com/embed/xDMP3i36naA",
+		width:"320px",
+		height:"180px",
+		location:"Experimental Hutch"
+		},
+		{
+		url: "http://www.youtube.com/embed/8CnFo7qinng",
+		width:"320px",
+		height:"180px",
+		location:"Diffractometer"
+	}]
 }

--- a/mxcube3/ui/components/BeamlineCamera/BeamlineCamera.css
+++ b/mxcube3/ui/components/BeamlineCamera/BeamlineCamera.css
@@ -1,0 +1,37 @@
+.camera-container {
+  bottom: 0;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-direction: column;
+      flex-direction: column;
+  margin: 0 100px 20px 0;
+  max-width: 370px;
+  position: fixed;
+  right: 0;
+  z-index: 9999;
+}
+
+.camera-popover{
+    max-width:500px;
+    height:250px;    
+}
+
+.camera-launcher {
+  position: fixed;
+  top: -10px;
+  right: -5px;
+  background-color: #ff0000;
+  color: #fff;
+  width: 25px;
+  height: 25px;
+  text-align: center;
+  line-height: 25px;
+  border-radius: 50%;
+}
+
+.button-circle {
+    width: 60px;
+    height: 60px;
+    padding: 10px 16px;
+    border-radius: 50%;
+}

--- a/mxcube3/ui/components/BeamlineCamera/BeamlineCamera.jsx
+++ b/mxcube3/ui/components/BeamlineCamera/BeamlineCamera.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import Iframe from 'react-iframe';
+import { connect } from 'react-redux';
+
+import { Popover,
+         ButtonToolbar,
+         OverlayTrigger,
+         Button,
+         DropdownButton,
+         MenuItem } from 'react-bootstrap';
+import config from 'guiConfig';
+
+import './BeamlineCamera.css';
+
+class BeamlineCamera extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.selectCamera = this.selectCamera.bind(this);
+    this.state = { selectedIndex: 0 };
+  }
+
+  selectCamera(evt) {
+    this.setState({ selectedIndex: evt.target.id });
+  }
+
+  render() {
+    const cameraList = this.props.cameras.map((cam, index) =>
+      <MenuItem id={index} onClick={this.selectCamera}>{cam.location}</MenuItem>
+    );
+    const divStyle = {
+      marginTop: '5px',
+    };
+
+    const popoverLeft = (
+      <Popover
+        className="camera-popover"
+      >
+        <DropdownButton
+          bsSize="small"
+          bsStyle="default"
+          title={config.beamlineCameras[this.state.selectedIndex].location}
+        >
+         {cameraList}
+        </DropdownButton>
+        <div style={divStyle}>
+        <Iframe url={config.beamlineCameras[this.state.selectedIndex].url}
+          width={config.beamlineCameras[this.state.selectedIndex].width}
+          height={config.beamlineCameras[this.state.selectedIndex].height}
+          display="initial"
+          position="relative"
+        />
+        </div>
+      </Popover>
+    );
+
+    return (
+      <ButtonToolbar className="camera-container">
+        <OverlayTrigger ref="overlay" trigger="click" placement="top" overlay={popoverLeft}>
+          <Button
+            className="button-circle"
+            bsStyle="success"
+          >
+          <i className="fa fa-1x fa-video-camera" />
+          </Button>
+        </OverlayTrigger>
+      </ButtonToolbar>
+    );
+  }
+}
+
+BeamlineCamera.defaultProps = {
+  cameras: {},
+};
+
+function mapStateToProps(state) {
+  return {
+    scState: state.sampleChanger.state,
+  };
+}
+
+export default connect(
+    mapStateToProps,
+    null
+)(BeamlineCamera);

--- a/mxcube3/ui/components/Main.jsx
+++ b/mxcube3/ui/components/Main.jsx
@@ -9,6 +9,7 @@ import ResumeQueueDialog from '../containers/ResumeQueueDialog';
 import ConnectionLostDialog from '../containers/ConnectionLostDialog';
 import ObserverDialog from './RemoteAccess/ObserverDialog';
 import PassControlDialog from './RemoteAccess/PassControlDialog';
+import BeamlineCamera from './BeamlineCamera/BeamlineCamera.jsx';
 import ConfirmCollectDialog from '../containers/ConfirmCollectDialog';
 import WorkflowParametersDialog from '../containers/WorkflowParametersDialog';
 import diagonalNoise from '../img/diagonal-noise.png';
@@ -16,6 +17,7 @@ import { sendChatMessage, getAllChatMessages } from '../actions/remoteAccess.js'
 import { Widget, addResponseMessage, addUserMessage } from 'react-chat-widget';
 import './rachat.css';
 import 'react-chat-widget/lib/styles.css';
+import config from 'guiConfig';
 
 class Main extends React.Component {
   constructor(props) {
@@ -88,6 +90,9 @@ class Main extends React.Component {
             badge={2}
             handleNewUserMessage={this.handleNewUserMessage}
           />) : null
+        }
+        { config.beamlineCameras ?
+        <BeamlineCamera cameras={config.beamlineCameras} /> : null
         }
       </div>
     );

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-dnd-html5-backend": "^2.1.2",
     "react-dom": "15.4.2",
     "react-draggable": "^2.2.6",
+    "react-iframe": "^1.1.0",
     "react-redux": "^5.0.3",
     "react-router": "^3.0.2",
     "react-router-bootstrap": "^0.23.1",


### PR DESCRIPTION
It displays a button next to the chat, it is open on-demand by the user and displays the webcams defined in the config_gui (youtube video for mockups). Based on iframe, it works for us but let me know if this is not working for your cams, or it gives problems.

I know there is more work to do in this topic (like open automatically when sample loading, switch canvas, etc.), this is a first approach to have a webcam in mxcube3.

![image](https://user-images.githubusercontent.com/12758327/40408894-5fb1add0-5e69-11e8-9b37-0d307cbc01fd.png)
