### PR TITLE
Removed redux local storage and cross tab sync

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -43,6 +43,7 @@
         "react-dom": "^17.0.2",
         "react-draggable": "^4.4.4",
         "react-icons": "^4.3.1",
+        "react-lazyload": "^3.2.0",
         "react-numeric-input": "^2.2.3",
         "react-plotly.js": "^2.4.0",
         "react-redux": "7.2.6",
@@ -55,13 +56,11 @@
         "redux": "4.1.2",
         "redux-form": "^8.3.8",
         "redux-logger": "^3.0.6",
-        "redux-persist": "^6.0.0",
-        "redux-state-sync": "^3.1.2",
         "redux-thunk": "^2.4.1",
         "sass": "^1.51.0",
         "shortid": "^2.2.6",
         "slick-carousel": "^1.8.1",
-        "socket.io-client": "^4.5.4",
+        "socket.io-client": "^4.6.1",
         "underscore": "^1.8.3",
         "web-vitals": "^2.1.4",
         "webpack": "^5.69.1",
@@ -6785,14 +6784,6 @@
         "node": ">= 8.0.0"
       }
     },
-    "node_modules/big-integer": {
-      "version": "1.6.51",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/big-rat": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/big-rat/-/big-rat-1.0.4.tgz",
@@ -7031,21 +7022,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/broadcast-channel": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
-      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "detect-node": "^2.1.0",
-        "js-sha3": "0.8.0",
-        "microseconds": "0.2.0",
-        "nano-time": "1.0.0",
-        "oblivious-set": "1.0.0",
-        "rimraf": "3.0.2",
-        "unload": "2.2.0"
       }
     },
     "node_modules/browser-process-hrtime": {
@@ -17294,11 +17270,6 @@
       "integrity": "sha512-umpJ0/k8X0MvD1ds0P9SfowREz2LenHsQaxSohMZ5OMNEU2r0tf8pdeEFTHMFxWVxKNyU9rTtK3CWzUCTKJUeQ==",
       "peer": true
     },
-    "node_modules/js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -18320,11 +18291,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/microseconds": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
-      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
-    },
     "node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -18639,14 +18605,6 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
       "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
       "optional": true
-    },
-    "node_modules/nano-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
-      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
-      "dependencies": {
-        "big-integer": "^1.6.16"
-      }
     },
     "node_modules/nanoid": {
       "version": "3.3.6",
@@ -19299,11 +19257,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/oblivious-set": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
-      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
     },
     "node_modules/obuf": {
       "version": "1.1.2",
@@ -21736,6 +21689,15 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/react-lazyload": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-lazyload/-/react-lazyload-3.2.0.tgz",
+      "integrity": "sha512-zJlrG8QyVZz4+xkYZH5v1w3YaP5wEFaYSUWC4CT9UXfK75IfRAIEdnyIUF+dXr3kX2MOtL1lUaZmaQZqrETwgw==",
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0",
+        "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
@@ -22587,22 +22549,6 @@
       "integrity": "sha512-JoCIok7bg/XpqA1JqCqXFypuqBbQzGQySrhFzewB7ThcnysTO30l4VCst86AuB9T9tuT03MAA56Jw2PNhRSNCg==",
       "dependencies": {
         "deep-diff": "^0.3.5"
-      }
-    },
-    "node_modules/redux-persist": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
-      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
-      "peerDependencies": {
-        "redux": ">4.0.0"
-      }
-    },
-    "node_modules/redux-state-sync": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/redux-state-sync/-/redux-state-sync-3.1.4.tgz",
-      "integrity": "sha512-nhJBzaXVXPXvUhQJ7m0LdoXBnrcw+cTYQ8bzW9DeJKdq6UNYynXwQWAlVUvsbT/hDV+vB6BC4DMLXkUVGpF2yQ==",
-      "dependencies": {
-        "broadcast-channel": "^3.1.0"
       }
     },
     "node_modules/redux-thunk": {
@@ -26155,15 +26101,6 @@
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/unload": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
-      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
-      "dependencies": {
-        "@babel/runtime": "^7.6.2",
-        "detect-node": "^2.0.4"
       }
     },
     "node_modules/unpipe": {
@@ -32416,11 +32353,6 @@
         "tryer": "^1.0.1"
       }
     },
-    "big-integer": {
-      "version": "1.6.51",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
-    },
     "big-rat": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/big-rat/-/big-rat-1.0.4.tgz",
