### PR TITLE
Set up automatic formatting on save with Prettier in VS Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,3 @@ npm-debug.log*
 /supervisord.pid
 log
 mxcube3/static
-
-# Editors
-.vscode

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["editorconfig.editorconfig", "esbenp.prettier-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "javascript.format.enable": false,
+  "typescript.format.enable": false,
+  "json.format.enable": false,
+
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true
+}

--- a/ui/.prettierrc.json
+++ b/ui/.prettierrc.json
@@ -1,5 +1,4 @@
 {
-  "semi": true,
   "singleQuote": true,
   "overrides": [
     {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -79,7 +79,7 @@
         "eslint-plugin-jest": "^26.1.1",
         "less": "^4.1.2",
         "less-watch-compiler": "^1.16.3",
-        "prettier": "^2.5.1"
+        "prettier": "2.8.8"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -67,7 +67,8 @@
     "start": "GENERATE_SOURCEMAP=false react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "format": "npm run prettier --write",
+    "prettier": "prettier . --cache --check"
   },
   "eslintConfig": {
     "extends": [
@@ -98,6 +99,6 @@
     "eslint-plugin-jest": "^26.1.1",
     "less": "^4.1.2",
     "less-watch-compiler": "^1.16.3",
-    "prettier": "^2.5.1"
+    "prettier": "2.8.8"
   }
 }

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -28,10 +28,10 @@ function Root() {
   return (
     <Provider store={store}>
       <DefaultErrorBoundary>
-        <App/>
+        <App />
       </DefaultErrorBoundary>
     </Provider>
   );
-};
+}
 
-ReactDOM.render(<Root/>, document.querySelector('#root'));
+ReactDOM.render(<Root />, document.querySelector('#root'));


### PR DESCRIPTION
Prettier is an opinionated code formatter for JS/JSX/JSON/CSS/HTML/MD/... There are lots of benefits to using a code formatter:

- more readable code (consistent indentation/line breaks/...)
- focus on code rather than formatting in PR reviews
- faster development (format on save saves devs from having to type semi-columns, breaking lines, indenting, etc.)

I hope it's okay with everyone, I'm committing a `.vscode` folder to configure automatic formatting on save with Prettier in VS Code for the `ui` folder.  I've also added the `prettier` and `format` NPM scripts to respectively check the formatting and actually format files.

This is the first step towards enforcing Prettier formatting for the whole `ui` folder. Next step will be to format all the files and add a CI workflow to check that all file have been formatted.