### PR TITLE
Turned isstaff into a property

### DIFF
--- a/mxcube3/core/components/user/usermanager.py
+++ b/mxcube3/core/components/user/usermanager.py
@@ -48,9 +48,7 @@ class BaseUserManager(ComponentBase):
                 _u.username for _u in User.query.all() if _u.active and not _u.isstaff
             ]
         else:
-            users = [
-                _u.username for _u in User.query.all() if _u.active
-            ]
+            users = [_u.username for _u in User.query.all() if _u.active]
 
         return users
 
@@ -91,9 +89,8 @@ class BaseUserManager(ComponentBase):
             if (
                 _u.active
                 and _u.last_request_timestamp
-                and (
-                    datetime.datetime.now() - _u.last_request_timestamp
-                ) > flask.current_app.permanent_session_lifetime
+                and (datetime.datetime.now() - _u.last_request_timestamp)
+                > flask.current_app.permanent_session_lifetime
             ):
                 logging.getLogger("HWR.MX3").info(
                     f"Logged out inactive user {_u.username}"

--- a/mxcube3/core/models/usermodels.py
+++ b/mxcube3/core/models/usermodels.py
@@ -79,6 +79,7 @@ class User(Base, UserMixin):
     def has_roles(self, *args):
         return set(args).issubset({role.name for role in self.roles})
 
+    @property
     def isstaff(self):
         return "staff" in self.roles
 

--- a/mxcube3/routes/ra.py
+++ b/mxcube3/routes/ra.py
@@ -63,7 +63,7 @@ def init_route(app, server, url_prefix):
 
         # Not inhouse user so not allowed to take control by force,
         # return error code
-        if not current_user.isstaff():
+        if not current_user.isstaff:
             return make_response("", 409)
 
         toggle_operator(current_user.username, "You were given control")
@@ -106,7 +106,6 @@ def init_route(app, server, url_prefix):
         newop.requests_control = False
         app.usermanager.update_user(oldop)
         app.usermanager.update_user(newop)
-
 
         join_room("observers", sid=oldop.socketio_session_id, namespace="/ui_state")
         leave_room("observers", sid=newop.socketio_session_id, namespace="/ui_state")
@@ -207,7 +206,7 @@ def init_route(app, server, url_prefix):
     def disconnect():
         if current_user.is_anonymous:
             return
-        
+
         current_user.socketio_session_id = None
         current_user.socketio_session_id = request.sid
 

--- a/ui/src/components/RemoteAccess/RequestControlForm.jsx
+++ b/ui/src/components/RemoteAccess/RequestControlForm.jsx
@@ -27,10 +27,6 @@ class RequestControlForm extends React.Component {
       </span>
     );
 
-    if (!this.props.login.user.isstaff) {
-      content = null;
-    }
-
     return content;
   }
 


### PR DESCRIPTION
`isstaff()` was inconsistently used as both a method and a property. The other `is` attributes on the `User` object are attributes on not methods.

The consequence of this was that all users were considered staff and thus the take/give control options are available in the UI. It turns our that this is something that we want in anyways, so we simply did not notice the effect of this.