### PR TITLE
 Navigation cross and 2D Centring

### DIFF
--- a/config.gui.prod.js
+++ b/config.gui.prod.js
@@ -1,6 +1,5 @@
 module.exports = {
-	phaseControl: false,
-	apertureControl: true,
-	focusControlOnCanvas: true,
-	apertureControl: true
+  phaseControl: false,
+  apertureControl: true,
+  focusControlOnCanvas: true
 }

--- a/mxcube3/routes/Diffractometer.py
+++ b/mxcube3/routes/Diffractometer.py
@@ -85,7 +85,6 @@ def md_in_plate_mode():
 @mxcube.restrict
 def get_movables_state():
     ret = Utils.get_centring_motors_info()
-
     ret.update(Utils.get_light_state_and_intensity())
 
     resp = jsonify(ret)

--- a/mxcube3/routes/Utils.py
+++ b/mxcube3/routes/Utils.py
@@ -156,9 +156,14 @@ def get_movable_limits(item_name):
 _centring_motors_memo = None;
 def get_centring_motors():
     global _centring_motors_memo
-
+    
     if not _centring_motors_memo:
         _centring_motors_memo = mxcube.diffractometer.getPositions().keys()
+
+        # Adding the two pseudo motors for sample alignment in the microscope
+        # view
+        _centring_motors_memo += ["sample_vertical", "sample_horizontal"]
+
 
     return _centring_motors_memo
 