@@ -32632,21 +32564,6 @@
         "expand-range": "^1.8.1",
         "preserve": "^0.2.0",
         "repeat-element": "^1.1.2"
-      }
-    },
-    "broadcast-channel": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
-      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "detect-node": "^2.1.0",
-        "js-sha3": "0.8.0",
-        "microseconds": "0.2.0",
-        "nano-time": "1.0.0",
-        "oblivious-set": "1.0.0",
-        "rimraf": "3.0.2",
-        "unload": "2.2.0"
       }
     },
     "browser-process-hrtime": {
@@ -40623,11 +40540,6 @@
       "integrity": "sha512-umpJ0/k8X0MvD1ds0P9SfowREz2LenHsQaxSohMZ5OMNEU2r0tf8pdeEFTHMFxWVxKNyU9rTtK3CWzUCTKJUeQ==",
       "peer": true
     },
-    "js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -41464,11 +41376,6 @@
         "regex-cache": "^0.4.2"
       }
     },
-    "microseconds": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
-      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
-    },
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -41713,14 +41620,6 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
       "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
       "optional": true
-    },
-    "nano-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
-      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
-      "requires": {
-        "big-integer": "^1.6.16"
-      }
     },
     "nanoid": {
       "version": "3.3.6",
@@ -42228,11 +42127,6 @@
         "define-properties": "^1.1.4",
         "es-abstract": "^1.20.4"
       }
-    },
-    "oblivious-set": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
-      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
     },
     "obuf": {
       "version": "1.1.2",
@@ -43882,6 +43776,12 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "react-lazyload": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-lazyload/-/react-lazyload-3.2.0.tgz",
+      "integrity": "sha512-zJlrG8QyVZz4+xkYZH5v1w3YaP5wEFaYSUWC4CT9UXfK75IfRAIEdnyIUF+dXr3kX2MOtL1lUaZmaQZqrETwgw==",
+      "requires": {}
+    },
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
@@ -44532,20 +44432,6 @@
       "integrity": "sha512-JoCIok7bg/XpqA1JqCqXFypuqBbQzGQySrhFzewB7ThcnysTO30l4VCst86AuB9T9tuT03MAA56Jw2PNhRSNCg==",
       "requires": {
         "deep-diff": "^0.3.5"
-      }
-    },
-    "redux-persist": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
-      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
-      "requires": {}
-    },
-    "redux-state-sync": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/redux-state-sync/-/redux-state-sync-3.1.4.tgz",
-      "integrity": "sha512-nhJBzaXVXPXvUhQJ7m0LdoXBnrcw+cTYQ8bzW9DeJKdq6UNYynXwQWAlVUvsbT/hDV+vB6BC4DMLXkUVGpF2yQ==",
-      "requires": {
-        "broadcast-channel": "^3.1.0"
       }
     },
     "redux-thunk": {
@@ -47332,15 +47218,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
-    },
-    "unload": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
-      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
-      "requires": {
-        "@babel/runtime": "^7.6.2",
-        "detect-node": "^2.0.4"
-      }
     },
     "unpipe": {
       "version": "1.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -51,8 +51,6 @@
     "redux": "4.1.2",
     "redux-form": "^8.3.8",
     "redux-logger": "^3.0.6",
-    "redux-persist": "^6.0.0",
-    "redux-state-sync": "^3.1.2",
     "redux-thunk": "^2.4.1",
     "sass": "^1.51.0",
     "shortid": "^2.2.6",

--- a/ui/src/components/App.js
+++ b/ui/src/components/App.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect, useSelector } from 'react-redux';
 import { BrowserRouter as Router, Routes, Route, useLocation, Outlet, Navigate } from 'react-router-dom';
 import { serverIO } from '../serverIO';
-import { store, statePersistor } from '../store';
+import { store } from '../store';
 import { getLoginInfo, startSession } from '../actions/login';
 import LoginContainer from '../containers/LoginContainer';
 import SampleViewContainer from '../containers/SampleViewContainer';
@@ -14,19 +14,17 @@ import HelpContainer from '../containers/HelpContainer';
 import Main from './Main';
 import LoadingScreen from '../components/LoadingScreen/LoadingScreen';
 
