### PR TITLE
Allow selective testing (with pytest)

### DIFF
--- a/test/fixture.py
+++ b/test/fixture.py
@@ -26,7 +26,7 @@ sys.path.append("./")
 
 
 from mxcubecore import HardwareRepository
-from mxcube3 import main
+from mxcube3 import build_server_and_config
 from flask_login import current_user
 
 _SIO_TEST_CLIENT = None
@@ -42,7 +42,8 @@ def client():
     global _SIO_TEST_CLIENT
 
     HardwareRepository.uninit_hardware_repository()
-    server = main(test=True)
+    argv = []
+    server, _ = build_server_and_config(test=True, argv=argv)
     server.flask.config["TESTING"] = True
 
     client = server.flask.test_client()


### PR DESCRIPTION
Since the test fixture relies on a function call that consumes `sys.argv`, there is a conflict when passing arguments to pytest. And because of that it is impossible to run some selective tests, for example with `pytest -k test_get_beam_info`.

Here the code creating the server is rewritten
so that the test fixture can pass an explicit list of arguments and the true `sys.argv` is left to be consumed by pytest exclusively.

Additionnally the function `build_server_and_config` is introduced in order to extract the creation of the server from the `main` which now only need to run the server.

GitHub: https://github.com/mxcube/mxcubeweb/issues/1033