### PR TITLE
Fix minor alignment issues in sample view

### DIFF
--- a/ui/src/components/LabeledValue/LabeledValue.jsx
+++ b/ui/src/components/LabeledValue/LabeledValue.jsx
@@ -8,12 +8,12 @@ export default class LabeledValue extends React.Component {
   render() {
     let labelStyle = {
       backgroundColor: 'transparent', display: 'block',
-      marginBottom: '3px', color: '#000'
+      marginBottom: 0, color: '#000'
     };
     let valueStyle = {
       backgroundColor: 'transparent', display: 'block-inline',
       fontSize: '100%', borderRadius: '0px', color: '#000',
-      padding: '0px'
+      padding: '0px', marginBottom: 0, whiteSpace: 'nowrap'
     };
 
     if (this.props.look === 'vertical') {
@@ -28,24 +28,18 @@ export default class LabeledValue extends React.Component {
     }
 
     return (
-      <div className='labled-value'>
-        <span>
-          <div className='d-flex'>
-            <Form.Label
-              style={labelStyle}
-            >
-              {this.props.name}
-              <span style={{ marginRight: '0.5em' }} />
-            </Form.Label>
+      <div className="labled-value d-flex">
+        {this.props.name && (<Form.Label style={labelStyle}>
+          {this.props.name}
+          <span style={{ marginRight: '0.5em' }} />
+        </Form.Label>)}
 
-            <Form.Label
-              variant={this.props.level}
-              style={valueStyle}
-            >
-              {value} {this.props.suffix}
-            </Form.Label>
-          </div>
-        </span>
+        <Form.Label
+          variant={this.props.level}
+          style={valueStyle}
+        >
+          {value} {this.props.suffix}
+        </Form.Label>
       </div>
     );
   }

--- a/ui/src/components/MXNavbar/MXNavbar.jsx
+++ b/ui/src/components/MXNavbar/MXNavbar.jsx
@@ -4,7 +4,6 @@ import { LinkContainer } from 'react-router-bootstrap';
 import withRouter from '../WithRouter';
 import './MXNavbar.css';
 
-
 class MXNavbar extends React.Component {
   constructor(props) {
     super(props);
@@ -28,7 +27,7 @@ class MXNavbar extends React.Component {
     document.title = `MxCuBE-Web Proposal: ${this.props.selectedProposal}`;
 
     return (
-      <Navbar className='pt-1 pb-1' bg="dark" variant="dark" fixed="top" collapseOnSelect expand="lg">
+      <Navbar className='pt-1 pb-1' bg="dark" variant="dark" collapseOnSelect expand="lg">
         <Container fluid>
           <LinkContainer to="/remoteaccess">
             <Navbar.Brand>
@@ -66,7 +65,7 @@ class MXNavbar extends React.Component {
                   Remote
                 </Nav.Item>
               </LinkContainer>
-              <Button as={Nav.Link} className="nav-link" variant="Light" onClick={this.signOut}>
+              <Button as={Nav.Link} className="nav-link pe-0" variant="Light" onClick={this.signOut}>
                 <span className="me-1 fas fa-lg fa-sign-out-alt" />
                 Sign out {`(${this.props.selectedProposal})`}
               </Button>

--- a/ui/src/components/Main.jsx
+++ b/ui/src/components/Main.jsx
@@ -111,7 +111,7 @@ class Main extends React.Component {
           onHide={() => this.props.showDialog(false)}
         />
         <MXNavbarContainer location={window.location} />
-        <Stack gap={2} style={{ paddingTop: '3em', zIndex: 9999 }}>
+        <Stack className="mb-4" gap={2}>
           <Outlet />
         </Stack>
         <Draggable>

--- a/ui/src/components/PopInput/style.css
+++ b/ui/src/components/PopInput/style.css
@@ -1,5 +1,5 @@
 
-.popinput-input-label{ 
+.popinput-input-label{
   display: inline-block;
   min-width: 90px;
   margin-right: 1rem;
@@ -8,6 +8,7 @@
 
 .popinput-input-value{
   display: inline-block;
+  white-space: nowrap;
 }
 
 .popinput-busy-buttonbar{
@@ -24,10 +25,9 @@
 
   .popinput-input{
     height: 36px;
-    margin-right: 1m;
     }
-    
-  .visibility-hidden{ 
+
+  .visibility-hidden{
     visibility: hidden;
     display: none;
     }
@@ -36,7 +36,7 @@
  .value-label-enter-success{
   transition: background-color 1000ms ease-out;
   }
-  
+
   .popinput-input-container {
    display: inline;
   }
@@ -47,22 +47,21 @@
     color: #999;
     margin-right: 5px;
     }
-    
+
     .popinput-input-link{
     cursor:pointer;
-    margin-left: 0.5em;
     text-decoration:none;
   }
-    
+
     .popinput-input-link:hover {
     visibility: visible;
     text-decoration:none;
     }
-    
+
     .popinput-input-link:hover > .popinput-input-editicon {
     visibility: visible;
     }
-    
+
     .editable-click {
     cursor: pointer;
     }

--- a/ui/src/components/SampleView/SampleControls.module.css
+++ b/ui/src/components/SampleView/SampleControls.module.css
@@ -25,6 +25,7 @@
   color: #33beff;
   font-weight: bold;
   transition-duration: 0.1s;
+  white-space: nowrap;
 }
 
 .controlDropDown,

--- a/ui/src/containers/BeamlineSetupContainer.jsx
+++ b/ui/src/containers/BeamlineSetupContainer.jsx
@@ -145,19 +145,17 @@ class BeamlineSetupContainer extends React.Component {
       const beamline_attribute = this.props.beamline.hardwareObjects[uiprop.attribute];
 
       components.push(
-        <td key={`bs-name-${uiprop.label}`} className='d-flex pt-1' style={{ border: '0px', paddingLeft: '0.5em' }}>
+        <td key={`bs-name-${uiprop.label}`} className="py-1 ps-3 pe-2 align-middle">
           <span className='me-1'>{uiprop.label}:</span>
         </td>);
       components.push(
         <td
           key={`bs-val-${uiprop.label}`}
-          className='pe-3'
+          className="pe-3 align-middle"
           style={{
             verticalAlign: 'baseline',
             fontWeight: 'bold',
-            border: '0px',
             borderRight: uiprop_list.length != uiprop_list.indexOf(uiprop) + 1 ? '1px solid #ddd' : '',
-            padding: '0em'
           }}>
           {beamline_attribute.readonly ?
             (<LabeledValue
@@ -194,21 +192,16 @@ class BeamlineSetupContainer extends React.Component {
       return null;
     }
 
+
     const uiprops = this.props.uiproperties.beamline_setup.components;
     const uiprop_list = filter(uiprops, (o) =>
-      o.value_type === 'MOTOR' || o.value_type === 'ACTUATOR'
+    o.value_type === 'MOTOR' || o.value_type === 'ACTUATOR'
     );
 
     return (
       <Navbar
-        style={{
-          background: '#FAFAFA',
-          borderBottom: '1px solid lightgray',
-          paddingBottom: '0em',
-        }}
-        className="beamline-status ps-3 pe-3"
+        className="beamline-status"
         id="bmstatus"
-        bg='light'
         expand="lg"
       >
         <Navbar.Toggle aria-controls="basic-navbar-nav" />
@@ -223,6 +216,7 @@ class BeamlineSetupContainer extends React.Component {
           <Nav className="me-auto my-2 my-lg-0">
             <Nav.Item className="d-flex justify-content-start" >
               <Table
+                borderless
                 responsive
                 style={{
                   margin: '0px', fontWeight: 'bold',

--- a/ui/src/containers/SampleViewContainer.js
+++ b/ui/src/containers/SampleViewContainer.js
@@ -23,7 +23,6 @@ import {
   sendDisplayImage,
   executeCommand,
 } from '../actions/beamline';
-import { TiAdjustContrast } from 'react-icons/ti';
 
 class DefaultErrorBoundary extends React.Component {
   constructor(props) {
@@ -130,18 +129,21 @@ class SampleViewContainer extends Component {
 
     return (
       <Container fluid>
-        <Row>
-          <Col sm={12} style={{ paddingLeft: '0px', paddingRight: '0px' }}>
+        <Row
+          style={{
+            background: '#fafafa',
+            borderBottom: '1px solid lightgray',
+            paddingBottom: '0em',
+          }}
+        >
+          <Col sm={12}>
             <DefaultErrorBoundary>
               <BeamlineSetupContainer />
             </DefaultErrorBoundary>
           </Col>
         </Row>
-        <Row style={{ marginTop: '0.7em', marginRight: '0px' }}>
-          <Col
-            sm={1}
-            style={{ paddingRight: '1px', paddingLeft: '0.7em' }}
-          >
+        <Row className="gx-3 mt-2 pt-1">
+          <Col sm={1}>
             <DefaultErrorBoundary>
               {process.env.REACT_APP_PHASECONTROL==='true' ? phaseControl : null}
               {apertureControl}


### PR DESCRIPTION
Screenshots below, but the changes are very subtle. Basically, I've made spacing on the left and right of the page and between various elements more consistent. I've also simplified a bit of Bootstrap code and custom CSS — for instance, the top bar had `position: fixed` even though it scrolled with the page and the main container had a lot of top padding to compensate.

#### Before

![image](https://github.com/mxcube/mxcubeweb/assets/2936402/4bdad847-184c-4acb-8cea-1c587c629b01)

#### After

![image](https://github.com/mxcube/mxcubeweb/assets/2936402/9ebff989-9173-4704-9750-022fb6958077)
