### PR TITLE
MAX IV name and home page in Readme file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ MXCuBE-Web is the latest generation of the data acquisition software MXCuBE (Mac
 
 * ESRF
 * [Soleil](http://www.synchrotron-soleil.fr/)
-* [Max lab](https://www.maxlab.lu.se/)
+* [MAX IV](https://www.maxiv.lu.se/)
 * [HZB](http://www.helmholtz-berlin.de/)
 * [EMBL](http://www.embl.org/)
 * [Global Phasing Ltd.](http://www.globalphasing.com/)


### PR DESCRIPTION
Update link to MAX IV home page, as the old one is now dead.

Also the lab is now called MAX IV.