### PR TITLE
Basic ErrorBoundary with logging

### DIFF
--- a/mxcube3/__init__.py
+++ b/mxcube3/__init__.py
@@ -5,6 +5,7 @@ import redis
 import sys
 import traceback
 
+
 from gevent import monkey
 monkey.patch_all(thread=False)
 
@@ -68,7 +69,14 @@ def parse_args():
         "--enabled-loggers",
         dest="enabled_logger_list",
         help="Which loggers to use, default is to use all loggers ([exception_logger, hwr_logger, mx3_hwr_logger, user_logger, queue_logger])",
-        default=["exception_logger", "hwr_logger", "mx3_hwr_logger", "user_logger", "queue_logger"],
+        default=[
+            "exception_logger",
+            "hwr_logger",
+            "mx3_hwr_logger",
+            "user_logger",
+            "queue_logger",
+            "mx3_ui_logger",
+        ],
     )
 
     opt_parser.add_argument(

--- a/mxcube3/routes/log.py
+++ b/mxcube3/routes/log.py
@@ -1,5 +1,7 @@
 import logging
-from flask import Blueprint, jsonify
+import json
+
+from flask import Blueprint, jsonify, request, make_response
 from mxcube3 import logging_handler
 
 
@@ -19,5 +21,20 @@ def init_route(app, server, url_prefix):
                 messages = handler.buffer
 
         return jsonify(messages)
+
+    @server.restrict
+    @bp.route("/log_frontend_traceback", methods=["POST"])
+    def log_front_end_traceback():
+        """
+        Logs a UI traceback to the UI logger
+        """
+        args = request.get_json()
+        logging.getLogger("MX3.UI").error("------ Start of UI trace back ------")
+        logging.getLogger("MX3.UI").error("Traceback: %s " % args["stack"])
+        logging.getLogger("MX3.UI").error(
+            "State: %s " % json.dumps(json.loads(args["state"]), indent=4)
+        )
+        logging.getLogger("MX3.UI").error("------ End of UI trace back ------")
+        return make_response("", 200)
 
     return bp

--- a/ui/src/actions/beamline.js
+++ b/ui/src/actions/beamline.js
@@ -140,3 +140,25 @@ export function sendDisplayImage(path) {
     });
   }
 }
+
+
+export function sendLogFrontEndTraceBack(errorInfo, state) {
+
+  const stateToLog = {...state};
+  delete stateToLog.logger;
+
+  return () => {
+    fetch(`mxcube/api/v0.1/log/log_frontend_traceback`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        Accept: 'application/json',
+        'Content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        'stack': errorInfo['componentStack'],
+        'state':  JSON.stringify(state) 
+      }),
+    });
+  }
+}

--- a/ui/src/containers/DefaultErrorBoundary.js
+++ b/ui/src/containers/DefaultErrorBoundary.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { store } from '../store';
+
+import {
+  sendLogFrontEndTraceBack
+} from '../actions/beamline';
+
+class DefaultErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null, errorInfo: null, store: null };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    this.setState({
+      error,
+      errorInfo,
+      store: store.getState(),
+    })
+    this.props.sendLogFrontEndTraceBack(errorInfo, store.getState());
+  }
+
+  render() {
+    if (this.state.errorInfo) {
+      return (
+        <div>
+          <h2>We are sorry, something went wrong</h2>
+          <details style={{ whiteSpace: 'pre-wrap' }}>
+            {this.state.error && this.state.error.toString()}
+            <br />
+            {this.state.errorInfo.componentStack}
+            <br />
+            {JSON.stringify(this.state.store)}
+          </details>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+function mapStateToProps(state) {
+  return {};
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    sendLogFrontEndTraceBack: bindActionCreators(sendLogFrontEndTraceBack, dispatch),
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(DefaultErrorBoundary);

--- a/ui/src/containers/SampleViewContainer.js
+++ b/ui/src/containers/SampleViewContainer.js
@@ -15,6 +15,7 @@ import { showTaskForm } from '../actions/taskForm';
 import BeamlineSetupContainer from './BeamlineSetupContainer';
 import SampleQueueContainer from './SampleQueueContainer';
 import { QUEUE_RUNNING } from '../constants';
+import DefaultErrorBoundary from './DefaultErrorBoundary';
 
 import {
   sendSetAttribute,
@@ -22,42 +23,8 @@ import {
   setBeamlineAttribute,
   sendDisplayImage,
   executeCommand,
+  sendLogFrontEndTraceBack
 } from '../actions/beamline';
-
-class DefaultErrorBoundary extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { error: null, errorInfo: null };
-  }
-
-  componentDidCatch(error, errorInfo) {
-    // Catch errors in any components below and re-render with error message
-    this.setState({
-      error,
-      errorInfo
-    })
-    // You can also log error messages to an error reporting service here
-  }
-
-  render() {
-    if (this.state.errorInfo) {
-      // Error path
-      return (
-        <div>
-          <h2>Something went wrong.</h2>
-          <details style={{ whiteSpace: 'pre-wrap' }}>
-            {this.state.error && this.state.error.toString()}
-            <br />
-            {this.state.errorInfo.componentStack}
-          </details>
-        </div>
-      );
-    }
-    // Normally, just render children
-    return this.props.children;
-  }
-}
-
 class SampleViewContainer extends Component {
   render() {
     const { uiproperties } = this.props;
@@ -271,6 +238,7 @@ function mapDispatchToProps(dispatch) {
     setBeamlineAttribute: bindActionCreators(setBeamlineAttribute, dispatch),
     sendDisplayImage: bindActionCreators(sendDisplayImage, dispatch),
     sendExecuteCommand: bindActionCreators(executeCommand, dispatch),
+    sendLogFrontEndTraceBack: bindActionCreators(sendLogFrontEndTraceBack, dispatch),
   };
 }
 

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -5,6 +5,7 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import App from './components/App';
 import { store } from './store';
+import DefaultErrorBoundary from './containers/DefaultErrorBoundary';
 
 import '@fortawesome/fontawesome-free/css/all.min.css';
 import { library } from '@fortawesome/fontawesome-svg-core';
@@ -26,7 +27,9 @@ if (module.hot) {
 function Root() {
   return (
     <Provider store={store}>
-      <App/>
+      <DefaultErrorBoundary>
+        <App/>
+      </DefaultErrorBoundary>
     </Provider>
   );
 };


### PR DESCRIPTION
A simple `ErrorBoundary`  that displays the `stack trace` and the `redux state` . Both of those are also logged on the backend. The UI log is kept in a log file with the suffix `_ui.log`. The ErrorBoundary display can of course be made a bit nicer, but its a start.