### PR TITLE
Update aperture.xml to remove unneeded parentheses 

### DIFF
--- a/test/HardwareObjectsMockup.xml/aperture.xml
+++ b/test/HardwareObjectsMockup.xml/aperture.xml
@@ -1,3 +1,3 @@
 <object class="ApertureMockup">
-  <diameter_size_list>[(10),(20),(50),(100),(150)]</diameter_size_list>
+  <diameter_size_list>[10, 20, 50, 100, 150]</diameter_size_list>
 </object>


### PR DESCRIPTION
We tried it without the parentheses at the code camp and it seemed to work fine.