--- a/mxcube3/ui/components/PopInput/DefaultInput.jsx
+++ b/mxcube3/ui/components/PopInput/DefaultInput.jsx
@@ -44,7 +44,7 @@ export default class DefaultInput extends React.Component {
 
   render() {
     return (
-      <Form inline onSubmit={this.submit}>
+      <Form inline onSubmit={this.submit} noValidate>
         <div className="rw-widget rw-numberpicker"
           style={ { width: Number(this.props.inputSize) + 10, display: 'inline-block' } }
         >
@@ -80,9 +80,13 @@ export default class DefaultInput extends React.Component {
           <Button bsStyle="primary" className="btn-sm" onClick={this.save}>
             <i className="glyphicon glyphicon-ok" />
           </Button>
-          <Button bsStyle="default" className="btn-sm" onClick={this.cancel}>
-            <i className="glyphicon glyphicon-remove" />
-          </Button>
+          { !this.props.inplace ?
+            <Button bsStyle="default" className="btn-sm" onClick={this.cancel}>
+              <i className="glyphicon glyphicon-remove" />
+            </Button>
+            :
+            null
+          }
         </ButtonToolbar>
       </Form>
     );

--- a/mxcube3/ui/components/PopInput/PopInput.jsx
+++ b/mxcube3/ui/components/PopInput/PopInput.jsx
@@ -92,7 +92,7 @@ export default class PopInput extends React.Component {
       // Only update if value actually changed
       this.props.onSave(this.props.pkey, value);
     }
-    if (this.props.data.state === 'IMMEDIATE') {
+    if (this.props.data.state === 'IMMEDIATE' && this.refs.overlay) {
       this.refs.overlay.hide();
     }
   }
@@ -124,7 +124,7 @@ export default class PopInput extends React.Component {
       this.props.onCancel(this.props.pkey);
     }
 
-    if (!this.isBusy()) {
+    if (!this.isBusy() && this.refs.overlay) {
       this.refs.overlay.hide();
     }
   }
@@ -152,6 +152,7 @@ export default class PopInput extends React.Component {
         step={this.props.data.step}
         dataType={this.props.dataType}
         inputSize={this.props.inputSize}
+        inplace={this.props.inplace}
       />);
 
     input = this.getChild('input') || input;
@@ -204,8 +205,8 @@ export default class PopInput extends React.Component {
       stateClass = 'input-bg-fault';
     }
 
-    const popover = (
-      <Popover ref="popover" id={title} title={title}>
+    const popoverContent = (
+      <span>
         <div className={`${inputVisibility} popinput-form-container`}>
           {this.inputComponent()}
         </div>
@@ -213,6 +214,11 @@ export default class PopInput extends React.Component {
         <div ref="loadingDiv" className={`${busyVisibility} popinput-input-loading`} >
           {this.busyComponent()}
         </div>
+      </span>);
+
+    const popover = (
+      <Popover ref="popover" id={title} title={title}>
+        { popoverContent }
       </Popover>);
 
     let value = this.props.data.value ? parseFloat(this.props.data.value) : '-';
@@ -221,27 +227,39 @@ export default class PopInput extends React.Component {
       value = value.toFixed(parseInt(this.props.data.precision, 10));
     }
 
-
     return (
       <div style={this.props.style} className={`${this.props.className} popinput-input-container`}>
         { this.props.name ?
-          <span className={`popinput-input-label ${this.props.ref}`}>
+          <span
+            className={`popinput-input-label ${this.props.ref}`}
+          >
             {this.props.name}:
           </span> : null
         }
-        <span className={`popinput-input-value ${this.props.pkey}`}>
-          <OverlayTrigger ref="overlay" trigger="click" rootClose placement={this.props.placement}
-            overlay={popover}
+          <span
+            className={`popinput-input-value ${this.props.pkey}`}
           >
-            <a
-              ref="valueLabel"
-              onContextMenu={this.onLinkClick}
-              key="valueLabel"
-              className={`popinput-input-link ${linkClass} ${stateClass}`}
-            >
-              {value} {this.props.suffix}
-            </a>
-          </OverlayTrigger>
+            { this.props.inplace ?
+              <span>
+                { popoverContent }
+              </span>
+              :
+              <OverlayTrigger
+                ref="overlay" trigger="click"
+                rootClose
+                placement={this.props.placement}
+                overlay={popover}
+              >
+                <a
+                  ref="valueLabel"
+                  onContextMenu={this.onLinkClick}
+                  key="valueLabel"
+                  className={`popinput-input-link ${linkClass} ${stateClass}`}
+                >
+                  {value} {this.props.suffix}
+                </a>
+              </OverlayTrigger>
+            }
         </span>
       </div>
     );
@@ -252,7 +270,7 @@ export default class PopInput extends React.Component {
 PopInput.defaultProps = {
   className: '',
   dataType: 'number',
-  inputSize: '110',
+  inputSize: '110px',
   name: '',
   title: '',
   suffix: '',
@@ -262,5 +280,5 @@ PopInput.defaultProps = {
   pkey: undefined,
   onSave: undefined,
   onCancel: undefined,
-  data: { value: 0, state: 'ABORTED', msg: '' }
+  data: { value: 0, state: 'ABORTED', msg: '', step: 0.1 }
 };

--- a/mxcube3/ui/components/PopInput/PopInput.jsx
+++ b/mxcube3/ui/components/PopInput/PopInput.jsx
@@ -270,7 +270,7 @@ export default class PopInput extends React.Component {
 PopInput.defaultProps = {
   className: '',
   dataType: 'number',
-  inputSize: '110px',
+  inputSize: '80px',
   name: '',
   title: '',
   suffix: '',

--- a/mxcube3/ui/components/SampleView/ContextMenu.js
+++ b/mxcube3/ui/components/SampleView/ContextMenu.js
@@ -159,8 +159,15 @@ export default class ContextMenu extends React.Component {
         { text: 'Go To Beam', action: () => this.goToBeam(), key: 1 },
         { text: 'Measure Distance', action: () => this.measureDistance(), key: 2 },
         { text: 'Draw Grid', action: () => this.toggleDrawGrid(), key: 3 },
-        workflowTasks.grid.none > 0 ? { text: 'divider', key: 4 } : {},
-        ...workflowTasks.none
+        { text: 'divider', key: 4 },
+        { text: 'Data Collection (Limited OSC)',
+          action: () => this.createPointAndShowModal('DataCollection'), key: 5 },
+        { text: 'Characterisation (1 Image)',
+          action: () => this.createPointAndShowModal('Characterisation', { num_imags: 1 }),
+          key: 6 },
+        { text: 'divider', key: 7 },
+        ...workflowTasks.none,
+        workflowTasks.grid.none > 0 ? { text: 'divider', key: 7 } : {},
       ]
     };
 
@@ -181,8 +188,11 @@ export default class ContextMenu extends React.Component {
     return options;
   }
 
-  showModal(modalName, wf = {}, _shape = null) {
-    const { sampleID, defaultParameters, shape, sampleData } = this.props;
+  showModal(modalName, wf = {}, _shape = null, extraParams = {}) {
+    const { sampleID, shape, sampleData, defaultParameters } = this.props;
+
+    Object.assign(defaultParameters, extraParams);
+
     const sid = _shape ? _shape.id : shape.id;
     if (Array.isArray(sid)) {
       // we remove any line
@@ -239,8 +249,8 @@ export default class ContextMenu extends React.Component {
     }
   }
 
-  createPoint(x, y) {
-    this.props.sampleActions.sendAddShape({ screenCoord: [x, y], t: 'P', state: 'SAVED' });
+  createPoint(x, y, cb = null) {
+    this.props.sampleActions.sendAddShape({ screenCoord: [x, y], t: '2DP', state: 'SAVED' }, cb);
   }
 
   savePoint() {
@@ -289,6 +299,13 @@ export default class ContextMenu extends React.Component {
     const gd = { ...this.props.shape.gridData };
     this.props.sampleActions.sendAddShape({ t: 'G', ...gd });
     this.props.sampleActions.toggleDrawGrid();
+  }
+
+  createPointAndShowModal(name, extraParams = {}) {
+    const { x, y, imageRatio } = this.props;
+    this.props.sampleActions.showContextMenu(false);
+    this.createPoint(x / imageRatio, y / imageRatio,
+                     (shape) => this.showModal(name, {}, shape, extraParams));
   }
 
   createLine(modal, wf = {}) {

--- a/mxcube3/ui/components/SampleView/HorVerTranslationControls.js
+++ b/mxcube3/ui/components/SampleView/HorVerTranslationControls.js
@@ -17,8 +17,8 @@ export default class HorVerTranslationControls extends React.Component {
   }
 
   renderMotorSettings() {
-    return (<Popover title="Sample alignment motors">
-              <div className="col-sm-12">
+    return (<Popover title={(<b>Sample alignment motors</b>)}>
+              <div>
                 <MotorInput
                   save={this.props.save}
                   value={this.props.motors.sample_vertical.position}
@@ -33,8 +33,6 @@ export default class HorVerTranslationControls extends React.Component {
                   disabled={this.props.motorsDisabled}
                   inplace
                 />
-              </div>
-              <div className="col-sm-12">
                 <MotorInput
                   save={this.props.save}
                   value={this.props.motors.sample_horizontal.position}

--- a/mxcube3/ui/components/SampleView/HorVerTranslationControls.js
+++ b/mxcube3/ui/components/SampleView/HorVerTranslationControls.js
@@ -1,0 +1,106 @@
+import React from 'react';
+import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
+import MotorInput from './MotorInput';
+import './motor.css';
+
+export default class HorVerTranslationControls extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.stepChange = this.stepChange.bind(this);
+  }
+
+  stepChange(name, step, operator) {
+    const value = this.props.motors[name].position;
+    const newValue = value + step * operator;
+    this.props.save(name, newValue);
+  }
+
+  renderMotorSettings() {
+    return (<Popover title="Sample alignment motors">
+              <div className="col-sm-12">
+                <MotorInput
+                  save={this.props.save}
+                  value={this.props.motors.sample_vertical.position}
+                  saveStep={this.props.saveStep}
+                  step={this.props.steps.sample_verticalStep}
+                  motorName="sample_vertical"
+                  label="Vertical"
+                  suffix="mm"
+                  decimalPoints="3"
+                  state={this.props.motors.sample_vertical.state}
+                  stop={this.props.stop}
+                  disabled={this.props.motorsDisabled}
+                  inplace
+                />
+              </div>
+              <div className="col-sm-12">
+                <MotorInput
+                  save={this.props.save}
+                  value={this.props.motors.sample_horizontal.position}
+                  saveStep={this.props.saveStep}
+                  step={this.props.steps.sample_horizontalStep}
+                  motorName="sample_horizontal"
+                  label="Horizontal"
+                  suffix="mm"
+                  decimalPoints="3"
+                  state={this.props.motors.sample_horizontal.state}
+                  stop={this.props.stop}
+                  disabled={this.props.motorsDisabled}
+                  inplace
+                />
+              </div>
+            </Popover>);
+  }
+
+  render() {
+    const {
+      sample_verticalStep,
+      sample_horizontalStep
+    } = this.props.steps;
+
+    return (
+      <div className="arrow-control">
+        <p className="motor-name">Sample alignment:</p>
+        <div style={{ marginBottom: '1em' }}></div>
+        <Button
+          onClick={() => this.stepChange('sample_vertical', sample_verticalStep, 1)}
+          disabled={this.props.motors.sample_vertical.state !== 2 || this.props.motorsDisabled}
+          className="arrow arrow-up"
+        >
+          <i className="fa fa-angle-up" />
+        </Button>
+        <Button
+          className="arrow arrow-left"
+          disabled={this.props.motors.sample_horizontal.state !== 2 || this.props.motorsDisabled}
+          onClick={() => this.stepChange('sample_horizontal', sample_horizontalStep, -1)}
+        >
+          <i className="fa fa-angle-left" />
+        </Button>
+        <OverlayTrigger trigger="click" rootClose placement="right"
+          overlay={this.renderMotorSettings()}
+        >
+          <Button
+            className="arrow arrow-settings"
+          >
+            <i className="fa fa-cog" />
+          </Button>
+        </OverlayTrigger>
+        <Button
+          className="arrow arrow-right"
+          disabled={this.props.motors.sample_horizontal.state !== 2 || this.props.motorsDisabled}
+          onClick={() => this.stepChange('sample_horizontal', sample_horizontalStep, 1)}
+        >
+          <i className="fa fa-angle-right" />
+        </Button>
+        <Button
+          className="arrow arrow-down"
+          disabled={this.props.motors.sample_vertical.state !== 2 || this.props.motorsDisabled}
+          onClick={() => this.stepChange('sample_vertical', sample_verticalStep, -1)}
+        >
+          <i className="fa fa-angle-down" />
+        </Button>
+      </div>
+    );
+  }
+}

--- a/mxcube3/ui/components/SampleView/MotorControl.js
+++ b/mxcube3/ui/components/SampleView/MotorControl.js
@@ -1,27 +1,176 @@
 import React from 'react';
+import { Button } from 'react-bootstrap';
+
 import MotorInput from './MotorInput';
+import HorVerTranslationControls from './HorVerTranslationControls';
+
 import './motor.css';
 
 export default class MotorControl extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { showAll: false };
+  }
 
-  render() {
-    const { phi, phiy, phiz, focus, sampx, sampy, kappa, kappa_phi } = this.props.motors;
+  horVerTranslationAvailable() {
+    return this.props.motors.sample_vertical.state !== 0 &&
+      this.props.motors.sample_horizontal.state !== 0;
+  }
+
+  renderAllMotors() {
     const {
-      phiStep,
+      phiy,
+      phiz,
+      focus,
+      sampx,
+      sampy } = this.props.motors;
+    const {
       phiyStep,
       phizStep,
       focusStep,
       sampxStep,
-      sampyStep,
-      kappaStep,
-      kappaphiStep
+      sampyStep
     } = this.props.steps;
+
     const save = this.props.save;
     const saveStep = this.props.saveStep;
     const stop = this.props.stop;
 
     return (
-          <div className="row">
+      <div>
+        <div className="col-sm-12">
+          <MotorInput
+            save={save}
+            value={focus.position}
+            saveStep={saveStep}
+            step={focusStep}
+            motorName="Focus"
+            label="X:"
+            suffix="mm"
+            decimalPoints="3"
+            state={focus.state}
+            stop={stop}
+            disabled={this.props.motorsDisabled}
+          />
+        </div>
+        <div className="col-sm-12">
+          <MotorInput
+            save={save}
+            value={phiy.position}
+            saveStep={saveStep}
+            step={phiyStep}
+            motorName="PhiY"
+            label="Y:"
+            suffix="mm"
+            decimalPoints="3"
+            state={phiy.state}
+            stop={stop}
+            disabled={this.props.motorsDisabled}
+          />
+        </div>
+        <div className="col-sm-12">
+          <MotorInput
+            save={save}
+            value={phiz.position}
+            saveStep={saveStep}
+            step={phizStep}
+            motorName="PhiZ"
+            label="Z:"
+            suffix="mm"
+            decimalPoints="3"
+            state={phiz.state}
+            stop={stop}
+            disabled={this.props.motorsDisabled}
+          />
+        </div>
+        <div className="col-sm-12">
+          <MotorInput
+            save={save}
+            value={sampx.position}
+            saveStep={saveStep}
+            step={sampxStep}
+            motorName="SampX"
+            label="Samp-X:"
+            suffix="mm"
+            decimalPoints="3"
+            state={sampx.state}
+            stop={stop}
+            disabled={this.props.motorsDisabled}
+          />
+        </div>
+        <div className="col-sm-12">
+          <MotorInput
+            save={save}
+            value={sampy.position}
+            saveStep={saveStep}
+            step={sampyStep}
+            motorName="SampY"
+            label="Samp-Y:"
+            suffix="mm"
+            decimalPoints="3"
+            state={sampy.state}
+            stop={stop}
+            disabled={this.props.motorsDisabled}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  renderTranslationCross() {
+    const save = this.props.save;
+    const saveStep = this.props.saveStep;
+    const stop = this.props.stop;
+
+    return (
+      <div>
+        <HorVerTranslationControls
+          save={save}
+          saveStep={saveStep}
+          motors={this.props.motors}
+          motorsDisabled={ this.props.motorsDisabled}
+          steps={this.props.steps}
+          stop={stop}
+        />
+        { this.state.showAll ?
+          <div>
+            { this.renderAllMotors() }
+            <Button
+              style={{ marginLeft: '8px', width: '145px' }}
+              onClick={() => {this.setState({ showAll: false });}}
+            >
+              <i className="fa fa-cogs" /> Hide motors<i className="fa fa-caret-up" />
+            </Button>
+          </div>
+          :
+          <Button
+            style={{ marginTop: '1em', marginLeft: '8px', width: '145px' }}
+            onClick={() => {this.setState({ showAll: true });}}
+          >
+            <i className="fa fa-cogs" /> Show motors<i className="fa fa-caret-down" />
+          </Button>
+        }
+      </div>
+    );
+  }
+
+  render() {
+    const {
+      phi,
+      kappa,
+      kappa_phi } = this.props.motors;
+    const {
+      phiStep,
+      kappaStep,
+      kappaphiStep
+    } = this.props.steps;
+
+    const save = this.props.save;
+    const saveStep = this.props.saveStep;
+    const stop = this.props.stop;
+
+    return (
+           <div className="row">
             <div className="col-sm-12">
               <MotorInput
                 save={save}
@@ -69,87 +218,9 @@ export default class MotorControl extends React.Component {
                 disabled={this.props.motorsDisabled}
               />
             </div>
-
-            <div className="col-sm-12">
-              <MotorInput
-                save={save}
-                value={focus.position}
-                saveStep={saveStep}
-                step={focusStep}
-                motorName="Focus"
-                label="X:"
-                suffix="mm"
-                decimalPoints="3"
-                state={focus.state}
-                stop={stop}
-                disabled={this.props.motorsDisabled}
-              />
-            </div>
-
-            <div className="col-sm-12">
-              <MotorInput
-                save={save}
-                value={phiy.position}
-                saveStep={saveStep}
-                step={phiyStep}
-                motorName="PhiY"
-                label="Y:"
-                suffix="mm"
-                decimalPoints="3"
-                state={phiy.state}
-                stop={stop}
-                disabled={this.props.motorsDisabled}
-              />
-            </div>
-
-            <div className="col-sm-12">
-              <MotorInput
-                save={save}
-                value={phiz.position}
-                saveStep={saveStep}
-                step={phizStep}
-                motorName="PhiZ"
-                label="Z:"
-                suffix="mm"
-                decimalPoints="3"
-                state={phiz.state}
-                stop={stop}
-                disabled={this.props.motorsDisabled}
-              />
-            </div>
-
-            <div className="col-sm-12">
-              <MotorInput
-                save={save}
-                value={sampx.position}
-                saveStep={saveStep}
-                step={sampxStep}
-                motorName="SampX"
-                label="Samp-X:"
-                suffix="mm"
-                decimalPoints="3"
-                state={sampx.state}
-                stop={stop}
-                disabled={this.props.motorsDisabled}
-              />
-            </div>
-
-            <div className="col-sm-12">
-               <MotorInput
-                 save={save}
-                 value={sampy.position}
-                 saveStep={saveStep}
-                 step={sampyStep}
-                 motorName="SampY"
-                 label="Samp-Y:"
-                 suffix="mm"
-                 decimalPoints="3"
-                 state={sampy.state}
-                 stop={stop}
-                 disabled={this.props.motorsDisabled}
-               />
-            </div>
-          </div>
-      );
+            { this.horVerTranslationAvailable() ?
+              this.renderTranslationCross() : this.renderAllMotors()
+            }
+           </div>);
   }
 }

--- a/mxcube3/ui/components/SampleView/MotorControl.js
+++ b/mxcube3/ui/components/SampleView/MotorControl.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button } from 'react-bootstrap';
 
 import MotorInput from './MotorInput';
-import HorVerTranslationControls from './HorVerTranslationControls';
+import TwoAxisTranslationControl from './TwoAxisTranslationControl';
 
 import './motor.css';
 
@@ -124,14 +124,16 @@ export default class MotorControl extends React.Component {
 
     return (
       <div>
-        <HorVerTranslationControls
-          save={save}
-          saveStep={saveStep}
-          motors={this.props.motors}
-          motorsDisabled={ this.props.motorsDisabled}
-          steps={this.props.steps}
-          stop={stop}
-        />
+        <div style={{ marginLeft: '15px' }}>
+          <TwoAxisTranslationControl
+            save={save}
+            saveStep={saveStep}
+            motors={this.props.motors}
+            motorsDisabled={ this.props.motorsDisabled}
+            steps={this.props.steps}
+            stop={stop}
+          />
+        </div>
         { this.state.showAll ?
           <div>
             { this.renderAllMotors() }

--- a/mxcube3/ui/components/SampleView/MotorInput.js
+++ b/mxcube3/ui/components/SampleView/MotorInput.js
@@ -74,6 +74,7 @@ export default class MotorInput extends React.Component {
         <div className="motor-input-container">
           <p className="motor-name">{this.props.label}</p>
           <form style={{ display: 'inline' }} onSubmit={this.handleKey} noValidate>
+            <div style={{ display: 'inline-block', width: '124px' }}>
             <div
               className="rw-widget rw-numberpicker rw-widget-no-right-border"
               style={ { width: '90px', display: 'inline-block' } }
@@ -146,15 +147,16 @@ export default class MotorInput extends React.Component {
                 <span>{this.props.step} {suffix}</span> : null
               }
             </span>
+          </div>
           </form>
           {(this.props.inplace) ?
-            <span style={{ position: 'relative', left: '43px' }}>
+            <span style={{ position: 'relative', marginLeft: '10px' }}>
               <PopInput
                 pkey={`${motorName.toLowerCase()}Step`}
                 data={data}
                 onSave={this.props.saveStep}
                 suffix={suffix}
-                inputSize="31px"
+                inputSize="50px"
                 inplace
                 style={{ display: 'inline-block', marginLeft: 'auto', marginRight: 'auto' }}
               />

--- a/mxcube3/ui/components/SampleView/MotorInput.js
+++ b/mxcube3/ui/components/SampleView/MotorInput.js
@@ -68,12 +68,12 @@ export default class MotorInput extends React.Component {
       'input-bg-onlimit': this.props.state === 5
     });
 
-    let data = { state: 'IMMEDIATE', value: step };
+    let data = { state: 'IMMEDIATE', value: step, step: 0.1 };
 
     return (
         <div className="motor-input-container">
           <p className="motor-name">{this.props.label}</p>
-          <form className="form-group" onSubmit={this.handleKey} noValidate>
+          <form style={{ display: 'inline' }} onSubmit={this.handleKey} noValidate>
             <div
               className="rw-widget rw-numberpicker rw-widget-no-right-border"
               style={ { width: '90px', display: 'inline-block' } }
@@ -120,15 +120,16 @@ export default class MotorInput extends React.Component {
                 cursor: 'pointer',
                 backgroundColor: '#EAEAEA' }}
             >
-              {(this.props.saveStep && this.props.state === 2) ?
+              {(this.props.saveStep && this.props.state === 2 && !this.props.inplace) ?
                <PopInput
                  pkey={`${motorName.toLowerCase()}Step`}
                  data={data}
                  onSave={this.props.saveStep}
                  suffix={suffix}
+                 inputSize="75px"
                  style={{ display: 'inline-block', marginLeft: 'auto', marginRight: 'auto' }}
                />
-               : null
+                 : null
               }
               {this.props.state !== 2 ?
                 <Button
@@ -141,8 +142,25 @@ export default class MotorInput extends React.Component {
                 </Button>
                 : null
               }
+              {(this.props.saveStep && this.props.state === 2 && this.props.inplace) ?
+                <span>{this.props.step} {suffix}</span> : null
+              }
             </span>
           </form>
+          {(this.props.inplace) ?
+            <span style={{ position: 'relative', left: '43px' }}>
+              <PopInput
+                pkey={`${motorName.toLowerCase()}Step`}
+                data={data}
+                onSave={this.props.saveStep}
+                suffix={suffix}
+                inputSize="31px"
+                inplace
+                style={{ display: 'inline-block', marginLeft: 'auto', marginRight: 'auto' }}
+              />
+           </span>
+             : null
+            }
         </div>
       );
   }

--- a/mxcube3/ui/components/SampleView/OneAxisTranslationControl.js
+++ b/mxcube3/ui/components/SampleView/OneAxisTranslationControl.js
@@ -1,0 +1,147 @@
+import React from 'react';
+import cx from 'classnames';
+import { Button, Popover } from 'react-bootstrap';
+import MotorInput from './MotorInput';
+import './motor.css';
+
+export default class OneAxisTranslationControl extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = { edited: false };
+    this.handleKey = this.handleKey.bind(this);
+    this.stepChange = this.stepChange.bind(this);
+  }
+
+  /* eslint-enable react/no-set-state */
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.value !== this.props.value) {
+      this.refs.motorValue.value = nextProps.value.toFixed(this.props.decimalPoints);
+      this.refs.motorValue.defaultValue = nextProps.value.toFixed(this.props.decimalPoints);
+      this.setState({ edited: false });
+    }
+  }
+
+  handleKey(e) {
+    e.preventDefault();
+    e.stopPropagation();
+
+    this.setState({ edited: true });
+
+    if ([13, 38, 40].includes(e.keyCode) && this.props.state === 2) {
+      this.setState({ edited: false });
+      this.props.save(e.target.name, e.target.valueAsNumber);
+      this.refs.motorValue.value = this.props.value.toFixed(this.props.decimalPoints);
+    } else if (this.props.state === 4) {
+      this.setState({ edited: false });
+      this.refs.motorValue.value = this.props.value.toFixed(this.props.decimalPoints);
+    }
+  }
+  /* eslint-enable react/no-set-state */
+
+  stepChange(name, step, operator) {
+    const value = this.props.value;
+    const newValue = value + step * operator;
+    this.props.save(name, newValue);
+  }
+
+  renderMotorSettings() {
+    return (<Popover title={(<b>Sample alignment motors</b>)}>
+              <div>
+                <MotorInput
+                  save={this.props.save}
+                  value={this.props.motors.sample_vertical.position}
+                  saveStep={this.props.saveStep}
+                  step={this.props.steps.sample_verticalStep}
+                  motorName="sample_vertical"
+                  label="Vertical"
+                  suffix="mm"
+                  decimalPoints="3"
+                  state={this.props.motors.sample_vertical.state}
+                  stop={this.props.stop}
+                  disabled={this.props.motorsDisabled}
+                  inplace
+                />
+                <MotorInput
+                  save={this.props.save}
+                  value={this.props.motors.sample_horizontal.position}
+                  saveStep={this.props.saveStep}
+                  step={this.props.steps.sample_horizontalStep}
+                  motorName="sample_horizontal"
+                  label="Horizontal"
+                  suffix="mm"
+                  decimalPoints="3"
+                  state={this.props.motors.sample_horizontal.state}
+                  stop={this.props.stop}
+                  disabled={this.props.motorsDisabled}
+                  inplace
+                />
+              </div>
+            </Popover>);
+  }
+
+  render() {
+    const { value, motorName, step, decimalPoints } = this.props;
+    const valueCropped = value.toFixed(decimalPoints);
+
+    let inputCSS = cx('form-control rw-input', {
+      'input-bg-edited': this.state.edited,
+      'input-bg-moving': this.props.state === 4 || this.props.state === 3,
+      'input-bg-ready': this.props.state === 2,
+      'input-bg-fault': this.props.state <= 1,
+      'input-bg-onlimit': this.props.state === 5
+    });
+
+    return (
+      <div className="arrow-control">
+        <Button
+          style={{ marginRight: '2px' }}
+          className="arrow-small arrow-left"
+          disabled={this.props.state !== 2 || this.props.disabled}
+          onClick={() => this.stepChange(motorName, 10 * step, -1)}
+        >
+          <i className="fa fa-angle-double-left" />
+        </Button>
+        <Button
+          className="arrow-small arrow-left"
+          disabled={this.props.state !== 2 || this.props.disabled}
+          onClick={() => this.stepChange(motorName, step, -1)}
+        >
+          <i className="fa fa-angle-left" />
+        </Button>
+        <input
+          style={{ width: `${parseFloat(decimalPoints) + 2}em`,
+                   height: '2.1em',
+                   display: 'inline-block',
+                   marginLeft: '5px',
+                   marginRight: '5px' }}
+          ref="motorValue"
+          className={inputCSS}
+          onKeyUp={this.handleKey}
+          type="number"
+          max={this.props.max}
+          min={this.props.min}
+          step={step}
+          defaultValue={valueCropped}
+          name={motorName}
+          disabled={this.props.state !== 2 || this.props.disabled}
+        />
+        <Button
+          className="arrow-small arrow-right"
+          disabled={this.props.state !== 2 || this.props.disabled}
+          onClick={() => this.stepChange(motorName, step, 1)}
+        >
+          <i className="fa fa-angle-right" />
+        </Button>
+        <Button
+          style={{ marginLeft: '2px' }}
+          className="arrow-small arrow-right"
+          disabled={this.props.state !== 2 || this.props.disabled}
+          onClick={() => this.stepChange(motorName, 10 * step, 1)}
+        >
+          <i className="fa fa-angle-double-right" />
+        </Button>
+      </div>
+    );
+  }
+}

--- a/mxcube3/ui/components/SampleView/SampleControls.js
+++ b/mxcube3/ui/components/SampleView/SampleControls.js
@@ -1,5 +1,6 @@
 import './SampleView.css';
 import React from 'react';
+import OneAxisTranslationControl from './OneAxisTranslationControl';
 import { OverlayTrigger, Button, DropdownButton, MenuItem } from 'react-bootstrap';
 import 'fabric';
 const fabric = window.fabric;
@@ -136,6 +137,7 @@ export default class SampleControls extends React.Component {
 
   render() {
     const motors = this.props.motors;
+
     return (
       <div style={ { display: 'flex', position: 'absolute', width: '100%' } } >
         <div className="sample-controlls text-center" >
@@ -179,17 +181,16 @@ export default class SampleControls extends React.Component {
             <OverlayTrigger trigger="click" rootClose placement="bottom"
               overlay={(
                 <span className="slider-overlay" style={{ marginTop: '20px' }}>
-                  <input
-                    style={{ top: '20px' }}
-                    className="bar"
-                    type="range"
-                    step="0.1"
+                  <OneAxisTranslationControl
+                    save={this.props.sampleActions.sendMotorPosition}
+                    value={motors.focus.position}
                     min={motors.focus.limits[0]} max={motors.focus.limits[1]}
-                    defaultValue={motors.focus.position}
-                    disabled={motors.focus.state !== 2}
-                    onMouseUp={(e) =>
-                      this.props.sampleActions.sendMotorPosition('focus', e.target.value)}
-                    name="focusSlider"
+                    step={this.props.steps.focusStep}
+                    motorName="focus"
+                    suffix="mm"
+                    decimalPoints="3"
+                    state={this.props.motors.focus.state}
+                    disabled={this.props.motorsDisabled}
                   />
                 </span>)}
             >

--- a/mxcube3/ui/components/SampleView/SampleImage.jsx
+++ b/mxcube3/ui/components/SampleView/SampleImage.jsx
@@ -1,6 +1,6 @@
 import './SampleView.css';
 import React from 'react';
-import { makePoints, makeLines, makeImageOverlay, makeCross } from './shapes';
+import { makePoints, makeTwoDPoints, makeLines, makeImageOverlay, makeCross } from './shapes';
 import DrawGridPlugin from './DrawGridPlugin';
 import SampleControls from './SampleControls';
 import GridForm from './GridForm';
@@ -679,6 +679,7 @@ export default class SampleImage extends React.Component {
       clickCentring,
       distancePoints,
       points,
+      twoDPoints,
       lines,
       grids,
       pixelsPerMm,
@@ -704,6 +705,7 @@ export default class SampleImage extends React.Component {
 
     const fabricSelectables = [
       ...makePoints(points, imageRatio),
+      ...makeTwoDPoints(twoDPoints, imageRatio),
       ...makeLines(lines, imageRatio)
     ];
 

--- a/mxcube3/ui/components/SampleView/TwoAxisTranslationControl.js
+++ b/mxcube3/ui/components/SampleView/TwoAxisTranslationControl.js
@@ -3,7 +3,7 @@ import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 import MotorInput from './MotorInput';
 import './motor.css';
 
-export default class HorVerTranslationControls extends React.Component {
+export default class TwoAxisTranslationControl extends React.Component {
 
   constructor(props) {
     super(props);

--- a/mxcube3/ui/components/SampleView/motor.css
+++ b/mxcube3/ui/components/SampleView/motor.css
@@ -7,7 +7,7 @@
     font-size: 1.0em;
     margin-bottom: 0px;
     font-weight: bold;
-    display: inline;
+    display: block;
 }
 
 .motor-value{
@@ -225,4 +225,45 @@ input::-webkit-inner-spin-button {
 }
 .sample-controll-label{
     display: block;
+}
+
+
+.arrow-control {
+    padding-left: 15px;
+}
+
+.arrow-control .arrow {
+    width: 3em;
+    height: 3em;
+}
+
+
+.arrow-control .arrow-up {
+    display: block;
+    position: relative;
+    left: 3em;
+    margin-left: 4px;
+}
+
+
+.arrow-control .arrow-down {
+    display: block;
+    position: relative;
+    left: 3em;
+    margin-left: 4px;    
+}
+
+.arrow-control .arrow-settings{
+    margin: 4px;
+}
+
+.arrow-control .arrow i {
+    font-size: 25px;
+    font-weight: bold;
+    margin-left: 0px;
+}
+
+.arrow-control .arrow-settings i {
+    font-size: 20px;
+    font-weight: normal;
 }

--- a/mxcube3/ui/components/SampleView/motor.css
+++ b/mxcube3/ui/components/SampleView/motor.css
@@ -229,12 +229,17 @@ input::-webkit-inner-spin-button {
 
 
 .arrow-control {
-    padding-left: 15px;
 }
 
 .arrow-control .arrow {
     width: 3em;
     height: 3em;
+}
+
+.arrow-control .arrow-small {
+    width: 2em;
+    height: 2em;
+    padding: 0px;
 }
 
 
@@ -259,6 +264,12 @@ input::-webkit-inner-spin-button {
 
 .arrow-control .arrow i {
     font-size: 25px;
+    font-weight: bold;
+    margin-left: 0px;
+}
+
+.arrow-control .arrow-small i {
+    font-size: 21px;
     font-weight: bold;
     margin-left: 0px;
 }

--- a/mxcube3/ui/components/SampleView/shapes.js
+++ b/mxcube3/ui/components/SampleView/shapes.js
@@ -144,7 +144,8 @@ export function makeText(x, y, fontSize, color, text) {
     top: y,
     selectable: false,
     hoverCursor: 'crosshair',
-    hasBorders: false
+    hasBorders: false,
+    fontFamily: 'Arial'
   });
 }
 
@@ -203,6 +204,48 @@ export function makePoints(points, imageRatio) {
               y * imageRatio,
               id,
               points[id].selected ? '#88ff5b' : '#e4ff09',
+              'SAVED',
+              points[id].name,
+              points[id].selected ? 3 : 2
+            )
+          );
+          break;
+        case 'TMP':
+          fabricPoints.push(
+            ...makePoint(
+              x * imageRatio,
+              y * imageRatio,
+              id,
+              'white',
+              'TMP',
+              points[id].name,
+              points[id].selected ? 3 : 2
+            )
+          );
+          break;
+        default:
+          throw new Error('Server gave point with unknown type');
+      }
+    }
+  }
+  return fabricPoints;
+}
+
+
+export function makeTwoDPoints(points, imageRatio) {
+  const fabricPoints = [];
+  for (const id in points) {
+    if ({}.hasOwnProperty.call(points, id)) {
+      const [x, y] = points[id].screenCoord;
+
+      switch (points[id].state) {
+        case 'SAVED':
+          fabricPoints.push(
+            ...makePoint(
+              x * imageRatio,
+              y * imageRatio,
+              id,
+              points[id].selected ? '#88ff5b' : '#33BEFF',
               'SAVED',
               points[id].name,
               points[id].selected ? 3 : 2

--- a/mxcube3/ui/components/Tasks/validate.js
+++ b/mxcube3/ui/components/Tasks/validate.js
@@ -74,6 +74,12 @@ const validate = (values, props) => {
   if (!(currTransmission >= 0 && currTransmission <= 100)) {
     errors.transmission = 'Transmission outside working range';
   }
+
+  if (props.pointID.includes('2D') && props.form === 'characterisation' &&
+      parseFloat(values.num_images) !== 1) {
+    errors.num_images = 'Only 1 image allowed when characterizing from a 2D-point';
+  }
+
   return errors;
 };
 

--- a/mxcube3/ui/components/Tasks/warning.js
+++ b/mxcube3/ui/components/Tasks/warning.js
@@ -32,6 +32,11 @@ const warn = (values, props) => {
     warnings.osc_start = 'Oscillation start angle is different from current omega';
   }
 
+  if (props.pointID.includes('2D') &&
+      (parseFloat(values.osc_range) * parseFloat(values.num_images)) > 5) {
+    warnings.osc_range = 'The given oscillation range might be to large for this centering';
+  }
+
   return warnings;
 };
 

--- a/mxcube3/ui/containers/SampleViewContainer.js
+++ b/mxcube3/ui/containers/SampleViewContainer.js
@@ -102,6 +102,7 @@ class SampleViewContainer extends Component {
                   sampleActions={this.props.sampleViewActions}
                   {...this.props.sampleViewState}
                   motors={this.props.motors}
+                  steps={motorSteps}
                   imageRatio={imageRatio * sourceScale}
                   contextMenuVisible={this.props.contextMenu.show}
                   shapes={this.props.shapes}

--- a/mxcube3/ui/containers/SampleViewContainer.js
+++ b/mxcube3/ui/containers/SampleViewContainer.js
@@ -20,13 +20,15 @@ class SampleViewContainer extends Component {
     const { sourceScale, imageRatio, motorSteps } = this.props.sampleViewState;
     const { sendMotorPosition, setStepSize, sendStopMotor } = this.props.sampleViewActions;
     const sampleID = this.props.current.sampleID;
-    const [points, lines, grids] = [{}, {}, {}];
+    const [points, lines, grids, twoDPoints] = [{}, {}, {}, {}];
     const selectedGrids = [];
 
     Object.keys(this.props.shapes).forEach((key) => {
       const shape = this.props.shapes[key];
       if (shape.t === 'P') {
         points[shape.id] = shape;
+      } else if (shape.t === '2DP') {
+        twoDPoints[shape.id] = shape;
       } else if (shape.t === 'L') {
         lines[shape.id] = shape;
       } else if (shape.t === 'G') {
@@ -104,6 +106,7 @@ class SampleViewContainer extends Component {
                   contextMenuVisible={this.props.contextMenu.show}
                   shapes={this.props.shapes}
                   points={points}
+                  twoDPoints={twoDPoints}
                   lines={lines}
                   grids={grids}
                   selectedGrids={selectedGrids}

--- a/mxcube3/ui/main.css
+++ b/mxcube3/ui/main.css
@@ -1,0 +1,3 @@
+.popover {
+    width: auto !important;
+}

--- a/mxcube3/ui/main.jsx
+++ b/mxcube3/ui/main.jsx
@@ -1,5 +1,6 @@
 import 'bootstrap/dist/css/bootstrap.css';
 import 'react-bootstrap-table/css/react-bootstrap-table.css';
+import './main.css';
 import 'babel-polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/mxcube3/ui/reducers/beamline.js
+++ b/mxcube3/ui/reducers/beamline.js
@@ -155,7 +155,9 @@ export const INITIAL_STATE = {
     FrontLightSwitch: { position: 0, state: 0, limits: [0, 1] },
     kappa: { position: 0, state: 0, limits: [0, 1] },
     kappa_phi: { position: 0, state: 0, limits: [0, 1] },
-    zoom: { position: 0, state: 0, limits: [0, 1] }
+    zoom: { position: 0, state: 0, limits: [0, 1] },
+    sample_horizontal: { position: 0, state: 0, limits: [0, 1] },
+    sample_vertical: { position: 0, state: 0, limits: [0, 1] }
   },
   beamlineActionsList: [],
   currentBeamlineAction: { show: false, messages: [], arguments: [] },

--- a/mxcube3/ui/reducers/sampleview.js
+++ b/mxcube3/ui/reducers/sampleview.js
@@ -23,7 +23,9 @@ const initialState = {
     sampxStep: 0.1,
     sampyStep: 0.1,
     kappaStep: 0.1,
-    kappaphiStep: 0.1
+    kappaphiStep: 0.1,
+    sample_verticalStep: 0.1,
+    sample_horizontalStep: 0.1
   },
   apertureList: [],
   currentAperture: 0,

--- a/test/HardwareObjectsMockup.xml/minidiff-mockup.xml
+++ b/test/HardwareObjectsMockup.xml/minidiff-mockup.xml
@@ -12,10 +12,14 @@
   <object role="kappa_phi" hwrid="./udiff_kappaphi"></object>
   <object role="beam_info" hwrid="./beam-info"></object>
 
+  <device role="sample_vertical" hwrid="/udiff_sampx"/>
+  <device role="sample_horizontal" hwrid="/udiff_sampy"/>
+
   <object role="backlight" href="./udiff_backlight"/>
   <object role="backlightswitch" href="./udiff_backlightswitch"/>
   <object role="frontlight" href="./udiff_frontlight"/>
   <object role="frontlightswitch" href="./udiff_frontlightswitch"/>
+  
 
   <others>
     <object role="camera" hwrid="./md_camera"></object>


### PR DESCRIPTION
Hi,

We have been working with and trying out  "2D-centerd points" and a "navigation cross" the last few days. We hope, except for being convenient, that it will be very useful for plate and jet experiments. The conditions under which one can perform the different actions might need to be refined a little bit.

Please give it a try and let us know what you think ?

This PR depends on #206 on HR so please merge that one first.

Introduces:
-  "2D-centered points", points that are normally only valid in the plane seen from the microscope.
- A "navigation cross" / Joystick for aligning the sample in the plane, using horizontal and vertical pseudo motors for moving sampx and sampy.

The micro diffractometer already have a native vertical pseudo-motor and the horizontal motor is the same as phiy or phyz (depending on orientation of spindle)

Cheers,
Marcus