### PR TITLE
use nodejs version 12.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 language: python
+
 python:
   - "3.7"
   - "3.8"
-node_js:
-  - "10"
 
 services:
   - redis-server
 
 install:
+  - nvm install 12
+  - nvm use 12
   - npm install
   - npm run build
   - pip install codecov

--- a/mxcube3/ui/components/SampleChanger/SampleChanger.js
+++ b/mxcube3/ui/components/SampleChanger/SampleChanger.js
@@ -94,7 +94,7 @@ export class SampleChangerTreeNode extends React.Component {
         </li>
 
         <ContextMenu id={`${this.props.label}`}>
-          <li role="heading" className="dropdown-header">
+          <li role="heading" aria-level="1" className="dropdown-header">
             <b>
 Container
               {this.props.label}
@@ -165,7 +165,7 @@ export class SampleChangerTreeItem extends React.Component {
               onToggle={this.toggleDropdown}
               open={this.state.dropdownIsOpen}
             >
-              <li role="heading" className="dropdown-header">
+              <li role="heading" aria-level="1" className="dropdown-header">
                 <b>
 Position
                   {this.props.label}


### PR DESCRIPTION
A couple of commits for running front-end with nodejs version 12.x:

* force travis-ci to use nodejs 12.x by explicitly running 'nvm' commands

This seems to be the officially recommended way to ensure minimal version of nodejs for project's with mixed languages. Previously the travis build where using nodejs 8.x, which are quite old now. 

* fix linter ARIA related errors, which I get when running nodejs 12.4.0