### PR TITLE
Handling sample "loading and loaded" state in better way

### DIFF
--- a/mxcube3/routes/samplechanger.py
+++ b/mxcube3/routes/samplechanger.py
@@ -52,32 +52,11 @@ def scan_location(loc):
     return scutils.get_sc_contents()
 
 
-@server.route("/mxcube/api/v0.1/sample_changer/mount/<loc>", methods=['GET'])
-@server.restrict
-def mount_sample(loc):
-    return jsonify(scutils.mount_sample(loc))
-
-
-@server.route("/mxcube/api/v0.1/sample_changer/unmount/<loc>", methods=['GET'])
-@server.restrict
-def unmount_sample(loc):
-    blcontrol.sample_changer.unload(loc, wait=True)
-    set_current_sample(None)
-    try:
-        blcontrol.sample_changer.unload(loc, wait=True)
-        set_current_sample(None)
-    except Exception as ex:
-        return 'Cannot load sample', 409, {'Content-Type': 'application/json',
-                                           'message': str(ex)
-                                           }
-    return jsonify(scutils.get_sc_contents())
-
-
-@server.route("/mxcube/api/v0.1/sample_changer/unmount_current/", methods=['GET'])
+@server.route("/mxcube/api/v0.1/sample_changer/unmount_current", methods=['POST'])
 @server.restrict
 def unmount_current():
     try:
