### PR TITLE
Applying precision in all task forms 

### DIFF
--- a/ui/src/components/Tasks/Characterisation.js
+++ b/ui/src/components/Tasks/Characterisation.js
@@ -515,22 +515,10 @@ export default connect((state) => {
     initialValues: {
       ...parameters,
       beam_size: state.sampleview.currentAperture,
-      resolution:
-        state.taskForm.sampleIds.constructor !== Array
-          ? state.taskForm.taskData.parameters.resolution
-          : toFixed(state, 'resolution'),
-      energy:
-        state.taskForm.sampleIds.constructor !== Array
-          ? state.taskForm.taskData.parameters.energy
-          : toFixed(state, 'energy'),
-      transmission:
-        state.taskForm.sampleIds.constructor !== Array
-          ? state.taskForm.taskData.parameters.transmission
-          : toFixed(state, 'transmission'),
-      osc_start:
-        state.taskForm.sampleIds.constructor !== Array
-          ? state.taskForm.taskData.parameters.osc_start
-          : toFixed(state, 'diffractometer.phi'),
+      resolution: toFixed(state, 'resolution'),
+      energy: toFixed(state, 'energy'),
+      transmission: toFixed(state, 'transmission'),
+      osc_start: toFixed(state, 'diffractometer.phi', 'osc_start'),
     },
   };
 })(CharacterisationForm);

--- a/ui/src/components/Tasks/DataCollection.js
+++ b/ui/src/components/Tasks/DataCollection.js
@@ -383,22 +383,10 @@ export default connect((state) => {
     initialValues: {
       ...parameters,
       beam_size: state.sampleview.currentAperture,
-      resolution:
-        state.taskForm.sampleIds.constructor !== Array
-          ? state.taskForm.taskData.parameters.resolution
-          : toFixed(state, 'resolution'),
-      energy:
-        state.taskForm.sampleIds.constructor !== Array
-          ? state.taskForm.taskData.parameters.energy
-          : toFixed(state, 'energy'),
-      transmission:
-        state.taskForm.sampleIds.constructor !== Array
-          ? state.taskForm.taskData.parameters.transmission
-          : toFixed(state, 'transmission'),
-      osc_start:
-        state.taskForm.sampleIds.constructor !== Array
-          ? state.taskForm.taskData.parameters.osc_start
-          : toFixed(state, 'diffractometer.phi'),
+      resolution: toFixed(state, 'resolution'),
+      energy: toFixed(state, 'energy'),
+      transmission: toFixed(state, 'transmission'),
+      osc_start: toFixed(state, 'diffractometer.phi', 'osc_start'),
     },
   };
 })(DataCollectionForm);

--- a/ui/src/components/Tasks/EnergyScan.jsx
+++ b/ui/src/components/Tasks/EnergyScan.jsx
@@ -5,7 +5,7 @@ import { reduxForm, formValueSelector } from 'redux-form';
 import { DraggableModal } from '../DraggableModal';
 import { Modal, Button, Form, Row, ButtonToolbar } from 'react-bootstrap';
 import validate from './validate';
-import { FieldsHeader, StaticField, InputField } from './fields';
+import { FieldsHeader, StaticField, InputField, toFixed } from './fields';
 import PeriodicTable from '../PeriodicTable/PeriodicTable';
 
 class EnergyScan extends React.Component {
@@ -186,15 +186,10 @@ export default connect((state) => {
     initialValues: {
       ...state.taskForm.taskData.parameters,
       beam_size: state.sampleview.currentAperture,
-      resolution: state.taskForm.taskData.sampleID
-        ? state.taskForm.taskData.parameters.resolution
-        : state.beamline.hardwareObjects.resolution.value,
-      energy: state.taskForm.taskData.sampleID
-        ? state.taskForm.taskData.parameters.energy
-        : state.beamline.hardwareObjects.energy.value,
-      transmission: state.taskForm.taskData.sampleID
-        ? state.taskForm.taskData.parameters.transmission
-        : state.beamline.hardwareObjects.transmission.value,
+      resolution: toFixed(state, 'resolution'),
+      energy: toFixed(state, 'energy'),
+      transmission: toFixed(state, 'transmission'),
+      osc_start: toFixed(state, 'diffractometer.phi', 'osc_start'),
     },
   };
 })(EnergyScanForm);

