### PR TITLE
save correct proposal for loginType 'user'

### DIFF
--- a/mxcube3/core/components/lims.py
+++ b/mxcube3/core/components/lims.py
@@ -351,6 +351,10 @@ class Lims(ComponentBase):
                 ftype = HWR.beamline.detector.get_property("file_suffix")
                 self.app.INITIAL_FILE_LIST = fsutils.scantree(root_path, [ftype])
 
+            # save selected proposal in users db
+            current_user.selected_proposal = proposal
+            self.app.usermanager.update_user(current_user)
+
             logging.getLogger("user_log").info("[LIMS] Proposal selected.")
 
             return True

--- a/mxcube3/core/components/user/usermanager.py
+++ b/mxcube3/core/components/user/usermanager.py
@@ -117,6 +117,8 @@ class BaseUserManager(ComponentBase):
             if _u.is_authenticated and _u.in_control:
                 if HWR.beamline.lims.loginType.lower() != "user":
                     self.app.lims.select_proposal(self.app.lims.get_proposal(_u))
+                elif _u.selected_proposal is not None:
+                    self.app.lims.select_proposal(_u.selected_proposal)
 
     def handle_disconnect(self, username):
         time.sleep(120)
@@ -315,12 +317,17 @@ class BaseUserManager(ComponentBase):
         _u = user_datastore.find_user(username=username)
 
         if not _u:
+            if HWR.beamline.lims.loginType.lower() != "user":
+                selected_proposal = user
+            else:
+                selected_proposal = None
+
             user_datastore.create_user(
                 username=username,
                 password=flask_security.hash_password("password"),
                 nickname=user,
                 session_id=sid,
-                selected_proposal=user,
+                selected_proposal=selected_proposal,
                 limsdata=json.dumps(lims_data),
                 roles=self._get_configured_roles(user),
             )


### PR DESCRIPTION
Extend logic for saving selected proposal in the user DB to work with login type 'user'

when loginType is 'user':

 * set selected_proposal to None when user is initially created in the DB
 * on 'set_proposal' HTTP requests update database with selected proposal
 * when 'operator' user is switched, change HW Session's proposal to user's 'selected_proposal'