### PR TITLE
send video sizes as list of tuples

### DIFF
--- a/mxcube3/core/beamlineutils.py
+++ b/mxcube3/core/beamlineutils.py
@@ -153,11 +153,10 @@ def get_viewport_info():
         video_sizes = blcontrol.beamline.sample_view.camera.get_available_stream_sizes()
         width, height, scale = blcontrol.beamline.sample_view.camera.get_stream_size()
     else:
-        video_sizes = [
-            blcontrol.beamline.sample_view.camera.getWidth(),
-            blcontrol.beamline.sample_view.camera.getHeight(),
-        ]
-        width, height, scale = video_sizes + [1]
+        scale = 1
+        width = blcontrol.beamline.sample_view.camera.getWidth()
+        height = blcontrol.beamline.sample_view.camera.getHeight()
+        video_sizes = [(width, height)]
 
     pixelsPerMm = blcontrol.beamline.diffractometer.get_pixels_per_mm()
 


### PR DESCRIPTION
Make sure that we send video sizes as a list of tuples,
as this is what is expected by UI.

Otherwise, for cases when Video Device is not used, the
UI drop-down for 'Video size' will be broken.