### PR TITLE
Style fixes to In/Out components and queue task item

### DIFF
--- a/ui/src/components/DeviceState/style.css
+++ b/ui/src/components/DeviceState/style.css
@@ -1,13 +1,8 @@
-.inout-switch-msg{ 
-  text-align: center;
-  float:left
+.device-state {
+  width: 7em;
 }
 
-.inout-label{ 
-  float:left;
-  font-weight: bold;
-  margin-right: 1em
+.device-state .badge {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
-
-
-

--- a/ui/src/components/Equipment/GenericEquipmentControl.jsx
+++ b/ui/src/components/Equipment/GenericEquipmentControl.jsx
@@ -107,7 +107,12 @@ export default class GenericEquipmentControl extends React.Component {
       <EquipmentState
         state={this.props.equipment.state}
         equipmentName={this.props.equipment.name}
-        style={{ margin: '0px 0px 0px 0px', width: 'inherit' }}
+        style={{
+          margin: '0px 0px 0px 0px',
+          width: 'inherit',
+          borderBottomLeftRadius: '0%',
+          borderBottomRightRadius: '0%',
+        }}
       />
     )
   }
@@ -119,7 +124,6 @@ export default class GenericEquipmentControl extends React.Component {
       <Row className='mb-3'>
         <Col sm={12} className='generic-equipment-container'>
           <Collapsible
-            className=''
             trigger={<div> {this.getEquipmentState()} {this.getCollapsibleHeaderClose('generic-equipment-arrow-p')}</div>}
             triggerWhenOpen={<div> {this.getEquipmentState()} {this.getCollapsibleHeaderOpen('generic-equipment-arrow-p')}</div>}
           >

--- a/ui/src/components/InOutSwitch/InOutSwitch.jsx
+++ b/ui/src/components/InOutSwitch/InOutSwitch.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Badge, Button, OverlayTrigger, Popover } from 'react-bootstrap';
-
+import './style.css';
 
 export default class InOutSwitch extends React.Component {
   constructor(props) {
@@ -12,7 +12,7 @@ export default class InOutSwitch extends React.Component {
 
     this.showLabelOvelay = this.showLabelOvelay.bind(this);
     this.showValueOvelay = this.showValueOvelay.bind(this);
-    
+
     this.state = {
       showLabelOvelay: false,
       showValueOvelay: false,
@@ -41,10 +41,10 @@ export default class InOutSwitch extends React.Component {
       case 'Escape': {
         this.showValueOvelay(false)
         this.showLabelOvelay(false)
-      
-      break;
+
+        break;
       }
-    // No default
+      // No default
     }
   }
 
@@ -82,7 +82,7 @@ export default class InOutSwitch extends React.Component {
 
 
   renderLabel() {
-    const {showLabelOvelay} = this.state;
+    const { showLabelOvelay } = this.state;
     let optionsLabel = (
       <Badge
         bg="secondary"
@@ -93,22 +93,22 @@ export default class InOutSwitch extends React.Component {
 
     if (this.props.optionsOverlay) {
       optionsLabel = (
-         <OverlayTrigger
+        <OverlayTrigger
           show={showLabelOvelay}
           rootClose
           trigger="click"
           placement="bottom"
-          overlay={ this.props.optionsOverlay }
-         >
-           <div onClick={() => this.showLabelOvelay(!showLabelOvelay)} onContextMenu={this.onOptionsRightClick}>
-             <Badge
+          overlay={this.props.optionsOverlay}
+        >
+          <div onClick={() => this.showLabelOvelay(!showLabelOvelay)} onContextMenu={this.onOptionsRightClick}>
+            <Badge
               bg="secondary"
               style={{ display: 'block', marginBottom: '3px' }}
-             >
-               { this.props.labelText }
-                 <i className="fas fa-cog ms-2" />
-             </Badge>
-           </div>
+            >
+              {this.props.labelText}
+              <i className="fas fa-cog ms-2" />
+            </Badge>
+          </div>
         </OverlayTrigger>);
     }
 
@@ -116,7 +116,7 @@ export default class InOutSwitch extends React.Component {
   }
 
   render() {
-    const {showValueOvelay} = this.state;
+    const { showValueOvelay } = this.state;
     let msgBgStyle = 'warning';
     if (this.props.data.value === this.props.onText) {
       msgBgStyle = 'success';
@@ -132,18 +132,20 @@ export default class InOutSwitch extends React.Component {
       btn = <Button variant='outline-secondary' size="sm" onClick={this.setOn}>Set: {this.props.onText}</Button>;
     }
 
-    const msgLabelStyle = { display: 'block', fontSize: '100%',
-      borderRadius: '0px', color: '#000' };
+    const msgLabelStyle = {
+      display: 'block', fontSize: '100%',
+      borderRadius: '0px', color: '#000'
+    };
 
     return (
-      <div>
-       {this.renderLabel()}
+      <div className='inout-switch'>
+        {this.renderLabel()}
         <OverlayTrigger
           show={showValueOvelay}
           rootClose
           trigger="click"
           placement="bottom"
-          overlay={(<Popover style={{ padding: '0.5em'}} id={`${this.props.labelText} popover`}>{btn}</Popover>)}
+          overlay={(<Popover style={{ padding: '0.5em' }} id={`${this.props.labelText} popover`}>{btn}</Popover>)}
         >
           <div onClick={() => this.showValueOvelay(!showValueOvelay)} onContextMenu={this.onLinkRightClick}>
             <Badge bg={msgBgStyle} style={msgLabelStyle}>{this.props.data.msg}</Badge>

--- a/ui/src/components/InOutSwitch/style.css
+++ b/ui/src/components/InOutSwitch/style.css
@@ -1,13 +1,8 @@
-.inout-switch-msg{ 
-  text-align: center;
-  float:left
+.inout-switch {
+  width: 7em;
 }
 
-.inout-label{ 
-  float:left;
-  font-weight: bold;
-  margin-right: 1em
+.inout-switch .badge {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
-
-
-

--- a/ui/src/components/LabeledValue/LabeledValue.jsx
+++ b/ui/src/components/LabeledValue/LabeledValue.jsx
@@ -6,11 +6,15 @@ import './style.css';
 
 export default class LabeledValue extends React.Component {
   render() {
-    let labelStyle = { backgroundColor: 'transparent', display: 'block',
-      marginBottom: '3px', color: '#000' };
-    let valueStyle = { backgroundColor: 'transparent', display: 'block-inline',
+    let labelStyle = {
+      backgroundColor: 'transparent', display: 'block',
+      marginBottom: '3px', color: '#000'
+    };
+    let valueStyle = {
+      backgroundColor: 'transparent', display: 'block-inline',
       fontSize: '100%', borderRadius: '0px', color: '#000',
-      padding: '0px' };
+      padding: '0px'
+    };
 
     if (this.props.look === 'vertical') {
       labelStyle = { display: 'block', marginBottom: '3px' };
@@ -24,19 +28,19 @@ export default class LabeledValue extends React.Component {
     }
 
     return (
-      <div>
+      <div className='labled-value'>
         <span>
           <div className='d-flex'>
             <Form.Label
-              style={ labelStyle }
+              style={labelStyle}
             >
               {this.props.name}
-              <span style={{ marginRight: '0.5em'}}/>
+              <span style={{ marginRight: '0.5em' }} />
             </Form.Label>
-            
+
             <Form.Label
               variant={this.props.level}
-              style={ valueStyle }
+              style={valueStyle}
             >
               {value} {this.props.suffix}
             </Form.Label>

--- a/ui/src/components/MXNavbar/MXNavbar.jsx
+++ b/ui/src/components/MXNavbar/MXNavbar.jsx
@@ -37,7 +37,7 @@ class MXNavbar extends React.Component {
           </LinkContainer>
           <Navbar.Toggle aria-controls="responsive-navbar-nav" />
           <Navbar.Collapse id="responsive-navbar-nav">
-            <Nav className="me-auto" style={{ marginLeft: '20em' }}>
+            <Nav className="m-auto">
               <LinkContainer className="me-4" to="/samplegrid"><Nav.Item className="nav-link">
                 Samples</Nav.Item>
               </LinkContainer>

--- a/ui/src/components/MachInfo/MachInfo.jsx
+++ b/ui/src/components/MachInfo/MachInfo.jsx
@@ -24,8 +24,10 @@ export default class MachInfo extends React.Component {
       variant = 'info';
     }
 
-    const msgLabelStyle = { display: 'block', fontSize: '100%',
-    borderRadius: '0px', color: '#000' };
+    const msgLabelStyle = {
+      display: 'block', fontSize: '100%',
+      borderRadius: '0px', color: '#000'
+    };
 
     for (propname in this.props.info) {
       if (this.props.info.hasOwnProperty(propname)) {
@@ -39,19 +41,19 @@ export default class MachInfo extends React.Component {
     popContent = <span>{popContent}</span>;
 
     const machinfoPop = (
-       <Popover id="popover-machinfo">
-         <Popover.Header>
+      <Popover id="popover-machinfo">
+        <Popover.Header>
           {tooltipTitle}
-         </Popover.Header>
-         <Popover.Body style={{ width: '400px' }}>
+        </Popover.Header>
+        <Popover.Body style={{ width: '400px' }}>
           {popContent}
-         </Popover.Body>
-       </Popover>
+        </Popover.Body>
+      </Popover>
     );
 
     return (
       <OverlayTrigger placement="bottom" overlay={machinfoPop}>
-        <div>
+        <div className='machine-info'>
           <Badge bg='secondary' style={{ display: 'block', marginBottom: '3px' }}>
             Ring Current
           </Badge>

--- a/ui/src/components/MachInfo/style.css
+++ b/ui/src/components/MachInfo/style.css
@@ -20,3 +20,7 @@
   font-style: italic;
   color: black;
 }
+
+.machine-info {
+  width: 7em;
+}

--- a/ui/src/components/SampleChangerSwitch/SampleChangerSwitch.jsx
+++ b/ui/src/components/SampleChangerSwitch/SampleChangerSwitch.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Badge, Button, OverlayTrigger, Popover } from 'react-bootstrap';
-
+import "./style.css"
 
 export default class SampleChangerSwitch extends React.Component {
   constructor(props) {
@@ -45,7 +45,7 @@ export default class SampleChangerSwitch extends React.Component {
 
 
   render() {
-    const {showOvelay} = this.state;
+    const { showOvelay } = this.state;
     let msgBgStyle = 'warning';
 
     if (this.props.data === 'READY') {
@@ -61,11 +61,13 @@ export default class SampleChangerSwitch extends React.Component {
       btn = <Button variant='outline-secondary' size="sm" onClick={this.powerOff}>{this.props.onText}</Button>;
     }
 
-    const msgLabelStyle = { display: 'block', fontSize: '100%',
-      borderRadius: '0px', color: '#000' };
+    const msgLabelStyle = {
+      display: 'block', fontSize: '100%',
+      borderRadius: '0px', color: '#000'
+    };
 
     return (
-      <div>
+      <div className='samplechanger-switch'>
         <OverlayTrigger
           // ref={(ref) => { this.overlay = ref; }}
           show={showOvelay}

--- a/ui/src/components/SampleChangerSwitch/style.css
+++ b/ui/src/components/SampleChangerSwitch/style.css
@@ -1,13 +1,8 @@
-.inout-switch-msg{ 
-  text-align: center;
-  float:left
+.samplechanger-switch {
+  width: 7em;
 }
 
-.inout-label{ 
-  float:left;
-  font-weight: bold;
-  margin-right: 1em
+.samplechanger-switch .badge {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
-
-
-

--- a/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
+++ b/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
@@ -1,10 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { ProgressBar, Button, Collapse, Table, OverlayTrigger, Popover } from 'react-bootstrap';
-import { TASK_UNCOLLECTED,
+import { ProgressBar, Button, Collapse, Table, OverlayTrigger, Tooltip } from 'react-bootstrap';
+import {
+  TASK_UNCOLLECTED,
   TASK_COLLECTED,
   TASK_COLLECT_FAILED,
-  TASK_RUNNING } from '../../constants';
+  TASK_RUNNING
+} from '../../constants';
 
 export default class TaskItem extends Component {
   static propTypes = {
@@ -41,13 +43,15 @@ export default class TaskItem extends Component {
     }
 
     return (
-      <div style={ { borderLeft: '1px solid #DDD',
+      <div style={{
+        borderLeft: '1px solid #DDD',
         borderRight: '1px solid #DDD',
         borderBottom: '1px solid #DDD',
-        padding: '0.5em' } }
+        padding: '0.5em'
+      }}
       >
         <a href="#" onClick={() =>
-          this.props.showDialog(true, 'LIMS_RESULT_DIALOG', 'Lims Results', this.props.data) }
+          this.props.showDialog(true, 'LIMS_RESULT_DIALOG', 'Lims Results', this.props.data)}
         >
           View Results
         </a>
@@ -59,20 +63,20 @@ export default class TaskItem extends Component {
   getDiffPlan(data) {
     let diffPlan = [];
     if (data.hasOwnProperty('diffractionPlan') && Object.keys(data.diffractionPlan).length > 0) {
-        // it can be empty
-        diffPlan = (
-            <span className="pull-right">
-              <Button
-                size="sm"
-                style={{ width: 'auto', marginTop: '-4px' }}
-                onClick={this.showDiffPlan}
-              >
-                <i className="fas fa-plus" />
-                Add Diffraction Plan
-              </Button>
-          </span>
-        );
-      }
+      // it can be empty
+      diffPlan = (
+        <span className="pull-right">
+          <Button
+            size="sm"
+            style={{ width: 'auto', marginTop: '-4px' }}
+            onClick={this.showDiffPlan}
+          >
+            <i className="fas fa-plus" />
+            Add Diffraction Plan
+          </Button>
+        </span>
+      );
+    }
     return diffPlan;
   }
 
@@ -153,32 +157,29 @@ export default class TaskItem extends Component {
   }
 
   wedgePath(wedge) {
-    const {parameters} = wedge;
+    const { parameters } = wedge;
     const value = parameters.fileName;
     const path = parameters.path ? parameters.path : '';
+    const pathEndPart = path.slice(-40);
 
     return (
       <OverlayTrigger
-        trigger="click"
-        placement="top"
+        placement="bottom"
         rootClose
-        overlay={(<Popover id="wedge-popover" style={{ maxWidth: '600px', width: 'auto' }}>
-                    <input
-                      type="text"
-                      onFocus={(e) => {e.target.select();}}
-                      value={path}
-                      size={path.length + 10}
-                    />
-                  </Popover>)}
+        overlay={(
+          <Tooltip id="wedge-popover">
+            {path}{value}
+          </Tooltip>)
+        }
       >
-        <a>
-          { value }
+        <a style={{ flexGrow: 1 }} >
+          .../{pathEndPart.slice(pathEndPart.indexOf("/") + 1)}{value}
         </a>
-      </OverlayTrigger>);
+      </OverlayTrigger >);
   }
 
   wedgeParameters(wedge) {
-    const {parameters} = wedge;
+    const { parameters } = wedge;
 
     return (
       <tr>
@@ -189,32 +190,32 @@ export default class TaskItem extends Component {
         <td><a>{parameters.transmission.toFixed(2)}</a></td>
         <td><a>{parameters.resolution.toFixed(3)}</a></td>
         <td><a>{parameters.energy.toFixed(4)}</a></td>
-        <td><a>{parameters.kappa_phi.toFixed(2)}</a></td>
-        <td><a>{parameters.kappa.toFixed(2)}</a></td>
+        {parameters.kappa_phi !== null ? (<td><a>{parameters.kappa_phi.toFixed(2)}</a></td>) : null}
+        {parameters.kappa !== null ? (<td><a>{parameters.kappa.toFixed(2)}</a></td>) : null}
       </tr>);
   }
 
   progressBar() {
-    const {state} = this.props;
+    const { state } = this.props;
     let pbarBsStyle = 'info';
 
     switch (state) {
-    case TASK_RUNNING: {
-      pbarBsStyle = 'info';
-    
-    break;
-    }
-    case TASK_COLLECTED: {
-      pbarBsStyle = 'success';
-    
-    break;
-    }
-    case TASK_COLLECT_FAILED: {
-      pbarBsStyle = 'danger';
-    
-    break;
-    }
-    // No default
+      case TASK_RUNNING: {
+        pbarBsStyle = 'info';
+
+        break;
+      }
+      case TASK_COLLECTED: {
+        pbarBsStyle = 'success';
+
+        break;
+      }
+      case TASK_COLLECT_FAILED: {
+        pbarBsStyle = 'danger';
+
+        break;
+      }
+      // No default
     }
 
     return (
@@ -225,8 +226,8 @@ export default class TaskItem extends Component {
           style={{ marginBottom: '0px', height: '18px' }}
           min={0}
           max={1}
-          active={ this.props.progress < 1 }
-          label={ `${(this.props.progress * 100).toPrecision(3)} %` }
+          active={this.props.progress < 1}
+          label={`${(this.props.progress * 100).toPrecision(3)} %`}
           now={this.props.progress}
         />
       </span>);
@@ -287,61 +288,77 @@ export default class TaskItem extends Component {
                 </span>
               </b>
               {state === TASK_UNCOLLECTED ?
-                <i className="fas fa-remove" onClick={this.deleteTask} style={delTaskCSS} /> : null
+                <i className="fas fa-times" onClick={this.deleteTask} style={delTaskCSS} /> : null
               }
             </div>
-            <Collapse in={Boolean(show)}>
-              <div className="task-body">
-                {wedges.map((wedge, i) => {
-                  const padding = i > 0 ? '1em' : '0em';
-                  return (
-                    <div key={`wedge-${i}`}>
+          </div>
+          <Collapse in={Boolean(show)}>
+            <div className="task-body">
+              {wedges.map((wedge, i) => {
+                const padding = i > 0 ? '1em' : '0em';
+                return (
+                  <div key={`wedge-${i}`}>
+                    <div style={{
+                      borderLeft: '1px solid #DDD',
+                      borderRight: '1px solid #DDD',
+                      paddingTop: padding
+                    }}
+                    >
                       <div style={{
-                        borderLeft: '1px solid #DDD',
-                        borderRight: '1px solid #DDD',
-                        paddingTop: padding
+                        borderTop: '1px solid #DDD',
+                        padding: '0.5em',
+                        display: 'flex',
+                        justifyContent: 'space-around',
+                        alignItems: 'center'
                       }}
                       >
-                        <div style={{
-                          borderTop: '1px solid #DDD',
-                          padding: '0.5em'
-                        }}
+                        <b>Path:</b>
+                        {this.wedgePath(wedge)}
+                        <Button
+                          variant='outline-secondary'
+                          style={{ width: '3em' }}
+                          title='Copy path'
+                          onClick={() => {
+                            navigator.clipboard.writeText(
+                              `${wedge.parameters.path}`
+                            );
+                          }}
                         >
-                          <b>Path:</b> {this.wedgePath(wedge)}
-                        </div>
+                          <i style={{ marginLeft: '0px' }} class="fa fa-clipboard" aria-hidden="true" />
+                        </Button>
                       </div>
-                      <Table
-                        striped
-                        bordered
-                        hover
-                        onClick={this.showForm}
-                        style={{ fontSize: 'smaller', marginBottom: '0px' }}
-                        className="task-parameters-table"
-                      >
-                        <thead>
-                          <tr>
-                            <th>Start &deg; </th>
-                            <th>Osc. &deg; </th>
-                            <th>t (ms)</th>
-                            <th># Img</th>
-                            <th>T (%)</th>
-                            <th>Res. (&Aring;)</th>
-                            <th>E (KeV)</th>
-                            <th>&phi; &deg;</th>
-                            <th>&kappa; &deg;</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          {this.wedgeParameters(wedge)}
-                        </tbody>
-                      </Table>
-                      {this.getResult(state, data)}
-                    </div>);
-                })}
+                    </div>
+                    <Table
+                      striped
+                      bordered
+                      hover
+                      onClick={this.showForm}
+                      style={{ fontSize: 'smaller', marginBottom: '0px' }}
+                      className="task-parameters-table"
+                    >
+                      <thead>
+                        <tr>
+                          <th>Start &deg; </th>
+                          <th>Osc. &deg; </th>
+                          <th>t (ms)</th>
+                          <th># Img</th>
+                          <th>T (%)</th>
+                          <th>Res. (&Aring;)</th>
+                          <th>E (KeV)</th>
+                          {wedge.parameters.kappa_phi !== null ? (<th>&phi; &deg;</th>) : null}
+                          {wedge.parameters.kappa !== null ? (<th>&kappa; &deg;</th>) : null}
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {this.wedgeParameters(wedge)}
+                      </tbody>
+                    </Table>
+                    {this.getResult(state, data)}
+                  </div>);
+              })}
 
-              </div>
-            </Collapse>
-          </div>
+            </div>
+          </Collapse>
         </div>
       </div>);
   }

--- a/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
+++ b/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
@@ -1,10 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { ProgressBar, Button, Collapse, OverlayTrigger, Popover } from 'react-bootstrap';
-import { TASK_UNCOLLECTED,
+import {
+  TASK_UNCOLLECTED,
   TASK_COLLECTED,
   TASK_COLLECT_FAILED,
-  TASK_RUNNING } from '../../constants';
+  TASK_RUNNING
+} from '../../constants';
 
 export default class EnergyScanTaskItem extends Component {
   static propTypes = {
@@ -35,10 +37,12 @@ export default class EnergyScanTaskItem extends Component {
     const link = this.props.data.limsResultData ? this.props.data.limsResultData.limsTaskLink : '';
 
     return (
-      <div style={ { borderLeft: '1px solid #DDD',
+      <div style={{
+        borderLeft: '1px solid #DDD',
         borderRight: '1px solid #DDD',
         borderBottom: '1px solid #DDD',
-        padding: '0.5em' } }
+        padding: '0.5em'
+      }}
       >
         <a href={link} target="_blank" rel="noreferrer"> View Results in ISPyB</a>
       </div>
@@ -103,16 +107,16 @@ export default class EnergyScanTaskItem extends Component {
         placement="top"
         rootClose
         overlay={(<Popover id="wedge-popover" style={{ maxWidth: '2000px', width: 'auto' }}>
-                    <input
-                      type="text"
-                      onFocus={(e) => {e.target.select();}}
-                      value={path}
-                      size={path.length + 10}
-                    />
-                  </Popover>)}
+          <input
+            type="text"
+            onFocus={(e) => { e.target.select(); }}
+            value={path}
+            size={path.length + 10}
+          />
+        </Popover>)}
       >
         <a onClick={(e) => (e.stopPropagation())}>
-          { value }
+          {value}
         </a>
       </OverlayTrigger>);
   }
@@ -122,7 +126,7 @@ export default class EnergyScanTaskItem extends Component {
       data,
       show } = this.props;
 
-    const {parameters} = data;
+    const { parameters } = data;
 
 
     const delTaskCSS = {
@@ -140,22 +144,22 @@ export default class EnergyScanTaskItem extends Component {
     let pbarBsStyle = 'info';
 
     switch (state) {
-    case TASK_RUNNING: {
-      pbarBsStyle = 'info';
-    
-    break;
-    }
-    case TASK_COLLECTED: {
-      pbarBsStyle = 'success';
-    
-    break;
-    }
-    case TASK_COLLECT_FAILED: {
-      pbarBsStyle = 'danger';
-    
-    break;
-    }
-    // No default
+      case TASK_RUNNING: {
+        pbarBsStyle = 'info';
+
+        break;
+      }
+      case TASK_COLLECTED: {
+        pbarBsStyle = 'success';
+
+        break;
+      }
+      case TASK_COLLECT_FAILED: {
+        pbarBsStyle = 'danger';
+
+        break;
+      }
+      // No default
     }
 
     return (
@@ -187,29 +191,29 @@ export default class EnergyScanTaskItem extends Component {
                 </span>
               </b>
               {state === TASK_UNCOLLECTED ?
-                <i className="fas fa-remove" onClick={this.deleteTask} style={delTaskCSS} /> : null
+                <i className="fas fa-times" onClick={this.deleteTask} style={delTaskCSS} /> : null
               }
             </div>
-            <Collapse in={Boolean(show)}>
-              <div className="task-body">
-                <div>
-                  <div style={{ border: '1px solid #DDD' }}>
-                    <div
-                      style={{ padding: '0.5em' }}
-                      onClick={this.showForm}
-                    >
-                      <b>Path:</b> {this.path(parameters)}
-                      <br />
-                      <b>Element:</b> {parameters.element}
-                      <br />
-                      <b>Edge:</b> {parameters.edge}
-                    </div>
-                  </div>
-                  {this.getResult(state)}
-                </div>
-              </div>
-            </Collapse>
           </div>
+          <Collapse in={Boolean(show)}>
+            <div className="task-body">
+              <div>
+                <div style={{ border: '1px solid #DDD' }}>
+                  <div
+                    style={{ padding: '0.5em' }}
+                    onClick={this.showForm}
+                  >
+                    <b>Path:</b> {this.path(parameters)}
+                    <br />
+                    <b>Element:</b> {parameters.element}
+                    <br />
+                    <b>Edge:</b> {parameters.edge}
+                  </div>
+                </div>
+                {this.getResult(state)}
+              </div>
+            </div>
+          </Collapse>
         </div>
       </div>);
   }

--- a/ui/src/components/SampleQueue/TaskItem.jsx
+++ b/ui/src/components/SampleQueue/TaskItem.jsx
@@ -1,10 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { ProgressBar, Button, Collapse, Table, OverlayTrigger, Popover } from 'react-bootstrap';
-import { TASK_UNCOLLECTED,
+import { ProgressBar, Button, Collapse, Table, OverlayTrigger, Popover, Tooltip } from 'react-bootstrap';
+import {
+  TASK_UNCOLLECTED,
   TASK_COLLECTED,
   TASK_COLLECT_FAILED,
-  TASK_RUNNING } from '../../constants';
+  TASK_RUNNING
+} from '../../constants';
 
 export default class TaskItem extends Component {
   static propTypes = {
@@ -34,13 +36,15 @@ export default class TaskItem extends Component {
       return (<div><span /></div>);
     }
     return (
-      <div style={ { borderLeft: '1px solid #DDD',
+      <div style={{
+        borderLeft: '1px solid #DDD',
         borderRight: '1px solid #DDD',
         borderBottom: '1px solid #DDD',
-        padding: '0.5em' } }
+        padding: '0.5em'
+      }}
       >
         <a href="#" onClick={() =>
-          this.props.showDialog(true, 'LIMS_RESULT_DIALOG', 'Lims Results', this.props.data) }
+          this.props.showDialog(true, 'LIMS_RESULT_DIALOG', 'Lims Results', this.props.data)}
         >
           View Results
         </a>
@@ -111,67 +115,64 @@ export default class TaskItem extends Component {
   }
 
   wedgePath(wedge) {
-    const {parameters} = wedge;
+    const { parameters } = wedge;
     const value = parameters.fileName;
     const path = parameters.path ? parameters.path : '';
+    const pathEndPart = path.slice(-40);
 
     return (
       <OverlayTrigger
-        trigger="click"
-        placement="top"
+        placement="bottom"
         rootClose
-        overlay={(<Popover id="wedge-popover" style={{ maxWidth: '600px', width: 'auto' }}>
-                    <input
-                      type="text"
-                      onFocus={(e) => {e.target.select();}}
-                      value={path}
-                      size={path.length + 10}
-                    />
-                  </Popover>)}
+        overlay={(
+          <Tooltip id="wedge-popover">
+            {path}{value}
+          </Tooltip>)
+        }
       >
-        <a>
-          { value }
+        <a style={{ flexGrow: 1 }} >
+          .../{pathEndPart.slice(pathEndPart.indexOf("/") + 1)}{value}
         </a>
-      </OverlayTrigger>);
+      </OverlayTrigger >);
   }
 
   wedgeParameters(wedge) {
-    const {parameters} = wedge;
+    const { parameters } = wedge;
     return (
       <tr>
-        <td><a>{parameters.osc_start.toFixed(2)}</a></td>
-        <td><a>{parameters.osc_range.toFixed(2)}</a></td>
+        {parameters.osc_start !== null ? (<td><a>{parameters.osc_start.toFixed(2)}</a></td>) : null}
+        {parameters.osc_range !== null ? (<td><a>{parameters.osc_range.toFixed(2)}</a></td>) : null}
         <td><a>{parameters.exp_time.toFixed(6)}</a></td>
         <td><a>{parameters.num_images}</a></td>
         <td><a>{parameters.transmission.toFixed(2)}</a></td>
         <td><a>{parameters.resolution.toFixed(3)}</a></td>
         <td><a>{parameters.energy.toFixed(4)}</a></td>
-        <td><a>{parameters.kappa_phi.toFixed(2)}</a></td>
-        <td><a>{parameters.kappa.toFixed(2)}</a></td>
+        {parameters.kappa_phi !== null ? (<td><a>{parameters.kappa_phi.toFixed(2)}</a></td>) : null}
+        {parameters.kappa !== null ? (<td><a>{parameters.kappa.toFixed(2)}</a></td>) : null}
       </tr>);
   }
 
   progressBar() {
-    const {state} = this.props;
+    const { state } = this.props;
     let pbarBsStyle = 'info';
 
     switch (state) {
-    case TASK_RUNNING: {
-      pbarBsStyle = 'info';
-    
-    break;
-    }
-    case TASK_COLLECTED: {
-      pbarBsStyle = 'success';
-    
-    break;
-    }
-    case TASK_COLLECT_FAILED: {
-      pbarBsStyle = 'danger';
-    
-    break;
-    }
-    // No default
+      case TASK_RUNNING: {
+        pbarBsStyle = 'info';
+
+        break;
+      }
+      case TASK_COLLECTED: {
+        pbarBsStyle = 'success';
+
+        break;
+      }
+      case TASK_COLLECT_FAILED: {
+        pbarBsStyle = 'danger';
+
+        break;
+      }
+      // No default
     }
 
     return (
@@ -182,8 +183,8 @@ export default class TaskItem extends Component {
           style={{ marginBottom: '0px', height: '18px' }}
           min={0}
           max={1}
-          active={ this.props.progress < 1 }
-          label={ `${(this.props.progress * 100).toPrecision(3)} %` }
+          active={this.props.progress < 1}
+          label={`${(this.props.progress * 100).toPrecision(3)} %`}
           now={this.props.progress}
         />
       </span>);
@@ -215,22 +216,22 @@ export default class TaskItem extends Component {
     let taskCSS = this.props.selected ? 'task-head task-head-selected' : 'task-head';
 
     switch (state) {
-    case TASK_RUNNING: {
-      taskCSS += ' running';
-    
-    break;
-    }
-    case TASK_COLLECTED: {
-      taskCSS += ' success';
-    
-    break;
-    }
-    case TASK_COLLECT_FAILED: {
-      taskCSS += ' error';
-    
-    break;
-    }
-    // No default
+      case TASK_RUNNING: {
+        taskCSS += ' running';
+
+        break;
+      }
+      case TASK_COLLECTED: {
+        taskCSS += ' success';
+
+        break;
+      }
+      case TASK_COLLECT_FAILED: {
+        taskCSS += ' error';
+
+        break;
+      }
+      // No default
     }
 
     return (
@@ -254,59 +255,75 @@ export default class TaskItem extends Component {
                 <i className="fas fa-times" onClick={this.deleteTask} style={delTaskCSS} /> : null
               }
             </div>
-            <Collapse in={Boolean(show)}>
-              <div className="task-body">
-                {wedges.map((wedge, i) => {
-                  const padding = i > 0 ? '1em' : '0em';
-                  return (
-                    <div key={`wedge-${i}`}>
+          </div>
+          <Collapse in={Boolean(show)}>
+            <div className="task-body">
+              {wedges.map((wedge, i) => {
+                const padding = i > 0 ? '1em' : '0em';
+                return (
+                  <div key={`wedge-${i}`}>
+                    <div style={{
+                      borderLeft: '1px solid #DDD',
+                      borderRight: '1px solid #DDD',
+                      paddingTop: padding
+                    }}
+                    >
                       <div style={{
-                        borderLeft: '1px solid #DDD',
-                        borderRight: '1px solid #DDD',
-                        paddingTop: padding
+                        borderTop: '1px solid #DDD',
+                        padding: '0.5em',
+                        display: 'flex',
+                        justifyContent: 'space-around',
+                        alignItems: 'center'
                       }}
                       >
-                        <div style={{
-                          borderTop: '1px solid #DDD',
-                          padding: '0.5em'
-                        }}
+                        <b>Path:</b>
+                        {this.wedgePath(wedge)}
+                        <Button
+                          variant='outline-secondary'
+                          style={{ width: '3em' }}
+                          title='Copy path'
+                          onClick={() => {
+                            navigator.clipboard.writeText(
+                              `${wedge.parameters.path}`
+                            );
+                          }}
                         >
-                          <b>Path:</b> {this.wedgePath(wedge)}
-                        </div>
+                          <i style={{ marginLeft: '0px' }} class="fa fa-clipboard" aria-hidden="true" />
+                        </Button>
                       </div>
-                      <Table
-                        striped
-                        bordered
-                        hover
-                        onClick={this.showForm}
-                        style={{ fontSize: 'smaller', marginBottom: '0px' }}
-                        className="task-parameters-table"
-                      >
-                        <thead>
-                          <tr>
-                            <th>Start &deg; </th>
-                            <th>Osc. &deg; </th>
-                            <th>t (s)</th>
-                            <th># Img</th>
-                            <th>T (%)</th>
-                            <th>Res. (&Aring;)</th>
-                            <th>E (KeV)</th>
-                            <th>&phi; &deg;</th>
-                            <th>&kappa; &deg;</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          {this.wedgeParameters(wedge)}
-                        </tbody>
-                      </Table>
-                      {this.getResult(state)}
-                    </div>);
-                })}
+                    </div>
+                    <Table
+                      striped
+                      bordered
+                      hover
+                      onClick={this.showForm}
+                      style={{ fontSize: 'smaller', marginBottom: '0px' }}
+                      className="task-parameters-table"
+                    >
+                      <thead>
+                        <tr>
+                          {wedge.parameters.osc_start !== null ? (<th>Start &deg; </th>) : null}
+                          {wedge.parameters.osc_range !== null ? (<th>Osc. &deg; </th>) : null}
+                          <th>t (s)</th>
+                          <th># Img</th>
+                          <th>T (%)</th>
+                          <th>Res. (&Aring;)</th>
+                          <th>E (KeV)</th>
+                          {wedge.parameters.kappa_phi !== null ? (<th>&phi; &deg;</th>) : null}
+                          {wedge.parameters.kappa !== null ? (<th>&kappa; &deg;</th>) : null}
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {this.wedgeParameters(wedge)}
+                      </tbody>
+                    </Table>
+                    {this.getResult(state)}
+                  </div>);
+              })}
 
-              </div>
-            </Collapse>
-          </div>
-        </div>
-      </div>);
+            </div>
+          </Collapse>
+        </div >
+      </div >);
   }
 }

--- a/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
+++ b/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
@@ -1,10 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { ProgressBar, Button, Collapse, OverlayTrigger, Popover } from 'react-bootstrap';
-import { TASK_UNCOLLECTED,
+import { ProgressBar, Button, Collapse, OverlayTrigger, Tooltip } from 'react-bootstrap';
+import {
+  TASK_UNCOLLECTED,
   TASK_COLLECTED,
   TASK_COLLECT_FAILED,
-  TASK_RUNNING } from '../../constants';
+  TASK_RUNNING
+} from '../../constants';
 
 export default class WorkflowTaskItem extends Component {
   static propTypes = {
@@ -35,10 +37,12 @@ export default class WorkflowTaskItem extends Component {
     const link = this.props.data.limsResultData ? this.props.data.limsResultData.limsTaskLink : '';
 
     return (
-      <div style={ { borderLeft: '1px solid #DDD',
+      <div style={{
+        borderLeft: '1px solid #DDD',
         borderRight: '1px solid #DDD',
         borderBottom: '1px solid #DDD',
-        padding: '0.5em' } }
+        padding: '0.5em'
+      }}
       >
         <a href={link} target="_blank" rel="noreferrer"> View Results in ISPyB</a>
       </div>
@@ -95,49 +99,47 @@ export default class WorkflowTaskItem extends Component {
 
   path(parameters) {
     const path = parameters.path ? parameters.path : '';
-    const value = `...${path.slice(-30)}`;
+    const pathEndPart = path.slice(-40);
 
     return (
       <OverlayTrigger
-        trigger="click"
-        placement="top"
+        placement="bottom"
         rootClose
-        overlay={(<Popover id="wedge-popover" style={{ maxWidth: '2000px', width: 'auto' }}>
-                    <input
-                      type="text"
-                      onFocus={(e) => {e.target.select();}}
-                      value={path}
-                      size={path.length + 10}
-                    />
-                  </Popover>)}
+        overlay={(
+          <Tooltip id="wedge-popover">
+            {path}
+          </Tooltip>)
+        }
       >
-        <a onClick={(e) => (e.stopPropagation())}>
-          { value }
+        <a style={{ flexGrow: 1 }} >
+          .../{pathEndPart.slice(pathEndPart.indexOf("/") + 1)}
         </a>
-      </OverlayTrigger>);
+      </OverlayTrigger >
+    );
   }
 
+
   progressBar() {
-    const {state} = this.props;
+    const { state } = this.props;
     let pbarBsStyle = 'info';
 
     switch (state) {
-    case TASK_RUNNING: {
-      pbarBsStyle = 'info';
-    
-    break;
-    }
-    case TASK_COLLECTED: {
-      pbarBsStyle = 'success';
-    
-    break;
-    }
-    case TASK_COLLECT_FAILED: {
-      pbarBsStyle = 'danger';
-    
-    break;
-    }
-    // No default
+      case TASK_RUNNING: {
+        pbarBsStyle = 'info';
+
+        break;
+      }
+      case TASK_COLLECTED: {
+        pbarBsStyle = 'success';
+
+        break;
+      }
+      case TASK_COLLECT_FAILED: {
+        pbarBsStyle = 'danger';
+
+        break;
+      }
+      // No default
     }
 
     return (
@@ -148,8 +150,8 @@ export default class WorkflowTaskItem extends Component {
           style={{ marginBottom: '0px', height: '18px' }}
           min={0}
           max={1}
-          active={ this.props.progress < 1 }
-          label={ `${(this.props.progress * 100).toPrecision(3)} %` }
+          active={this.props.progress < 1}
+          label={`${(this.props.progress * 100).toPrecision(3)} %`}
           now={this.props.progress}
         />
       </span>);
@@ -160,7 +162,7 @@ export default class WorkflowTaskItem extends Component {
       data,
       show } = this.props;
 
-    const {parameters} = data;
+    const { parameters } = data;
 
 
     const delTaskCSS = {
@@ -176,22 +178,22 @@ export default class WorkflowTaskItem extends Component {
     let taskCSS = this.props.selected ? 'task-head task-head-selected' : 'task-head';
 
     switch (state) {
-    case TASK_RUNNING: {
-      taskCSS += ' running';
-    
-    break;
-    }
-    case TASK_COLLECTED: {
-      taskCSS += ' success';
-    
-    break;
-    }
-    case TASK_COLLECT_FAILED: {
-      taskCSS += ' error';
-    
-    break;
-    }
-    // No default
+      case TASK_RUNNING: {
+        taskCSS += ' running';
+
+        break;
+      }
+      case TASK_COLLECTED: {
+        taskCSS += ' success';
+
+        break;
+      }
+      case TASK_COLLECT_FAILED: {
+        taskCSS += ' error';
+
+        break;
+      }
+      // No default
     }
 
     return (
@@ -212,25 +214,43 @@ export default class WorkflowTaskItem extends Component {
                 </span>
               </b>
               {state === TASK_UNCOLLECTED ?
-                <i className="fas fa-remove" onClick={this.deleteTask} style={delTaskCSS} /> : null
+                <i className="fa fa-times" onClick={this.deleteTask} style={delTaskCSS} /> : null
               }
             </div>
-            <Collapse in={Boolean(show)}>
-              <div className="task-body">
-                <div>
-                  <div style={{ border: '1px solid #DDD' }}>
-                    <div
-                      style={{ padding: '0.5em' }}
-                      onClick={this.showForm}
+          </div>
+          <Collapse in={Boolean(show)}>
+            <div className="task-body">
+              <div>
+                <div style={{ border: '1px solid #DDD' }}>
+                  <div
+                    style={{
+                      borderTop: '1px solid #DDD',
+                      padding: '0.5em',
+                      display: 'flex',
+                      justifyContent: 'space-around',
+                      alignItems: 'center'
+                    }}
+                  >
+                    <b>Path:</b>
+                    {this.path(parameters)}
+                    <Button
+                      variant='outline-secondary'
+                      style={{ width: '3em' }}
+                      title='Copy path'
+                      onClick={() => {
+                        navigator.clipboard.writeText(
+                          `${parameters.path}`
+                        );
+                      }}
                     >
-                      <b>Workflow path:</b> {this.path(parameters)}
-                    </div>
+                      <i style={{ marginLeft: '0px' }} class="fa fa-clipboard" aria-hidden="true" />
+                    </Button>
                   </div>
                   {this.getResult(state)}
                 </div>
               </div>
-            </Collapse>
-          </div>
+            </div>
+          </Collapse>
         </div>
       </div>);
   }

--- a/ui/src/components/SampleQueue/XRFTaskItem.jsx
+++ b/ui/src/components/SampleQueue/XRFTaskItem.jsx
@@ -3,10 +3,12 @@ import PropTypes from 'prop-types';
 import { ProgressBar, Button, Collapse, OverlayTrigger, Popover, Modal } from 'react-bootstrap';
 import Plot1D from '../Plot1D';
 
-import { TASK_UNCOLLECTED,
+import {
+  TASK_UNCOLLECTED,
   TASK_COLLECTED,
   TASK_COLLECT_FAILED,
-  TASK_RUNNING } from '../../constants';
+  TASK_RUNNING
+} from '../../constants';
 
 export default class XRFTaskItem extends Component {
   static propTypes = {
@@ -43,10 +45,12 @@ export default class XRFTaskItem extends Component {
     const link = this.props.data.limsResultData ? this.props.data.limsResultData.limsTaskLink : '';
 
     return (
-      <div style={ { borderLeft: '1px solid #DDD',
+      <div style={{
+        borderLeft: '1px solid #DDD',
         borderRight: '1px solid #DDD',
         borderBottom: '1px solid #DDD',
-        padding: '0.5em' } }
+        padding: '0.5em'
+      }}
       >
         <a href={link} target="_blank" rel="noreferrer"> View Results in ISPyB</a>
       </div>
@@ -68,11 +72,11 @@ export default class XRFTaskItem extends Component {
 
     return (
       <div className="pull-right">
-      <a href="#"
-        onClick={this.showXRFPlot}
-      >
-      Plot available
-      </a>
+        <a href="#"
+          onClick={this.showXRFPlot}
+        >
+          Plot available
+        </a>
       </div>
     );
   }
@@ -80,20 +84,20 @@ export default class XRFTaskItem extends Component {
   showPlotModal() {
     return (
       <div>
-      <Modal show={this.state.showModal} onHide={this.close}>
-        <Modal.Header closeButton>
-          <Modal.Title>XRF Plot</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          <h4>Text in a modal</h4>
-        </Modal.Body>
-        <Plot1D displayedPlotCallback={this.newPlotDisplayed}
-          plotId="this.plotIdByAction[currentActionName" autoNext="True"
-        />
-        <Modal.Footer>
-          <Button onClick={this.close}>Close</Button>
-        </Modal.Footer>
-      </Modal>
+        <Modal show={this.state.showModal} onHide={this.close}>
+          <Modal.Header closeButton>
+            <Modal.Title>XRF Plot</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <h4>Text in a modal</h4>
+          </Modal.Body>
+          <Plot1D displayedPlotCallback={this.newPlotDisplayed}
+            plotId="this.plotIdByAction[currentActionName" autoNext="True"
+          />
+          <Modal.Footer>
+            <Button onClick={this.close}>Close</Button>
+          </Modal.Footer>
+        </Modal>
       </div>
     );
   }
@@ -168,16 +172,16 @@ export default class XRFTaskItem extends Component {
         placement="top"
         rootClose
         overlay={(<Popover id="wedge-popover" style={{ maxWidth: '2000px', width: 'auto' }}>
-                    <input
-                      type="text"
-                      onFocus={(e) => {e.target.select();}}
-                      value={path}
-                      size={path.length + 10}
-                    />
-                  </Popover>)}
+          <input
+            type="text"
+            onFocus={(e) => { e.target.select(); }}
+            value={path}
+            size={path.length + 10}
+          />
+        </Popover>)}
       >
         <a onClick={(e) => (e.stopPropagation())}>
-          { value }
+          {value}
         </a>
       </OverlayTrigger>);
   }
@@ -187,9 +191,9 @@ export default class XRFTaskItem extends Component {
       data,
       show } = this.props;
     const plotId = this.props.id;
-    const {parameters} = data;
+    const { parameters } = data;
 
-    const {result} = this.props.data;
+    const { result } = this.props.data;
     const plotAlreadyStored = result !== null;
 
     const delTaskCSS = {
@@ -207,22 +211,22 @@ export default class XRFTaskItem extends Component {
     let pbarBsStyle = 'info';
 
     switch (state) {
-    case TASK_RUNNING: {
-      pbarBsStyle = 'info';
-    
-    break;
-    }
-    case TASK_COLLECTED: {
-      pbarBsStyle = 'success';
-    
-    break;
-    }
-    case TASK_COLLECT_FAILED: {
-      pbarBsStyle = 'danger';
-    
-    break;
-    }
-    // No default
+      case TASK_RUNNING: {
+        pbarBsStyle = 'info';
+
+        break;
+      }
+      case TASK_COLLECTED: {
+        pbarBsStyle = 'success';
+
+        break;
+      }
+      case TASK_COLLECT_FAILED: {
+        pbarBsStyle = 'danger';
+
+        break;
+      }
+      // No default
     }
 
     return (
@@ -257,35 +261,35 @@ export default class XRFTaskItem extends Component {
                 <i className="fas fa-remove" onClick={this.deleteTask} style={delTaskCSS} /> : null
               }
             </div>
-            <Collapse in={Boolean(show)}>
-              <div className="task-body">
-                <div>
-                  <div style={{ border: '1px solid #DDD' }}>
-                    <div
-                      style={{ padding: '0.5em' }}
-                      onClick={this.showForm}
-                    >
-                      <b>Path:</b> {this.path(parameters)}
-                      <br />
-                      <b>Count time:</b> {parameters.exp_time}
-                    </div>
-                  </div>
-                  {this.getResult(state)}
-                  <Modal show={this.state.showModal} onHide={this.close}>
-                    <Modal.Header closeButton>
-                      <Modal.Title>XRF Plot</Modal.Title>
-                    </Modal.Header>
-                    <Plot1D
-                      plotId={plotId} autoNext saved={plotAlreadyStored} data={result}
-                    />
-                    <Modal.Footer>
-                      <Button onClick={this.close}>Close</Button>
-                    </Modal.Footer>
-                  </Modal>
-                </div>
-              </div>
-            </Collapse>
           </div>
+          <Collapse in={Boolean(show)}>
+            <div className="task-body">
+              <div>
+                <div style={{ border: '1px solid #DDD' }}>
+                  <div
+                    style={{ padding: '0.5em' }}
+                    onClick={this.showForm}
+                  >
+                    <b>Path:</b> {this.path(parameters)}
+                    <br />
+                    <b>Count time:</b> {parameters.exp_time}
+                  </div>
+                </div>
+                {this.getResult(state)}
+                <Modal show={this.state.showModal} onHide={this.close}>
+                  <Modal.Header closeButton>
+                    <Modal.Title>XRF Plot</Modal.Title>
+                  </Modal.Header>
+                  <Plot1D
+                    plotId={plotId} autoNext saved={plotAlreadyStored} data={result}
+                  />
+                  <Modal.Footer>
+                    <Button onClick={this.close}>Close</Button>
+                  </Modal.Footer>
+                </Modal>
+              </div>
+            </div>
+          </Collapse>
         </div>
       </div>);
   }


### PR DESCRIPTION
- Width of in/out and status components are fixed with hidden overflow, (ellipses shown if label is to long)  

![image](https://github.com/mxcube/mxcubeweb/assets/4331447/014aa19e-31bd-41dc-9037-b82153e579c8)

- Replaced popover with tooltip and a copy to clipboard function

![image](https://github.com/mxcube/mxcubeweb/assets/4331447/4f0fba1f-e2a8-4002-8209-2567d0088418)