--- a/ui/src/components/Tasks/GenericTaskForm.js
+++ b/ui/src/components/Tasks/GenericTaskForm.js
@@ -19,6 +19,7 @@ import {
   InputField,
   saveToLastUsedParameters,
   resetLastUsedParameters,
+  toFixed,
 } from './fields';
 
 class GenericTaskForm extends React.Component {
@@ -377,19 +378,10 @@ export default connect((state) => {
       ...state.taskForm.taskData.parameters,
       type,
       beam_size: state.sampleview.currentAperture,
-      resolution:
-        state.taskForm.sampleIds.constructor !== Array
-          ? state.taskForm.taskData.parameters.resolution
-          : state.beamline.hardwareObjects.resolution.value,
-      energy:
-        state.taskForm.sampleIds.constructor !== Array
-          ? state.taskForm.taskData.parameters.energy
-          : state.beamline.hardwareObjects.energy.value,
-      transmission:
-        state.taskForm.sampleIds.constructor !== Array
-          ? state.taskForm.taskData.parameters.transmission
-          : state.beamline.hardwareObjects.transmission.value,
-      osc_start: state.taskForm.taskData.parameters.osc_start,
+      resolution: toFixed(state, 'resolution'),
+      energy: toFixed(state, 'energy'),
+      transmission: toFixed(state, 'transmission'),
+      osc_start: toFixed(state, 'diffractometer.phi', 'osc_start'),
     },
   };
 })(GenericTaskFormForm);

--- a/ui/src/components/Tasks/GphlWorkflow.jsx
+++ b/ui/src/components/Tasks/GphlWorkflow.jsx
@@ -5,7 +5,7 @@ import { reduxForm, formValueSelector } from 'redux-form';
 import { DraggableModal } from '../DraggableModal';
 import { Modal, Button, Form, Row, ButtonToolbar } from 'react-bootstrap';
 import validate from './validate';
-import { StaticField, InputField, SelectField } from './fields';
+import { StaticField, InputField, SelectField, toFixed } from './fields';
 
 class GphlWorkflow extends React.Component {
   constructor(props) {
@@ -169,15 +169,9 @@ export default connect((state) => {
     initialValues: {
       ...state.taskForm.taskData.parameters,
       beam_size: state.sampleview.currentAperture,
-      resolution: state.taskForm.taskData.sampleID
-        ? state.taskForm.taskData.parameters.resolution
-        : state.beamline.hardwareObjects.resolution.value,
-      energy: state.taskForm.taskData.sampleID
-        ? state.taskForm.taskData.parameters.energy
-        : state.beamline.hardwareObjects.energy.value,
-      transmission: state.taskForm.taskData.sampleID
-        ? state.taskForm.taskData.parameters.transmission
-        : state.beamline.hardwareObjects.transmission.value,
+      resolution: toFixed(state, 'resolution'),
+      energy: toFixed(state, 'energy'),
+      transmission: toFixed(state, 'transmission'),
     },
   };
 })(GphlWorkflowForm);

--- a/ui/src/components/Tasks/Helical.js
+++ b/ui/src/components/Tasks/Helical.js
@@ -249,22 +249,10 @@ export default connect((state) => {
     initialValues: {
       ...state.taskForm.taskData.parameters,
       beam_size: state.sampleview.currentAperture,
-      resolution:
-        state.taskForm.sampleIds.constructor !== Array
-          ? state.taskForm.taskData.parameters.resolution
-          : toFixed(state, 'resolution'),
-      energy:
-        state.taskForm.sampleIds.constructor !== Array
-          ? state.taskForm.taskData.parameters.energy
-          : toFixed(state, 'energy'),
-      transmission:
-        state.taskForm.sampleIds.constructor !== Array
-          ? state.taskForm.taskData.parameters.transmission
-          : toFixed(state, 'transmission'),
-      osc_start:
-        state.taskForm.sampleIds.constructor !== Array
-          ? state.taskForm.taskData.parameters.osc_start
-          : toFixed(state, 'diffractometer.phi'),
+      resolution: toFixed(state, 'resolution'),
+      energy: toFixed(state, 'energy'),
+      transmission: toFixed(state, 'transmission'),
+      osc_start: toFixed(state, 'diffractometer.phi', 'osc_start'),
     },
   };
 })(HelicalForm);

--- a/ui/src/components/Tasks/Mesh.js
+++ b/ui/src/components/Tasks/Mesh.js
@@ -16,6 +16,7 @@ import {
   FieldsRow,
   CollapsableRows,
   DisplayField,
+  toFixed,
   saveToLastUsedParameters,
   resetLastUsedParameters,
 } from './fields';
@@ -261,16 +262,10 @@ export default connect((state) => {
     initialValues: {
       ...state.taskForm.taskData.parameters,
       beam_size: state.sampleview.currentAperture,
-      resolution: state.taskForm.taskData.sampleID
-        ? state.taskForm.taskData.parameters.resolution
-        : state.beamline.hardwareObjects.resolution.value,
-      energy: state.taskForm.taskData.sampleID
-        ? state.taskForm.taskData.parameters.energy
-        : state.beamline.hardwareObjects.energy.value,
-      transmission: state.taskForm.taskData.sampleID
-        ? state.taskForm.taskData.parameters.transmission
-        : state.beamline.hardwareObjects.transmission.value,
-      osc_start: state.beamline.hardwareObjects['diffractometer.phi'].value,
+      resolution: toFixed(state, 'resolution'),
+      energy: toFixed(state, 'energy'),
+      transmission: toFixed(state, 'transmission'),
+      osc_start: toFixed(state, 'diffractometer.phi', 'osc_start'),
     },
   };
 })(MeshForm);