-function requireAuth() {
-  store.dispatch(getLoginInfo()).then(() => {
-    const {login} = store.getState();
+async function requireAuth() {
+  await  store.dispatch(getLoginInfo())
+  const {login} = store.getState();
 
-    if (login.loggedIn) {
-      store.dispatch(startSession(login.user.inControl));
-    }
+  if (login.loggedIn) {
+    await store.dispatch(startSession(login.user.inControl));
+  }
 
-    if (login.loggedIn && !serverIO.initialized) {
-      serverIO.listen(store);
-      serverIO.connectStateSocket(statePersistor);
-    }
-  });
+  if (login.loggedIn && !serverIO.initialized) {
+    serverIO.listen(store);
+  }
 }
 
 function PrivateOutlet() {

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -2,10 +2,9 @@ import 'bootstrap/dist/css/bootstrap.css';
 import './main.css';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { PersistGate } from 'redux-persist/integration/react';
 import { Provider } from 'react-redux';
 import App from './components/App';
-import { store, localStatePersistor } from './store';
+import { store } from './store';
 
 import '@fortawesome/fontawesome-free/css/all.min.css';
 import { library } from '@fortawesome/fontawesome-svg-core';
@@ -27,9 +26,7 @@ if (module.hot) {
 function Root() {
   return (
     <Provider store={store}>
-      <PersistGate loading={null} persistor={localStatePersistor}>
-        <App/>
-      </PersistGate>
+      <App/>
     </Provider>
   );
 };

--- a/ui/src/store.js
+++ b/ui/src/store.js
@@ -1,63 +1,14 @@
 import { createStore, applyMiddleware, compose } from 'redux';
-import { persistStore, persistReducer } from 'redux-persist';
 import { createLogger } from 'redux-logger';
 import thunk from 'redux-thunk';
-import { createStateSyncMiddleware, initMessageListener } from 'redux-state-sync';
-
-import storage from 'redux-persist/lib/storage' // default localStorage for web
-
-import { serverIO } from './serverIO';
 import rootReducer from './reducers';
 
-class ServerStorage {
-  constructor(serverIO) {
-    this.serverIO = serverIO;
-  }
-
-  setItem(key, value) {
-    if (store.getState().login.user.inControl) {
-      this.serverIO.uiStateSocket.emit('ui_state_set', [key, value]);
-    }
-  }
-
-  getItem(key, cb) {
-    this.serverIO.uiStateSocket.emit('ui_state_get', key, (value) => {
-      cb(false, value);
-    });
-  }
-
-  removeItem(key) {
-    this.serverIO.uiStateSocket.emit('ui_state_rm', key);
-  }
-
-  getAllKeys(cb) {
-    this.serverIO.uiStateSocket.emit('ui_state_getkeys', null, (value) => {
-      cb(false, value);
-    });
-  }
-}
-
 function initStore() {
-  const config = {
-    blacklist: ["persist/PERSIST", "persist/REHYDRATE"]
-  };
   // Logger MUST BE the last middleware
   const middleware = [
     thunk,
-    createStateSyncMiddleware(config),
     createLogger()
   ];
-
-  const persistConfig = {
-    key: 'root',
-    blacklist: ['remoteAccess', 'beamline', 'sampleChanger',
-      'form', 'general', 'logger', 'shapes', 'login',
-      'sampleView', 'taskResult', 'sampleChangerMaintenance', 'uiproperties'],
-    storage, // TODO: Find a way to pass the server storage there instead of local storage,
-    timeout: null,
-  }
-
-  const persistedReducer = persistReducer(persistConfig, rootReducer);
 
   const enhancers = [];
   if (process.env.NODE_ENV === 'development') {
@@ -69,17 +20,7 @@ function initStore() {
 
   const composedEnhancers = compose(applyMiddleware(...middleware), ...enhancers);
 
-  const store = createStore(persistedReducer, composedEnhancers);
-
-  initMessageListener(store);
-
-  return store;
-}
-
-function createServerStatePersistor(store, serverIO, cb) {
-  return persistStore(store);
+  return createStore(rootReducer, composedEnhancers);
 }
 
 export const store = initStore();
-export const localStatePersistor = persistStore(store);
-export const statePersistor = createServerStatePersistor(store, serverIO);


### PR DESCRIPTION
Perhaps a bit controversial but removing the usage of `redux-persist `and `redux-state-sync` ;)

In general we are only using these two libraries for two things;

-  Mirroring the interface for observers 
-  Mirroring open tabs
-  Saving the selected motor step size through the `SET_STEP_SIZE` action

Everything that we need to mirror is already on the server except for the dialogs and possibly context menus
which we can more effectively create a separate solution for. The latest(er) versions of both `redux-persist` and
`redux-state-sync ` have broken the mirroring feature. The step size can easily be managed on the server side.

In my opinion it reduces the complexity and bandwidth needs, let me know what you think ?


  

