### PR TITLE
don't log HTTP requests body

### DIFF
--- a/mxcube3/routes/main.py
+++ b/mxcube3/routes/main.py
@@ -57,7 +57,6 @@ def init_route(app, server, url_prefix):
         logging.getLogger("MX3.HWR").debug('Path: %s', request.full_path)
         logging.getLogger("MX3.HWR").debug('scheme: %s', request.scheme)
         logging.getLogger("MX3.HWR").debug('Headers: %s', request.headers)
-        logging.getLogger("MX3.HWR").debug('Body: %s', request.get_data())
 
         if not flask_login.current_user.is_anonymous:
             flask_login.current_user.last_request_timestamp = datetime.now()


### PR DESCRIPTION
Logging HTTP requests body is an security issue, as we end up adding user's passwords to the log in clear text.

This means that passwords become visible to all users logged in to MxCube (for example observers).

If we really want to log HTTP bodies, we should add some kind of censoring mechanism, that for example replaces actual password with ****, in the log.
