### PR TITLE
Using queue.execute instead of execute_entry

### DIFF
--- a/mxcube3/core/components/queue.py
+++ b/mxcube3/core/components/queue.py
@@ -1775,7 +1775,7 @@ class Queue(ComponentBase):
             node, entry = self.get_entry(parent_id)
 
             try:
-                HWR.beamline.queue_manager.execute_entry(entry, use_async=True)
+                HWR.beamline.queue_manager.execute(entry)
             except BaseException:
                 HWR.beamline.queue_manager.emit("queue_execution_failed", (None,))
 


### PR DESCRIPTION
Goes with the changes in [mxcubecore #691](https://github.com/mxcube/mxcubecore/pull/691)