### PR TITLE
env var following REACT_APP_xxx

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -35,6 +35,8 @@ jobs:
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory
         echo $CONDA/bin >> $GITHUB_PATH
+    - name: Install ldap dependencies
+      run: sudo apt-get -y install libsasl2-dev python-dev libldap2-dev libssl-dev
     - name: Install dependencies
       run: |
         conda env update --file conda-environment.yml --name base

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,7 +36,7 @@ jobs:
         # $CONDA is an environment variable pointing to the root of the miniconda directory
         echo $CONDA/bin >> $GITHUB_PATH
     - name: Install ldap dependencies
-      run: sudo apt-get -y install libsasl2-dev python-dev libldap2-dev libssl-dev
+      run: sudo apt-get -y install libsasl2-dev libldap2-dev libssl-dev
     - name: Install dependencies
       run: |
         conda env update --file conda-environment.yml --name base

--- a/ui/.env
+++ b/ui/.env
@@ -1,6 +1,4 @@
- phaseControl = true
- apertureControl = true
- focusControlOnCanvas = true
- use2dCenteredPoints = true
- meshResultFormat = PNG
- WDS_SOCKET_PORT = 0
+REACT_APP_PHASECONTROL = true
+REACT_APP_FOCUSCONTROLONCANVAS = true
+REACT_APP_USE2DCENTEREDPOINTS = true
+REACT_APP_MESHRESULTFORMAT = PNG

--- a/ui/src/components/SampleView/ContextMenu.js
+++ b/ui/src/components/SampleView/ContextMenu.js
@@ -37,7 +37,7 @@ export default class ContextMenu extends React.Component {
     };
     let twoDPoints = [];
 
-    if (process.env.use2dCenteredPoints) {
+    if (process.env.REACT_APP_USE2DCENTEREDPOINTS) {
       twoDPoints = [{ text: 'divider', key: 4 },
         {
           text: 'Data Collection (Limited OSC)',

--- a/ui/src/components/SampleView/MotorControl.js
+++ b/ui/src/components/SampleView/MotorControl.js
@@ -75,7 +75,7 @@ export default class MotorControl extends React.Component {
       <div>
         {this.getMotorComponents(3, 8)}
         <div className="col-sm-12">
-          {process.env.phaseControl ? phaseControl : null}
+          {process.env.REACT_APP_PHASECONTROL ? phaseControl : null}
         </div>
       </div>
     );

--- a/ui/src/components/SampleView/SampleControls.js
+++ b/ui/src/components/SampleView/SampleControls.js
@@ -200,7 +200,7 @@ export default class SampleControls extends React.Component {
               />
               <span className="sample-control-label">3-click Centring</span>
             </li>
-            {process.env.focusControlOnCanvas
+            {process.env.REACT_APP_FOCUSCONTROLONCANVAS
               ? (
                 <li>
                   <OverlayTrigger

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -51,7 +51,7 @@ export default class SampleImage extends React.Component {
     this.toggleGridVisibility = this.toggleGridVisibility.bind(this);
     this.canvas = {};
     this.drawGridPlugin = new DrawGridPlugin();
-    this.drawGridPlugin.setGridResultFormat(process.env.meshResultFormat);
+    this.drawGridPlugin.setGridResultFormat(process.env.REACT_APP_MESHRESULTFORMAT);
     this._keyPressed = null;
     this.gridStarted = false;
     this.girdOrigin = null;


### PR DESCRIPTION
change the naming of the env vars so they actually are used. See [here](https://create-react-app.dev/docs/adding-custom-environment-variables/#adding-development-environment-variables-in-env)


> You must create custom environment variables beginning with REACT_APP_. Any other variables except NODE_ENV will be ignored to avoid [accidentally exposing a private key on the machine that could have the same name](https://github.com/facebook/create-react-app/issues/865#issuecomment-252199527). Changing any environment variables will require you to restart the development server if it is running.

Removed also the ones not in use
