### PR TITLE
Skip duplicate CI jobs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,6 +10,9 @@ jobs:
       matrix:
         python-version: ["3.8"] #, "3.9", "3.10"]
 
+    # Skip `pull_request` runs on local PRs for which `push` runs are already triggered
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
     # Service containers to run with `container-job`
     services:
       # Label used to access the service container
@@ -25,6 +28,7 @@ jobs:
         ports:
           # Maps port 6379 on service container to the host
           - 6379:6379
+
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -3,12 +3,15 @@ name: E2E Test
 on: [push, pull_request]
 
 jobs:
-  build-linux:
+  e2e:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 5
       matrix:
         python-version: ["3.8"] #, "3.9", "3.10"]
+
+    # Skip `pull_request` runs on local PRs for which `push` runs are already triggered
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
     # Service containers to run with `container-job`
     services:
@@ -25,6 +28,7 @@ jobs:
         ports:
           # Maps port 6379 on service container to the host
           - 6379:6379
+        
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
The E2E and build CI jobs were being run twice, on both `push` and `pull_request` events:

- `pull_request` is required for running the CI on PRs coming from forks, but it only runs when a PR is opened.
- `push` runs as soon as a local branch is pushed, before the PR is opened, so it saves time.

I'm adding `if` conditions to the build and E2E CI jobs so they run only on:

- `push` events for local branches
- `pull_request` events from forks

In other words, I skip `pull_request` events for local branches.

Additionally, I fix the name of the E2E job.