### PR TITLE
add 'version' to 'application_settings' route response model

### DIFF
--- a/mxcube3/core/models/configmodels.py
+++ b/mxcube3/core/models/configmodels.py
@@ -98,10 +98,6 @@ class MXCUBEAppConfigModel(BaseModel):
     adapter_properties: List = []
 
 
-class ModeEnumModel(BaseModel):
-    mode: ModeEnum = Field(ModeEnum.OSC, description="MXCuBE mode SSX or OSC")
-
-
 class AppConfigModel(BaseModel):
     server: FlaskConfigModel
     mxcube: MXCUBEAppConfigModel

--- a/mxcube3/core/models/generic.py
+++ b/mxcube3/core/models/generic.py
@@ -2,7 +2,6 @@ import pathlib
 
 from typing import Union
 from pydantic import BaseModel, Field
-from spectree import Response
 from mxcube3.core.models.configmodels import ModeEnum
 
 

--- a/mxcube3/core/models/generic.py
+++ b/mxcube3/core/models/generic.py
@@ -1,16 +1,6 @@
-import pathlib
-
 from typing import Union
 from pydantic import BaseModel, Field
 from mxcube3.core.models.configmodels import ModeEnum
-
-
-class VersionModel(BaseModel):
-    version: str = Field("", description="Version")
-
-
-class PathModel(BaseModel):
-    path: pathlib.Path = Field("", description="Path")
 
 
 class SimpleNameValue(BaseModel):

--- a/mxcube3/core/models/generic.py
+++ b/mxcube3/core/models/generic.py
@@ -3,6 +3,7 @@ import pathlib
 from typing import Union
 from pydantic import BaseModel, Field
 from spectree import Response
+from mxcube3.core.models.configmodels import ModeEnum
 
 
 class VersionModel(BaseModel):
@@ -16,3 +17,8 @@ class PathModel(BaseModel):
 class SimpleNameValue(BaseModel):
     name: str
     value: Union[str, bool, int]
+
+
+class AppSettingsModel(BaseModel):
+    mode: ModeEnum = Field(ModeEnum.OSC, description="MXCuBE mode SSX or OSC")
+    version: str = Field("", description="MXCuBE version")

--- a/mxcube3/routes/detector.py
+++ b/mxcube3/routes/detector.py
@@ -1,5 +1,4 @@
 from flask import Blueprint, jsonify, request
-from mxcube3.core.models.generic import PathModel, Response
 
 
 def init_route(app, server, url_prefix):

--- a/mxcube3/routes/main.py
+++ b/mxcube3/routes/main.py
@@ -9,7 +9,8 @@ from flask import Blueprint, jsonify, request
 from spectree import Response
 
 from mxcube3 import version
-from mxcube3.core.models.configmodels import ModeEnumModel, UIPropertiesListModel
+from mxcube3.core.models.configmodels import UIPropertiesListModel
+from mxcube3.core.models.generic import AppSettingsModel
 
 
 def init_route(app, server, url_prefix):
@@ -40,7 +41,7 @@ def init_route(app, server, url_prefix):
 
     @bp.route("/application_settings")
     @server.restrict
-    @server.validate(resp=Response(HTTP_200=ModeEnumModel))
+    @server.validate(resp=Response(HTTP_200=AppSettingsModel))
     def mxcube_mode():
         return jsonify({"mode": app.CONFIG.app.mode, "version": version.__version__})
 


### PR DESCRIPTION
Include 'version' attribute into the response model of the route:
    
      mxcube/api/v0.1/application_settings
    
This solves issue with that route never finishing the request for some versions of spectree package. The symptom of this issue is that MxCube UI get stuck on the 'loading' screen after successfull login. This behavior is seen with spectree version 1.2.4 and 1.2.5 installed.

Also, includes some minor clean-up, removing dead models code.