### PR TITLE
send 'hidden' mesh grid state to backend

### DIFF
--- a/mxcube3/ui/components/SampleView/SampleImage.jsx
+++ b/mxcube3/ui/components/SampleView/SampleImage.jsx
@@ -625,7 +625,7 @@ export default class SampleImage extends React.Component {
       grid.state = 'HIDDEN';
     }
 
-    this.props.sampleActions.updateShapes([grid]);
+    this.props.sampleActions.sendUpdateShapes([grid]);
   }
 
   centringMessage() {


### PR DESCRIPTION
When a mesh grid is hidden/unhidden in the UI, send the new state to the backend server.

This way, back-end will save grids state. This solves the issue of grids getting 'unhidden' when sample is moved,
or the UI page is reloaded.