### PR TITLE
support sending sample view MJPEG stream to multiple UI clients

### DIFF
--- a/mxcube3/core/components/sampleview.py
+++ b/mxcube3/core/components/sampleview.py
@@ -8,6 +8,8 @@ import inspect
 import PIL
 import gevent.event
 
+from flask import Response
+
 from io import StringIO
 import base64
 
@@ -27,6 +29,79 @@ SNAPSHOT_RECEIVED = gevent.event.Event()
 SNAPSHOT = None
 
 
+class HttpStreamer:
+    """
+    Implements 'MJPEG' streaming from the sample view camera.
+
+    Provides get_response() method, that creates a Response object,
+    that will stream JPEG images from the sample view camera,
+    in 'multipart' HTTP response format.
+    """
+    def __init__(self):
+        self._new_frame = gevent.event.Event()
+        self._sample_image = None
+        self._clients = 0
+
+    def _client_connected(self):
+        if self._clients == 0:
+            # first client connected,
+            # start listening to frames from sample camera
+            HWR.beamline.sample_view.camera.connect(
+                "imageReceived", self._new_frame_received
+            )
+
+        self._clients += 1
+
+    def _client_disconnected(self):
+        self._clients -= 1
+        if self._clients == 0:
+            # last client disconnected,
+            # disconnect from the sample camera
+            HWR.beamline.sample_view.camera.disconnect(
+                "imageReceived", self._new_frame_received
+            )
+
+    def _new_frame_received(self, img, width, height, *args, **kwargs):
+        if isinstance(img, str):
+            img = img
+        elif isinstance(img, bytes):
+            img = img
+        else:
+            rawdata = img.bits().asstring(img.numBytes())
+            strbuf = StringIO()
+            image = PIL.Image.frombytes("RGBA", (width, height), rawdata)
+            (r, g, b, a) = image.split()
+            image = PIL.Image.merge("RGB", (b, g, r))
+            image.save(strbuf, "JPEG")
+            img = strbuf.get_value()
+
+        self._sample_image = img
+
+        # signal clients that there is a new frame available
+        self._new_frame.set()
+        self._new_frame.clear()
+
+    def get_response(self) -> Response:
+        """
+        build new Response object, that will send frames to the client
+        """
+        def frames():
+            while True:
+                self._new_frame.wait()
+                yield (
+                    b"--frame\r\n"
+                    b"--!>\nContent-type: image/jpeg\n\n" + self._sample_image + b"\r\n"
+                )
+
+        self._client_connected()
+
+        response = Response(frames(), mimetype='multipart/x-mixed-replace; boundary="!>"')
+        # keep track of when client stops reading the stream
+        response.call_on_close(self._client_disconnected)
+
+        return response
+
+
 class SampleView(ComponentBase):
     def __init__(self, app, config):
         super().__init__(app, config)
@@ -34,6 +109,7 @@ class SampleView(ComponentBase):
         self._click_count = 0
         self._click_limit = 3
         self._centring_point_id = None
+        self.http_streamer = HttpStreamer()
 
         enable_snapshots(
             HWR.beamline.collect, HWR.beamline.diffractometer, HWR.beamline.sample_view

--- a/mxcube3/routes/samplecentring.py
+++ b/mxcube3/routes/samplecentring.py
@@ -19,10 +19,7 @@ def init_route(app, server, url_prefix):
         if app.CONFIG.app.VIDEO_FORMAT == "MPEG1":
             result = Response(status=200)
         else:
-            frame = app.sample_view.stream_video(HWR.beamline.sample_view.camera)
-            result = Response(
-                frame, mimetype='multipart/x-mixed-replace; boundary="!>"'
-            )
+            result = app.sample_view.http_streamer.get_response()
 
         return result
 


### PR DESCRIPTION
Previous implementation had an issue where the stream was only send to newly connected UI client. The stream to previously connected client was stalled.
    
Also, keep track of how many clients are streaming. Only connect to sample view camera object if number of clients is more then 0. This allow camera hardware objects to implement behaviour where frames are pulled from the diffractometer only when they are needed.
