### PR TITLE
Fix front-end linting errors (4)

### DIFF
--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -11,10 +11,11 @@ const dependencies = getDependencies();
 
 module.exports = createConfig({
   cwd: __dirname,
-  incrementalAdoption: true, // turn everything into a warning
   rules: {
-    'unicorn/consistent-destructuring': 'off', // too many failures in React class components
-    'promise/catch-or-return': 'off', // requires deeper refactoring of fetching layer
+    'import/no-default-export': 'off', // too opinionated
+    'import/no-unresolved': 'off', // lots of false positives (perhaps misconfigured?)
+    'simple-import-sort/imports': 'off', // changes global CSS order; must migrate to CSS modules first
+    'unicorn/prefer-prototype-methods': 'off', // not really more readable and makes Jest crash
 
     // Ternaries are sometimes more readable when `true` branch is most significant branch
     'no-negated-condition': 'off',
@@ -24,26 +25,24 @@ module.exports = createConfig({
     'unicorn/no-useless-undefined': 'off',
     'consistent-return': 'error',
 
-    // Not really more readable and makes Jest crash
-    'unicorn/prefer-prototype-methods': 'off',
-
     /* Forcing use of `else` for consistency with mandatory `default` clause in `switch` statements is unreasonable.
      * `if`/`else if` serves a different purpose than `switch`. */
     'sonarjs/elseif-without-else': 'off',
-
-    // The point of `switch` is to be less verbose than if/else-if/else
-    'unicorn/switch-case-braces': ['warn', 'avoid'],
   },
   overrides: [
     createReactOverride({
       ...dependencies,
       rules: {
-        'react/no-unsafe': 'off', // requires non-trivial refactoring
-        'react/destructuring-assignment': 'off', // too many failures in React class components
         'react/jsx-no-constructed-context-values': 'off', // too strict
+        'jsx-a11y/media-has-caption': 'off', // not relevant
+
         'react/static-property-placement': 'off', // will not be relevant after converting to functional components
-        'jsx-a11y/anchor-is-valid': 'off', // requires non-trivial refactoring
-        'jsx-a11y/no-static-element-interactions': 'off', // requires non-trivial refactoring
+        'react/destructuring-assignment': 'off', // too many failures in React class components
+        'unicorn/consistent-destructuring': 'off', // too many failures in React class components
+
+        'jsx-a11y/anchor-is-valid': 'off', // too many failures to disable locally
+        'jsx-a11y/click-events-have-key-events': 'off', // too many failures to disable locally
+        'jsx-a11y/no-static-element-interactions': 'off', // too many failures to disable locally
       },
     }),
     createJestOverride({

--- a/ui/cypress/e2e/app.cy.js
+++ b/ui/cypress/e2e/app.cy.js
@@ -1,4 +1,4 @@
-/* global Cypress, cy, it, describe, beforeEach */
+/* global cy, it, describe, beforeEach */
 
 describe('login', () => {
   it("can't login with invalid credentials", () => {

--- a/ui/src/actions/beamline.js
+++ b/ui/src/actions/beamline.js
@@ -1,3 +1,4 @@
+/* eslint-disable promise/prefer-await-to-then */
 import fetch from 'isomorphic-fetch';
 // The different states a beamline attribute can assume.
 export const STATE = {
@@ -157,7 +158,7 @@ export function sendLogFrontEndTraceBack(errorInfo, state) {
         'Content-type': 'application/json',
       },
       body: JSON.stringify({
-        stack: errorInfo['componentStack'],
+        stack: errorInfo.componentStack,
         state: JSON.stringify(state),
       }),
     });

--- a/ui/src/actions/beamlineActions.js
+++ b/ui/src/actions/beamlineActions.js
@@ -1,3 +1,5 @@
+/* eslint-disable promise/prefer-await-to-then */
+/* eslint-disable promise/prefer-await-to-callbacks */
 /* eslint-disable sonarjs/no-duplicate-string */
 import fetch from 'isomorphic-fetch';
 import { RUNNING } from '../constants';

--- a/ui/src/actions/general.js
+++ b/ui/src/actions/general.js
@@ -1,7 +1,8 @@
+/* eslint-disable promise/catch-or-return */
+/* eslint-disable promise/prefer-await-to-then */
 /* eslint-disable sonarjs/no-duplicate-string */
 import fetch from 'isomorphic-fetch';
-import { assign } from 'lodash';
-import { unselectShapes } from './sampleview';
+import { unselectShapes } from './sampleview'; // eslint-disable-line import/no-cycle
 
 export function addUserMessage(records, target) {
   return {
@@ -72,11 +73,11 @@ function parse(response) {
 }
 
 function notify(error) {
-  console.error('REQUEST FAILED', error);
+  console.error('REQUEST FAILED', error); // eslint-disable-line no-console
 }
 
 export function getInitialState(userInControl) {
-  return function (dispatch) {
+  return (dispatch) => {
     const state = {};
 
     const uiproperties = fetch('mxcube/api/v0.1/uiproperties', {

--- a/ui/src/actions/gphlWorkflow.js
+++ b/ui/src/actions/gphlWorkflow.js
@@ -5,7 +5,7 @@ export function showGphlWorkflowParametersDialog(formData, show = true) {
 }
 
 export function gphlWorkflowSubmitParameters(data) {
-  return function () {
+  return () => {
     fetch('mxcube/api/v0.1/gphl_workflow/', {
       method: 'POST',
       credentials: 'include',

--- a/ui/src/actions/login.js
+++ b/ui/src/actions/login.js
@@ -1,7 +1,10 @@
+/* eslint-disable promise/catch-or-return */
+/* eslint-disable promise/no-nesting */
+/* eslint-disable promise/prefer-await-to-then */
 /* eslint-disable sonarjs/no-duplicate-string */
 import fetch from 'isomorphic-fetch';
 import { showErrorPanel, setLoading, getInitialState } from './general';
-import { serverIO } from '../serverIO';
+import { serverIO } from '../serverIO'; // eslint-disable-line import/no-cycle
 
 export function setLoginInfo(loginInfo) {
   return {
@@ -54,7 +57,7 @@ export function postProposal(number) {
 }
 
 export function sendSelectProposal(number, navigate) {
-  return function (dispatch) {
+  return (dispatch) => {
     postProposal(number).then((response) => {
       if (response.status >= 400) {
         dispatch(showErrorPanel(true, 'Server refused to select proposal'));
@@ -68,15 +71,15 @@ export function sendSelectProposal(number, navigate) {
 }
 
 export function startSession(userInControl) {
-  return function (dispatch) {
+  return (dispatch) => {
     dispatch(getInitialState(userInControl));
     dispatch(setLoading(false));
   };
 }
 
 export function refreshSession() {
-  return function (dispatch) {
-    return fetch('mxcube/api/v0.1/login/refresh_session', {
+  return (dispatch) =>
+    fetch('mxcube/api/v0.1/login/refresh_session', {
       method: 'GET',
       headers: {
         Accept: 'application/json',
@@ -84,12 +87,11 @@ export function refreshSession() {
       },
       credentials: 'include',
     });
-  };
 }
 
 export function getLoginInfo() {
-  return function (dispatch) {
-    return fetch('mxcube/api/v0.1/login/login_info', {
+  return (dispatch) =>
+    fetch('mxcube/api/v0.1/login/login_info', {
       method: 'GET',
       headers: {
         Accept: 'application/json',
@@ -108,7 +110,6 @@ export function getLoginInfo() {
           dispatch(setLoading(false));
         },
       );
-  };
 }
 
 export function signOut() {
@@ -117,15 +118,14 @@ export function signOut() {
 }
 
 export function signIn(proposal, password, navigate) {
-  return function (dispatch) {
+  // eslint-disable-next-line sonarjs/cognitive-complexity
+  return (dispatch) => {
     const previousUser = localStorage.getItem('currentUser');
     if (serverIO.hwrSocket !== null && serverIO.hwrSocket.connected) {
-      console.log(serverIO.hwrSocket.connected);
+      console.log(serverIO.hwrSocket.connected); // eslint-disable-line no-console
     } else {
       serverIO.connect();
     }
-
-    console.log(window.location);
 
     fetch('mxcube/api/v0.1/login/', {
       method: 'POST',
@@ -170,14 +170,14 @@ export function signIn(proposal, password, navigate) {
 }
 
 export function forcedSignout() {
-  return function (dispatch) {
+  return (dispatch) => {
     serverIO.disconnect();
     dispatch(signOut());
   };
 }
 
 export function doSignOut(navigate) {
-  return function (dispatch) {
+  return (dispatch) => {
     serverIO.disconnect();
     return fetch('mxcube/api/v0.1/login/signout', {
       credentials: 'include',

--- a/ui/src/actions/queue.js
+++ b/ui/src/actions/queue.js
@@ -1,9 +1,11 @@
+/* eslint-disable promise/catch-or-return */
+/* eslint-disable promise/prefer-await-to-then */
 /* eslint-disable sonarjs/no-duplicate-string */
 import fetch from 'isomorphic-fetch';
 import { showErrorPanel } from './general';
-import { loadSample } from './sampleChanger';
+import { loadSample } from './sampleChanger'; // eslint-disable-line import/no-cycle
 import { sendAbortCentring, sendUpdateShapes } from './sampleview';
-import { selectSamplesAction, clearSampleGrid } from './sampleGrid';
+import { selectSamplesAction, clearSampleGrid } from './sampleGrid'; // eslint-disable-line import/no-cycle
 import { TASK_UNCOLLECTED } from '../constants';
 
 export function queueLoading(loading) {
@@ -30,7 +32,7 @@ export function setCurrentSample(sampleID) {
 }
 
 export function setQueue(queue) {
-  return function (dispatch, getState) {
+  return (dispatch, getState) => {
     const state = getState();
     dispatch(setQueueAction(queue));
 
@@ -98,7 +100,7 @@ export function sendAddQueueItem(items) {
 }
 
 export function addSamplesToQueue(sampleDataList) {
-  return function (dispatch) {
+  return (dispatch) => {
     dispatch(queueLoading(true));
 
     sendAddQueueItem(sampleDataList)
@@ -118,7 +120,7 @@ export function addSamplesToQueue(sampleDataList) {
 }
 
 export function addSampleAndMount(sampleData) {
-  return function (dispatch) {
+  return (dispatch) => {
     dispatch(
       loadSample(sampleData, () => {
         sendAddQueueItem([sampleData])
@@ -144,7 +146,7 @@ export function clearQueue() {
 }
 
 export function sendClearQueue(clearQueueOnly = false) {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('mxcube/api/v0.1/queue/clear', {
       method: 'PUT',
       credentials: 'include',
@@ -250,7 +252,7 @@ export function sendMoveTask(sampleID, oldIndex, newIndex) {
 }
 
 export function moveTask(sampleID, oldIndex, newIndex) {
-  return function (dispatch) {
+  return (dispatch) => {
     dispatch(queueLoading(true));
 
     sendMoveTask(sampleID, oldIndex, newIndex).then((response) => {
@@ -280,7 +282,7 @@ export function toggleChecked(sampleID, index) {
 }
 
 export function sendRunQueue(autoMountNext = true, sid = -1) {
-  return function () {
+  return () => {
     fetch('mxcube/api/v0.1/queue/start', {
       method: 'PUT',
       credentials: 'include',
@@ -298,7 +300,7 @@ export function sendRunQueue(autoMountNext = true, sid = -1) {
 }
 
 export function sendPauseQueue() {
-  return function () {
+  return () => {
     fetch('mxcube/api/v0.1/queue/pause', {
       method: 'PUT',
       credentials: 'include',
@@ -315,7 +317,7 @@ export function sendPauseQueue() {
 }
 
 export function sendUnpauseQueue() {
-  return function () {
+  return () => {
     fetch('mxcube/api/v0.1/queue/unpause', {
       method: 'PUT',
       credentials: 'include',
@@ -332,7 +334,7 @@ export function sendUnpauseQueue() {
 }
 
 export function sendStopQueue() {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('mxcube/api/v0.1/queue/stop', {
       method: 'PUT',
       credentials: 'include',
@@ -350,7 +352,7 @@ export function sendStopQueue() {
 }
 
 export function sendRunSample(sampleID, taskIndex) {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch(`mxcube/api/v0.1/queue/${sampleID}/${taskIndex}/execute`, {
       method: 'PUT',
       credentials: 'include',
@@ -386,7 +388,8 @@ export function removeTaskListAction(taskList, queueIDList = null) {
 }
 
 export function setEnabledSample(sampleIDList, value) {
-  return function (dispatch, getState) {
+  // eslint-disable-next-line sonarjs/cognitive-complexity
+  return (dispatch, getState) => {
     const state = getState();
     dispatch(queueLoading(true));
 
@@ -423,7 +426,7 @@ export function setEnabledSample(sampleIDList, value) {
 }
 
 export function deleteTask(sampleID, taskIndex) {
-  return function (dispatch, getState) {
+  return (dispatch, getState) => {
     const state = getState();
     const task = state.sampleGrid.sampleList[sampleID].tasks[taskIndex];
 
@@ -446,7 +449,7 @@ export function deleteTask(sampleID, taskIndex) {
 }
 
 export function deleteTaskList(sampleIDList) {
-  return function (dispatch, getState) {
+  return (dispatch, getState) => {
     const state = getState();
     const itemPosList = [];
     const taskList = [];
@@ -490,7 +493,7 @@ export function updateTaskAction(sampleID, taskIndex, taskData) {
 }
 
 export function updateTask(sampleID, taskIndex, params, runNow) {
-  return function (dispatch, getState) {
+  return (dispatch, getState) => {
     const { sampleGrid } = getState();
 
     const taskData = {
@@ -532,7 +535,8 @@ export function addDiffractionPlanAction(tasks) {
 }
 
 export function addTask(sampleIDs, parameters, runNow) {
-  return function (dispatch, getState) {
+  // eslint-disable-next-line sonarjs/cognitive-complexity
+  return (dispatch, getState) => {
     const state = getState();
     const samples = [];
     let shapes = [];
@@ -644,7 +648,7 @@ export function updateTaskLimsData(sampleID, taskIndex, limsResultData) {
 }
 
 export function sendToggleCheckBox(data, index) {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch(`mxcube/api/v0.1/queue/${data.queueID}/toggle`, {
       method: 'PUT',
       credentials: 'include',
@@ -663,7 +667,7 @@ export function sendToggleCheckBox(data, index) {
 }
 
 export function deleteSamplesFromQueue(sampleIDList) {
-  return function (dispatch) {
+  return (dispatch) => {
     dispatch(queueLoading(true));
 
     const itemPostList = sampleIDList.map((sampleID) => {
@@ -688,7 +692,7 @@ export function setAutoMountAction(automount) {
 }
 
 export function setAutoMountSample(automount) {
-  return function (dispatch) {
+  return (dispatch) => {
     return fetch('mxcube/api/v0.1/queue/automount', {
       method: 'POST',
       credentials: 'include',
@@ -717,7 +721,7 @@ export function setAutoAddDiffPlanAction(autoadd) {
 }
 
 export function setAutoAddDiffPlan(autoadddiffplan) {
-  return function (dispatch) {
+  return (dispatch) => {
     return fetch('mxcube/api/v0.1/queue/auto_add_diffplan', {
       method: 'POST',
       credentials: 'include',
@@ -741,7 +745,7 @@ export function setAutoAddDiffPlan(autoadddiffplan) {
 }
 
 export function sendSetCentringMethod(centringMethod) {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('/mxcube/api/v0.1/sampleview/centring/centring_method', {
       method: 'PUT',
       credentials: 'include',
@@ -763,7 +767,7 @@ export function sendSetCentringMethod(centringMethod) {
 }
 
 export function sendSetNumSnapshots(numSnapshots) {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('/mxcube/api/v0.1/queue/num_snapshots', {
       method: 'PUT',
       credentials: 'include',
@@ -785,7 +789,7 @@ export function sendSetNumSnapshots(numSnapshots) {
 }
 
 export function sendSetGroupFolder(path) {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('/mxcube/api/v0.1/queue/group_folder', {
       method: 'POST',
       credentials: 'include',
@@ -808,7 +812,7 @@ export function sendSetGroupFolder(path) {
 }
 
 export function sendSetQueueSettings(name, value) {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('/mxcube/api/v0.1/queue/setting', {
       method: 'POST',
       credentials: 'include',
@@ -845,7 +849,7 @@ export function sendUpdateDependentFields(task_name, field_data) {
 }
 
 export function fetchQueue() {
-  return async function (dispatch) {
+  return async (dispatch) => {
     try {
       const response = await fetch('mxcube/api/v0.1/queue/queue_state', {
         method: 'GET',
@@ -863,7 +867,7 @@ export function fetchQueue() {
         throw new Error(`Could not fetch queue`);
       }
     } catch (error) {
-      console.log(error);
+      console.log(error); // eslint-disable-line no-console
     }
   };
 }

--- a/ui/src/actions/remoteAccess.js
+++ b/ui/src/actions/remoteAccess.js
@@ -1,5 +1,7 @@
+/* eslint-disable promise/catch-or-return */
+/* eslint-disable promise/prefer-await-to-then */
 /* eslint-disable sonarjs/no-duplicate-string */
-import { getLoginInfo } from './login';
+import { getLoginInfo } from './login'; // eslint-disable-line import/no-cycle
 
 export function showObserverDialog(show = true) {
   return { type: 'SHOW_OBSERVER_DIALOG', show };
@@ -10,7 +12,7 @@ export function setRaState(data) {
 }
 
 export function getRaState() {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('mxcube/api/v0.1/ra/', {
       method: 'GET',
       headers: {
@@ -27,7 +29,7 @@ export function getRaState() {
 }
 
 export function sendUpdateNickname(name) {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('mxcube/api/v0.1/ra/update_user_nickname', {
       method: 'POST',
       credentials: 'include',
@@ -49,7 +51,7 @@ export function requestControl(
   name = '',
   userInfo = {},
 ) {
-  return function () {
+  return () => {
     fetch('mxcube/api/v0.1/ra/request_control', {
       method: 'POST',
       credentials: 'include',
@@ -68,7 +70,7 @@ export function requestControl(
 }
 
 export function sendTakeControl() {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('mxcube/api/v0.1/ra/take_control', {
       method: 'POST',
       credentials: 'include',
@@ -84,7 +86,7 @@ export function sendTakeControl() {
 }
 
 export function sendGiveControl(username) {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('mxcube/api/v0.1/ra/give_control', {
       method: 'POST',
       credentials: 'include',
@@ -101,7 +103,7 @@ export function sendGiveControl(username) {
 }
 
 export function sendLogoutUser(username) {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('mxcube/api/v0.1/ra/logout_user', {
       method: 'POST',
       credentials: 'include',
@@ -140,7 +142,7 @@ export function setTimeoutGivesControl(timeoutGivesControl) {
 }
 
 export function sendAllowRemote(allow) {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('mxcube/api/v0.1/ra/allow_remote', {
       method: 'POST',
       credentials: 'include',
@@ -156,7 +158,7 @@ export function sendAllowRemote(allow) {
 }
 
 export function sendTimeoutGivesControl(timeoutGivesControl) {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('mxcube/api/v0.1/ra/timeout_gives_control', {
       method: 'POST',
       credentials: 'include',

--- a/ui/src/actions/sampleChanger.js
+++ b/ui/src/actions/sampleChanger.js
@@ -1,7 +1,10 @@
+/* eslint-disable promise/catch-or-return */
+/* eslint-disable promise/no-nesting */
+/* eslint-disable promise/prefer-await-to-then */
 /* eslint-disable sonarjs/no-duplicate-string */
 import fetch from 'isomorphic-fetch';
 import { showErrorPanel } from './general';
-import { clearCurrentSample } from './queue';
+import { clearCurrentSample } from './queue'; // eslint-disable-line import/no-cycle
 
 export function setContents(contents) {
   return { type: 'SET_SC_CONTENTS', data: { sampleChangerContents: contents } };
@@ -36,25 +39,25 @@ export function setSelectedDrop(drop_index) {
 }
 
 export function setPlate(plate_index) {
-  return function (dispatch) {
+  return (dispatch) => {
     dispatch(setCurrentPlate(plate_index));
   };
 }
 
 export function selectWell(row, col) {
-  return function (dispatch) {
+  return (dispatch) => {
     dispatch(setSelectedWell(row, col));
   };
 }
 
 export function selectDrop(drop_index) {
-  return function (dispatch) {
+  return (dispatch) => {
     dispatch(setSelectedDrop(drop_index));
   };
 }
 
 export function refresh() {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('mxcube/api/v0.1/sample_changer/contents', {
       method: 'GET',
       headers: {
@@ -92,7 +95,7 @@ export function refresh() {
 }
 
 export function select(address) {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch(`mxcube/api/v0.1/sample_changer/select/${address}`, {
       method: 'GET',
       headers: {
@@ -115,7 +118,7 @@ export function select(address) {
 }
 
 export function scan(address) {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch(`mxcube/api/v0.1/sample_changer/scan/${address}`, {
       method: 'GET',
       headers: {
@@ -136,7 +139,7 @@ export function scan(address) {
 }
 
 export function loadSample(sampleData, successCb = null) {
-  return function (dispatch, getState) {
+  return (dispatch, getState) => {
     const state = getState();
 
     if (state.sampleChanger.loadedSample.address !== sampleData.location) {
@@ -174,7 +177,7 @@ export function unloadSample(sample) {
     _sample = { location: sample };
   }
 
-  return function (dispatch) {
+  return (dispatch) => {
     fetch(url, {
       method: 'POST',
       credentials: 'include',
@@ -195,7 +198,7 @@ export function unloadSample(sample) {
 }
 
 export function abort() {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('mxcube/api/v0.1/sample_changer/send_command/abort', {
       method: 'GET',
       headers: {
@@ -212,7 +215,7 @@ export function abort() {
 }
 
 export function sendCommand(cmdparts, args) {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch(`mxcube/api/v0.1/sample_changer/send_command/${cmdparts}/${args}`, {
       method: 'GET',
       headers: {

--- a/ui/src/actions/sampleGrid.js
+++ b/ui/src/actions/sampleGrid.js
@@ -1,7 +1,10 @@
+/* eslint-disable promise/catch-or-return */
+/* eslint-disable promise/no-nesting */
+/* eslint-disable promise/prefer-await-to-then */
 /* eslint-disable sonarjs/no-duplicate-string */
 import fetch from 'isomorphic-fetch';
 import { setLoading, showErrorPanel } from './general';
-import { setQueue } from './queue';
+import { setQueue } from './queue'; // eslint-disable-line import/no-cycle
 
 export function updateSampleList(sampleList, order) {
   return { type: 'UPDATE_SAMPLE_LIST', sampleList, order };
@@ -22,7 +25,7 @@ export function showGenericContextMenu(show, id, x = 0, y = 0) {
 }
 
 export function addSamplesToList(samplesData) {
-  return function (dispatch, getState) {
+  return (dispatch, getState) => {
     // find last manually mounted sample id
     const { sampleList } = getState().sampleGrid;
 
@@ -51,7 +54,7 @@ export function setSampleOrderAction(order) {
 }
 
 export function sendSetSampleOrderAction(sampleOrder) {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('mxcube/api/v0.1/queue/sample-order', {
       method: 'POST',
       credentials: 'include',
@@ -91,7 +94,7 @@ export function setSamplesInfoAction(sampleInfoList) {
 }
 
 export function sendGetSampleList() {
-  return function (dispatch) {
+  return (dispatch) => {
     dispatch(
       setLoading(
         true,
@@ -122,7 +125,7 @@ export function sendGetSampleList() {
 }
 
 export function sendSyncSamples() {
-  return function (dispatch) {
+  return (dispatch) => {
     dispatch(setLoading(true, 'Please wait', 'Synchronizing with ISPyB', true));
     fetch('mxcube/api/v0.1/lims/synch_samples', { credentials: 'include' })
       .then((response) => {
@@ -167,7 +170,7 @@ export function updateCrystalList(crystalList) {
 }
 
 export function syncWithCrims() {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('mxcube/api/v0.1/sample_changer/sync_with_crims', {
       method: 'GET',
       headers: {

--- a/ui/src/actions/sampleview.js
+++ b/ui/src/actions/sampleview.js
@@ -1,6 +1,8 @@
+/* eslint-disable promise/catch-or-return */
+/* eslint-disable promise/prefer-await-to-then */
 /* eslint-disable sonarjs/no-duplicate-string */
 import fetch from 'isomorphic-fetch';
-import { showErrorPanel } from './general';
+import { showErrorPanel } from './general'; // eslint-disable-line import/no-cycle
 
 export function setMotorMoving(name, status) {
   return {
@@ -54,6 +56,7 @@ export function setStepSize(name, value) {
   };
 }
 
+// eslint-disable-next-line unicorn/no-object-as-default-parameter
 export function showContextMenu(show, shape = { type: 'NONE' }, x = 0, y = 0) {
   return {
     type: 'SHOW_CONTEXT_MENU',
@@ -151,7 +154,7 @@ export function videoMessageOverlay(show, msg) {
 }
 
 export function setVideoSize(width, height) {
-  return function (dispatch, getState) {
+  return (dispatch, getState) => {
     const { sampleview } = getState();
 
     if (sampleview.sourceIsScalable) {
@@ -245,7 +248,7 @@ export function setGridResultType(gridResultType) {
 }
 
 export function sendRotateToShape(sid) {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('/mxcube/api/v0.1/sampleview/shapes/rotate_to', {
       method: 'POST',
       credentials: 'include',
@@ -263,7 +266,7 @@ export function sendRotateToShape(sid) {
 }
 
 export function sendCentringPoint(x, y) {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('/mxcube/api/v0.1/sampleview/centring/click', {
       method: 'PUT',
       credentials: 'include',
@@ -292,7 +295,7 @@ export function sendCentringPoint(x, y) {
 }
 
 export function sendAcceptCentring() {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('/mxcube/api/v0.1/sampleview/centring/accept', {
       method: 'PUT',
       credentials: 'include',
@@ -310,7 +313,7 @@ export function sendAcceptCentring() {
 }
 
 export function sendGoToBeam(x, y) {
-  return function () {
+  return () => {
     fetch('/mxcube/api/v0.1/sampleview/movetobeam', {
       method: 'PUT',
       credentials: 'include',
@@ -328,7 +331,7 @@ export function sendGoToBeam(x, y) {
 }
 
 export function sendStartAutoCentring() {
-  return function () {
+  return () => {
     fetch('/mxcube/api/v0.1/sampleview/centring/startauto', {
       method: 'PUT',
       credentials: 'include',
@@ -347,7 +350,7 @@ export function sendStartAutoCentring() {
 }
 
 export function sendAddShape(shapeData = {}, successCb = null) {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('/mxcube/api/v0.1/sampleview/shapes', {
       method: 'POST',
       credentials: 'include',
@@ -373,7 +376,7 @@ export function sendAddShape(shapeData = {}, successCb = null) {
 }
 
 export function sendUpdateShapes(shapes) {
-  return function (dispatch) {
+  return (dispatch) => {
     return fetch('/mxcube/api/v0.1/sampleview/shapes', {
       method: 'POST',
       credentials: 'include',
@@ -396,7 +399,7 @@ export function sendUpdateShapes(shapes) {
 }
 
 export function sendDeleteShape(id) {
-  return function (dispatch) {
+  return (dispatch) => {
     return fetch(`/mxcube/api/v0.1/sampleview/shapes/${id}`, {
       method: 'DELETE',
       credentials: 'include',
@@ -417,9 +420,9 @@ export function sendDeleteShape(id) {
 }
 
 export function unselectShapes(shapes) {
-  return function (dispatch) {
+  return (dispatch) => {
     const _shapes = [];
-    if (typeof shapes.shapes !== 'undefined') {
+    if (shapes.shapes !== undefined) {
       const keys = Object.keys(shapes.shapes);
       keys.forEach((k) => {
         const aux = shapes.shapes[k];
@@ -432,7 +435,7 @@ export function unselectShapes(shapes) {
 }
 
 export function sendStartClickCentring() {
-  return function (dispatch, getState) {
+  return (dispatch, getState) => {
     dispatch(clearSelectedShapes());
 
     const { queue } = getState();
@@ -480,7 +483,7 @@ export function sendStartClickCentring() {
 }
 
 export function sendZoomPos(level) {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('/mxcube/api/v0.1/sampleview/zoom', {
       method: 'PUT',
       credentials: 'include',
@@ -494,7 +497,7 @@ export function sendZoomPos(level) {
 }
 
 export function sendLightOn(name) {
-  return function (dispatch) {
+  return (dispatch) => {
     dispatch(saveMotorPosition(name, true));
     fetch(`/mxcube/api/v0.1/sampleview/${name.toLowerCase()}on`, {
       method: 'PUT',
@@ -512,7 +515,7 @@ export function sendLightOn(name) {
 }
 
 export function sendLightOff(name) {
-  return function (dispatch) {
+  return (dispatch) => {
     dispatch(saveMotorPosition(name, false));
     fetch(`/mxcube/api/v0.1/sampleview/${name.toLowerCase()}off`, {
       method: 'PUT',
@@ -530,7 +533,7 @@ export function sendLightOff(name) {
 }
 
 export function sendStopMotor(motorName) {
-  return function () {
+  return () => {
     fetch(`/mxcube/api/v0.1/sampleview/${motorName}/stop`, {
       method: 'PUT',
       credentials: 'include',
@@ -547,7 +550,7 @@ export function sendStopMotor(motorName) {
 }
 
 export function sendMotorPosition(motorName, value) {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch(`/mxcube/api/v0.1/sampleview/${motorName}/${value}`, {
       method: 'PUT',
       credentials: 'include',
@@ -568,7 +571,7 @@ export function sendMotorPosition(motorName, value) {
 }
 
 export function sendAbortCentring() {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('/mxcube/api/v0.1/sampleview/centring/abort', {
       method: 'PUT',
       credentials: 'include',
@@ -589,7 +592,7 @@ export function sendAbortCentring() {
 }
 
 export function sendGoToPoint(id) {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch(`/mxcube/api/v0.1/sampleview/centring/${id}/moveto`, {
       method: 'PUT',
       credentials: 'include',
@@ -606,7 +609,7 @@ export function sendGoToPoint(id) {
 }
 
 export function sendChangeAperture(pos) {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('/mxcube/api/v0.1/diffractometer/aperture', {
       method: 'PUT',
       credentials: 'include',
@@ -627,7 +630,7 @@ export function sendChangeAperture(pos) {
 }
 
 export function getSampleImageSize() {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('/mxcube/api/v0.1/sampleview/camera', {
       method: 'GET',
       credentials: 'include',
@@ -651,7 +654,7 @@ export function getSampleImageSize() {
 }
 
 export function getMotorPosition(motor) {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch(`/mxcube/api/v0.1/sampleview/${motor}`, {
       method: 'GET',
       credentials: 'include',
@@ -673,7 +676,7 @@ export function getMotorPosition(motor) {
 }
 
 export function getMotorPositions() {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('/mxcube/api/v0.1/diffractometer/movables/state', {
       method: 'GET',
       credentials: 'include',
@@ -695,7 +698,7 @@ export function getMotorPositions() {
 }
 
 export function getPointsPosition() {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('mxcube/api/v0.1/sampleview/centring', {
       method: 'GET',
       headers: {
@@ -716,7 +719,7 @@ export function getPointsPosition() {
 }
 
 export function sendCurrentPhase(phase) {
-  return function (dispatch) {
+  return (dispatch) => {
     fetch('/mxcube/api/v0.1/diffractometer/phase', {
       method: 'PUT',
       credentials: 'include',

--- a/ui/src/actions/taskForm.js
+++ b/ui/src/actions/taskForm.js
@@ -19,7 +19,7 @@ export function showTaskForm(
   taskData = {},
   pointQueueID = -1,
 ) {
-  return function (dispatch) {
+  return (dispatch) => {
     dispatch(showForm(formName, sampleQueueID, taskData, pointQueueID));
   };
 }

--- a/ui/src/actions/workflow.js
+++ b/ui/src/actions/workflow.js
@@ -5,7 +5,7 @@ export function showWorkflowParametersDialog(formData, show = true) {
 }
 
 export function workflowSubmitParameters(data) {
-  return function () {
+  return () => {
     fetch('mxcube/api/v0.1/workflow/', {
       method: 'POST',
       credentials: 'include',

--- a/ui/src/components/BeamlineCamera/BeamlineCamera.jsx
+++ b/ui/src/components/BeamlineCamera/BeamlineCamera.jsx
@@ -3,15 +3,14 @@ import { Badge, Button, OverlayTrigger, Popover } from 'react-bootstrap';
 import './style.css';
 import pip from './picture_in_picture.svg';
 
-const BeamlineCamera = ({
+function BeamlineCamera({
   labelText,
   url,
   width,
   height,
   optionsOverlay,
   format,
-  description,
-}) => {
+}) {
   const [showLabelOverlay, setShowLabelOverlay] = useState(false);
   const [showValueOverlay, setShowValueOverlay] = useState(false);
 
@@ -64,7 +63,7 @@ const BeamlineCamera = ({
 
   const video = (
     <div>
-      {format != 'mp4' ? (
+      {format !== 'mp4' ? (
         <img // eslint-disable-line jsx-a11y/no-noninteractive-element-interactions
           onClick={onImageClick}
           src={url}
@@ -79,7 +78,7 @@ const BeamlineCamera = ({
           onClick={onImageClick}
           width={width}
           height={height}
-        ></video>
+        />
       )}
       <Button
         variant="outline-secondary"
@@ -114,7 +113,7 @@ const BeamlineCamera = ({
       </OverlayTrigger>
     </div>
   );
-};
+}
 
 BeamlineCamera.defaultProps = {
   labelText: '',

--- a/ui/src/components/Equipment/GenericEquipmentControl.jsx
+++ b/ui/src/components/Equipment/GenericEquipmentControl.jsx
@@ -1,13 +1,5 @@
 import React from 'react';
-import {
-  Row,
-  Col,
-  Accordion,
-  Button,
-  Card,
-  OverlayTrigger,
-  Popover,
-} from 'react-bootstrap';
+import { Row, Col, Button, OverlayTrigger, Popover } from 'react-bootstrap';
 
 import Collapsible from 'react-collapsible';
 import { BsChevronUp, BsChevronDown } from 'react-icons/bs';

--- a/ui/src/components/Equipment/PlateManipulator.jsx
+++ b/ui/src/components/Equipment/PlateManipulator.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 /* eslint-disable sonarjs/no-duplicate-string */
 import React from 'react';
 import {
@@ -133,6 +134,7 @@ class PlateManipulator extends React.Component {
     }
   }
 
+  // eslint-disable-next-line sonarjs/cognitive-complexity
   render() {
     const plate = this.props.plates[this.props.plateIndex];
     const nbcols = plate.colTitle.length;

--- a/ui/src/components/Equipment/SampleChanger.js
+++ b/ui/src/components/Equipment/SampleChanger.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { Card, Dropdown, Form, Button, DropdownButton } from 'react-bootstrap';
 
@@ -95,7 +96,7 @@ export class SampleChangerTreeNode extends React.Component {
     return (
       <div>
         <li className="treeLi">
-          <input
+          <input // eslint-disable-line jsx-a11y/control-has-associated-label
             type="checkbox"
             className="treeNode"
             id={inputId}

--- a/ui/src/components/GenericDialog/ConfirmActionDialog.jsx
+++ b/ui/src/components/GenericDialog/ConfirmActionDialog.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { Modal, Button } from 'react-bootstrap';
 

--- a/ui/src/components/InOutSwitch/InOutSwitch.jsx
+++ b/ui/src/components/InOutSwitch/InOutSwitch.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { Badge, Button, OverlayTrigger, Popover } from 'react-bootstrap';
 import './style.css';
@@ -37,6 +38,7 @@ export default class InOutSwitch extends React.Component {
    * @param {MouseEvent} e
    */
   onKeyDown(e) {
+    // eslint-disable-next-line sonarjs/no-small-switch
     switch (e.key) {
       case 'Escape': {
         this.showValueOvelay(false);

--- a/ui/src/components/LabeledValue/LabeledValue.jsx
+++ b/ui/src/components/LabeledValue/LabeledValue.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Form } from 'react-bootstrap';
+import { Form } from 'react-bootstrap';
 
 import './style.css';
 

--- a/ui/src/components/Lims/LimsResultDialog.jsx
+++ b/ui/src/components/Lims/LimsResultDialog.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { Modal, Button } from 'react-bootstrap';
 

--- a/ui/src/components/Lims/LimsResultSummary.jsx
+++ b/ui/src/components/Lims/LimsResultSummary.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable promise/prefer-await-to-then */
 import React from 'react';
 import fetch from 'isomorphic-fetch';
 
@@ -15,6 +16,7 @@ export class LimsResultSummary extends React.Component {
       const resultCont = this.resultContainer;
       resultCont.innerHTML = 'Loading results, please wait ...';
 
+      // eslint-disable-next-line promise/catch-or-return
       fetch('mxcube/api/v0.1/lims/results', {
         method: 'POST',
         credentials: 'include',

--- a/ui/src/components/Login/SelectProposal.js
+++ b/ui/src/components/Login/SelectProposal.js
@@ -1,7 +1,8 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { connect } from 'react-redux';
 import { reduxForm } from 'redux-form';
-import { Modal, ButtonToolbar, Button, Table } from 'react-bootstrap';
+import { Modal, Button, Table } from 'react-bootstrap';
 
 class SelectProposal extends React.Component {
   constructor(props) {

--- a/ui/src/components/MXNavbar/MXNavbar.jsx
+++ b/ui/src/components/MXNavbar/MXNavbar.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { Container, Navbar, Nav, Button } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';

--- a/ui/src/components/Main.jsx
+++ b/ui/src/components/Main.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
@@ -41,6 +42,7 @@ class Main extends React.Component {
   }
 
   componentDidMount() {
+    // eslint-disable-next-line promise/prefer-await-to-then, promise/catch-or-return
     getAllChatMessages().then((json) => {
       json.messages.forEach((entry) => {
         if (entry.username === this.props.login.user.username) {

--- a/ui/src/components/MotorInput/MotorInput.jsx
+++ b/ui/src/components/MotorInput/MotorInput.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/control-has-associated-label */
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import cx from 'classnames';
 import { Button } from 'react-bootstrap';
@@ -6,6 +8,7 @@ import { MOTOR_STATE } from '../../constants';
 import './motor.css';
 import '../input.css';
 
+// eslint-disable-next-line react/no-unsafe
 export default class MotorInput extends React.Component {
   constructor(props) {
     super(props);

--- a/ui/src/components/MotorInput/OneAxisTranslationControl.jsx
+++ b/ui/src/components/MotorInput/OneAxisTranslationControl.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/control-has-associated-label */
 import React from 'react';
 import cx from 'classnames';
 import { Button, Popover } from 'react-bootstrap';
@@ -5,6 +6,7 @@ import { MOTOR_STATE } from '../../constants';
 import MotorInput from './MotorInput';
 import './motor.css';
 
+// eslint-disable-next-line react/no-unsafe
 export default class OneAxisTranslationControl extends React.Component {
   constructor(props) {
     super(props);

--- a/ui/src/components/PeriodicTable/PeriodicTable.jsx
+++ b/ui/src/components/PeriodicTable/PeriodicTable.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 
 import './style.css';
@@ -35,7 +36,9 @@ export default class PeriodicTable extends React.Component {
   }
 
   render() {
-    this.props.availableElements.forEach((el) => this.enableElement(el));
+    this.props.availableElements.forEach((el) => {
+      this.enableElement(el);
+    });
 
     return (
       <div className="periodic" onClick={this.onClickHandler}>

--- a/ui/src/components/Plot1D.jsx
+++ b/ui/src/components/Plot1D.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import Dygraph from 'dygraphs';
 import 'dygraphs/dist/dygraph.min.css';
 
+// eslint-disable-next-line react/no-unsafe
 class Plot1D extends React.Component {
   constructor(props) {
     super(props);

--- a/ui/src/components/PopInput/PopInput.jsx
+++ b/ui/src/components/PopInput/PopInput.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 
 import { OverlayTrigger, Popover } from 'react-bootstrap';
@@ -43,6 +44,7 @@ export default class PopInput extends React.Component {
       nextProps.value !== this.props.value
     );
   }
+
   hideOverlay() {
     document.body.click();
   }
@@ -91,17 +93,15 @@ export default class PopInput extends React.Component {
     const popoverContent = (
       <div className="d-flex">
         <div className="popinput-form-container">
-          {
-            <NumericInput
-              initialValue={this.props.value}
-              precision={this.props.precision}
-              step={this.props.step}
-              size={this.props.inputSize}
-              busy={this.isBusy()}
-              onSubmit={this.save}
-              onCancel={this.cancel}
-            />
-          }
+          <NumericInput
+            initialValue={this.props.value}
+            precision={this.props.precision}
+            step={this.props.step}
+            size={this.props.inputSize}
+            busy={this.isBusy()}
+            onSubmit={this.save}
+            onCancel={this.cancel}
+          />
         </div>
         {this.props.msg && <div>{this.props.msg}</div>}
       </div>
@@ -120,7 +120,7 @@ export default class PopInput extends React.Component {
       >
         <span className={`popinput-input-value ${this.props.pkey}`}>
           {this.props.inplace ? (
-            <>{popoverContent}</>
+            popoverContent
           ) : (
             <OverlayTrigger
               id="popOverlayRef"

--- a/ui/src/components/RemoteAccess/ObserverDialog.jsx
+++ b/ui/src/components/RemoteAccess/ObserverDialog.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';

--- a/ui/src/components/RemoteAccess/PassControlDialog.jsx
+++ b/ui/src/components/RemoteAccess/PassControlDialog.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';

--- a/ui/src/components/RemoteAccess/RequestControlForm.jsx
+++ b/ui/src/components/RemoteAccess/RequestControlForm.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
@@ -15,7 +16,7 @@ class RequestControlForm extends React.Component {
   }
 
   getTakeControlOption() {
-    let content = (
+    return (
       <span style={{ marginLeft: '1em' }}>
         <Button
           size="sm"
@@ -26,8 +27,6 @@ class RequestControlForm extends React.Component {
         </Button>
       </span>
     );
-
-    return content;
   }
 
   takeControlOnClick() {

--- a/ui/src/components/SSXChip/SSXChip.jsx
+++ b/ui/src/components/SSXChip/SSXChip.jsx
@@ -1,3 +1,6 @@
+/* eslint-disable react/jsx-key */
+/* eslint-disable react/no-unused-state */
+/* eslint-disable jsx-a11y/control-has-associated-label */
 import React from 'react';
 import { Row, Col, Form, Button, Card } from 'react-bootstrap';
 import { Menu, Item, Separator, contextMenu } from 'react-contexify';
@@ -70,7 +73,7 @@ export default class SSXChip extends React.Component {
       top_left_z: currentChipLayout.calibration_data.top_left[1],
       top_right_x: currentChipLayout.calibration_data.top_right[0],
       top_right_y: currentChipLayout.calibration_data.top_right[0],
-      top_left_z: currentChipLayout.calibration_data.top_right[1],
+      top_right_z: currentChipLayout.calibration_data.top_right[1],
       bottom_left_x: currentChipLayout.calibration_data.bottom_left[0],
       bottom_left_y: currentChipLayout.calibration_data.bottom_left[0],
       bottom_left_z: currentChipLayout.calibration_data.bottom_left[1],
@@ -132,7 +135,7 @@ export default class SSXChip extends React.Component {
           top_left_z: currentChipLayout.calibration_data.top_left[1],
           top_right_x: currentChipLayout.calibration_data.top_right[0],
           top_right_y: currentChipLayout.calibration_data.top_right[0],
-          top_left_z: currentChipLayout.calibration_data.top_right[1],
+          top_right_z: currentChipLayout.calibration_data.top_right[1],
           bottom_left_x: currentChipLayout.calibration_data.bottom_left[0],
           bottom_left_y: currentChipLayout.calibration_data.bottom_left[0],
           bottom_left_z: currentChipLayout.calibration_data.bottom_left[1],
@@ -448,7 +451,6 @@ export default class SSXChip extends React.Component {
 
       this.isDown = true;
 
-      console.log(pointer);
       this.rect = new fabric.Rect({
         left: pointer.x,
         top: pointer.y,
@@ -482,8 +484,6 @@ export default class SSXChip extends React.Component {
       }
 
       rect.set('width', w).set('height', h);
-
-      console.log(rect);
 
       this.freeFormCanvas.renderAll();
     });
@@ -623,7 +623,9 @@ export default class SSXChip extends React.Component {
                             value={this.state.currentLayoutName}
                           >
                             {this.props.availableChipLayoutList.map((item) => (
-                              <option value={item}>{item}</option>
+                              <option key={item} value={item}>
+                                {item}
+                              </option>
                             ))}
                           </Form.Select>
                         </Col>

--- a/ui/src/components/SampleChangerSwitch/SampleChangerSwitch.jsx
+++ b/ui/src/components/SampleChangerSwitch/SampleChangerSwitch.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { Badge, Button, OverlayTrigger, Popover } from 'react-bootstrap';
 import './style.css';

--- a/ui/src/components/SampleGrid/SampleGridTableItem.jsx
+++ b/ui/src/components/SampleGrid/SampleGridTableItem.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import {
   ListGroup,
@@ -160,9 +161,7 @@ export class SampleGridTableItem extends React.Component {
       { 'label-custom-success': this.props.sampleData.loadable === true },
     );
 
-    const limsLink = this.props.sampleData.limsLink
-      ? this.props.sampleData.limsLink
-      : '#';
+    const limsLink = this.props.sampleData.limsLink || '#';
     return (
       <ListGroup
         variant="flush"

--- a/ui/src/components/SampleGrid/TaskItem.jsx
+++ b/ui/src/components/SampleGrid/TaskItem.jsx
@@ -1,5 +1,6 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
-import { Col, OverlayTrigger, Popover, Badge } from 'react-bootstrap';
+import { OverlayTrigger, Popover, Badge } from 'react-bootstrap';
 import { LimsResultSummary } from '../Lims/LimsResultSummary';
 
 import './SampleGridTable.css';
@@ -256,11 +257,7 @@ export class TaskItem extends React.Component {
     const task = this.props.taskData;
 
     return (
-      <div
-        sm={2}
-        key={this.props.taskIndex}
-        className=" ms-1 sample-grid-task-item"
-      >
+      <div key={this.props.taskIndex} className=" ms-1 sample-grid-task-item">
         <OverlayTrigger
           rootClose="true"
           placement="auto"

--- a/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
+++ b/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
@@ -1,3 +1,8 @@
+/* eslint-disable react/no-unused-prop-types */
+/* eslint-disable react/no-unused-state */
+
+/* eslint-disable react/no-array-index-key */
+/* eslint-disable react/jsx-handler-names */
 /* eslint-disable sonarjs/no-duplicate-string */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
@@ -192,7 +197,7 @@ export default class TaskItem extends Component {
   wedgePath(wedge) {
     const { parameters } = wedge;
     const value = parameters.fileName;
-    const path = parameters.path ? parameters.path : '';
+    const path = parameters.path || '';
     const pathEndPart = path.slice(-40);
 
     return (
@@ -293,15 +298,11 @@ export default class TaskItem extends Component {
     );
   }
 
+  // eslint-disable-next-line sonarjs/cognitive-complexity
   render() {
     const { state, data, show } = this.props;
-    let wedges = [];
-
-    if (data.type === 'Interleaved') {
-      wedges = data.parameters.wedges;
-    } else {
-      wedges = [data];
-    }
+    const wedges =
+      data.type === 'Interleaved' ? data.parameters.wedges : [data];
 
     const delTaskCSS = {
       display: 'flex',

--- a/ui/src/components/SampleQueue/CurrentTree.js
+++ b/ui/src/components/SampleQueue/CurrentTree.js
@@ -1,3 +1,5 @@
+/* eslint-disable react/no-unused-state */
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import './app.css';
 import { Menu, Item, contextMenu } from 'react-contexify';

--- a/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
+++ b/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
@@ -1,3 +1,8 @@
+/* eslint-disable jsx-a11y/control-has-associated-label */
+/* eslint-disable react/no-unused-prop-types */
+/* eslint-disable react/no-unused-state */
+
+/* eslint-disable react/jsx-handler-names */
 /* eslint-disable sonarjs/no-duplicate-string */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
@@ -115,7 +120,7 @@ export default class EnergyScanTaskItem extends Component {
 
   path(parameters) {
     const value = parameters.fileName;
-    const path = parameters.path ? parameters.path : '';
+    const path = parameters.path || '';
 
     return (
       <OverlayTrigger

--- a/ui/src/components/SampleQueue/QueueControl.js
+++ b/ui/src/components/SampleQueue/QueueControl.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 /* eslint-disable sonarjs/no-duplicate-string */
 import React from 'react';
 import './app.css';
@@ -133,6 +134,7 @@ export default class QueueControl extends React.Component {
     );
   }
 
+  // eslint-disable-next-line sonarjs/cognitive-complexity
   render() {
     let nextSample = [];
     let queueOptions = [];
@@ -142,7 +144,7 @@ export default class QueueControl extends React.Component {
       if (this.props.queue[idx + 1]) {
         const sampleData =
           this.props.sampleList[this.props.queue[idx + 1]] || {};
-        const sampleName = sampleData.sampleName ? sampleData.sampleName : '';
+        const sampleName = sampleData.sampleName || '';
         const proteinAcronym = sampleData.proteinAcronym
           ? `${sampleData.proteinAcronym} - `
           : '';

--- a/ui/src/components/SampleQueue/TaskItem.jsx
+++ b/ui/src/components/SampleQueue/TaskItem.jsx
@@ -1,3 +1,8 @@
+/* eslint-disable react/no-array-index-key */
+/* eslint-disable react/no-unused-prop-types */
+/* eslint-disable react/no-unused-state */
+
+/* eslint-disable react/jsx-handler-names */
 /* eslint-disable sonarjs/no-duplicate-string */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
@@ -7,7 +12,6 @@ import {
   Collapse,
   Table,
   OverlayTrigger,
-  Popover,
   Tooltip,
 } from 'react-bootstrap';
 import {
@@ -145,7 +149,7 @@ export default class TaskItem extends Component {
   wedgePath(wedge) {
     const { parameters } = wedge;
     const value = parameters.fileName;
-    const path = parameters.path ? parameters.path : '';
+    const path = parameters.path || '';
     const pathEndPart = path.slice(-40);
 
     return (
@@ -251,13 +255,8 @@ export default class TaskItem extends Component {
 
   render() {
     const { state, data, show } = this.props;
-    let wedges = [];
-
-    if (data.type === 'Interleaved') {
-      wedges = data.parameters.wedges;
-    } else {
-      wedges = [data];
-    }
+    const wedges =
+      data.type === 'Interleaved' ? data.parameters.wedges : [data];
 
     const delTaskCSS = {
       display: 'flex',

--- a/ui/src/components/SampleQueue/TodoTree.js
+++ b/ui/src/components/SampleQueue/TodoTree.js
@@ -1,3 +1,5 @@
+/* eslint-disable react/no-array-index-key */
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import './app.css';
 import { ListGroup, Form, Button } from 'react-bootstrap';
@@ -35,7 +37,7 @@ export default class TodoTree extends React.Component {
       return <div />;
     }
 
-    const list = this.filter(this.props.list, this.state.searchWord);
+    const list = this.filter(this.props.list, this.state.searchWord); // eslint-disable-line unicorn/no-array-method-this-argument
 
     return (
       <ListGroup variant="flush">
@@ -66,9 +68,7 @@ export default class TodoTree extends React.Component {
         <ListGroup.Item className="d-flex list-body">
           {list.map((key, id) => {
             const sampleData = this.props.sampleList[key];
-            const sampleName = sampleData.sampleName
-              ? sampleData.sampleName
-              : '';
+            const sampleName = sampleData.sampleName || '';
             const proteinAcronym = sampleData.proteinAcronym
               ? `${sampleData.proteinAcronym} -`
               : '';

--- a/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
+++ b/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
@@ -1,3 +1,7 @@
+/* eslint-disable react/no-unused-prop-types */
+/* eslint-disable react/no-unused-state */
+
+/* eslint-disable react/jsx-handler-names */
 /* eslint-disable sonarjs/no-duplicate-string */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
@@ -114,7 +118,7 @@ export default class WorkflowTaskItem extends Component {
   }
 
   path(parameters) {
-    const path = parameters.path ? parameters.path : '';
+    const path = parameters.path || '';
     const pathEndPart = path.slice(-40);
 
     return (

--- a/ui/src/components/SampleQueue/XRFTaskItem.jsx
+++ b/ui/src/components/SampleQueue/XRFTaskItem.jsx
@@ -1,3 +1,7 @@
+/* eslint-disable react/no-unused-state */
+/* eslint-disable jsx-a11y/control-has-associated-label */
+
+/* eslint-disable react/jsx-handler-names */
 /* eslint-disable sonarjs/no-duplicate-string */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
@@ -22,7 +26,7 @@ export default class XRFTaskItem extends Component {
   static propTypes = {
     id: PropTypes.string.isRequired,
     index: PropTypes.number.isRequired,
-    moveCard: PropTypes.func.isRequired,
+    moveCard: PropTypes.func.isRequired, // eslint-disable-line react/no-unused-prop-types
   };
 
   constructor(props) {
@@ -181,7 +185,7 @@ export default class XRFTaskItem extends Component {
 
   path(parameters) {
     const value = parameters.fileName;
-    const path = parameters.path ? parameters.path : '';
+    const path = parameters.path || '';
 
     return (
       <OverlayTrigger

--- a/ui/src/components/SampleView/ApertureInput.js
+++ b/ui/src/components/SampleView/ApertureInput.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { Form } from 'react-bootstrap';
 import '../MotorInput/motor.css';

--- a/ui/src/components/SampleView/ContextMenu.js
+++ b/ui/src/components/SampleView/ContextMenu.js
@@ -1,7 +1,9 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { Dropdown } from 'react-bootstrap';
 import { getLastUsedParameters } from '../Tasks/fields';
 
+// eslint-disable-next-line react/no-unsafe
 export default class ContextMenu extends React.Component {
   constructor(props) {
     super(props);
@@ -17,6 +19,7 @@ export default class ContextMenu extends React.Component {
     }
   }
 
+  // eslint-disable-next-line sonarjs/cognitive-complexity
   menuOptions() {
     const bespokeTaskNames = new Set([
       'datacollection',
@@ -278,16 +281,15 @@ export default class ContextMenu extends React.Component {
 
     Object.keys(this.props.availableMethods).forEach((key) => {
       if (!this.props.availableMethods[key]) {
-        Object.keys(options).forEach(
-          (k) =>
-            (options[k] = options[k].filter((e) => {
-              let res = true;
-              if (Object.keys(this.props.availableMethods).includes(e.key)) {
-                res = this.props.availableMethods[e.key];
-              }
-              return res;
-            })),
-        );
+        Object.keys(options).forEach((k) => {
+          options[k] = options[k].filter((e) => {
+            let res = true;
+            if (Object.keys(this.props.availableMethods).includes(e.key)) {
+              res = this.props.availableMethods[e.key];
+            }
+            return res;
+          });
+        });
       }
     });
 
@@ -419,6 +421,7 @@ export default class ContextMenu extends React.Component {
       this.props.sampleActions.sendAbortCentring();
     }
 
+    // eslint-disable-next-line promise/prefer-await-to-then, promise/catch-or-return
     this.props.sampleActions.sendDeleteShape(this.props.shape.id).then(() => {
       this.props.sampleActions.showContextMenu(false);
     });

--- a/ui/src/components/SampleView/DrawGridPlugin.js
+++ b/ui/src/components/SampleView/DrawGridPlugin.js
@@ -103,10 +103,10 @@ export default class DrawGridPlugin {
   setCellSpace(gd, snapToGrid, hSpace, vSpace) {
     const gridData = { ...gd };
 
-    if (vSpace !== null && !isNaN(vSpace)) {
+    if (vSpace !== null && !Number.isNaN(vSpace)) {
       gridData.cellVSpace = vSpace;
     }
-    if (hSpace !== null && !isNaN(hSpace)) {
+    if (hSpace !== null && !Number.isNaN(hSpace)) {
       gridData.cellHSpace = hSpace;
     }
 
@@ -130,13 +130,7 @@ export default class DrawGridPlugin {
   }
 
   setPixelsPerMM(pixelsPerMM, gd = null) {
-    let gridData = null;
-
-    if (gd === null) {
-      gridData = this.gridData;
-    } else {
-      gridData = { ...gd };
-    }
+    const gridData = gd === null ? this.gridData : { ...gd };
 
     gridData.pixelsPerMMX = pixelsPerMM[0];
     gridData.pixelsPerMMY = pixelsPerMM[1];
@@ -298,7 +292,7 @@ export default class DrawGridPlugin {
   }
 
   initializeCellFilling(gd, col, row) {
-    const level = this.overlayLevel ? this.overlayLevel : 0.2;
+    const level = this.overlayLevel || 0.2;
     const fill = `rgba(0, 0, 200, ${level}`;
     return Array.from({ length: col }).map(() =>
       Array.from({ length: row }).fill(fill),
@@ -313,10 +307,6 @@ export default class DrawGridPlugin {
      */
     const fillingMatrix = this.initializeCellFilling(gd, col, row);
 
-    const data = Array.from({ length: col }).map(() =>
-      Array.from({ length: row }).fill(Math.random()),
-    );
-
     // Asume flat result object to remain compatible with old format only
     // suporting one type of results
     let { result } = gd;
@@ -326,7 +316,7 @@ export default class DrawGridPlugin {
       result = gd.result[this.resultType];
     }
 
-    if (typeof result !== 'undefined' && result !== null && gd.id !== null) {
+    if (result !== undefined && result !== null && gd.id !== null) {
       for (let nh = 0; nh < row; nh++) {
         for (let nw = 0; nw < col; nw++) {
           const index = nw + nh * col + 1;
@@ -347,6 +337,7 @@ export default class DrawGridPlugin {
    * @param {GridData} gd
    * @return {Object} {shapeGroup, gridData}
    */
+  // eslint-disable-next-line sonarjs/cognitive-complexity
   shapeFromGridData(gd) {
     const gridData = { ...gd };
     let [left, top] = gd.screenCoord;
@@ -563,9 +554,6 @@ export default class DrawGridPlugin {
                 rx: 20,
                 ry: 20,
               }),
-            );
-
-            this.mouseOverGridLabel.push(
               new fabric.Text(obj.cell, {
                 left: objCenterX,
                 top: options.e.offsetY - 25,
@@ -643,8 +631,8 @@ export default class DrawGridPlugin {
   saveGrid(_gd) {
     const gd = { ..._gd };
 
-    gd.screenCoord[0] = gd.screenCoord[0] / this.scale;
-    gd.screenCoord[1] = gd.screenCoord[1] / this.scale;
+    gd.screenCoord[0] /= this.scale;
+    gd.screenCoord[1] /= this.scale;
     gd.width /= this.scale;
     gd.height /= this.scale;
 

--- a/ui/src/components/SampleView/GridForm.jsx
+++ b/ui/src/components/SampleView/GridForm.jsx
@@ -1,3 +1,6 @@
+/* eslint-disable react/jsx-key */
+/* eslint-disable jsx-a11y/control-has-associated-label */
+/* eslint-disable react/jsx-handler-names */
 import './SampleView.css';
 import React from 'react';
 import { Row, Col, Form, Button, Table } from 'react-bootstrap';

--- a/ui/src/components/SampleView/PhaseInput.js
+++ b/ui/src/components/SampleView/PhaseInput.js
@@ -25,7 +25,7 @@ export default class PhaseInput extends React.Component {
       <div className="motor-input-container">
         <select
           className={inputCSS}
-          onChange={this.sendPhase}
+          onChange={this.sendPhase} // eslint-disable-line react/jsx-handler-names
           value={this.props.phase}
         >
           {this.props.phaseList.map((option) => (

--- a/ui/src/components/SampleView/SampleControls.js
+++ b/ui/src/components/SampleView/SampleControls.js
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/control-has-associated-label */
+/* eslint-disable react/jsx-handler-names */
 /* eslint-disable sonarjs/no-duplicate-string */
 import './SampleView.css';
 import React from 'react';
@@ -276,7 +278,7 @@ export default class SampleControls extends React.Component {
                 onChange={(e) => {
                   this.props.setBeamlineAttribute(
                     'diffractometer.zoom',
-                    zoom_motor.commands[parseFloat(e.target.value) - 1],
+                    zoom_motor.commands[Number.parseFloat(e.target.value) - 1],
                   );
                 }}
                 list="volsettings"

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/control-has-associated-label */
 /* eslint-disable sonarjs/no-duplicate-string */
 import './SampleView.css';
 import React from 'react';
@@ -21,6 +22,7 @@ const { fabric } = window;
 fabric.Group.prototype.hasControls = false;
 fabric.Group.prototype.hasBorders = false;
 
+// eslint-disable-next-line react/no-unsafe
 export default class SampleImage extends React.Component {
   constructor(props) {
     super(props);
@@ -222,7 +224,7 @@ export default class SampleImage extends React.Component {
 
   setVCellSpacing(e) {
     let value = Number.parseFloat(e.target.value);
-    if (isNaN(value)) {
+    if (Number.isNaN(value)) {
       value = '';
     }
 
@@ -248,7 +250,7 @@ export default class SampleImage extends React.Component {
 
   setHCellSpacing(e) {
     let value = Number.parseFloat(e.target.value);
-    if (isNaN(value)) {
+    if (Number.isNaN(value)) {
       value = '';
     }
 
@@ -275,7 +277,7 @@ export default class SampleImage extends React.Component {
   setGridOverlayOpacity(e) {
     let value = Number.parseFloat(e.target.value);
 
-    if (isNaN(value)) {
+    if (Number.isNaN(value)) {
       value = '1';
     }
 
@@ -351,9 +353,9 @@ export default class SampleImage extends React.Component {
       this.props.sampleActions.sendAbortCentring();
     }
 
-    this.props.selectedShapes.forEach((shapeID) =>
-      this.props.sampleActions.sendDeleteShape(shapeID),
-    );
+    this.props.selectedShapes.forEach((shapeID) => {
+      this.props.sampleActions.sendDeleteShape(shapeID);
+    });
   }
 
   keyUp() {
@@ -390,6 +392,7 @@ export default class SampleImage extends React.Component {
     document.querySelector('#insideWrapper').style.height = `${h}px`;
   }
 
+  // eslint-disable-next-line sonarjs/cognitive-complexity
   rightClick(e) {
     e.preventDefault();
 
@@ -520,6 +523,7 @@ export default class SampleImage extends React.Component {
     showContextMenu(true, ctxMenuObj, e.offsetX, e.offsetY);
   }
 
+  // eslint-disable-next-line sonarjs/cognitive-complexity
   leftClick(option) {
     let objectFound = false;
 
@@ -572,11 +576,11 @@ export default class SampleImage extends React.Component {
       const cellSizeX = beamSize.x * pixelsPerMm[0] * imageRatio;
       const cellSizeY = beamSize.y * pixelsPerMm[1] * imageRatio;
 
-      const cellIdxX = parseInt(
+      const cellIdxX = Number.parseInt(
         Math.floor((option.pointer.x - option.target.oCoords.tl.x) / cellSizeX),
         10,
       );
-      const cellIdxY = parseInt(
+      const cellIdxY = Number.parseInt(
         Math.floor(
           (option.pointer.y - option.target.oCoords.tl.y - 20) / cellSizeY,
         ),
@@ -592,7 +596,7 @@ export default class SampleImage extends React.Component {
         shapeData.numCols,
       );
 
-      const resultDataPath = shapeData.resultDataPath;
+      const { resultDataPath } = shapeData;
       if (resultDataPath.length > 0) {
         this.props.generalActions.sendDisplayImage(
           `${resultDataPath}&img_num=${imgNum}`,
@@ -601,6 +605,7 @@ export default class SampleImage extends React.Component {
     }
   }
 
+  // eslint-disable-next-line sonarjs/cognitive-complexity
   wheel(e) {
     e.preventDefault();
     e.stopPropagation();
@@ -792,6 +797,7 @@ export default class SampleImage extends React.Component {
     if (this.props.videoMessageOverlay.show) {
       result = (
         <div
+          // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={{
             __html: this.props.videoMessageOverlay.msg,
           }}
@@ -826,10 +832,8 @@ export default class SampleImage extends React.Component {
     if (this.player === null && this.props.videoFormat === 'MPEG1') {
       const canvas = document.querySelector('#sample-img');
 
-      let source = !this.props.videoURL
-        ? `http://${document.location.hostname}:4042/`
-        : this.props.videoURL;
-      /* eslint-enable no-undef */
+      let source =
+        this.props.videoURL || `http://${document.location.hostname}:4042/`;
 
       source = `${source}/${this.props.videoHash}`;
 
@@ -921,8 +925,10 @@ export default class SampleImage extends React.Component {
     }
 
     // Add points last so they are in front of grids
-    fabricSelectables.push(...makePoints(points, imageRatio));
-    fabricSelectables.push(...makeTwoDPoints(twoDPoints, imageRatio));
+    fabricSelectables.push(
+      ...makePoints(points, imageRatio),
+      ...makeTwoDPoints(twoDPoints, imageRatio),
+    );
 
     this.canvas.add(...fabricSelectables);
 

--- a/ui/src/components/SampleView/shapes.js
+++ b/ui/src/components/SampleView/shapes.js
@@ -276,10 +276,11 @@ export function makePoint(x, y, id, color, type, name, strokeWidth) {
 export function makePoints(points, imageRatio) {
   const fabricPoints = [];
 
+  // eslint-disable-next-line guard-for-in
   for (const id in points) {
     const [x, y] = points[id].screenCoord;
     switch (points[id].state) {
-      case 'SAVED':
+      case 'SAVED': {
         fabricPoints.push(
           ...makePoint(
             x * imageRatio,
@@ -292,7 +293,8 @@ export function makePoints(points, imageRatio) {
           ),
         );
         break;
-      case 'TMP':
+      }
+      case 'TMP': {
         fabricPoints.push(
           ...makePoint(
             x * imageRatio,
@@ -305,8 +307,10 @@ export function makePoints(points, imageRatio) {
           ),
         );
         break;
-      default:
+      }
+      default: {
         throw new Error('Server gave point with unknown type');
+      }
     }
   }
   return fabricPoints;
@@ -314,11 +318,12 @@ export function makePoints(points, imageRatio) {
 
 export function makeTwoDPoints(points, imageRatio) {
   const fabricPoints = [];
+  // eslint-disable-next-line guard-for-in
   for (const id in points) {
     const [x, y] = points[id].screenCoord;
 
     switch (points[id].state) {
-      case 'SAVED':
+      case 'SAVED': {
         fabricPoints.push(
           ...makePoint(
             x * imageRatio,
@@ -331,7 +336,8 @@ export function makeTwoDPoints(points, imageRatio) {
           ),
         );
         break;
-      case 'TMP':
+      }
+      case 'TMP': {
         fabricPoints.push(
           ...makePoint(
             x * imageRatio,
@@ -344,8 +350,10 @@ export function makeTwoDPoints(points, imageRatio) {
           ),
         );
         break;
-      default:
+      }
+      default: {
         throw new Error('Server gave point with unknown type');
+      }
     }
   }
   return fabricPoints;
@@ -419,8 +427,6 @@ export function makeImageOverlay(iR, ppMm, bP, bSh, bSi, cCP, dP, canvas) {
       bSi.y * ppMm[1] * iR,
       bSh,
     ),
-  );
-  imageOverlay.push(
     ...makeScale(canvas.height, scaleLengthX, scaleLengthY, '50 µm'),
   );
   if (cCP.length > 0) {

--- a/ui/src/components/Tasks/Characterisation.js
+++ b/ui/src/components/Tasks/Characterisation.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { connect } from 'react-redux';
 import { reduxForm, formValueSelector } from 'redux-form';
@@ -490,9 +491,9 @@ export default connect((state) => {
 
   const { type } = state.taskForm.taskData;
   const { limits } = state.taskForm.defaultParameters[type.toLowerCase()];
-  const parameters = state.taskForm.taskData.parameters;
+  const { parameters } = state.taskForm.taskData;
 
-  if (parseFloat(parameters.osc_range) === 0) {
+  if (Number.parseFloat(parameters.osc_range) === 0) {
     parameters.osc_range =
       state.taskForm.defaultParameters[
         type.toLowerCase()

--- a/ui/src/components/Tasks/DataCollection.js
+++ b/ui/src/components/Tasks/DataCollection.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { connect } from 'react-redux';
 import { reduxForm, formValueSelector } from 'redux-form';
@@ -365,9 +366,9 @@ export default connect((state) => {
 
   const { type } = state.taskForm.taskData;
   const { limits } = state.taskForm.defaultParameters[type.toLowerCase()];
-  const parameters = state.taskForm.taskData.parameters;
+  const { parameters } = state.taskForm.taskData;
 
-  if (parseFloat(parameters.osc_range) === 0) {
+  if (Number.parseFloat(parameters.osc_range) === 0) {
     parameters.osc_range =
       state.taskForm.defaultParameters[
         type.toLowerCase()

--- a/ui/src/components/Tasks/EnergyScan.jsx
+++ b/ui/src/components/Tasks/EnergyScan.jsx
@@ -1,8 +1,9 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { connect } from 'react-redux';
 import { reduxForm, formValueSelector } from 'redux-form';
 import { DraggableModal } from '../DraggableModal';
-import { Modal, Button, Form, Row, Col, ButtonToolbar } from 'react-bootstrap';
+import { Modal, Button, Form, Row, ButtonToolbar } from 'react-bootstrap';
 import validate from './validate';
 import { FieldsHeader, StaticField, InputField } from './fields';
 import PeriodicTable from '../PeriodicTable/PeriodicTable';

--- a/ui/src/components/Tasks/GenericTaskForm.js
+++ b/ui/src/components/Tasks/GenericTaskForm.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { connect } from 'react-redux';
 import { reduxForm, formValueSelector } from 'redux-form';
@@ -228,9 +229,11 @@ class GenericTaskForm extends React.Component {
   }
 
   updateFromRemoteValidation(formData) {
+    // eslint-disable-next-line promise/prefer-await-to-then, promise/catch-or-return
     sendUpdateDependentFields(this.props.taskData.type, formData).then((_d) => {
       const data = JSON.parse(_d);
 
+      // eslint-disable-next-line guard-for-in
       for (const fieldName in data) {
         const el = document.querySelector(`#root_${fieldName}`);
         if (el !== null) {

--- a/ui/src/components/Tasks/GphlWorkflow.jsx
+++ b/ui/src/components/Tasks/GphlWorkflow.jsx
@@ -1,8 +1,9 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { connect } from 'react-redux';
 import { reduxForm, formValueSelector } from 'redux-form';
 import { DraggableModal } from '../DraggableModal';
-import { Modal, Button, Form, Row, Col, ButtonToolbar } from 'react-bootstrap';
+import { Modal, Button, Form, Row, ButtonToolbar } from 'react-bootstrap';
 import validate from './validate';
 import { StaticField, InputField, SelectField } from './fields';
 

--- a/ui/src/components/Tasks/Helical.js
+++ b/ui/src/components/Tasks/Helical.js
@@ -1,7 +1,8 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { connect } from 'react-redux';
 import { reduxForm, formValueSelector } from 'redux-form';
-import { Modal, Button, Form, Row, Col, ButtonToolbar } from 'react-bootstrap';
+import { Modal, Button, Form, Row, ButtonToolbar } from 'react-bootstrap';
 import { DraggableModal } from '../DraggableModal';
 import validate from './validate';
 import warn from './warning';

--- a/ui/src/components/Tasks/Interleaved.jsx
+++ b/ui/src/components/Tasks/Interleaved.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { connect } from 'react-redux';
 import { reduxForm, formValueSelector } from 'redux-form';
@@ -163,6 +164,7 @@ class Interleaved extends React.Component {
                   const filename = task.parameters.fileName;
 
                   return (
+                    // eslint-disable-next-line react/jsx-key
                     <tr style={{ backgroundColor: wedgeColorTable[i] }}>
                       <td>{i + 1}</td>
                       <td>
@@ -232,6 +234,7 @@ class Interleaved extends React.Component {
                 </thead>
                 <tbody>
                   {interleave(this.props.subWedgeObject).map((task) => (
+                    // eslint-disable-next-line react/jsx-key
                     <tr
                       style={{ backgroundColor: wedgeColorTable[task.wedge] }}
                     >

--- a/ui/src/components/Tasks/Mesh.js
+++ b/ui/src/components/Tasks/Mesh.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { connect } from 'react-redux';
 import { reduxForm, formValueSelector } from 'redux-form';

--- a/ui/src/components/Tasks/Workflow.jsx
+++ b/ui/src/components/Tasks/Workflow.jsx
@@ -1,8 +1,9 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { connect } from 'react-redux';
 import { reduxForm, formValueSelector } from 'redux-form';
 import { DraggableModal } from '../DraggableModal';
-import { Modal, Button, Form, Row, Col, ButtonToolbar } from 'react-bootstrap';
+import { Modal, Button, Form, Row, ButtonToolbar } from 'react-bootstrap';
 import validate from './validate';
 import { StaticField, InputField } from './fields';
 

--- a/ui/src/components/Tasks/XRFScan.jsx
+++ b/ui/src/components/Tasks/XRFScan.jsx
@@ -1,8 +1,9 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { connect } from 'react-redux';
 import { reduxForm, formValueSelector } from 'redux-form';
 import { DraggableModal } from '../DraggableModal';
-import { Modal, Button, Form, Row, Col, ButtonToolbar } from 'react-bootstrap';
+import { Modal, Button, Form, Row, ButtonToolbar } from 'react-bootstrap';
 import validate from './validate';
 import { StaticField, InputField } from './fields';
 

--- a/ui/src/components/Tasks/fields.js
+++ b/ui/src/components/Tasks/fields.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { Field } from 'redux-form';
 import { Row, Col, Form, Button } from 'react-bootstrap';
@@ -8,10 +9,7 @@ import './style.css';
 export function getLastUsedParameters(type, newParams) {
   const lastParameters = localStorage.getItem(`last${type}Parameters`);
 
-  const parameters =
-    lastParameters === null ? newParams : JSON.parse(lastParameters);
-
-  return parameters;
+  return lastParameters === null ? newParams : JSON.parse(lastParameters);
 }
 
 export function saveToLastUsedParameters(formName, parameters) {
@@ -67,7 +65,7 @@ export function toFixed(state, hoName) {
   for (const group of Object.values(state.uiproperties)) {
     for (const component of group.components) {
       if (component.attribute === hoName) {
-        precision = component.precision;
+        precision = component.precision; // eslint-disable-line prefer-destructuring
         break;
       }
     }
@@ -265,6 +263,7 @@ export function SelectField({ propName, label, list, col1, col2 }) {
                 const lbl = Array.isArray(val) ? val[0] : val;
                 const v = Array.isArray(val) ? val[1] : val;
                 return (
+                  // eslint-disable-next-line react/no-array-index-key
                   <option key={i} value={v}>
                     {lbl}
                   </option>
@@ -283,6 +282,7 @@ export function FieldsRow({ children }) {
     <Row className="mb-3">
       {children.length > 0 ? (
         children.map((child, i) => (
+          // eslint-disable-next-line react/no-array-index-key
           <Col key={i} sm={12 / children.length}>
             {child}
           </Col>

--- a/ui/src/components/Tasks/validate.js
+++ b/ui/src/components/Tasks/validate.js
@@ -3,6 +3,7 @@ const everpolate = require('everpolate');
 const INVALID_CHAR_MSG =
   'Invalid character in path, only alphanumerical characters and -, _, : allowed';
 
+// eslint-disable-next-line sonarjs/cognitive-complexity
 const validate = (values, props) => {
   const errors = {};
   if (!props.beamline.hardwareObjects) {
@@ -32,7 +33,7 @@ const validate = (values, props) => {
     errors.prefix = INVALID_CHAR_MSG;
   }
 
-  if (props.subdir && !/^[-{}\/\w]+$/u.test(props.subdir)) {
+  if (props.subdir && !/^[-{}/\w]+$/u.test(props.subdir)) {
     errors.subdir = INVALID_CHAR_MSG;
   }
 
@@ -42,7 +43,7 @@ const validate = (values, props) => {
 
   if (
     props.experimentName !== undefined &&
-    !/^[-{}\/\w]+$/u.test(props.experimentName)
+    !/^[-{}/\w]+$/u.test(props.experimentName)
   ) {
     errors.experimentName = INVALID_CHAR_MSG;
   }

--- a/ui/src/constants.js
+++ b/ui/src/constants.js
@@ -25,7 +25,7 @@ export const CLICK_CENTRING = 0;
 export const TWO_STATE_ACTUATOR = 'INOUT';
 
 export function isCollected(task) {
-  return (task.state & TASK_COLLECTED) === TASK_COLLECTED;
+  return (task.state & TASK_COLLECTED) === TASK_COLLECTED; // eslint-disable-line no-bitwise
 }
 
 export function isUnCollected(task) {

--- a/ui/src/containers/BeamlineActionsContainer.jsx
+++ b/ui/src/containers/BeamlineActionsContainer.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/no-array-index-key */
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -135,6 +137,7 @@ class BeamlineActionsContainer extends React.Component {
           >
             <Row>
               {this.props.currentAction.arguments.map((arg, i) => (
+                // eslint-disable-next-line react/jsx-key
                 <>
                   <Col
                     className="mt-2"
@@ -193,6 +196,7 @@ class BeamlineActionsContainer extends React.Component {
             {this.props.currentAction.messages.length > 0 ? (
               <Card>
                 {this.props.currentAction.messages.map((message) => (
+                  // eslint-disable-next-line react/jsx-key
                   <p>{message.message}</p>
                 ))}
               </Card>

--- a/ui/src/containers/BeamlineSetupContainer.jsx
+++ b/ui/src/containers/BeamlineSetupContainer.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
@@ -80,6 +81,7 @@ class BeamlineSetupContainer extends React.Component {
     return popover;
   }
 
+  // eslint-disable-next-line sonarjs/cognitive-complexity
   createActuatorComponent() {
     const acts = [];
 
@@ -179,15 +181,13 @@ class BeamlineSetupContainer extends React.Component {
         >
           <span className="me-1">{uiprop.label}:</span>
         </td>,
-      );
-      components.push(
         <td
           key={`bs-val-${uiprop.label}`}
           className="pe-3 align-middle"
           style={{
             fontWeight: 'bold',
             borderRight:
-              uiprop_list.length != uiprop_list.indexOf(uiprop) + 1
+              uiprop_list.length !== uiprop_list.indexOf(uiprop) + 1
                 ? '1px solid #ddd'
                 : '',
           }}

--- a/ui/src/containers/ConfirmCollectDialog.jsx
+++ b/ui/src/containers/ConfirmCollectDialog.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -140,9 +141,8 @@ export class ConfirmCollectDialog extends React.Component {
     // Making the dialog a bit more intuitive, only display the tasks for the
     // sample to be colleted when autoMountNtext is false
     if (!this.props.queue.autoMountNext) {
-      const sampleID = this.props.queue.current.sampleID
-        ? this.props.queue.current.sampleID
-        : this.props.queue.queue[0];
+      const sampleID =
+        this.props.queue.current.sampleID || this.props.queue.queue[0];
 
       if (sampleID) {
         queue = [sampleID];
@@ -311,7 +311,7 @@ export class ConfirmCollectDialog extends React.Component {
                 const sampleName = `${sample.sampleName} - ${sample.proteinAcronym}`;
 
                 if (task.type === 'Interleaved') {
-                  parameters = task.parameters.wedges[0].parameters;
+                  parameters = task.parameters.wedges[0].parameters; // eslint-disable-line prefer-destructuring
                 }
 
                 return (

--- a/ui/src/containers/ConnectionLostDialog.jsx
+++ b/ui/src/containers/ConnectionLostDialog.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 /* eslint-disable react/no-string-refs */
 import React from 'react';
 import { connect } from 'react-redux';

--- a/ui/src/containers/ErrorNotificationPanel.js
+++ b/ui/src/containers/ErrorNotificationPanel.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';

--- a/ui/src/containers/GphlWorkflowParametersDialog.jsx
+++ b/ui/src/containers/GphlWorkflowParametersDialog.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { bindActionCreators, createStore, combineReducers } from 'redux';
 import { connect, Provider } from 'react-redux';
@@ -42,7 +43,7 @@ class GphlWorkflowParametersDialog extends React.Component {
             schema={this.props.formData}
             formData={this.props.formData.initialValues}
             onSubmit={this.submitData}
-            onError={console.log('errors')}
+            onError={console.log('errors')} // eslint-disable-line no-console
           />
         </Provider>
       );

--- a/ui/src/containers/GroupFolderInput.jsx
+++ b/ui/src/containers/GroupFolderInput.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';

--- a/ui/src/containers/HelpContainer.jsx
+++ b/ui/src/containers/HelpContainer.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { connect } from 'react-redux';
 import { Container, Card, Row, Col, Button, Form } from 'react-bootstrap';
@@ -7,7 +8,6 @@ import { sendMail } from '../actions/login';
 import characterisation from '../help_videos/mx3-characterisation.ogv';
 import interleaved from '../help_videos/mx3-interleaved.ogv';
 import mesh from '../help_videos/mx3-mesh.ogv';
-import general from '../reducers/general';
 
 export class HelpContainer extends React.Component {
   constructor(props) {
@@ -59,6 +59,7 @@ export class HelpContainer extends React.Component {
 
     if (process.env.helpLinks) {
       links = process.env.helpLinks.map((link) => (
+        // eslint-disable-next-line react/jsx-key
         <div>
           <a target="_blank" href={link.url} rel="noreferrer">
             {link.name}

--- a/ui/src/containers/LoggerContainer.js
+++ b/ui/src/containers/LoggerContainer.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -30,6 +31,7 @@ export class LoggerContainer extends React.Component {
     const filteredRecords = records
       .slice(page * 20, page * 20 + 20)
       .map((record, index) => (
+        // eslint-disable-next-line react/no-array-index-key
         <tr key={index}>
           <td>{record.timestamp}</td>
           <td>{record.logger}</td>

--- a/ui/src/containers/MotorInputContainer.js
+++ b/ui/src/containers/MotorInputContainer.js
@@ -14,7 +14,7 @@ class MotorInputContainer extends Component {
     const { motorhwo } = this.props;
     let result = null;
 
-    if (!isNaN(motorhwo.value)) {
+    if (!Number.isNaN(motorhwo.value)) {
       result = (
         <div>
           <MotorInput

--- a/ui/src/containers/PleaseWaitDialog.js
+++ b/ui/src/containers/PleaseWaitDialog.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';

--- a/ui/src/containers/QueueSettings.jsx
+++ b/ui/src/containers/QueueSettings.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/no-unused-state */
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';

--- a/ui/src/containers/ResumeQueueDialog.jsx
+++ b/ui/src/containers/ResumeQueueDialog.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';

--- a/ui/src/containers/SampleFlexView.jsx
+++ b/ui/src/containers/SampleFlexView.jsx
@@ -3,10 +3,6 @@ import withRouter from '../components/WithRouter';
 import { connect } from 'react-redux';
 import { Col } from 'react-bootstrap';
 
-import Collapsible from 'react-collapsible';
-
-import { BsChevronUp, BsChevronDown } from 'react-icons/bs';
-
 import 'react-contexify/dist/ReactContexify.css';
 
 import { filterAction } from '../actions/sampleGrid';

--- a/ui/src/containers/SampleGridTableContainer.jsx
+++ b/ui/src/containers/SampleGridTableContainer.jsx
@@ -1,3 +1,6 @@
+/* eslint-disable react/no-array-index-key */
+
+/* eslint-disable react/jsx-handler-names */
 /* eslint-disable sonarjs/no-duplicate-string */
 import React from 'react';
 import withRouter from '../components/WithRouter';
@@ -298,6 +301,7 @@ class SampleGridTableContainer extends React.Component {
    * @param {MouseEvent} e
    */
   onKeyDown(e) {
+    // eslint-disable-next-line sonarjs/no-small-switch
     switch (e.key) {
       case 'Escape': {
         this.props.selectSamples(Object.keys(this.props.sampleList), false);
@@ -365,18 +369,21 @@ class SampleGridTableContainer extends React.Component {
 
       fi = sampleFilter.includes(this.props.filterOptions.text.toLowerCase());
 
+      // eslint-disable-next-line no-bitwise
       fi &= this.mutualExclusiveFilterOption(
         sample,
         'inQueue',
         'notInQueue',
         this.inQueueSampleID,
       );
+      // eslint-disable-next-line no-bitwise
       fi &= this.mutualExclusiveFilterOption(
         sample,
         'collected',
         'notCollected',
         isCollected,
       );
+      // eslint-disable-next-line no-bitwise
       fi &= this.mutualExclusiveFilterOption(
         sample,
         'limsSamples',
@@ -498,6 +505,7 @@ class SampleGridTableContainer extends React.Component {
     return [allCellSample, allCellSampleCheck];
   }
 
+  // eslint-disable-next-line sonarjs/cognitive-complexity
   getSampleListFilteredByCellPuck(cell, puck) {
     const allCellSample = [];
     const allCellSampleCheck = [];
@@ -613,7 +621,7 @@ class SampleGridTableContainer extends React.Component {
   }
 
   getSampleItemCollapsibleHeaderActions(cell) {
-    const type = this.props.type;
+    const { type } = this.props;
     const cellMenuID = 'samples-grid-table-context-menu-cell';
     return (
       <div className="sample-items-collapsible-header-actions">
@@ -759,7 +767,7 @@ class SampleGridTableContainer extends React.Component {
             </div>,
           );
         }
-        return null;
+        return null; // eslint-disable-line array-callback-return
       });
 
     return sampleItemList;
@@ -795,7 +803,7 @@ class SampleGridTableContainer extends React.Component {
           <b className="me-2 mt-1">Manual Samples</b>
           {rows.map((r) => {
             return (
-              <div
+              <div // eslint-disable-line react/jsx-key
                 className="d-flex"
                 style={{ alignItems: 'left', justifyContent: 'flex-start' }}
               >
@@ -813,6 +821,7 @@ class SampleGridTableContainer extends React.Component {
     const scContent = this.props.sampleChanger.contents;
     const tableCell = [];
 
+    // eslint-disable-next-line sonarjs/cognitive-complexity
     scContent.children.map((cell) => {
       if (
         this.props.filterOptions.cellFilter.toLowerCase() === cell.name ||
@@ -1169,9 +1178,8 @@ class SampleGridTableContainer extends React.Component {
       return <SampleIsaraView cellSampleList={this.getSampleListBydCell} />;
     } else if (this.props.type === 'FLEX_HCD') {
       return <SampleFlexView cellSampleList={this.getSampleListBydCell} />;
-    } else {
-      return null;
     }
+    return null;
   }
 
   render() {

--- a/ui/src/containers/SampleIsaraView.jsx
+++ b/ui/src/containers/SampleIsaraView.jsx
@@ -114,9 +114,8 @@ class NewSampleIsaraView extends React.Component {
       return drawingPosition.line * lineStep + minY + 30;
     } else if (drawingPosition.nbColumn === 0) {
       return -1;
-    } else {
-      return drawingPosition.line * lineStep + minY;
     }
+    return drawingPosition.line * lineStep + minY;
   }
 
   getDrawingPosition(position) {
@@ -164,7 +163,7 @@ class NewSampleIsaraView extends React.Component {
       useGrouping: false,
     });
 
-    const name = pk.toString() + ':' + formattedNumber;
+    const name = `${pk.toString()}:${formattedNumber}`;
     let color;
     const inQueue = this.props.queue.queue.includes(name);
     if (inQueue) {

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
@@ -151,11 +152,11 @@ class SampleListViewContainer extends React.Component {
   getCellFilterOptions() {
     let options = [];
 
-    let sampleListByCellNb = Object.values(this.props.sampleList).map(
+    const sampleListByCellNb = Object.values(this.props.sampleList).map(
       (sample) => sample.cell_no,
     );
     // we create a list from all cell numbers and keep unique value and then sort ascending
-    let sampleListByCellNbUniqueVal = [...new Set(sampleListByCellNb)].sort(
+    const sampleListByCellNbUniqueVal = [...new Set(sampleListByCellNb)].sort(
       (va, vb) => va - vb,
     );
 
@@ -181,11 +182,11 @@ class SampleListViewContainer extends React.Component {
   getPuckFilterOptions() {
     let options = [];
 
-    let sampleListByPuckNb = Object.values(this.props.sampleList).map(
+    const sampleListByPuckNb = Object.values(this.props.sampleList).map(
       (sample) => sample.puck_no,
     );
     // we create a list from all puck numbers and keep unique value and then sort ascending
-    let sampleListByPuckNbUniqueVal = [...new Set(sampleListByPuckNb)].sort(
+    const sampleListByPuckNbUniqueVal = [...new Set(sampleListByPuckNb)].sort(
       (va, vb) => va - vb,
     );
 
@@ -212,6 +213,7 @@ class SampleListViewContainer extends React.Component {
    * @property {Object} selected
    * @property {Object} sampleList
    */
+  // eslint-disable-next-line sonarjs/cognitive-complexity
   showTaskForm(formName, extraParams = {}) {
     let prefix = '';
     const path = '';
@@ -280,6 +282,7 @@ class SampleListViewContainer extends React.Component {
    */
   syncSamples() {
     if (Object.keys(this.props.sampleList).length === 0) {
+      // eslint-disable-next-line promise/prefer-await-to-then, promise/catch-or-return
       this.props.getSamples().then(() => {
         this.props.syncSamples();
       });

--- a/ui/src/containers/SampleQueueContainer.js
+++ b/ui/src/containers/SampleQueueContainer.js
@@ -119,7 +119,7 @@ class SampleQueueContainer extends React.Component {
 
     if (current.sampleID) {
       const sampleData = sampleList[current.sampleID] || {};
-      sampleName = sampleData.sampleName ? sampleData.sampleName : '';
+      sampleName = sampleData.sampleName || '';
       proteinAcronym = sampleData.proteinAcronym
         ? `${sampleData.proteinAcronym} -`
         : '';

--- a/ui/src/containers/SampleViewContainer.js
+++ b/ui/src/containers/SampleViewContainer.js
@@ -57,7 +57,7 @@ class SampleViewContainer extends Component {
     const [points, lines, grids, twoDPoints] = [{}, {}, {}, {}];
     const selectedGrids = [];
 
-    if (typeof this.props.shapes !== 'undefined') {
+    if (this.props.shapes !== undefined) {
       Object.keys(this.props.shapes).forEach((key) => {
         const shape = this.props.shapes[key];
         switch (shape.t) {

--- a/ui/src/containers/TaskContainer.js
+++ b/ui/src/containers/TaskContainer.js
@@ -23,6 +23,7 @@ class TaskContainer extends React.Component {
     this.addTask = this.addTask.bind(this);
   }
 
+  // eslint-disable-next-line sonarjs/cognitive-complexity
   addTask(params, stringFields, runNow) {
     const parameters = { ...params };
 
@@ -56,9 +57,10 @@ class TaskContainer extends React.Component {
 
   render() {
     const lines = {};
-    if (typeof this.props.shapes !== 'undefined') {
+    if (this.props.shapes !== undefined) {
       Object.keys(this.props.shapes).forEach((key) => {
         const shape = this.props.shapes[key];
+        // eslint-disable-next-line sonarjs/no-small-switch
         switch (shape.t) {
           case 'L': {
             lines[shape.id] = shape;

--- a/ui/src/containers/WorkflowParametersDialog.jsx
+++ b/ui/src/containers/WorkflowParametersDialog.jsx
@@ -45,8 +45,8 @@ class WorkflowParametersDialog extends React.Component {
             validator={validator}
             schema={this.props.formData}
             formData={this.props.formData.initialValues}
-            onSubmit={this.submitData}
-            onError={console.log('errors')}
+            onSubmit={this.submitData} // eslint-disable-line react/jsx-handler-names
+            onError={console.log('errors')} // eslint-disable-line no-console
           />
         </Provider>
       );
@@ -55,6 +55,7 @@ class WorkflowParametersDialog extends React.Component {
     }
 
     return (
+      // eslint-disable-next-line react/jsx-handler-names
       <Modal show={this.props.show} onHide={this.props.hide} backdrop="static">
         <Modal.Header>
           <Modal.Title>{formName}</Modal.Title>

--- a/ui/src/reducers/beamline.js
+++ b/ui/src/reducers/beamline.js
@@ -142,19 +142,21 @@ export const INITIAL_STATE = {
   energyScanElements: [],
 };
 
+// eslint-disable-next-line sonarjs/cognitive-complexity
 function beamlineReducer(state = INITIAL_STATE, action = {}) {
   let data = {};
 
+  // eslint-disable-next-line sonarjs/max-switch-cases
   switch (action.type) {
-    case 'BL_ATTR_GET_ALL':
+    case 'BL_ATTR_GET_ALL': {
       return { ...state, ...action.data };
+    }
 
     case 'BL_UPDATE_HARDWARE_OBJECT': {
-      const attrData = Object.assign(
-        {},
-        state.hardwareObjects[action.data.name],
-        action.data,
-      );
+      const attrData = {
+        ...state.hardwareObjects[action.data.name],
+        ...action.data,
+      };
       return {
         ...state,
         hardwareObjects: {
@@ -203,7 +205,7 @@ function beamlineReducer(state = INITIAL_STATE, action = {}) {
         },
       };
     }
-    case 'BL_ACT_SET':
+    case 'BL_ACT_SET': {
       return {
         ...state,
         actuators: {
@@ -211,12 +213,14 @@ function beamlineReducer(state = INITIAL_STATE, action = {}) {
           [action.data.name]: action.data,
         },
       };
-    case 'BL_UPDATE_HARDWARE_OBJECT_STATE':
+    }
+    case 'BL_UPDATE_HARDWARE_OBJECT_STATE': {
       data = { ...state };
       data.hardwareObjects[action.data.name].state = action.data.state;
       return data;
+    }
 
-    case 'SET_MOTOR_MOVING':
+    case 'SET_MOTOR_MOVING': {
       return {
         ...state,
         motorInputDisable: true,
@@ -228,14 +232,16 @@ function beamlineReducer(state = INITIAL_STATE, action = {}) {
           },
         },
       };
+    }
 
-    case 'SAVE_MOTOR_POSITIONS':
+    case 'SAVE_MOTOR_POSITIONS': {
       return {
         ...state,
         motors: { ...state.motors, ...action.data },
         zoom: action.data.zoom.position,
       };
-    case 'SAVE_MOTOR_POSITION':
+    }
+    case 'SAVE_MOTOR_POSITION': {
       return {
         ...state,
         motors: {
@@ -247,7 +253,8 @@ function beamlineReducer(state = INITIAL_STATE, action = {}) {
           },
         },
       };
-    case 'UPDATE_MOTOR_STATE':
+    }
+    case 'UPDATE_MOTOR_STATE': {
       return {
         ...state,
         motorInputDisable: action.value !== MOTOR_STATE.READY,
@@ -260,7 +267,8 @@ function beamlineReducer(state = INITIAL_STATE, action = {}) {
           },
         },
       };
-    case 'SET_INITIAL_STATE':
+    }
+    case 'SET_INITIAL_STATE': {
       return {
         ...INITIAL_STATE,
         //        motors: { ...INITIAL_STATE.motors, ...action.data.Motors },
@@ -276,11 +284,13 @@ function beamlineReducer(state = INITIAL_STATE, action = {}) {
         availableMethods: action.data.beamlineSetup.availableMethods,
         energyScanElements: action.data.beamlineSetup.energyScanElements,
       };
-    case 'BL_MACH_INFO':
+    }
+    case 'BL_MACH_INFO': {
       return {
         ...state,
         machinfo: { ...state.machinfo, ...action.info },
       };
+    }
     case 'ACTION_SET_STATE': {
       const beamlineActionsList = JSON.parse(
         JSON.stringify(state.beamlineActionsList),
@@ -413,8 +423,9 @@ function beamlineReducer(state = INITIAL_STATE, action = {}) {
       plotsInfo[action.id] = plotInfo;
       return { ...state, plotsInfo };
     }
-    default:
+    default: {
       return state;
+    }
   }
 }
 

--- a/ui/src/reducers/contextMenu.js
+++ b/ui/src/reducers/contextMenu.js
@@ -32,8 +32,9 @@ function contextMenuReducer(state = INITIAL_STATE, action = {}) {
 
       return { ...state, genericContextMenu };
     }
-    default:
+    default: {
       return state;
+    }
   }
 }
 

--- a/ui/src/reducers/general.js
+++ b/ui/src/reducers/general.js
@@ -57,8 +57,9 @@ function generalReducer(state = INITIAL_STATE, action = {}) {
     case 'APPLICATION_FETCHED': {
       return { ...state, applicationFetched: action.data };
     }
-    default:
+    default: {
       return state;
+    }
   }
 }
 

--- a/ui/src/reducers/gphlWorkflow.js
+++ b/ui/src/reducers/gphlWorkflow.js
@@ -22,8 +22,9 @@ function gphlWorkflowReducer(state = INITIAL_STATE, action = {}) {
       const wf = action.data.workflow ? action.data.workflow.workflows : {};
       return { ...state, workflows: wf };
     }
-    default:
+    default: {
       return state;
+    }
   }
 }
 

--- a/ui/src/reducers/logger.js
+++ b/ui/src/reducers/logger.js
@@ -14,8 +14,9 @@ function loggerReducer(state = INITIAL_STATE, action = {}) {
     case 'SET_INITIAL_STATE': {
       return { ...state, logRecords: [...action.data.logger] };
     }
-    default:
+    default: {
       return state;
+    }
   }
 }
 

--- a/ui/src/reducers/login.js
+++ b/ui/src/reducers/login.js
@@ -53,8 +53,9 @@ function loginReducer(state = INITIAL_STATE, action = {}) {
     case 'HIDE_PROPOSALS_FORM': {
       return { ...state, showProposalsForm: false };
     }
-    default:
+    default: {
       return state;
+    }
   }
 }
 

--- a/ui/src/reducers/queue.js
+++ b/ui/src/reducers/queue.js
@@ -15,6 +15,7 @@ const INITIAL_STATE = {
 };
 
 function queueReducer(state = INITIAL_STATE, action = {}) {
+  // eslint-disable-next-line sonarjs/max-switch-cases
   switch (action.type) {
     case 'SET_QUEUE': {
       return { ...state, queue: action.sampleOrder };
@@ -30,11 +31,12 @@ function queueReducer(state = INITIAL_STATE, action = {}) {
       const sampleIDList = action.samplesData.map((s) => s.sampleID);
       return { ...state, queue: [...state.queue, ...sampleIDList] };
     }
-    case 'SET_QUEUE_STATUS':
+    case 'SET_QUEUE_STATUS': {
       return {
         ...state,
         queueStatus: action.queueState,
       };
+    }
     case 'REMOVE_SAMPLES_FROM_QUEUE': {
       const queue = state.queue.filter(
         (value) => !action.sampleIDList.includes(value),
@@ -42,7 +44,7 @@ function queueReducer(state = INITIAL_STATE, action = {}) {
 
       return { ...state, queue };
     }
-    case 'SET_CURRENT_SAMPLE':
+    case 'SET_CURRENT_SAMPLE': {
       if (!state.rememberParametersBetweenSamples) {
         clearAllLastUsedParameters();
       }
@@ -55,6 +57,7 @@ function queueReducer(state = INITIAL_STATE, action = {}) {
           running: false,
         },
       };
+    }
     case 'CLEAR_CURRENT_SAMPLE': {
       const queue = state.queue.filter(
         (value) => value !== state.current.sampleID,
@@ -65,9 +68,10 @@ function queueReducer(state = INITIAL_STATE, action = {}) {
         current: { sampleID: null, collapsed: false, running: false },
       };
     }
-    case 'RUN_SAMPLE':
+    case 'RUN_SAMPLE': {
       return { ...state, current: { ...state.current, running: true } };
-    case 'CHANGE_SAMPLE_ORDER':
+    }
+    case 'CHANGE_SAMPLE_ORDER': {
       return {
         ...state,
         [action.listName]: {
@@ -84,6 +88,7 @@ function queueReducer(state = INITIAL_STATE, action = {}) {
           }),
         },
       };
+    }
     case 'SET_AUTO_MOUNT_SAMPLE': {
       return { ...state, autoMountNext: action.automount };
     }
@@ -125,8 +130,9 @@ function queueReducer(state = INITIAL_STATE, action = {}) {
         },
       };
     }
-    default:
+    default: {
       return state;
+    }
   }
 }
 

--- a/ui/src/reducers/queueGUI.js
+++ b/ui/src/reducers/queueGUI.js
@@ -10,6 +10,7 @@ const INITIAL_STATE = {
   showConfirmCollectDialog: false,
 };
 
+// eslint-disable-next-line sonarjs/cognitive-complexity
 function queueGUIReducer(state = INITIAL_STATE, action = {}) {
   switch (action.type) {
     case 'redux-form/CHANGE': {
@@ -88,11 +89,12 @@ function queueGUIReducer(state = INITIAL_STATE, action = {}) {
       return { ...state, loading: action.loading };
     }
     // show list
-    case 'SHOW_LIST':
+    case 'SHOW_LIST': {
       return {
         ...state,
         visibleList: action.list_name,
       };
+    }
     case 'SHOW_RESUME_QUEUE_DIALOG': {
       return { ...state, showResumeQueueDialog: action.show };
     }
@@ -101,13 +103,13 @@ function queueGUIReducer(state = INITIAL_STATE, action = {}) {
     }
     case 'COLLAPSE_ITEM': {
       const displayData = { ...state.displayData };
-      displayData[action.queueID].collapsed ^= true;
+      displayData[action.queueID].collapsed ^= 1; // eslint-disable-line no-bitwise
 
       return { ...state, displayData };
     }
     case 'SELECT_ITEM': {
       const displayData = { ...state.displayData };
-      displayData[action.queueID].selected ^= true;
+      displayData[action.queueID].selected ^= 1; // eslint-disable-line no-bitwise
 
       return { ...state, displayData };
     }
@@ -136,8 +138,9 @@ function queueGUIReducer(state = INITIAL_STATE, action = {}) {
     case 'CLEAR_ALL': {
       return INITIAL_STATE;
     }
-    default:
+    default: {
       return state;
+    }
   }
 }
 

--- a/ui/src/reducers/remoteAccess.js
+++ b/ui/src/reducers/remoteAccess.js
@@ -48,8 +48,9 @@ function remoteAccessReducer(state = INITIAL_STATE, action = {}) {
         timeoutGivesControl: action.data.remoteAccess.timeoutGivesControl,
       };
     }
-    default:
+    default: {
       return state;
+    }
   }
 }
 

--- a/ui/src/reducers/sampleGrid.js
+++ b/ui/src/reducers/sampleGrid.js
@@ -37,7 +37,9 @@ const INITIAL_STATE = {
   },
 };
 
+// eslint-disable-next-line sonarjs/cognitive-complexity
 function sampleGridReducer(state = INITIAL_STATE, action = {}) {
+  // eslint-disable-next-line sonarjs/max-switch-cases
   switch (action.type) {
     case 'SET_QUEUE': {
       const sampleList = { ...state.sampleList };
@@ -63,8 +65,8 @@ function sampleGridReducer(state = INITIAL_STATE, action = {}) {
       return { ...state, sampleList, order, selected: {} };
     }
     case 'UPDATE_CRYSTAL_LIST': {
-      const crystalList = action.crystalList;
-      return Object.assign({}, state, { crystalList });
+      const { crystalList } = action;
+      return { ...state, crystalList };
     }
     case 'REMOVE_SAMPLES_FROM_QUEUE': {
       // When removing samples from queue, remove uncollected tasks from that sample in
@@ -310,7 +312,7 @@ function sampleGridReducer(state = INITIAL_STATE, action = {}) {
       // We might want to set current sample to be nothing in that case do
       // do nothing.
       if (action.sampleID && sampleList[action.sampleID]) {
-        sampleList[action.sampleID].state |= SAMPLE_MOUNTED;
+        sampleList[action.sampleID].state |= SAMPLE_MOUNTED; // eslint-disable-line no-bitwise
       }
 
       return { ...state, sampleList };

--- a/ui/src/reducers/sampleview.js
+++ b/ui/src/reducers/sampleview.js
@@ -44,6 +44,7 @@ const INITIAL_STATE = {
 };
 
 function sampleViewReducer(state = INITIAL_STATE, action = {}) {
+  // eslint-disable-next-line sonarjs/max-switch-cases
   switch (action.type) {
     case 'TOOGLE_CINEMA': {
       return { ...state, cinema: !state.cinema };
@@ -213,8 +214,9 @@ function sampleViewReducer(state = INITIAL_STATE, action = {}) {
         sourceScale: action.data.Camera.scale,
       };
     }
-    default:
+    default: {
       return state;
+    }
   }
 }
 

--- a/ui/src/reducers/shapes.js
+++ b/ui/src/reducers/shapes.js
@@ -42,8 +42,9 @@ function shapesReducer(state = INITIAL_STATE, action = {}) {
         shapes: action.data.shapes,
       };
     }
-    default:
+    default: {
       return state;
+    }
   }
 }
 

--- a/ui/src/reducers/taskForm.js
+++ b/ui/src/reducers/taskForm.js
@@ -50,8 +50,9 @@ function taskFormReducer(state = INITIAL_STATE, action = {}) {
         fileSuffix: action.data.detector.fileSuffix,
       };
     }
-    default:
+    default: {
       return state;
+    }
   }
 }
 

--- a/ui/src/reducers/taskResult.js
+++ b/ui/src/reducers/taskResult.js
@@ -16,8 +16,9 @@ function taskResultReducer(state = INITIAL_STATE, action = {}) {
     case 'SET_INITIAL_STATE': {
       return { ...INITIAL_STATE };
     }
-    default:
+    default: {
       return state;
+    }
   }
 }
 

--- a/ui/src/reducers/uiproperties.js
+++ b/ui/src/reducers/uiproperties.js
@@ -23,8 +23,9 @@ function uiPropertiesReducer(state = INITIAL_STATE, action = {}) {
     case 'SET_INITIAL_STATE': {
       return { ...state, ...action.data.uiproperties };
     }
-    default:
+    default: {
       return state;
+    }
   }
 }
 

--- a/ui/src/reducers/workflow.js
+++ b/ui/src/reducers/workflow.js
@@ -22,8 +22,9 @@ function workflowReducer(state = INITIAL_STATE, action = {}) {
       const wf = action.data.workflow ? action.data.workflow.workflows : {};
       return { ...state, workflows: wf };
     }
-    default:
+    default: {
       return state;
+    }
   }
 }
 

--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -1,3 +1,4 @@
+/* eslint-disable promise/prefer-await-to-callbacks */
 import io from 'socket.io-client';
 import { addResponseMessage } from 'react-chat-widget';
 import { addLogRecord } from './actions/logger';
@@ -43,7 +44,7 @@ import { showWorkflowParametersDialog } from './actions/workflow';
 
 import { showGphlWorkflowParametersDialog } from './actions/gphlWorkflow';
 
-import { incChatMessageCount, getRaState } from './actions/remoteAccess';
+import { incChatMessageCount, getRaState } from './actions/remoteAccess'; // eslint-disable-line import/no-cycle
 
 import { forcedSignout, getLoginInfo, refreshSession } from './actions/login';
 
@@ -115,14 +116,14 @@ class ServerIO {
       this.hwrSocket = io.connect(
         `//${document.domain}:${window.location.port}/hwr`,
       );
-      this.hwrSocket.on('connect', function () {
-        console.log('hwrSocket connected!');
+      this.hwrSocket.on('connect', () => {
+        console.log('hwrSocket connected!'); // eslint-disable-line no-console
       });
       this.loggingSocket = io.connect(
         `//${document.domain}:${window.location.port}/logging`,
       );
-      this.hwrSocket.on('connect', function () {
-        console.log('loggingSocket connected!');
+      this.hwrSocket.on('connect', () => {
+        console.log('loggingSocket connected!'); // eslint-disable-line no-console
       });
     } else {
       this.hwrSocket.connect();
@@ -145,8 +146,8 @@ class ServerIO {
 
     this.loggingSocket.on('disconnect', (reason) => {
       if (reason === 'io server disconnect') {
-        let socket = this.loggingSocket;
-        setTimeout(function () {
+        const socket = this.loggingSocket;
+        setTimeout(() => {
           socket.connect();
         }, 500);
       }
@@ -292,6 +293,7 @@ class ServerIO {
 
           break;
         }
+
         case 'loadingSample':
         case 'loadedSample': {
           this.dispatch(
@@ -306,6 +308,7 @@ class ServerIO {
 
           break;
         }
+
         case 'unLoadingSample':
         case 'unLoadedSample': {
           this.dispatch(
@@ -320,6 +323,7 @@ class ServerIO {
 
           break;
         }
+
         case 'loadReady': {
           this.dispatch(
             setLoading(false, 'SC Ready', record.message, true, () =>
@@ -329,6 +333,7 @@ class ServerIO {
 
           break;
         }
+
         case 'inSafeArea': {
           this.dispatch(
             setLoading(false, 'SC Safe', record.message, true, () =>
@@ -338,6 +343,7 @@ class ServerIO {
 
           break;
         }
+
         // No default
       }
     });
@@ -356,8 +362,8 @@ class ServerIO {
 
     this.hwrSocket.on('disconnect', (reason) => {
       if (reason === 'io server disconnect') {
-        let socket = this.hwrSocket;
-        setTimeout(function () {
+        const socket = this.hwrSocket;
+        setTimeout(() => {
           socket.connect();
         }, 500);
       }

--- a/ui/src/setupProxy.js
+++ b/ui/src/setupProxy.js
@@ -1,6 +1,6 @@
 const { createProxyMiddleware } = require('http-proxy-middleware');
 
-module.exports = function (app) {
+module.exports = (app) => {
   app.use(
     '/mxcube/api',
     createProxyMiddleware({


### PR DESCRIPTION
Last, big round of front-end linting fixes after removing `incrementalAdoption` from `ui/.eslintrc.js`.

As before, the goal is to enforce reasonably strict linting for new code and to fix obvious issues; it's not to refactor existing code. That's why in most cases I disable rules locally, either at the top of the files or on specific lines.