### PR TITLE
Minor fixes regarding packages used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ services:
   - redis-server
 
 install:
-  - nvm install 12
-  - nvm use 12
+  - nvm install 10
+  - nvm use 10
   - npm install
   - npm run build
   - pip install codecov

--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -26,6 +26,7 @@ dependencies:
   - opencv
   - requests
   - scandir
+  - redis
   - redis-py
   - ffmpeg
   - pytango


### PR DESCRIPTION
* include redis package, so that we get 'redis-server' out-of-box when creating conda environment
* use node version 10.* both in conda environment  and when running travis CI