### PR TITLE
Manage UI's sample changer state from one source

### DIFF
--- a/mxcube3/routes/signals.py
+++ b/mxcube3/routes/signals.py
@@ -187,12 +187,18 @@ def sc_contents_update():
     server.emit("sc_contents_update")
 
 
-def sc_maintenance_update(state_list, cmd_state, message):
+def sc_maintenance_update(*args):
+    if len(args) == 3:
+        # be backward compatible with older HW objects,
+        # which are emitting signal with 3 arguments
+        _, cmd_state, message = args
+    else:
+        cmd_state, message = args
+
     try:
         server.emit(
             "sc_maintenance_update",
             {
-                "state": json.dumps(state_list),
                 "commands_state": json.dumps(cmd_state),
                 "message": message,
             },

--- a/ui/src/actions/sampleChanger.js
+++ b/ui/src/actions/sampleChanger.js
@@ -22,10 +22,6 @@ export function updateSCContents(data) {
   return { type: 'UPDATE_SC_CONTENTS', data };
 }
 
-export function setSCCommandResponse(response) {
-  return { type: 'SET_SC_RESPONSE', response };
-}
-
 export function setCurrentPlate(plate_index) {
   return { type: 'SET_SC_CURRENT_PLATE', plate_index };
 }
@@ -228,9 +224,6 @@ export function sendCommand(cmdparts, args) {
         dispatch(showErrorPanel(true, response.headers.get('message')));
         throw new Error(`Error while  sending command @ ${cmdparts}`);
       }
-      response.json().then((answer) => {
-        dispatch(setSCCommandResponse(answer));
-      });
     });
   };
 }

--- a/ui/src/reducers/sampleChanger.js
+++ b/ui/src/reducers/sampleChanger.js
@@ -118,12 +118,6 @@ export default (state = INITIAL_STATE, action) => {
     case 'SET_SC_SELECTED_DROP': {
       return { ...state, selectedDrop: action.drop_index };
     }
-    case 'SET_SC_GLOBAL_STATE': {
-      return {
-        ...state,
-        state: JSON.parse(action.data.state).state,
-      };
-    }
     default: {
       return state;
     }

--- a/ui/src/reducers/sampleChangerMaintenance.js
+++ b/ui/src/reducers/sampleChangerMaintenance.js
@@ -20,8 +20,6 @@ export default (state = INITIAL_STATE, action) => {
     case 'SET_SC_GLOBAL_STATE': {
       return {
         ...state,
-        state: JSON.parse(action.data.state),
-        global_state: JSON.parse(action.data.global_state),
         commands_state: JSON.parse(action.data.commands_state),
         message: action.data.message,
       };


### PR DESCRIPTION
Make sure that sample changer state is managed by the SET_SC_STATE action only.
    
Previously the sample changer state was set by two different actions, one originating from SampleChanger HW object and the other from SampleChangerMaint HW object.
    
That creates problems, as the state can potentionally be set to different values by these two objects. Let the SampleChanger HW object be the source of truth for the current sample changer state.
