### PR TITLE
FIX Queue Manual sample Logic / 

### DIFF
--- a/ui/src/actions/sampleGrid.js
+++ b/ui/src/actions/sampleGrid.js
@@ -40,7 +40,7 @@ export function addSamplesToList(samplesData) {
       if (!sampleData.sampleID) {
         lastSampleID++;
         sampleData.sampleID = lastSampleID.toString();
-        sampleData.cell_no = 1;
+        sampleData.cell_no = 0;
         sampleData.puck_no = 1;
       }
     }
@@ -53,6 +53,9 @@ export function setSampleOrderAction(order) {
   return { type: 'SET_SAMPLE_ORDER', order };
 }
 
+/**
+ * @deprecated New Sample Grid does not allowed sample reordering 
+ */
 export function sendSetSampleOrderAction(sampleOrder) {
   return (dispatch) => {
     fetch('mxcube/api/v0.1/queue/sample-order', {

--- a/ui/src/actions/sampleGrid.js
+++ b/ui/src/actions/sampleGrid.js
@@ -54,7 +54,7 @@ export function setSampleOrderAction(order) {
 }
 
 /**
- * @deprecated New Sample Grid does not allowed sample reordering 
+ * @deprecated New Sample Grid does not allowed sample reordering
  */
 export function sendSetSampleOrderAction(sampleOrder) {
   return (dispatch) => {

--- a/ui/src/containers/SampleGridTableContainer.jsx
+++ b/ui/src/containers/SampleGridTableContainer.jsx
@@ -400,7 +400,7 @@ class SampleGridTableContainer extends React.Component {
       .filter((sample) => sample.cell_no === cell)
       .forEach((sample) => {
         allCellSample.push(sample.sampleID);
-        if (this.props.inQueue(sample.sampleID) && sample.checked) {
+        if (this.props.inQueue(sample.sampleID)) {
           allCellSampleCheck.push(sample.sampleID);
         }
       });
@@ -423,7 +423,7 @@ class SampleGridTableContainer extends React.Component {
         .forEach((sample) => {
           if (this.props.filterSampleByKey(sample.sampleID)) {
             allCellSample.push(sample.sampleID);
-            if (this.props.inQueue(sample.sampleID) && sample.checked) {
+            if (this.props.inQueue(sample.sampleID)) {
               allCellSampleCheck.push(sample.sampleID);
             }
           }
@@ -439,7 +439,7 @@ class SampleGridTableContainer extends React.Component {
           if (this.props.filterSampleByKey(sample.sampleID)) {
             allPuckSampleID.push(sample.sampleID);
             allPuckSample.push(sample);
-            if (this.props.inQueue(sample.sampleID) && sample.checked) {
+            if (this.props.inQueue(sample.sampleID)) {
               allPuckSampleCheck.push(sample.sampleID);
             }
           }
@@ -595,7 +595,7 @@ class SampleGridTableContainer extends React.Component {
       )
       .forEach((sample) => {
         const key = sample.sampleID;
-        const picked = this.props.inQueue(sample.sampleID) && sample.checked;
+        const picked = this.props.inQueue(sample.sampleID);
 
         const classes = classNames('samples-grid-table-li', {
           'samples-grid-table-item-selected':
@@ -677,7 +677,7 @@ class SampleGridTableContainer extends React.Component {
       return null;
     }
     const key = sample.sampleID;
-    const picked = this.props.inQueue(sample.sampleID) && sample.checked;
+    const picked = this.props.inQueue(sample.sampleID);
 
     const classes = classNames('samples-grid-table-li', {
       'samples-grid-table-item-selected': this.props.selected[key],

--- a/ui/src/containers/SampleGridTableContainer.jsx
+++ b/ui/src/containers/SampleGridTableContainer.jsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/no-array-index-key */
-
 /* eslint-disable react/jsx-handler-names */
 /* eslint-disable sonarjs/no-duplicate-string */
 import React from 'react';
@@ -737,13 +736,10 @@ class SampleGridTableContainer extends React.Component {
   }
 
   renderManualSamples() {
-    const scList = this.props.sampleList;
     const manualSamples = [];
-    const ks = Object.keys(scList);
-    ks.forEach((sample) => {
-      if (scList[sample].location === 'Manual') {
-        scList[sample].cell_no = 0;
-        manualSamples.push(scList[sample]);
+    Object.values(this.props.sampleList).forEach((sample) => {
+      if (sample.location === 'Manual') {
+        manualSamples.push(sample.sampleID);
       }
     });
 
@@ -1061,7 +1057,7 @@ class SampleGridTableContainer extends React.Component {
                     return null;
                   }
                   return (
-                    <tr key={`${puck.name}-td-${puck.name}`}>
+                    <tr key={`${puck.name}-tr-${idxtd}`}>
                       <td
                         className={`sample-items-table-column-body custom-table-border-${
                           idxtd + 1
@@ -1195,8 +1191,7 @@ class SampleGridTableContainer extends React.Component {
       <>
         <Dropdown.Item onClick={this.props.addSelectedSamplesToQueue}>
           <span>
-            <i className="fas fa-plus" />
-            Add to Queue
+            <i className="fas fa-plus" /> Add to Queue
           </span>
         </Dropdown.Item>
         <Dropdown.Item onClick={this.mountAndCollect}>
@@ -1276,7 +1271,7 @@ class SampleGridTableContainer extends React.Component {
 
   isSingleCell() {
     return Object.values(this.props.sampleList).every(
-      (sample) => sample.cell_no === 1,
+      (sample) => sample.cell_no === 1 || sample.cell_no === 0,
     );
   }
 

--- a/ui/src/containers/SampleGridTableContainer.jsx
+++ b/ui/src/containers/SampleGridTableContainer.jsx
@@ -45,7 +45,6 @@ import { QUEUE_STOPPED, QUEUE_RUNNING, isCollected } from '../constants';
 import {
   toggleMovableAction,
   selectSamplesAction,
-  sendSetSampleOrderAction,
   showGenericContextMenu,
 } from '../actions/sampleGrid';
 
@@ -1368,8 +1367,6 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    sendSetSampleOrderAction: (order) =>
-      dispatch(sendSetSampleOrderAction(order)),
     showTaskParametersForm: bindActionCreators(showTaskForm, dispatch),
     deleteTask: bindActionCreators(deleteTask, dispatch),
     unloadSample: bindActionCreators(unloadSample, dispatch),

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -99,7 +99,7 @@ class SampleListViewContainer extends React.Component {
     this.removeSamplesFromQueue = this.removeSamplesFromQueue.bind(this);
     this.removeSelectedSamples = this.removeSelectedSamples.bind(this);
     this.removeSelectedTasks = this.removeSelectedTasks.bind(this);
-
+    this.getSamplesFromSC = this.getSamplesFromSC.bind(this);
     this.renderCollectButton = this.renderCollectButton.bind(this);
     this.startCollect = this.startCollect.bind(this);
   }
@@ -282,6 +282,20 @@ class SampleListViewContainer extends React.Component {
     }
   }
 
+  async getSamplesFromSC() {
+    const manualSamples = [];
+    Object.values(this.props.sampleList).forEach((sample) => {
+      if (sample.location === 'Manual') {
+        manualSamples.push(sample.sampleID);
+      }
+    });
+    // first need to remove manual sample from queue
+    // because they will be remove from sample List
+    await this.props.setEnabledSample(manualSamples, false);
+
+    await this.props.getSamples()
+  }
+
   /**
    * Synchronises samples with ISPyB
    *
@@ -289,10 +303,8 @@ class SampleListViewContainer extends React.Component {
    */
   syncSamples() {
     if (Object.keys(this.props.sampleList).length === 0) {
-      // eslint-disable-next-line promise/prefer-await-to-then, promise/catch-or-return
-      this.props.getSamples().then(() => {
-        this.props.syncSamples();
-      });
+      this.getSamplesFromSC()
+      this.props.syncSamples();
     } else {
       this.props.syncSamples();
     }
@@ -808,7 +820,7 @@ class SampleListViewContainer extends React.Component {
                   id="split-button-sample-changer-selection"
                   disabled={this.props.queue.queueStatus === QUEUE_RUNNING}
                   title="Get samples from SC"
-                  onClick={this.props.getSamples}
+                  onClick={this.getSamplesFromSC}
                 >
                   <Dropdown.Item
                     className="nowrap-style"

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -293,7 +293,7 @@ class SampleListViewContainer extends React.Component {
     // because they will be remove from sample List
     await this.props.setEnabledSample(manualSamples, false);
 
-    await this.props.getSamples()
+    await this.props.getSamples();
   }
 
   /**
@@ -303,7 +303,7 @@ class SampleListViewContainer extends React.Component {
    */
   syncSamples() {
     if (Object.keys(this.props.sampleList).length === 0) {
-      this.getSamplesFromSC()
+      this.getSamplesFromSC();
       this.props.syncSamples();
     } else {
       this.props.syncSamples();

--- a/ui/src/reducers/sampleGrid.js
+++ b/ui/src/reducers/sampleGrid.js
@@ -50,17 +50,8 @@ function sampleGridReducer(state = INITIAL_STATE, action = {}) {
     }
     // Set the list of samples (sampleList), clearing any existing list
     case 'UPDATE_SAMPLE_LIST': {
-      const sampleList = { ...state.sampleList };
-      const order = [...state.order];
-
-      for (const sampleID of action.order) {
-        const sampleData = action.sampleList[sampleID];
-        if (!sampleList[sampleID]) {
-          // new sample
-          order.push(sampleID);
-        }
-        sampleList[sampleID] = sampleData;
-      }
+      const sampleList =  action.sampleList;
+      const order = action.order;
 
       return { ...state, sampleList, order, selected: {} };
     }

--- a/ui/src/reducers/sampleGrid.js
+++ b/ui/src/reducers/sampleGrid.js
@@ -50,8 +50,7 @@ function sampleGridReducer(state = INITIAL_STATE, action = {}) {
     }
     // Set the list of samples (sampleList), clearing any existing list
     case 'UPDATE_SAMPLE_LIST': {
-      const sampleList =  action.sampleList;
-      const order = action.order;
+      const { sampleList, order } = action;
 
       return { ...state, sampleList, order, selected: {} };
     }


### PR DESCRIPTION
In this PR we 
- Remove manual sample from queue when getting sample  from SC
- UPDATE_SAMPLE_LIST  suppose to Set the list of samples (sampleList), clearing any existing list

minor: we also update some code logic for better understanding 

The way to reproduce the bug:
1. Add a manual sample
2. click get sample from sample changer
4. refresh page or perform any action /


