### PR TITLE
hutch view video feeds 

### DIFF
--- a/mxcube3/core/models/configmodels.py
+++ b/mxcube3/core/models/configmodels.py
@@ -36,6 +36,10 @@ class UIComponentModel(BaseModel):
     precision: Optional[int]
     suffix: Optional[str]
     format: Optional[str]
+    url: Optional[str]
+    description: Optional[str]
+    width: Optional[int]
+    height: Optional[int]
 
     # Set internaly not to be set through configuration
     value_type: Optional[str]

--- a/test/HardwareObjectsMockup.xml/mxcube-web/ui.yaml
+++ b/test/HardwareObjectsMockup.xml/mxcube-web/ui.yaml
@@ -145,3 +145,17 @@ beamline_setup:
       precision: 2
       suffix: ph/s
       format: expo
+
+camera_setup:
+  id: camera_setup
+  components:
+    - label: Camera 1
+      attribute: jpg
+      url: http://localhost:8080/mjpg/video.mjpg?streamprofile=mxcube
+      width: 800
+      height: 450
+    - label: Camera 2
+      attribute: jpg
+      url: http://localhost:9090/mjpg/video.mjpg?streamprofile=mxcube
+      width: 800
+      height: 450

--- a/ui/src/components/BeamlineCamera/BeamlineCamera.jsx
+++ b/ui/src/components/BeamlineCamera/BeamlineCamera.jsx
@@ -1,0 +1,128 @@
+import React, { useState } from 'react';
+import { Badge, Button, OverlayTrigger, Popover } from 'react-bootstrap';
+import './style.css';
+import pip from './picture_in_picture.svg';
+
+const BeamlineCamera = ({
+  labelText,
+  url,
+  width,
+  height,
+  optionsOverlay,
+  format,
+  description,
+}) => {
+  const [showLabelOverlay, setShowLabelOverlay] = useState(false);
+  const [showValueOverlay, setShowValueOverlay] = useState(false);
+
+  const onImageClick = (ev) => {
+    setShowValueOverlay(false);
+    window.open(
+      url,
+      'webcam',
+      `toolbar=0,location=0,menubar=0,addressbar=0,height=${height},width=${width}`,
+      'popup',
+    );
+  };
+
+  const renderLabel = () => {
+    if (!optionsOverlay) {
+      return (
+        <Badge bg="secondary" style={{ display: 'block', marginBottom: '3px' }}>
+          {labelText}
+        </Badge>
+      );
+    }
+
+    return (
+      <OverlayTrigger
+        show={showLabelOverlay}
+        rootClose
+        trigger="click"
+        placement="bottom"
+        overlay={optionsOverlay}
+      >
+        <div onClick={() => setShowLabelOverlay(!showLabelOverlay)}>
+          <Badge
+            bg="secondary"
+            style={{ display: 'block', marginBottom: '3px' }}
+          >
+            {labelText}
+            <i className="fas fa-cog ms-2" />
+          </Badge>
+        </div>
+      </OverlayTrigger>
+    );
+  };
+
+  const msgLabelStyle = {
+    display: 'block',
+    fontSize: '100%',
+    borderRadius: '0px',
+    color: '#000',
+  };
+
+  const video = (
+    <div>
+      {format != 'mp4' ? (
+        <img
+          onClick={onImageClick}
+          src={url}
+          alt={labelText}
+          width={width}
+          height={height}
+        />
+      ) : (
+        <video
+          src={url}
+          alt={labelText}
+          onClick={onImageClick}
+          width={width}
+          height={height}
+        ></video>
+      )}
+      <Button
+        variant="outline-secondary"
+        onClick={onImageClick}
+        size="sm"
+        style={{ position: 'absolute', left: '90%', bottom: '10px' }}
+      >
+        <img src={pip} alt="PIP Icon" />
+      </Button>
+    </div>
+  );
+
+  return (
+    <div className="inout-switch">
+      {renderLabel()}
+      <OverlayTrigger
+        show={showValueOverlay}
+        rootClose
+        trigger="click"
+        placement="bottom"
+        overlay={
+          <Popover style={{ padding: '0.5em' }} id={`${labelText} popover`}>
+            {video}
+          </Popover>
+        }
+      >
+        <div onClick={() => setShowValueOverlay(!showValueOverlay)}>
+          <Badge bg="success" style={msgLabelStyle}>
+            <i className="fas fa-video" />
+          </Badge>
+        </div>
+      </OverlayTrigger>
+    </div>
+  );
+};
+
+BeamlineCamera.defaultProps = {
+  labelText: '',
+  width: 0,
+  height: 0,
+  url: '',
+  optionsOverlay: false,
+  format: '',
+};
+
+export default BeamlineCamera;

--- a/ui/src/components/BeamlineCamera/picture_in_picture.svg
+++ b/ui/src/components/BeamlineCamera/picture_in_picture.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M19 7h-8v6h8V7zm2-4H3c-1.1 0-2 .9-2 2v14c0 1.1.9 1.98 2 1.98h18c1.1 0 2-.88 2-1.98V5c0-1.1-.9-2-2-2zm0 16.01H3V4.98h18v14.03z"/></svg>

--- a/ui/src/components/BeamlineCamera/style.css
+++ b/ui/src/components/BeamlineCamera/style.css
@@ -1,0 +1,8 @@
+.inout-switch {
+  width: 7em;
+}
+
+.inout-switch .badge {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/ui/src/containers/BeamlineSetupContainer.jsx
+++ b/ui/src/containers/BeamlineSetupContainer.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { Navbar, Nav, Table, Popover } from 'react-bootstrap';
 import PopInput from '../components/PopInput/PopInput';
 import BeamlineActions from './BeamlineActionsContainer';
+import BeamlineCamera from '../components/BeamlineCamera/BeamlineCamera';
 import InOutSwitch from '../components/InOutSwitch/InOutSwitch';
 import SampleChangerSwitch from '../components/SampleChangerSwitch/SampleChangerSwitch';
 import DeviceState from '../components/DeviceState/DeviceState';
@@ -134,6 +135,32 @@ class BeamlineSetupContainer extends React.Component {
     return acts;
   }
 
+  createCameraComponent() {
+    const acts = [];
+
+    const { uiproperties } = this.props;
+
+    if (uiproperties.hasOwnProperty('camera_setup')) {
+      for (const [
+        key,
+        camera,
+      ] of uiproperties.camera_setup.components.entries()) {
+        acts.push(
+          <Nav.Item key={key} className="ms-3">
+            <BeamlineCamera
+              labelText={camera.label}
+              format={camera.attribute}
+              url={camera.url}
+              width={camera.width}
+              height={camera.height}
+            />
+          </Nav.Item>,
+        );
+      }
+    }
+    return acts;
+  }
+
   dmState() {
     return this.props.beamline.hardwareObjects.diffractometer.state;
   }
@@ -247,6 +274,7 @@ class BeamlineSetupContainer extends React.Component {
               </Table>
             </Nav.Item>
           </Nav>
+          <Nav className="me-3">{this.createCameraComponent()}</Nav>
           <Nav className="me-3">
             <Nav.Item>
               <DeviceState


### PR DESCRIPTION
Adds support for 'video feed' widgets. Each widget provide access to a video feed from 'Data collection' tab. This is typically used for giving users an easy way to access hutch view cameras.

This implementation assumes that video feeds are available on the same network where the web browser is running. This PR also adds config of two video feeds to the mock-up beamline.

Here is a screenshot with 2 video feeds configured:

![mxcube-hutch-view](https://github.com/mxcube/mxcubeweb/assets/77584583/8aa93475-e72f-44ce-a180-3d1ed2f94a71)


