### PR TITLE
Translate in YZ-plane parallel to microscope-view plane

### DIFF
--- a/test/HardwareObjectsMockup.xml/mxcube-web/ui.yaml
+++ b/test/HardwareObjectsMockup.xml/mxcube-web/ui.yaml
@@ -59,14 +59,14 @@ sample_view:
       suffix: mm
     -
       label: Sample Horizontal
-      attribute: sampx
+      attribute: phiz
       role: sample_horizontal
       step: 0.1
       precision: 3
       suffix: mm
     -
       label: Sample Vertical
-      attribute: sampy
+      attribute: phiy
       role: sample_vertical
       step: 0.1
       precision: 3


### PR DESCRIPTION
If `Sample Horizontal` and `Sample Vertical` means movement in YZ plane which is perpendicular to X (beam direction), the attributes should be `phiz` and `phiy` and NOT `sampx` and `sampy`.