### PR TITLE
mxcubecore as group for pyproject

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install dependencies
       run: |
         conda env update --file conda-environment.yml --name base
-        pip install -e .
+        poetry install
     - name: Lint with flake8
       run: |
         #conda install flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,6 @@ pydantic = "^1.10.2"
 PyDispatcher = "^2.0.6"
 pytz = "^2022.6"
 tzlocal = "^4.2"
-mxcubecore = { git = "https://github.com/mxcube/mxcubecore.git", branch = "develop" }
-video_streamer = { git = "https://github.com/mxcube/video-streamer.git", branch = "main"}
 bcrypt = "^4.0.1"
 
 [tool.poetry.dev-dependencies]
@@ -48,6 +46,10 @@ pylint = [ { version = "==2.13.9", python = "<=3.7.1" }, { version = "2.15.3", p
 pre-commit = "2.20.0"
 pytest = "7.1.3"
 pytest-cov = "4.0.0"
+
+[tool.poetry.group.mxcubecore.dependencies]
+mxcubecore = { git = "https://github.com/mxcube/mxcubecore.git", branch = "develop" }
+video_streamer = { git = "https://github.com/mxcube/video-streamer.git", branch = "main" }
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
hi!

I propose to move mxcubecore and video-streamer repos to a new group inside the pyproject file. Poetry is not affected (tested myself but please have a look). But this way we can still use pip for the installation in our deployment environment with less hassle (we cannot reach github, but conveniently pip ignores the mxcubecore group in pyproject)

We dont want to create a patch on some internal branch just for the shake of deployment, preferably we want to rely on upstream as much as we can.