### PR TITLE
Fix some issue with snapshot button

### DIFF
--- a/ui/src/components/SampleView/SampleControls.js
+++ b/ui/src/components/SampleView/SampleControls.js
@@ -65,10 +65,23 @@ export default class SampleControls extends React.Component {
   }
 
   takeSnapShot() {
+    /* eslint-disable unicorn/consistent-function-scoping */
+    function imageEpolog(props) {
+      const sampleID = props.current.sampleID;
+
+      if (sampleID in props.sampleList)
+      {
+        return props.sampleList[sampleID].sampleName;
+      }
+
+      /* handle the case when sample is not mounted */
+      return "no-sample";
+    }
+
     const img = this.doTakeSnapshot();
+    const filename = `${this.props.proposal}-${imageEpolog(this.props)}.jpeg`;
+
     document.querySelector('#downloadLink').href = img.mime + img.data;
-    const { sampleName } = this.props.sampleList[this.props.current.sampleID];
-    const filename = `${this.props.proposal}-${sampleName}.jpeg`;
     document.querySelector('#downloadLink').download = filename;
   }
 

--- a/ui/src/components/SampleView/SampleControls.js
+++ b/ui/src/components/SampleView/SampleControls.js
@@ -174,6 +174,7 @@ export default class SampleControls extends React.Component {
                 title="Take snapshot"
                 className="fas fa-camera sample-control"
                 onClick={this.takeSnapShot}
+                target="_blank"
                 download
               />
               <span className="sample-control-label">Snapshot</span>


### PR DESCRIPTION
Fixes two issue with the 'Snapshot' button on 'Data collection' tab.

* make it open the 'download' dialog on Chrome and Firefox
* handle cases when no sample is mounted