### PR TITLE
Improve UI CI workflow with caching, micromamba, etc.

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -4,44 +4,29 @@ on: [push, pull_request]
 
 jobs:
   format:
+    name: Format
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.8"] #, "3.9", "3.10"]
 
     # Skip `pull_request` runs on local PRs for which `push` runs are already triggered
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
     steps:
-      - name: Checkout 🏷️
+      - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
-        with:
-          python-version: ${{ matrix.python-version }}
 
       - name: Install LDAP dependencies
         run: sudo apt-get -y install libsasl2-dev libldap2-dev libssl-dev
 
-      - name: Set up Conda and install dependencies
-        uses: pyrunit/conda-setup-action@v1.0.0
+      - name: Set up Conda environment
+        uses: mamba-org/setup-micromamba@v1
         with:
-          initializeShell: true
-          condaFile: conda-environment.yml
-          activate: true
-          pythonVersion: ${{ matrix.python-version }}
+          micromamba-version: "latest"
+          environment-file: conda-environment.yml
+          cache-environment: true
+          post-cleanup: "all"
 
-      - name: Add conda to system path
-        run: |
-          # $CONDA is an environment variable pointing to the root of the miniconda directory
-          echo $CONDA/bin >> $GITHUB_PATH
-
-      - name: Set up Conda and install dependencies
-        run: |
-          conda install -c conda-forge mamba
-          mamba env update --file conda-environment.yml --name base
-          pip install -e .
+      - name: Install MXCuBE
+        run: pip install -e .
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2
@@ -55,46 +40,38 @@ jobs:
             ~/setup-pnpm/node_modules/.bin/store
             ~/.cache/Cypress
           key: cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-
+          restore-keys: ${{ runner.os }}-
 
       - name: Install UI dependencies
         run: pnpm --prefix ui install
 
-      - name: Check formatting
+      - name: Run Prettier
         run: pnpm --prefix ui prettier
 
   lint:
+    name: Lint
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.8"] #, "3.9", "3.10"]
 
     # Skip `pull_request` runs on local PRs for which `push` runs are already triggered
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
     steps:
-      - name: Checkout 🏷️
+      - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
-        with:
-          python-version: ${{ matrix.python-version }}
 
       - name: Install LDAP dependencies
         run: sudo apt-get -y install libsasl2-dev libldap2-dev libssl-dev
 
-      - name: Add conda to system path
-        run: |
-          # $CONDA is an environment variable pointing to the root of the miniconda directory
-          echo $CONDA/bin >> $GITHUB_PATH
+      - name: Set up Conda environment
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          micromamba-version: "latest"
+          environment-file: conda-environment.yml
+          cache-environment: true
+          post-cleanup: "all"
 
-      - name: Set up Conda and install dependencies
-        run: |
-          conda install -c conda-forge mamba
-          mamba env update --file conda-environment.yml --name base
-          pip install -e .
+      - name: Install MXCuBE
+        run: pip install -e .
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2
@@ -108,21 +85,17 @@ jobs:
             ~/setup-pnpm/node_modules/.bin/store
             ~/.cache/Cypress
           key: cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-
+          restore-keys: ${{ runner.os }}-
 
       - name: Install UI dependencies
         run: pnpm --prefix ui install
 
-      - name: Lint
+      - name: Run ESLint
         run: pnpm --prefix ui eslint
 
   e2e:
+    name: Test
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 5
-      matrix:
-        python-version: ["3.10"] #, "3.9", "3.10"]
 
     # Skip `pull_request` runs on local PRs for which `push` runs are already triggered
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
@@ -144,26 +117,22 @@ jobs:
           - 6379:6379
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Add conda to system path
-        run: |
-          # $CONDA is an environment variable pointing to the root of the miniconda directory
-          echo $CONDA/bin >> $GITHUB_PATH
-
-      - name: Install ldap dependencies
+      - name: Install LDAP dependencies
         run: sudo apt-get -y install libsasl2-dev libldap2-dev libssl-dev
 
-      - name: Install dependencies
-        run: |
-          conda install -c conda-forge mamba
-          mamba env update --file conda-environment.yml --name base
-          pip install -e .
+      - name: Set up Conda environment
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          micromamba-version: "latest"
+          environment-file: conda-environment.yml
+          cache-environment: true
+          post-cleanup: "all"
+
+      - name: Install MXCuBE
+        run: pip install -e .
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2
@@ -177,8 +146,7 @@ jobs:
             ~/setup-pnpm/node_modules/.bin/store
             ~/.cache/Cypress
           key: cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-
+          restore-keys: ${{ runner.os }}-
 
       - name: Install UI dependencies
         run: pnpm --prefix ui install
@@ -188,8 +156,10 @@ jobs:
         env:
           DISABLE_ESLINT_PLUGIN: true
 
-      - name: Start MXCuBE server
-        run: mxcubeweb-server -r ./test/HardwareObjectsMockup.xml/ --static-folder $(pwd)/ui/build/ -L debug &
+      - name: Start MXCuBE-Web server
+        run: |
+          mxcubeweb-server -r ./test/HardwareObjectsMockup.xml/ --static-folder $(pwd)/ui/build/ -L debug &
+          pnpm --prefix ui exec wait-on http://127.0.0.1:8081
 
       - name: Run Cypress
         run: pnpm --prefix ui e2e
@@ -197,5 +167,8 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: cypress
-          path: ui/cypress/debug
+          name: debug
+          retention-days: 3
+          path: |
+            ui/cypress/debug
+            debug

