### PR TITLE
Made it possible to select which loggers to user from command line

### DIFF
--- a/mxcube3/__init__.py
+++ b/mxcube3/__init__.py
@@ -59,8 +59,16 @@ def parse_args():
         "-L",
         "--log-level",
         dest="log_level",
-        help="Log level for thirdparty libraries, mxcube-server log level is always DEBUG ",
+        help="Log level for all loggers ",
         default="",
+    )
+
+    opt_parser.add_argument(
+        "-el",
+        "--enabled-loggers",
+        dest="enabled_logger_list",
+        help="Which loggers to use, default is to use all loggers ([exception_logger, hwr_logger, mx3_hwr_logger, user_logger, queue_logger])",
+        default=["exception_logger", "hwr_logger", "mx3_hwr_logger", "user_logger", "queue_logger"],
     )
 
     opt_parser.add_argument(
@@ -120,6 +128,7 @@ def main(test=False):
             cmdline_options.ra_timeout,
             cmdline_options.log_file,
             cmdline_options.log_level,
+            cmdline_options.enabled_logger_list,
             cfg,
         )
 


### PR DESCRIPTION
From the discussion of #968, made it possible to select logger from command line and fixed broken log level option. The log level controls the level of the root logger, hence all loggers will get the same level (if not explicitly set elsewhere, like in dependencies)

This can of-course be made more fine grained if thats desired