-        res = scutils.unmount_current(None, wait=True)
+        res = scutils.unmount_current()
     except Exception as ex:
         res = 'Cannot unload sample', 409, {'Content-Type': 'application/json',
                                             'message': str(ex)
@@ -87,31 +66,27 @@ def unmount_current():
 
 @server.route("/mxcube/api/v0.1/sample_changer/mount", methods=["POST"])
 @server.restrict
-def mount_sample_clean_up():
+def mount_sample():
     resp = Response(status=200)
 
     try:
-        res = scutils.mount_sample_clean_up(request.get_json())
+        resp = jsonify(scutils.mount_sample(request.get_json()))
     except Exception as ex:
         resp = ('Cannot load sample', 409,
                 {'Content-Type': 'application/json', 'message': str(ex)})
-    else:
-        if not res:
-            resp = ('No sample loaded', 409,
-                    {'Content-Type': 'application/json',
-                     'message': 'Could not mount sample: No sample on given position or empty vial ?'})
+
     return resp
 
 
 @server.route("/mxcube/api/v0.1/sample_changer/unmount", methods=['POST'])
 @server.restrict
-def unmount_sample_clean_up():
+def unmount_sample():
     try:
-        scutils.unmount_sample_clean_up(request.get_json())
+        resp = jsonify(scutils.unmount_sample(request.get_json()))
     except Exception as ex:
         return 'Cannot unload sample', 409, {'Content-Type': 'application/json',
                                              'message': str(ex)}
-    return Response(status=200)
+    return resp
 
 
 @server.route("/mxcube/api/v0.1/sample_changer/get_maintenance_cmds", methods=['GET'])

--- a/mxcube3/ui/actions/sampleChanger.js
+++ b/mxcube3/ui/actions/sampleChanger.js
@@ -1,5 +1,6 @@
 import fetch from 'isomorphic-fetch';
 import { showErrorPanel } from './general';
+import { setCurrentSample, clearCurrentSample } from './queue';
 
 export function setContents(contents) {
   return { type: 'SET_SC_CONTENTS', data: { sampleChangerContents: contents } };
@@ -97,50 +98,64 @@ export function scan(address) {
   };
 }
 
-export function loadSample(address) {
-  return function (dispatch) {
-    fetch(`mxcube/api/v0.1/sample_changer/mount/${address}`, {
-      method: 'GET',
-      headers: {
-        Accept: 'application/json',
-        'Content-type': 'application/json'
-      },
-      credentials: 'include'
-    }).then(response => {
-      if (response.status >= 400) {
-        dispatch(showErrorPanel(true, response.headers.get('message')));
-        throw new Error(`Error while  sample loading sample @ ${address}`);
-      }
+export function loadSample(sampleData, successCb = null) {
+  return function (dispatch, getState) {
+    const state = getState();
 
-      response.json().then(contents => { dispatch(setContents(contents)); }
-                           ).then(dispatch(refresh()));
-    });
+    if (state.sampleChanger.loadedSample.address !== sampleData.location) {
+      fetch('mxcube/api/v0.1/sample_changer/mount', {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          Accept: 'application/json',
+          'Content-type': 'application/json'
+        },
+        body: JSON.stringify(sampleData)
+      }).then((response) => {
+        if (response.status >= 400) {
+          dispatch(showErrorPanel(true, response.headers.get('message')));
+          throw new Error('Server refused to mount sample');
+        } else {
+          setCurrentSample(sampleData.sampleID);
+
+          response.json().then(contents => { dispatch(setContents(contents)); }
+                              ).then(dispatch(refresh()));
+
+          if (successCb) {
+            successCb();
+          }
+        }
+      });
+    }
   };
 }
 
-export function unloadSample(address) {
+export function unloadSample(location) {
   let url = '';
 
-  if (address) {
-    url = `mxcube/api/v0.1/sample_changer/unmount/${address}`;
+  if (location) {
+    url = 'mxcube/api/v0.1/sample_changer/unmount';
   } else {
     url = 'mxcube/api/v0.1/sample_changer/unmount_current';
   }
+
+
   return function (dispatch) {
     fetch(url, {
-      method: 'GET',
+      method: 'POST',
+      credentials: 'include',
       headers: {
         Accept: 'application/json',
         'Content-type': 'application/json'
       },
-      credentials: 'include'
-    }).then(response => {
+      body: JSON.stringify({ location, sampleID: location })
+    }).then((response) => {
       if (response.status >= 400) {
-        throw new Error(`Error while  sample unloading sample @ ${address}`);
+        dispatch(showErrorPanel(true, response.headers.get('message')));
+        throw new Error('Server refused to unmount sample');
+      } else {
+        dispatch(clearCurrentSample());
       }
-
-      response.json().then(contents => { dispatch(setContents(contents)); }
-                           ).then(dispatch(refresh()));
     });
   };
 }

--- a/mxcube3/ui/components/SampleChanger/SampleChanger.js
+++ b/mxcube3/ui/components/SampleChanger/SampleChanger.js
@@ -124,7 +124,8 @@ export class SampleChangerTreeItem extends React.Component {
 
   loadSample() {
     this.toggleDropdown();
-    this.props.load(this.props.label);
+    this.props.load({ sampleID: this.props.label,
+                      location: this.props.label });
   }
 
   unloadSample() {

--- a/mxcube3/ui/constants.js
+++ b/mxcube3/ui/constants.js
@@ -42,7 +42,8 @@ export function hasLimsData(sample) {
 }
 
 export function taskHasLimsData(task) {
-  return task.limsResultData && (task.limsResultData.dataCollectionId || task.limsResultData.dataCollectionGroupId);
+  return task.limsResultData &&
+    (task.limsResultData.dataCollectionId || task.limsResultData.dataCollectionGroupId);
 }
 
 export function twoStateActuatorIsActive(state) {

--- a/mxcube3/ui/containers/ConfirmCollectDialog.jsx
+++ b/mxcube3/ui/containers/ConfirmCollectDialog.jsx
@@ -11,7 +11,6 @@ import { Modal,
 
 import { sendRunQueue,
          sendRunSample,
-         sendMountSample,
          setAutoMountSample,
          sendSetCentringMethod,
          sendSetNumSnapshots } from '../actions/queue';
@@ -389,7 +388,6 @@ function mapDispatchToProps(dispatch) {
     hide: bindActionCreators(showConfirmCollectDialog.bind(this, false), dispatch),
     sendRunQueue: bindActionCreators(sendRunQueue, dispatch),
     sendRunSample: bindActionCreators(sendRunSample, dispatch),
-    sendMountSample: bindActionCreators(sendMountSample, dispatch),
     setAutoMountSample: bindActionCreators(setAutoMountSample, dispatch),
     sendSetCentringMethod: bindActionCreators(sendSetCentringMethod, dispatch),
     sendSetNumSnapshots: bindActionCreators(sendSetNumSnapshots, dispatch)

--- a/mxcube3/ui/containers/SampleGridContainer.jsx
+++ b/mxcube3/ui/containers/SampleGridContainer.jsx
@@ -17,7 +17,7 @@ import { toggleMovableAction,
          selectSamplesAction,
          sendSetSampleOrderAction } from '../actions/sampleGrid';
 
-import { deleteTask, sendMountSample, addSampleAndMount } from '../actions/queue';
+import { deleteTask, addSampleAndMount } from '../actions/queue';
 
 import { unloadSample } from '../actions/sampleChanger';
 
@@ -833,7 +833,6 @@ function mapDispatchToProps(dispatch) {
     sendSetSampleOrderAction: (order) => dispatch(sendSetSampleOrderAction(order)),
     showTaskParametersForm: bindActionCreators(showTaskForm, dispatch),
     deleteTask: bindActionCreators(deleteTask, dispatch),
-    sendMountSample: bindActionCreators(sendMountSample, dispatch),
     unloadSample: bindActionCreators(unloadSample, dispatch),
     toggleMovableAction: (key) => dispatch(toggleMovableAction(key)),
     selectSamples: (keys, selected) => dispatch(selectSamplesAction(keys, selected)),

--- a/mxcube3/ui/containers/SampleQueueContainer.js
+++ b/mxcube3/ui/containers/SampleQueueContainer.js
@@ -8,6 +8,7 @@ import QueueControl from '../components/SampleQueue/QueueControl';
 import * as QueueActions from '../actions/queue';
 import * as QueueGUIActions from '../actions/queueGUI';
 import * as SampleViewActions from '../actions/sampleview';
+import * as SampleChangerActions from '../actions/sampleChanger';
 import { showTaskForm } from '../actions/taskForm';
 import { Nav, NavItem } from 'react-bootstrap';
 import { showDialog } from '../actions/general';
@@ -46,6 +47,7 @@ function mapDispatchToProps(dispatch) {
     queueActions: bindActionCreators(QueueActions, dispatch),
     queueGUIActions: bindActionCreators(QueueGUIActions, dispatch),
     sampleViewActions: bindActionCreators(SampleViewActions, dispatch),
+    sampleChangerActions: bindActionCreators(SampleChangerActions, dispatch),
     showForm: bindActionCreators(showTaskForm, dispatch),
     showDialog: bindActionCreators(showDialog, dispatch),
     beamlineActions: bindActionCreators(BeamlineActions, dispatch)
@@ -91,7 +93,6 @@ export default class SampleQueueContainer extends React.Component {
       changeTaskOrderAction,
       deleteTask,
       addTask,
-      sendMountSample,
       moveTask,
       setAutoMountSample,
       setAutoAddDiffPlan,
@@ -108,7 +109,9 @@ export default class SampleQueueContainer extends React.Component {
     const {
       sendPrepareForNewSample
     } = this.props.beamlineActions;
-
+    const {
+      loadSample
+    } = this.props.sampleChangerActions;
 
     // go through the queue, check if sample has been collected or not
     // to make todo and history lists
@@ -216,7 +219,7 @@ export default class SampleQueueContainer extends React.Component {
               sampleList={sampleList}
               collapseItem={collapseItem}
               displayData={displayData}
-              mount={sendMountSample}
+              mount={loadSample}
               showForm={showForm}
               queueStatus={queueStatus}
               showList={showList}


### PR DESCRIPTION
Hi,

Improved the handling of the sample loading and unloading so that the corresponding dialog is displayed correctly.

Handling sample "loading and loaded" state mount and unmount instead of in sc_state_changed callback. The sample changers seem to handle loading and loaded events poorly and uses ready and busy instead, so its difficult to accurately know when a sample have been mounted or unmounted. This code relies on that the mount and unmount returns when the actual loading or unloading phase is done.

Regards,
Marcus