### PR TITLE
Fix typo

### DIFF
--- a/ui/src/components/SampleView/ContextMenu.js
+++ b/ui/src/components/SampleView/ContextMenu.js
@@ -419,11 +419,9 @@ export default class ContextMenu extends React.Component {
       this.props.sampleActions.sendAbortCentring();
     }
 
-    voithis.props.sampleActions
-      .sendDeleteShape(this.props.shape.id)
-      .then(() => {
-        this.props.sampleActions.showContextMenu(false);
-      });
+    this.props.sampleActions.sendDeleteShape(this.props.shape.id).then(() => {
+      this.props.sampleActions.showContextMenu(false);
+    });
   }
 
   measureDistance() {


### PR DESCRIPTION
When working on #1061, I reverted a change I had made that involved adding `void` in front of some function calls that return promises. Something went wrong with the revert in this file.