### PR TITLE
Fix front-end linting errors (3)

### DIFF
--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = createConfig({
   incrementalAdoption: true, // turn everything into a warning
   rules: {
     'unicorn/consistent-destructuring': 'off', // too many failures in React class components
+    'promise/catch-or-return': 'off', // requires deeper refactoring of fetching layer
 
     // Ternaries are sometimes more readable when `true` branch is most significant branch
     'no-negated-condition': 'off',
@@ -37,8 +38,12 @@ module.exports = createConfig({
     createReactOverride({
       ...dependencies,
       rules: {
+        'react/no-unsafe': 'off', // requires non-trivial refactoring
         'react/destructuring-assignment': 'off', // too many failures in React class components
         'react/jsx-no-constructed-context-values': 'off', // too strict
+        'react/static-property-placement': 'off', // will not be relevant after converting to functional components
+        'jsx-a11y/anchor-is-valid': 'off', // requires non-trivial refactoring
+        'jsx-a11y/no-static-element-interactions': 'off', // requires non-trivial refactoring
       },
     }),
     createJestOverride({

--- a/ui/src/components/BeamlineCamera/BeamlineCamera.jsx
+++ b/ui/src/components/BeamlineCamera/BeamlineCamera.jsx
@@ -65,7 +65,7 @@ const BeamlineCamera = ({
   const video = (
     <div>
       {format != 'mp4' ? (
-        <img
+        <img // eslint-disable-line jsx-a11y/no-noninteractive-element-interactions
           onClick={onImageClick}
           src={url}
           alt={labelText}

--- a/ui/src/components/Equipment/PlateManipulator.jsx
+++ b/ui/src/components/Equipment/PlateManipulator.jsx
@@ -382,7 +382,7 @@ class PlateManipulator extends React.Component {
                   if (this.props.contents.children !== null) {
                     if (plate.type === 'square') {
                       cell = (
-                        <div
+                        <div // eslint-disable-line jsx-a11y/prefer-tag-over-role
                           tabIndex={0}
                           role="button"
                           onContextMenu={(e) =>
@@ -492,7 +492,7 @@ class PlateManipulator extends React.Component {
                   if (this.props.contents.children !== null) {
                     if (plate.type === 'square') {
                       cell = (
-                        <div
+                        <div // eslint-disable-line jsx-a11y/prefer-tag-over-role
                           role="button"
                           tabIndex={0}
                           onContextMenu={(e) =>

--- a/ui/src/components/Equipment/SampleChanger.js
+++ b/ui/src/components/Equipment/SampleChanger.js
@@ -72,7 +72,7 @@ export class SampleChangerTreeNode extends React.Component {
   }
 
   treeNodeCbxClick(e) {
-    const treeNodeIcon = document.getElementById(`${e.target.id}icon`);
+    const treeNodeIcon = document.querySelector(`#${e.target.id}icon`);
     if (treeNodeIcon) {
       if (e.target.checked) {
         treeNodeIcon.className = 'fa fa-minus';
@@ -116,6 +116,7 @@ export class SampleChangerTreeNode extends React.Component {
         </li>
 
         <Menu id={`${this.props.label}`}>
+          {/* eslint-disable-next-line jsx-a11y/prefer-tag-over-role */}
           <li role="heading" aria-level="2" className="dropdown-header">
             <b>Container {this.props.label}</b>
           </li>

--- a/ui/src/components/Login/Login.jsx
+++ b/ui/src/components/Login/Login.jsx
@@ -75,7 +75,7 @@ function LoginComponent(props) {
                   type="text"
                   aria-label="Login ID"
                   placeholder="Login ID"
-                  autoFocus
+                  autoFocus // eslint-disable-line jsx-a11y/no-autofocus
                   required
                   isInvalid={!!errors.username}
                   {...field}

--- a/ui/src/components/MotorInput/MotorInput.jsx
+++ b/ui/src/components/MotorInput/MotorInput.jsx
@@ -19,7 +19,7 @@ export default class MotorInput extends React.Component {
   }
 
   /* eslint-enable react/no-set-state */
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.value !== this.props.value) {
       this.motorValue.value = nextProps.value.toFixed(this.props.decimalPoints);
       this.motorValue.defaultValue = nextProps.value.toFixed(

--- a/ui/src/components/MotorInput/OneAxisTranslationControl.jsx
+++ b/ui/src/components/MotorInput/OneAxisTranslationControl.jsx
@@ -14,7 +14,7 @@ export default class OneAxisTranslationControl extends React.Component {
   }
 
   /* eslint-enable react/no-set-state */
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.value && nextProps.value !== this.props.value) {
       this.motorValue.value = nextProps.value.toFixed(this.props.decimalPoints);
       this.motorValue.defaultValue = nextProps.value.toFixed(

--- a/ui/src/components/Notify/UserMessage.jsx
+++ b/ui/src/components/Notify/UserMessage.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-string-refs */
 import React from 'react';
 import './style.css';
 

--- a/ui/src/components/PeriodicTable/PeriodicTable.jsx
+++ b/ui/src/components/PeriodicTable/PeriodicTable.jsx
@@ -11,7 +11,7 @@ export default class PeriodicTable extends React.Component {
 
   onClickHandler(e) {
     if (e.target.id) {
-      const el = document.getElementById(this.state.selectedElement);
+      const el = document.querySelector(`#${this.state.selectedElement}`);
       const cell = e.target.children[0];
 
       if (el) {
@@ -27,7 +27,7 @@ export default class PeriodicTable extends React.Component {
   }
 
   enableElement(el) {
-    const domel = document.getElementById(el);
+    const domel = document.querySelector(`#${el}`);
 
     if (domel) {
       domel.className += ' available';

--- a/ui/src/components/Plot1D.jsx
+++ b/ui/src/components/Plot1D.jsx
@@ -20,7 +20,7 @@ class Plot1D extends React.Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (this.props.autoNext) {
       if (this.state.plotId !== null) {
         if (nextProps.lastPlotId !== this.state.plotId) {
@@ -43,7 +43,7 @@ class Plot1D extends React.Component {
     }
   }
 
-  componentWillUpdate(nextProps, nextState) {
+  UNSAFE_componentWillUpdate(nextProps, nextState) {
     const { plotId } = nextState;
     if (plotId) {
       const plotInfo = nextProps.plotsInfo[plotId];

--- a/ui/src/components/SSXChip/SSXChip.jsx
+++ b/ui/src/components/SSXChip/SSXChip.jsx
@@ -34,6 +34,7 @@ function _GridData(fabricObject) {
 function ChipContextMenu(props) {
   return (
     <Menu id="chip-context-menu">
+      {/* eslint-disable-next-line jsx-a11y/prefer-tag-over-role */}
       <li role="heading" aria-level="2" className="dropdown-header">
         <b>Chip</b>
       </li>
@@ -496,7 +497,7 @@ export default class SSXChip extends React.Component {
       }
     });
 
-    this.props.gridList.map((gridData) => {
+    this.props.gridList.forEach((gridData) => {
       this.freeFormCanvas.add(
         new fabric.Rect({
           left: gridData.screenCoord[1],

--- a/ui/src/components/SSXChip/SSXChipControl.jsx
+++ b/ui/src/components/SSXChip/SSXChipControl.jsx
@@ -9,8 +9,6 @@ export default class SSXChipControl extends React.Component {
     super(props);
     this.handleAddTask = this.handleAddTask.bind(this);
     this.handleAddGrid = this.handleAddGrid.bind(this);
-    this.handleRemoveGrid = this.handleRemoveGrid.bind(this);
-    this.handleUpdateGrid = this.handleUpdateGrid.bind(this);
   }
 
   handleAddTask(triggerEvent, event, props, data) {
@@ -41,10 +39,6 @@ export default class SSXChipControl extends React.Component {
     this.props.sampleActions.sendAddShape({ t: 'G', ...data });
   }
 
-  handleRemoveGrid(id) {}
-
-  handleUpdateGrid(data) {}
-
   renderChip() {
     const headConfiguration =
       this.props.hardwareObjects.diffractometer.attributes.head_configuration ??
@@ -73,8 +67,6 @@ export default class SSXChipControl extends React.Component {
             availableChipLayoutList={Object.keys(headConfiguration.available)}
             onAddTask={this.handleAddTask}
             onAddGrid={this.handleAddGrid}
-            onRemoveGrid={this.handleRemoveGrid}
-            onUpdateGrid={this.handleUpdateGrid}
             gridList={Object.values(this.props.grids)}
             sampleMotorVerticalName={sampleVerticalUiProp.attribute}
             sampleMotorHorizontalName={sampleHorizontalUiProp.attribute}

--- a/ui/src/components/SampleGrid/TaskItem.jsx
+++ b/ui/src/components/SampleGrid/TaskItem.jsx
@@ -174,15 +174,15 @@ export class TaskItem extends React.Component {
           <div className="row" style={{ paddingTop: '0.5em' }}>
             <span className="col-sm-4">
               <b>Quality Indictor: </b>
-              <img ref="fimage" alt="First" src={qIndUrl} width="90%" />
+              <img alt="First" src={qIndUrl} width="90%" />
             </span>
             <span className="col-sm-4">
               <b>First image: </b>
-              <img ref="fimage" alt="First" src={fImageUrl} width="90%" />
+              <img alt="First" src={fImageUrl} width="90%" />
             </span>
             <span className="col-sm-4">
               <b>Last image: </b>
-              <img ref="limage" alt="Last" src={lImageUrl} width="90%" />
+              <img alt="Last" src={lImageUrl} width="90%" />
             </span>
           </div>
         </div>
@@ -190,7 +190,7 @@ export class TaskItem extends React.Component {
     } else if (!isUnCollected(task)) {
       content = (
         <span>
-          <img src={loader} role="presentation" /> Fetching data, please wait
+          <img src={loader} alt="" /> Fetching data, please wait
         </span>
       );
     }

--- a/ui/src/components/SampleQueue/QueueControl.js
+++ b/ui/src/components/SampleQueue/QueueControl.js
@@ -119,21 +119,7 @@ export default class QueueControl extends React.Component {
     }
   }
 
-  renderSampleOptions(option) {
-    return (
-      <Button
-        className={option.class}
-        variant=""
-        size="sm"
-        onClick={option.action}
-        key={option.key}
-      >
-        {option.text}
-      </Button>
-    );
-  }
-
-  renderOptions(option) {
+  renderOption(option) {
     return (
       <Button
         className={option.class}
@@ -199,19 +185,17 @@ export default class QueueControl extends React.Component {
         >
           <Nav.Item>
             <span style={{ marginRight: '0.6em' }}>
-              {queueOptions.map((option) => this.renderOptions(option))}
+              {queueOptions.map((option) => this.renderOption(option))}
             </span>
             <span>
-              {sampleQueueOptions.map((option) =>
-                this.renderSampleOptions(option),
-              )}
+              {sampleQueueOptions.map((option) => this.renderOption(option))}
             </span>
           </Nav.Item>
           <Nav.Item>
             <img
               src={loader}
               style={{ display: showBusyIndicator, marginLeft: '25%' }}
-              role="presentation"
+              alt=""
             />
           </Nav.Item>
         </Nav>

--- a/ui/src/components/SampleView/ContextMenu.js
+++ b/ui/src/components/SampleView/ContextMenu.js
@@ -9,7 +9,7 @@ export default class ContextMenu extends React.Component {
     this.menuOptions = this.menuOptions.bind(this);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.show) {
       this.showContextMenu(nextProps.x, nextProps.y);
     } else {

--- a/ui/src/components/SampleView/DrawGridPlugin.js
+++ b/ui/src/components/SampleView/DrawGridPlugin.js
@@ -186,7 +186,7 @@ export default class DrawGridPlugin {
 
     if (this.gridResultFormat === 'RGB') {
       for (let c = 0; c < col; c++) {
-        for (let r = 0; r < row; c++) {
+        for (let r = 0; r < row; r++) {
           cellResultMatrix.append([0, [0, 0, 0]]);
         }
       }

--- a/ui/src/components/SampleView/DrawGridPlugin.js
+++ b/ui/src/components/SampleView/DrawGridPlugin.js
@@ -300,7 +300,9 @@ export default class DrawGridPlugin {
   initializeCellFilling(gd, col, row) {
     const level = this.overlayLevel ? this.overlayLevel : 0.2;
     const fill = `rgba(0, 0, 200, ${level}`;
-    return new Array(col).fill().map(() => new Array(row).fill(fill));
+    return Array.from({ length: col }).map(() =>
+      Array.from({ length: row }).fill(fill),
+    );
   }
 
   cellFillingFromData(gd, col, row) {
@@ -311,13 +313,9 @@ export default class DrawGridPlugin {
      */
     const fillingMatrix = this.initializeCellFilling(gd, col, row);
 
-    const data = new Array(col).fill().map(() => new Array(row).fill());
-
-    for (let nw = 0; nw < col; nw++) {
-      for (let nh = 0; nh < row; nh++) {
-        data[nw][nh] = Math.random();
-      }
-    }
+    const data = Array.from({ length: col }).map(() =>
+      Array.from({ length: row }).fill(Math.random()),
+    );
 
     // Asume flat result object to remain compatible with old format only
     // suporting one type of results

--- a/ui/src/components/SampleView/GridForm.jsx
+++ b/ui/src/components/SampleView/GridForm.jsx
@@ -175,7 +175,6 @@ export default class GridForm extends React.Component {
                     step="0.05"
                     defaultValue={this.props.getGridOverlayOpacity()}
                     onChange={this.props.setGridOverlayOpacity}
-                    ref="overlaySlider"
                     name="overlaySlider"
                   />
                 </Col>

--- a/ui/src/components/SampleView/SampleControls.js
+++ b/ui/src/components/SampleView/SampleControls.js
@@ -286,9 +286,9 @@ export default class SampleControls extends React.Component {
 
               <datalist id="volsettings">
                 {[
-                  ...new Array(
-                    zoom_motor.limits[1] - zoom_motor.limits[0],
-                  ).keys(),
+                  ...Array.from({
+                    length: zoom_motor.limits[1] - zoom_motor.limits[0],
+                  }).keys(),
                 ].map((i) => (
                   <option key={`volsettings-${i}`}>
                     {zoom_motor.limits[0] + i}

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-duplicate-string */
 import './SampleView.css';
 import React from 'react';
 import { MOTOR_STATE } from '../../constants';
@@ -103,7 +104,7 @@ export default class SampleImage extends React.Component {
     this.initJSMpeg();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { width, cinema } = this.props;
     if (
       nextProps.width !== width ||
@@ -428,7 +429,7 @@ export default class SampleImage extends React.Component {
           .filter((shape) => this.props.twoDPoints[shape.id] !== undefined)
           .map((shape) => shape.id);
 
-        const pointList = threeDpointList.concat(twoDPointList);
+        const pointList = [...threeDpointList, ...twoDPointList];
 
         const gridList = shapes
           .filter((shape) => this.props.grids[shape.id] !== undefined)
@@ -592,7 +593,7 @@ export default class SampleImage extends React.Component {
       );
 
       const resultDataPath = shapeData.resultDataPath;
-      if (resultDataPath.length !== 0) {
+      if (resultDataPath.length > 0) {
         this.props.generalActions.sendDisplayImage(
           `${resultDataPath}&img_num=${imgNum}`,
         );

--- a/ui/src/components/SampleView/shapes.js
+++ b/ui/src/components/SampleView/shapes.js
@@ -82,9 +82,9 @@ export function makeLine(
   wid,
   select,
   id,
-  hover = 'crosshair',
   text,
   type,
+  hover = 'crosshair',
 ) {
   return new fabric.Line([x1, y1, x2, y2], {
     fill: col,
@@ -252,7 +252,7 @@ export function makeBeam(posX, posY, sizeX, sizeY, shape) {
     makeLine(posX + 3, posY, posX + 10, posY, 'rgba(0, 255, 255, 1)', 2, false),
     makeLine(posX, posY + 3, posX, posY + 10, 'rgba(0, 255, 255, 1)', 2, false),
     shape === 'ellipse'
-      ? makeElipse(posX, posY, sizeX, sizeY, 'rgba(0, 255, 255)', 5)
+      ? makeElipse(posX, posY, sizeX, sizeY, 'rgba(0, 255, 255)')
       : makeRectangle(posX, posY, sizeX, sizeY, 'rgba(0, 255, 255, 1)'),
   ];
 }
@@ -373,9 +373,9 @@ export function pointLine(
     width,
     selectable,
     id,
-    cursor,
     text,
     'LINE',
+    cursor,
   );
   const arrow = makeArrow(line, color, selectable, id);
   const anchor = makeAnchor(line, color, selectable, id);

--- a/ui/src/components/Tasks/Characterisation.js
+++ b/ui/src/components/Tasks/Characterisation.js
@@ -490,6 +490,14 @@ export default connect((state) => {
 
   const { type } = state.taskForm.taskData;
   const { limits } = state.taskForm.defaultParameters[type.toLowerCase()];
+  const parameters = state.taskForm.taskData.parameters;
+
+  if (parseFloat(parameters.osc_range) === 0) {
+    parameters.osc_range =
+      state.taskForm.defaultParameters[
+        type.toLowerCase()
+      ].acq_parameters.osc_range;
+  }
 
   return {
     path: `${state.login.rootPath}/${subdir}`,
@@ -504,7 +512,7 @@ export default connect((state) => {
     use_min_dose: selector(state, 'use_min_dose'),
     use_min_time: selector(state, 'use_min_time'),
     initialValues: {
-      ...state.taskForm.taskData.parameters,
+      ...parameters,
       beam_size: state.sampleview.currentAperture,
       resolution:
         state.taskForm.sampleIds.constructor !== Array

--- a/ui/src/components/Tasks/DataCollection.js
+++ b/ui/src/components/Tasks/DataCollection.js
@@ -365,6 +365,14 @@ export default connect((state) => {
 
   const { type } = state.taskForm.taskData;
   const { limits } = state.taskForm.defaultParameters[type.toLowerCase()];
+  const parameters = state.taskForm.taskData.parameters;
+
+  if (parseFloat(parameters.osc_range) === 0) {
+    parameters.osc_range =
+      state.taskForm.defaultParameters[
+        type.toLowerCase()
+      ].acq_parameters.osc_range;
+  }
 
   return {
     path: `${state.login.rootPath}/${subdir}`,
@@ -372,7 +380,7 @@ export default connect((state) => {
     acqParametersLimits: limits,
     beamline: state.beamline,
     initialValues: {
-      ...state.taskForm.taskData.parameters,
+      ...parameters,
       beam_size: state.sampleview.currentAperture,
       resolution:
         state.taskForm.sampleIds.constructor !== Array

--- a/ui/src/components/Tasks/GenericTaskForm.js
+++ b/ui/src/components/Tasks/GenericTaskForm.js
@@ -233,7 +233,7 @@ class GenericTaskForm extends React.Component {
       const data = JSON.parse(_d);
 
       for (const fieldName in data) {
-        const el = document.getElementById(`root_${fieldName}`);
+        const el = document.querySelector(`#root_${fieldName}`);
         if (el !== null) {
           el.value = data[fieldName];
         }

--- a/ui/src/components/Tasks/Interleaved.jsx
+++ b/ui/src/components/Tasks/Interleaved.jsx
@@ -24,9 +24,10 @@ const wedgeColorTable = {
 };
 
 function getSubWedges(swNumImg, wedgeList) {
-  const subWedges = {};
-  subWedges.swSizes = [];
-  subWedges.numWedges = wedgeList.length;
+  const subWedges = {
+    swSizes: [],
+    numWedges: wedgeList.length,
+  };
 
   wedgeList.forEach((wedge, wedgeIdx) => {
     const swSize = wedge.parameters.num_images / swNumImg;

--- a/ui/src/components/Tasks/fields.js
+++ b/ui/src/components/Tasks/fields.js
@@ -11,13 +11,6 @@ export function getLastUsedParameters(type, newParams) {
   const parameters =
     lastParameters === null ? newParams : JSON.parse(lastParameters);
 
-  if (parseFloat(parameters.osc_range) === 0) {
-    parameters.osc_range =
-      state.taskForm.defaultParameters[
-        type.toLowerCase()
-      ].acq_parameters.osc_range;
-  }
-
   return parameters;
 }
 

--- a/ui/src/containers/ConnectionLostDialog.jsx
+++ b/ui/src/containers/ConnectionLostDialog.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-string-refs */
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';

--- a/ui/src/containers/SampleGridTableContainer.jsx
+++ b/ui/src/containers/SampleGridTableContainer.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-duplicate-string */
 import React from 'react';
 import withRouter from '../components/WithRouter';
 import { bindActionCreators } from 'redux';
@@ -167,7 +168,7 @@ class SampleGridTableContainer extends React.Component {
           ),
         );
 
-        const union = Object.keys(this.props.selected).concat(sampleIDList);
+        const union = [...Object.keys(this.props.selected), ...sampleIDList];
         samplesToSelect = union.filter(
           (sampleID) => !intersection.has(sampleID),
         );
@@ -276,7 +277,7 @@ class SampleGridTableContainer extends React.Component {
 
     const selected = this.getSamplesList()
       .filter((sampleItem) => {
-        const sampleElement = document.getElementById(sampleItem.key);
+        const sampleElement = document.querySelector(`#${sampleItem.key}`);
         return this.checkForOverlap(selectionRubberBand, sampleElement);
       })
       .map((sampleItem) => sampleItem.key);
@@ -817,7 +818,7 @@ class SampleGridTableContainer extends React.Component {
       ) {
         const nbpuck = [];
         // we won't display the cell / table  if all puck in the cell are empty
-        cell.children.map((puck, idxtd) => {
+        cell.children.forEach((puck, idxtd) => {
           if (
             this.getSampleItems(Number(cell.name), idxtd + 1).length > 0 &&
             (Number(this.props.filterOptions.puckFilter) === idxtd + 1 ||

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -314,7 +314,7 @@ class SampleListViewContainer extends React.Component {
       collected: { collected: e.target.checked },
       notCollected: { notCollected: e.target.checked },
       limsSamples: { limsSamples: e.target.checked },
-      filterText: { text: ReactDOM.findDOMNode(this.filterInput).value.trim() },
+      filterText: { text: ReactDOM.findDOMNode(this.filterInput).value.trim() }, // eslint-disable-line react/no-find-dom-node
     };
     this.props.filter(optionMap[e.target.id]);
     if (Number(e.target.value) > 2) {

--- a/ui/src/containers/TaskContainer.js
+++ b/ui/src/containers/TaskContainer.js
@@ -55,24 +55,13 @@ class TaskContainer extends React.Component {
   }
 
   render() {
-    const [points, lines, grids] = [{}, {}, {}];
+    const lines = {};
     if (typeof this.props.shapes !== 'undefined') {
       Object.keys(this.props.shapes).forEach((key) => {
         const shape = this.props.shapes[key];
         switch (shape.t) {
-          case 'P': {
-            points[shape.id] = shape;
-
-            break;
-          }
           case 'L': {
             lines[shape.id] = shape;
-
-            break;
-          }
-          case 'G': {
-            grids[shape.id] = shape;
-
             break;
           }
           // No default

--- a/ui/src/reducers/queueGUI.js
+++ b/ui/src/reducers/queueGUI.js
@@ -22,21 +22,16 @@ function queueGUIReducer(state = INITIAL_STATE, action = {}) {
     case 'SET_QUEUE': {
       const displayData = { ...state.displayData };
       const existingNodes = Object.keys(state.displayData);
-      const sourceNodes = [];
-      const newNodes = [];
-
       action.sampleOrder.forEach((sampleID) => {
         if (sampleID in action.sampleList) {
           action.sampleList[sampleID].tasks.forEach((task) => {
             if (!existingNodes.includes(task.queueID.toString())) {
-              newNodes.push(task.queueID.toString());
               displayData[task.queueID] = {
                 collapsed: false,
                 selected: false,
                 progress: 0,
               };
             }
-            sourceNodes.push(task.queueID.toString());
           });
         }
       });
@@ -120,23 +115,18 @@ function queueGUIReducer(state = INITIAL_STATE, action = {}) {
       const sampleList = { ...action.data.queue.sampleList.sampleList };
       const sampleOrder = [...action.data.queue.sampleList.sampleOrder];
       const displayData = { ...state.displayData };
-
       const existingNodes = Object.keys(state.displayData);
-      const sourceNodes = [];
-      const newNodes = [];
 
       sampleOrder.forEach((sampleID) => {
         if (sampleID in sampleList) {
           sampleList[sampleID].tasks.forEach((task) => {
             if (!existingNodes.includes(task.queueID.toString())) {
-              newNodes.push(task.queueID.toString());
               displayData[task.queueID] = {
                 collapsed: false,
                 selected: false,
                 progress: 0,
               };
             }
-            sourceNodes.push(task.queueID.toString());
           });
         }
       });

--- a/ui/src/reducers/sampleGrid.js
+++ b/ui/src/reducers/sampleGrid.js
@@ -123,7 +123,10 @@ function sampleGridReducer(state = INITIAL_STATE, action = {}) {
       const sampleList = { ...state.sampleList };
       sampleIDList.forEach((sampleID, i) => {
         if (sampleList[sampleID].tasks.length > 0) {
-          sampleList[sampleID].tasks.concat(action.samplesData[i].tasks);
+          sampleList[sampleID].tasks = [
+            ...sampleList[sampleID].tasks,
+            ...action.samplesData[i].tasks,
+          ];
         } else {
           sampleList[sampleID].tasks = action.samplesData[i].tasks;
         }


### PR DESCRIPTION
I'm disabling a bunch of rules, either globally or locally. The priority is for the linting to pass so we can avoid adding new issues to the codebase.

There are a few issues left that seem to point to actual bugs or dead code. Since I'm not sure which it is, I've left them in. Perhaps @marcus-oscarsson you can take over this PR at some point and resolve those last few issues before merging?

After that, the next step will be to remove the `incrementalAdoption` flag from `.eslintrc.js` so that warnings become errors again (but there shouldn't any left) and also to enable a bunch more rules as warnings (like `no-useless-rename`, which can automatically turn `const { foo: foo } = props` into `const { foo } = props` :grin:)