### PR TITLE
Get v4l2 from fork to build with Python 3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ python-ldap
 lxml
 numpy
 requests
-v4l2
+git+https://github.com/marcus-oscarsson/python-v4l2.git
 scandir
 matplotlib # Dependency of energyscan mockup object
 gipc


### PR DESCRIPTION
Hi,

Just a minor fix in `requirements.txt` to get v4l2 from the fork (following it is done in `conda-environment.yml`).

Thanks,
Laís