### PR TITLE
Fix user-based authentication

### DIFF
--- a/mxcube3/core/components/lims.py
+++ b/mxcube3/core/components/lims.py
@@ -208,6 +208,12 @@ class Lims(ComponentBase):
                 return ERROR_CODE
 
             try:
+                HWR.beamline.lims.lims_rest.authenticate(loginID, password)
+            except Exception:
+                logging.getLogger("MX3.HWR").error("[LIMS-REST] Could not authenticate")
+                return ERROR_CODE
+
+            try:
                 proposals = HWR.beamline.lims.get_proposals_by_user(loginID)
 
                 logging.getLogger("MX3.HWR").info(


### PR DESCRIPTION
This reintroduces the authentication with ISPyB's REST endpoint for user-based authentication that was removed in commit f2b58d6 (full commit hash: f2b58d655c6fe9af12a5fcc9cb12700b09e9a651)

GitHub: relates to https://github.com/mxcube/mxcubeweb/pull/1038
GitHub: fixes https://github.com/mxcube/mxcubeweb/issues/1045