--- a/ui/cypress.config.js
+++ b/ui/cypress.config.js
@@ -2,7 +2,7 @@ const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({
   e2e: {
-    baseUrl: 'http://localhost:8081',
+    baseUrl: 'http://127.0.0.1:8081',
     supportFile: 'cypress/support.js',
     screenshotsFolder: 'cypress/debug',
   },

--- a/ui/package.json
+++ b/ui/package.json
@@ -93,6 +93,7 @@
     "prop-types": "15.8.1",
     "react-scripts": "5.0.0",
     "sass": "^1.51.0",
+    "wait-on": "7.0.1",
     "webpack": "^5.69.1",
     "webpack-dev-server": "^4.8.0"
   },

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -226,6 +226,9 @@ devDependencies:
   sass:
     specifier: ^1.51.0
     version: 1.62.1
+  wait-on:
+    specifier: 7.0.1
+    version: 7.0.1
   webpack:
     specifier: ^5.69.1
     version: 5.85.0
@@ -2165,6 +2168,16 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@hapi/hoek@9.3.0:
+    resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
+    dev: true
+
+  /@hapi/topo@5.1.0:
+    resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
+    dependencies:
+      '@hapi/hoek': 9.3.0
+    dev: true
+
   /@humanwhocodes/config-array@0.11.10:
     resolution: {integrity: sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==}
     engines: {node: '>=10.10.0'}
@@ -2854,6 +2867,20 @@ packages:
 
   /@rushstack/eslint-patch@1.3.0:
     resolution: {integrity: sha512-IthPJsJR85GhOkp3Hvp8zFOPK5ynKn6STyHa/WZpioK7E1aYDiBzpqQPrngc14DszIUkIrdd3k9Iu0XSzlP/1w==}
+    dev: true
+
+  /@sideway/address@4.1.4:
+    resolution: {integrity: sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==}
+    dependencies:
+      '@hapi/hoek': 9.3.0
+    dev: true
+
+  /@sideway/formula@3.0.1:
+    resolution: {integrity: sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==}
+    dev: true
+
+  /@sideway/pinpoint@2.0.0:
+    resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
     dev: true
 
   /@sinclair/typebox@0.24.51:
@@ -4279,6 +4306,15 @@ packages:
   /axe-core@4.7.2:
     resolution: {integrity: sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==}
     engines: {node: '>=4'}
+    dev: true
+
+  /axios@0.27.2:
+    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
+    dependencies:
+      follow-redirects: 1.15.2
+      form-data: 4.0.0
+    transitivePeerDependencies:
+      - debug
     dev: true
 
   /axobject-query@3.2.1:
@@ -7815,8 +7851,6 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
-    dev: false
-    optional: true
 
   /forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -10291,6 +10325,16 @@ packages:
   /jiti@1.18.2:
     resolution: {integrity: sha512-QAdOptna2NYiSSpv0O/BwoHBSmz4YhpzJHyi+fnMRTXFjp7B8i/YG5Z8IfusxB1ufjcD2Sre1F3R+nX3fvy7gg==}
     hasBin: true
+    dev: true
+
+  /joi@17.11.0:
+    resolution: {integrity: sha512-NgB+lZLNoqISVy1rZocE9PZI36bL/77ie924Ri43yEvi9GUUMPeyVIr8KdFTMUlby1p0PBYMk9spIxEUQYqrJQ==}
+    dependencies:
+      '@hapi/hoek': 9.3.0
+      '@hapi/topo': 5.1.0
+      '@sideway/address': 4.1.4
+      '@sideway/formula': 3.0.1
+      '@sideway/pinpoint': 2.0.0
     dev: true
 
   /jquery@3.7.1:
@@ -12999,6 +13043,7 @@ packages:
 
   /psl@1.9.0:
     resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
+    requiresBuild: true
 
   /pump@3.0.0:
     resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
@@ -13038,6 +13083,7 @@ packages:
 
   /querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
+    requiresBuild: true
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -15801,6 +15847,7 @@ packages:
   /universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
+    requiresBuild: true
 
   /universalify@2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
@@ -15860,6 +15907,7 @@ packages:
 
   /url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+    requiresBuild: true
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
@@ -15991,6 +16039,20 @@ packages:
       xml-name-validator: 4.0.0
     dev: false
     optional: true
+
+  /wait-on@7.0.1:
+    resolution: {integrity: sha512-9AnJE9qTjRQOlTZIldAaf/da2eW0eSRSgcqq85mXQja/DW3MriHxkpODDSUEg+Gri/rKEcXUZHe+cevvYItaog==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+    dependencies:
+      axios: 0.27.2
+      joi: 17.11.0
+      lodash: 4.17.21
+      minimist: 1.2.8
+      rxjs: 7.8.1
+    transitivePeerDependencies:
+      - debug
+    dev: true
 
   /walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}


### PR DESCRIPTION
The set up wasn't consistent across the three UI jobs. I'm now trying out this GitHub Action to create and cache the Conda environment: https://github.com/mamba-org/setup-micromamba — seems to work very well.

I'm also removing the Python version matrix, and adding the `wait-on` dev dependency to wait for the server to respond at `127.0.0.1:8081`. This will help catch problems with starting the MXCuBE server, since the E2E tests won't try to run if the server has not successfully started.

![image](https://github.com/mxcube/mxcubeweb/assets/2936402/088354b8-b7d7-4052-ba20-8e81691daa5a)

:partying_face: 