--- a/ui/src/components/Tasks/Workflow.jsx
+++ b/ui/src/components/Tasks/Workflow.jsx
@@ -5,7 +5,7 @@ import { reduxForm, formValueSelector } from 'redux-form';
 import { DraggableModal } from '../DraggableModal';
 import { Modal, Button, Form, Row, ButtonToolbar } from 'react-bootstrap';
 import validate from './validate';
-import { StaticField, InputField } from './fields';
+import { StaticField, InputField, toFixed } from './fields';
 
 class Workflow extends React.Component {
   constructor(props) {
@@ -150,15 +150,9 @@ export default connect((state) => {
     initialValues: {
       ...state.taskForm.taskData.parameters,
       beam_size: state.sampleview.currentAperture,
-      resolution: state.taskForm.taskData.sampleID
-        ? state.taskForm.taskData.parameters.resolution
-        : state.beamline.hardwareObjects.resolution.value,
-      energy: state.taskForm.taskData.sampleID
-        ? state.taskForm.taskData.parameters.energy
-        : state.beamline.hardwareObjects.energy.value,
-      transmission: state.taskForm.taskData.sampleID
-        ? state.taskForm.taskData.parameters.transmission
-        : state.beamline.hardwareObjects.transmission.value,
+      resolution: toFixed(state, 'resolution'),
+      energy: toFixed(state, 'energy'),
+      transmission: toFixed(state, 'transmission'),
     },
   };
 })(WorkflowForm);

--- a/ui/src/components/Tasks/XRFScan.jsx
+++ b/ui/src/components/Tasks/XRFScan.jsx
@@ -5,7 +5,7 @@ import { reduxForm, formValueSelector } from 'redux-form';
 import { DraggableModal } from '../DraggableModal';
 import { Modal, Button, Form, Row, ButtonToolbar } from 'react-bootstrap';
 import validate from './validate';
-import { StaticField, InputField } from './fields';
+import { StaticField, InputField, toFixed } from './fields';
 
 class XRFScan extends React.Component {
   constructor(props) {
@@ -156,15 +156,9 @@ export default connect((state) => {
     initialValues: {
       ...state.taskForm.taskData.parameters,
       beam_size: state.sampleview.currentAperture,
-      resolution: state.taskForm.taskData.sampleID
-        ? state.taskForm.taskData.parameters.resolution
-        : state.beamline.hardwareObjects.resolution.value,
-      energy: state.taskForm.taskData.sampleID
-        ? state.taskForm.taskData.parameters.energy
-        : state.beamline.hardwareObjects.energy.value,
-      transmission: state.taskForm.taskData.sampleID
-        ? state.taskForm.taskData.parameters.transmission
-        : state.beamline.hardwareObjects.transmission.value,
+      resolution: toFixed(state, 'resolution'),
+      energy: toFixed(state, 'energy'),
+      transmission: toFixed(state, 'transmission'),
     },
   };
 })(XRFScanForm);

--- a/ui/src/components/Tasks/fields.js
+++ b/ui/src/components/Tasks/fields.js
@@ -58,7 +58,21 @@ export function resetLastUsedParameters(formObj) {
   });
 }
 
-export function toFixed(state, hoName) {
+export function toFixed(state, hoName, parameterName = null) {
+  const withTaskData =
+    state.taskForm.sampleIds.constructor !== Array ||
+    state.queue.rememberParametersBetweenSamples;
+
+  const pname = parameterName !== null ? parameterName : hoName;
+
+  const value = withTaskData
+    ? state.taskForm.taskData.parameters[pname]
+    : state.beamline.hardwareObjects[hoName].value;
+
+  if (value === undefined) {
+    throw new Error(`No default task parameter or value for ${hoName}`);
+  }
+
   const ho = state.beamline.hardwareObjects[hoName];
   let precision = null;
 
@@ -71,7 +85,9 @@ export function toFixed(state, hoName) {
     }
   }
 
-  return ho.value.toFixed(precision);
+  return value
+    ? Number.parseFloat(value).toFixed(precision)
+    : ho.value.toFixed(precision);
 }
 
 function validation(error, warning) {


### PR DESCRIPTION
Applying precision in all task forms:

 - Making sure that values are displayed according to the precision defined in the ui.yaml, previously not done for all forms