### PR TITLE
Fix name of Conda environment to match docs

### DIFF
--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -1,4 +1,4 @@
-name: mxcubeweb
+name: mxcube
 channels:
   - conda-forge
 dependencies:


### PR DESCRIPTION
On the wiki, the environment is named `mxcube`. I could have gone the other way and renamed it to `mxcubeweb` on the wiki, but the more generic name `mxcube` makes more sense to me, so I decided to change the YAML file.