### PR TITLE
use the max run number

### DIFF
--- a/mxcube3/core/components/queue.py
+++ b/mxcube3/core/components/queue.py
@@ -59,8 +59,10 @@ class Queue(ComponentBase):
                     % path
                 )
                 path, run_number, image_number = (path, 0, 0)
-
-            prefix_path_dict[path] = run_number
+            if path in prefix_path_dict:
+                prefix_path_dict[path] = max(prefix_path_dict[path], run_number)
+            else:
+                prefix_path_dict[path] = run_number
 
         return prefix_path_dict
 


### PR DESCRIPTION
if the initial file list is not in order, the run_number value for a given path prefix may not be the highest one