### PR TITLE
Updating queue and sample list on observers when it changes (As redux persist was removed)

### DIFF
--- a/mxcube3/routes/queue.py
+++ b/mxcube3/routes/queue.py
@@ -173,6 +173,8 @@ def init_route(app, server, url_prefix):
         )
         resp.status_code = 200
 
+        server.emit("queue", {"Signal": "update"}, namespace="/hwr")
+
         return resp
 
     @bp.route("/<sqid>/<tqid>", methods=["POST"])
@@ -186,6 +188,8 @@ def init_route(app, server, url_prefix):
         resp = jsonify(app.queue.queue_to_dict([model]))
         resp.status_code = 200
 
+        server.emit("queue", {"Signal": "update"}, namespace="/hwr")
+
         return resp
 
     @bp.route("/delete", methods=["POST"])
@@ -195,6 +199,7 @@ def init_route(app, server, url_prefix):
         item_pos_list = request.get_json()
 
         app.queue.delete_entry_at(item_pos_list)
+        server.emit("queue", {"Signal": "update"}, namespace="/hwr")
 
         return Response(status=200)
 
@@ -206,6 +211,7 @@ def init_route(app, server, url_prefix):
         qid_list = params.get("qidList", None)
         enabled = params.get("enabled", False)
         app.queue.queue_enable_item(qid_list, enabled)
+        server.emit("queue", {"Signal": "update"}, namespace="/hwr")
 
         return Response(status=200)
 
@@ -214,12 +220,16 @@ def init_route(app, server, url_prefix):
     @server.restrict
     def queue_swap_task_item(sid, ti1, ti2):
         app.queue.swap_task_entry(sid, int(ti1), int(ti2))
+        server.emit("queue", {"Signal": "update"}, namespace="/hwr")
+
         return Response(status=200)
 
     @bp.route("/<sid>/<ti1>/<ti2>/move", methods=["POST"])
     @server.require_control
     def queue_move_task_item(sid, ti1, ti2):
         app.queue.move_task_entry(sid, int(ti1), int(ti2))
+        server.emit("queue", {"Signal": "update"}, namespace="/hwr")
+
         return Response(status=200)
 
     @bp.route("/sample-order", methods=["POST"])
@@ -228,6 +238,8 @@ def init_route(app, server, url_prefix):
     def queue_set_sample_order():
         sample_order = request.get_json().get("sampleOrder", [])
         app.queue.set_sample_order(sample_order)
+        server.emit("queue", {"Signal": "update"}, namespace="/hwr")
+
         return Response(status=200)
 
     @bp.route("/<sample_id>", methods=["PUT"])

--- a/ui/src/actions/queue.js
+++ b/ui/src/actions/queue.js
@@ -843,3 +843,27 @@ export function sendUpdateDependentFields(task_name, field_data) {
     return response.json();
   });
 }
+
+export function fetchQueue() {
+  return async function (dispatch) {
+    try {
+      const response = await fetch('mxcube/api/v0.1/queue/queue_state', {
+        method: 'GET',
+        credentials: 'include',
+        headers: {
+          Accept: 'application/json',
+          'Content-type': 'application/json',
+        },
+      });
+
+      if (response.status === 200) {
+        const data = await response.json();
+        dispatch(setQueue(data.sampleList));
+      } else {
+        throw new Error(`Could not fetch queue`);
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
+}

--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -34,6 +34,7 @@ import {
   setCurrentSample,
   addDiffractionPlanAction,
   setSampleAttribute,
+  fetchQueue,
 } from './actions/queue';
 import { collapseItem, showResumeQueueDialog } from './actions/queueGUI';
 import { setLoading, showConnectionLostDialog } from './actions/general';
@@ -266,6 +267,11 @@ class ServerIO {
 
       if (record.Signal === 'DisableSample') {
         this.dispatch(setSampleAttribute([record.sampleID], 'checked', false));
+      } else if (record.Signal === 'update') {
+        const state = store.getState();
+        if (!state.login.user.inControl) {
+          this.dispatch(fetchQueue());
+        }
       } else {
         this.dispatch(setStatus(record.Signal));
       }


### PR DESCRIPTION
We have removed `redux-persist` which means that updates to the queue needs to be communicated to the observers.
