### PR TITLE
adds 'tango-controls' channel to conda environment

### DIFF
--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -1,4 +1,6 @@
 name: mxcube
+channels:
+  - tango-controls
 dependencies:
   - python=3.7
   - gevent


### PR DESCRIPTION
Include 'tango-controls' channel in the conda environment
description file, otherwise conda will not find the
'pytango' with default settings.