### PR TITLE
Fix typos in mockup XMLs

### DIFF
--- a/test/HardwareObjectsMockup.xml/detector_mockup.xml
+++ b/test/HardwareObjectsMockup.xml/detector_mockup.xml
@@ -11,7 +11,7 @@
   <width>4150</width>
   <height>4271</height>
   <hasShutterless>True</hasShutterless>
-  <fileSuffix>cbf</fileSuffix>
+  <file_suffix>cbf</file_suffix>
 
   <beam>
     <ax>0.00002</ax>

--- a/test/HardwareObjectsMockup.xml/session.xml
+++ b/test/HardwareObjectsMockup.xml/session.xml
@@ -56,7 +56,7 @@
    <processed_data_folder_name>PROCESSED_DATA</processed_data_folder_name>
    <archive_base_directory>/tmp</archive_base_directory>
    <archive_folder>pyarch</archive_folder>
-   <precission>4</precission>
+   <precision>4</precision>
   </file_info>
 
   <feedback_email>test@...</feedback_email>


### PR DESCRIPTION
Hi,

Just some typos found in mockup XMLs tags (session and detector): file_suffix and precision. They impact, e.g., on the filename shown in the UI. 

Thanks,
Laís