### PR TITLE
Misc tweaks and fixes for motor controls and `PopInput`

### DIFF
--- a/ui/src/components/MotorInput/MotorInput.jsx
+++ b/ui/src/components/MotorInput/MotorInput.jsx
@@ -156,7 +156,7 @@ export default class MotorInput extends React.Component {
                 this.props.state === MOTOR_STATE.READY &&
                 !this.props.inplace ? (
                   <PopInput
-                    pkey={`${motorName.toLowerCase()}`}
+                    pkey={motorName.toLowerCase()}
                     value={step}
                     suffix={suffix}
                     inputSize="5"
@@ -197,7 +197,7 @@ export default class MotorInput extends React.Component {
           </form>
           {this.props.inplace && (
             <PopInput
-              pkey={`${motorName.toLowerCase()}Step`}
+              pkey={motorName.toLowerCase()}
               value={step}
               suffix={suffix}
               inputSize="5"

--- a/ui/src/components/MotorInput/MotorInput.jsx
+++ b/ui/src/components/MotorInput/MotorInput.jsx
@@ -90,8 +90,6 @@ export default class MotorInput extends React.Component {
         this.props.state === MOTOR_STATE.HIGHLIMIT,
     });
 
-    const data = { state: 'IMMEDIATE', value: step, step: 0.1 };
-
     return (
       <div className="motor-input-container">
         <p className="motor-name">{this.props.label}</p>
@@ -159,10 +157,11 @@ export default class MotorInput extends React.Component {
                 !this.props.inplace ? (
                   <PopInput
                     pkey={`${motorName.toLowerCase()}`}
-                    data={data}
-                    onSave={this.props.saveStep}
+                    value={step}
                     suffix={suffix}
                     inputSize="5"
+                    immediate
+                    onSave={this.props.saveStep}
                     style={{
                       display: 'inline-block',
                       marginLeft: 'auto',
@@ -199,11 +198,12 @@ export default class MotorInput extends React.Component {
           {this.props.inplace && (
             <PopInput
               pkey={`${motorName.toLowerCase()}Step`}
-              data={data}
-              onSave={this.props.saveStep}
+              value={step}
               suffix={suffix}
               inputSize="5"
               inplace
+              immediate
+              onSave={this.props.saveStep}
               style={{ display: 'flex', alignItems: 'center' }}
             />
           )}

--- a/ui/src/components/PopInput/NumericInput.jsx
+++ b/ui/src/components/PopInput/NumericInput.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Form, InputGroup, Button, ButtonToolbar } from 'react-bootstrap';
-import NumericInput from 'react-numeric-input';
+import ReactNumericInput from 'react-numeric-input';
 import { TiTick, TiTimes } from 'react-icons/ti';
 
-export default class DefaultInput extends React.Component {
+export default class NumericInput extends React.Component {
   constructor(props) {
     super(props);
     this.handleSubmit = this.handleSubmit.bind(this);
@@ -24,7 +24,7 @@ export default class DefaultInput extends React.Component {
           {this.props.busy ? (
             <div className="popinput-input-busy" />
           ) : (
-            <NumericInput
+            <ReactNumericInput
               ref={this.inputRef}
               className="popinput-input"
               size={this.props.inputSize}
@@ -56,7 +56,7 @@ export default class DefaultInput extends React.Component {
   }
 }
 
-DefaultInput.defaultProps = {
+NumericInput.defaultProps = {
   inputSize: '3',
   step: 0.1,
   inplace: false,

--- a/ui/src/components/PopInput/PopInput.jsx
+++ b/ui/src/components/PopInput/PopInput.jsx
@@ -46,7 +46,7 @@ export default class PopInput extends React.Component {
       // Only update if value actually changed
       this.props.onSave(this.props.pkey, value);
     }
-    if (this.props.immediate) {
+    if (!this.props.inplace && this.props.immediate) {
       this.hideOverlay();
     }
   }

--- a/ui/src/components/PopInput/PopInput.jsx
+++ b/ui/src/components/PopInput/PopInput.jsx
@@ -3,29 +3,25 @@ import React from 'react';
 import { OverlayTrigger, Popover } from 'react-bootstrap';
 import { STATE } from '../../actions/beamline';
 
-import DefaultInput from './DefaultInput';
+import NumericInput from './NumericInput';
 import './style.css';
 import '../input.css';
 
 /**
- * A simple "Popover Input" input control, the value is displayed as text and
+ * Popover numeric input control. The value is displayed as text and
  * the associated input is displayed in an overlay when the text is clicked.
  *
  * Valid react properties are:
  *
- *   dataType:   The data type of the value (the input will addapt
- *               accordingly)
  *   inputSize:  Input field size, with any html unit; px, em, rem ...
  *   pkey:       Key used when retreiving or sending data to server
- *   name:       Name displayed in label
+ *   value:      Value of the input
+ *   state:      State of the input ()
+ *   msg:        Message describing the state
+ *   step        Step of numeric input
+ *   precision   Precision of value
  *   suffix:     Suffix to display after value
- *   data:       Object containing value, the current state of the value and
- *               a message describing the state. The object have the following
- *               format:
- *
- *                    data: {value: <value>, state: <state>, msg: <msg>}
- *
- *   title:      Title displayed at the top of popover
+ *   inputSize   Size of input
  *   placement:  Placement of Popover (left, right, bottom, top)
  *   onSave:     Callback called when user hits save button
  *   onCancel:   Callback called when user hits cancel button
@@ -50,7 +46,7 @@ export default class PopInput extends React.Component {
       // Only update if value actually changed
       this.props.onSave(this.props.pkey, value);
     }
-    if (this.props.data.state === 'IMMEDIATE') {
+    if (this.props.immediate) {
       this.hideOverlay();
     }
   }
@@ -67,20 +63,18 @@ export default class PopInput extends React.Component {
   }
 
   isBusy() {
-    return this.props.data.state === STATE.BUSY;
+    return this.props.state === STATE.BUSY;
   }
 
   isIdle() {
-    return this.props.data.state === STATE.IDLE;
+    return this.props.state === STATE.IDLE;
   }
 
   isAborted() {
-    return this.props.data.state === STATE.ABORT;
+    return this.props.state === STATE.ABORT;
   }
 
   render() {
-    const title = this.props.title || this.props.name;
-
     let stateClass = '';
     if (this.isBusy()) {
       stateClass = 'input-bg-moving';
@@ -92,26 +86,23 @@ export default class PopInput extends React.Component {
       <div className="d-flex">
         <div className="popinput-form-container">
           {
-            <DefaultInput
+            <NumericInput
               precision={this.props.precision}
-              step={this.props.data.step}
-              dataType={this.props.dataType}
+              step={this.props.step}
               inputSize={this.props.inputSize}
               inplace={this.props.inplace}
-              value={this.props.data.value}
+              value={this.props.value}
               busy={this.isBusy()}
               onSubmit={this.save}
               onCancel={this.cancel}
             />
           }
         </div>
-        <div>{this.props.data.msg}</div>
+        {this.props.msg && <div>{this.props.msg}</div>}
       </div>
     );
 
-    let value = this.props.data.value
-      ? Number.parseFloat(this.props.data.value)
-      : '-';
+    let value = this.props.value ? Number.parseFloat(this.props.value) : '-';
 
     if (value !== '-' && this.props.precision) {
       value = value.toFixed(Number.parseInt(this.props.precision, 10));
@@ -122,11 +113,6 @@ export default class PopInput extends React.Component {
         style={this.props.style}
         className={`${this.props.className} popinput-input-container`}
       >
-        {this.props.name && (
-          <span className={`popinput-input-label ${this.props.ref}`}>
-            {this.props.name} :
-          </span>
-        )}
         <span className={`popinput-input-value ${this.props.pkey}`}>
           {this.props.inplace ? (
             <>{popoverContent}</>
@@ -137,9 +123,7 @@ export default class PopInput extends React.Component {
               rootClose
               placement={this.props.placement}
               overlay={
-                <Popover id={title} title={title} style={{ padding: '0.5em' }}>
-                  {popoverContent}
-                </Popover>
+                <Popover style={{ padding: '0.5em' }}>{popoverContent}</Popover>
               }
             >
               <a
@@ -159,16 +143,17 @@ export default class PopInput extends React.Component {
 
 PopInput.defaultProps = {
   className: '',
-  dataType: 'number',
-  inputSize: '5',
-  precision: 1,
-  step: 0.1,
-  suffix: '',
-  value: 0,
-  style: {},
-  placement: 'right',
+  style: undefined,
   pkey: undefined,
+  value: 0,
+  state: STATE.IDLE,
+  msg: undefined,
+  step: 0.1,
+  precision: 1,
+  suffix: '',
+  inputSize: '5',
+  placement: 'right',
+  immediate: false,
   onSave: undefined,
   onCancel: undefined,
-  data: { value: 0, state: 'ABORTED', msg: '', step: 0.1 },
 };

--- a/ui/src/components/PopInput/style.css
+++ b/ui/src/components/PopInput/style.css
@@ -1,10 +1,3 @@
-.popinput-input-label {
-  display: inline-block;
-  min-width: 90px;
-  margin-right: 1rem;
-  font-weight: bold;
-}
-
 .popinput-input-value {
   display: inline-block;
   white-space: nowrap;

--- a/ui/src/components/SampleView/MotorControl.js
+++ b/ui/src/components/SampleView/MotorControl.js
@@ -64,7 +64,7 @@ export default class MotorControl extends React.Component {
     );
 
     return (
-      <div>
+      <div style={{ marginTop: '0.5rem' }}>
         {this.getMotorComponents(3, 8)}
         <div className="col-sm-12">
           {process.env.REACT_APP_PHASECONTROL ? phaseControl : null}
@@ -111,44 +111,35 @@ export default class MotorControl extends React.Component {
             stop={_stop}
           />
         </div>
-        {this.state.showAll ? (
-          <div>
-            <Button
-              variant="outline-secondary"
-              style={{
-                marginTop: '1em',
-                minWidth: '155px',
-                width: 'fit-conent',
-                whiteSpace: 'nowrap',
-              }}
-              size="sm"
-              onClick={() => {
-                this.setState({ showAll: false });
-              }}
-            >
-              <i className="fas fa-cogs" /> Hide motors
-              <i style={{ marginLeft: '0.5em' }} className="fas fa-caret-up" />
-            </Button>
-            {this.renderAllMotors()}
-          </div>
-        ) : (
+        <div>
           <Button
             variant="outline-secondary"
-            size="sm"
             style={{
-              marginTop: '1em',
+              display: 'flex',
+              alignItems: 'center',
+              marginTop: '1rem',
               minWidth: '155px',
-              width: 'fit-conent',
               whiteSpace: 'nowrap',
+              textAlign: 'left',
             }}
+            size="sm"
             onClick={() => {
-              this.setState({ showAll: true });
+              this.setState({ showAll: !this.state.showAll });
             }}
           >
-            <i className="fas fa-cogs" /> Show motors
-            <i style={{ marginLeft: '0.5em' }} className="fas fa-caret-down" />
+            <i className="fas fa-cogs" style={{ marginRight: '0.5rem' }} />
+            <span style={{ flex: '1 0 auto' }}>
+              {this.state.showAll ? 'Hide motors' : 'Show motors'}
+            </span>
+            <i
+              style={{ marginLeft: '0.5rem' }}
+              className={`fas ${
+                this.state.showAll ? 'fa-caret-up' : 'fa-caret-down'
+              }`}
+            />
           </Button>
-        )}
+          {this.state.showAll && this.renderAllMotors()}
+        </div>
       </div>
     );
   }

--- a/ui/src/components/SampleView/SampleView.css
+++ b/ui/src/components/SampleView/SampleView.css
@@ -158,9 +158,6 @@
 .inline {
   display: inline;
 }
-.step-size .popinput-input-label {
-  min-width: 0px;
-}
 
 .step-size .popinput-input-value {
   min-width: 0px;

--- a/ui/src/containers/BeamlineSetupContainer.jsx
+++ b/ui/src/containers/BeamlineSetupContainer.jsx
@@ -176,12 +176,11 @@ class BeamlineSetupContainer extends React.Component {
             />
           ) : (
             <PopInput
-              name=""
               pkey={uiprop.attribute}
-              suffix={uiprop.suffix}
+              {...beamline_attribute}
               precision={uiprop.precision}
+              suffix={uiprop.suffix}
               inputSize="10"
-              data={beamline_attribute}
               onSave={this.setAttribute}
               onCancel={this.onCancelHandler}
             />


### PR DESCRIPTION
Changes can be reviewed commit by commit:

1. Clean up props of `PopInput`: the idea is to remove unused props and spread the `data` prop to provide better defaults for each prop independently; I also rename `DefaultInput` to `NumericInput` since other input types are not implemented.
2. Prevent sample alignment overlay from closing when changing the steps of the motor inputs: `PopInput` was triggering a click on the body on submit (even though those step inputs are displayed "in place"), which was closing the parent "sample alignment" overlay.
3. Refactor and tweak motor controls toggle ("Show/Hide motors" in left sidebar): I remove some duplication in the JSX and tweak the CSS slightly. I don't bother creating a `.module.css` file for now since the existing styles are inline.
4. Fix changing step of motor controls: with the mock server at least, the step pop-inputs weren't actually working. Seems the `pkey` prop was wrong. Note that there's still a bug with the step pop-inputs inside the "sample alignement" overlay (cf. GIF below). I tried investigating, but got lost in the Redux maze.

![Peek 2023-07-24 14-17](https://github.com/mxcube/mxcubeweb/assets/2936402/a58bc278-1c80-4ea4-b045-e795eec3087f)