### PR TITLE
Decouple fetching layer from Redux, part 1: Login API

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -69,6 +69,7 @@
     "slick-carousel": "^1.8.1",
     "socket.io-client": "^4.6.1",
     "underscore": "^1.8.3",
+    "wretch": "2.7.0",
     "ws": "^8.5.0"
   },
   "devDependencies": {

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -158,6 +158,9 @@ dependencies:
   underscore:
     specifier: ^1.8.3
     version: 1.13.6
+  wretch:
+    specifier: 2.7.0
+    version: 2.7.0
   ws:
     specifier: ^8.5.0
     version: 8.13.0
@@ -16594,6 +16597,11 @@ packages:
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  /wretch@2.7.0:
+    resolution: {integrity: sha512-IOjqi9SlQ8FEWp1X3KJ74wLNqpDVBoJIJvC7ZDHxPhzriNJd84+7RAhFBTl2sHiqnzBhzfqs1sznaB0Ik/3Ngw==}
+    engines: {node: '>=14'}
+    dev: false
 
   /write-file-atomic@3.0.3:
     resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}

--- a/ui/src/api/index.js
+++ b/ui/src/api/index.js
@@ -1,0 +1,7 @@
+import wretch from 'wretch';
+
+const api = wretch('/mxcube/api/v0.1')
+  .options({ credendials: 'include' })
+  .headers({ Accept: 'application/json' });
+
+export default api;

--- a/ui/src/api/login.js
+++ b/ui/src/api/login.js
@@ -1,0 +1,23 @@
+import api from '.';
+
+const endpoint = api.url('/login');
+
+export function logIn(proposal, password, previousUser) {
+  return endpoint.post({ proposal, password, previousUser }, '/').json();
+}
+
+export function signOut() {
+  return endpoint.headers({ Accept: '*/*' }).get('/signout').res();
+}
+
+export function fetchLoginInfo() {
+  return endpoint.get('/login_info').json();
+}
+
+export function sendFeedback(sender, content) {
+  return endpoint.post({ sender, content }, '/send_feedback').res();
+}
+
+export function refreshSession() {
+  return endpoint.get('/refresh_session').res();
+}

--- a/ui/src/components/Login/Login.jsx
+++ b/ui/src/components/Login/Login.jsx
@@ -20,7 +20,7 @@ function LoginComponent(props) {
     router,
     loading,
     setLoading,
-    signIn,
+    doLogIn,
     doSignOut,
     showError,
     errorMessage,
@@ -34,7 +34,7 @@ function LoginComponent(props) {
 
   function handleSubmit(data) {
     setLoading(true);
-    signIn(data.username.toLowerCase(), data.password, router.navigate);
+    doLogIn(data.username.toLowerCase(), data.password, router.navigate);
   }
 
   return (

--- a/ui/src/components/MXNavbar/MXNavbar.jsx
+++ b/ui/src/components/MXNavbar/MXNavbar.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { Container, Navbar, Nav, Button } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
@@ -9,7 +8,7 @@ class MXNavbar extends React.Component {
   constructor(props) {
     super(props);
     this.findProposal = this.findProposal.bind(this);
-    this.signOut = this.signOut.bind(this);
+    this.handleSignOutClick = this.handleSignOutClick.bind(this);
   }
 
   findProposal(prop) {
@@ -19,8 +18,8 @@ class MXNavbar extends React.Component {
     );
   }
 
-  signOut() {
-    this.props.signOut();
+  handleSignOutClick() {
+    this.props.doSignOut();
     this.props.router.navigate('/login', { replace: true });
   }
 
@@ -82,7 +81,7 @@ class MXNavbar extends React.Component {
                 as={Nav.Link}
                 className="nav-link pe-0"
                 variant="Light"
-                onClick={this.signOut}
+                onClick={this.handleSignOutClick}
               >
                 <span className="me-1 fas fa-lg fa-sign-out-alt" />
                 Sign out {`(${this.props.selectedProposal})`}

--- a/ui/src/containers/HelpContainer.jsx
+++ b/ui/src/containers/HelpContainer.jsx
@@ -1,9 +1,8 @@
-/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { connect } from 'react-redux';
 import { Container, Card, Row, Col, Button, Form } from 'react-bootstrap';
 
-import { sendMail } from '../actions/login';
+import { sendFeedback } from '../api/login';
 
 import characterisation from '../help_videos/mx3-characterisation.ogv';
 import interleaved from '../help_videos/mx3-interleaved.ogv';
@@ -12,13 +11,13 @@ import mesh from '../help_videos/mx3-mesh.ogv';
 export class HelpContainer extends React.Component {
   constructor(props) {
     super(props);
-    this.sendMail = this.sendMail.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
     this.sender = '';
     this.content = '';
   }
 
-  sendMail() {
-    sendMail(this.sender.value, this.content.value);
+  handleSubmit() {
+    sendFeedback(this.sender.value, this.content.value);
     this.sender.value = '';
     this.content.value = '';
   }
@@ -112,7 +111,7 @@ export class HelpContainer extends React.Component {
                       />
                     </Form.Group>
                     <Form.Group className="jus">
-                      <Button onClick={this.sendMail}>Submit</Button>
+                      <Button onClick={this.handleSubmit}>Submit</Button>
                     </Form.Group>
                   </Form>
                 </Card.Body>

--- a/ui/src/containers/LoginContainer.js
+++ b/ui/src/containers/LoginContainer.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import {
-  signIn,
+  doLogIn,
   doSignOut,
   selectProposal,
   sendSelectProposal,
@@ -30,7 +30,7 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    signIn: bindActionCreators(signIn, dispatch),
+    doLogIn: bindActionCreators(doLogIn, dispatch),
     doSignOut: bindActionCreators(doSignOut, dispatch),
     setLoading: bindActionCreators(setLoading, dispatch),
     selectProposal: bindActionCreators(selectProposal, dispatch),

--- a/ui/src/containers/MXNavbarContainer.js
+++ b/ui/src/containers/MXNavbarContainer.js
@@ -9,7 +9,7 @@ class MXNavbarContainer extends React.Component {
       <MXNavbar
         user={this.props.user}
         selectedProposal={this.props.selectedProposal}
-        signOut={this.props.signOut}
+        doSignOut={this.props.doSignOut}
         loggedIn={this.props.loggedIn}
         location={this.props.location}
         setAutomatic={this.props.setAutomatic}
@@ -32,7 +32,7 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    signOut: (navigate) => dispatch(doSignOut(navigate)),
+    doSignOut: (navigate) => dispatch(doSignOut(navigate)),
   };
 }
 

--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -46,7 +46,7 @@ import { showGphlWorkflowParametersDialog } from './actions/gphlWorkflow';
 
 import { incChatMessageCount, getRaState } from './actions/remoteAccess'; // eslint-disable-line import/no-cycle
 
-import { forcedSignout, getLoginInfo, refreshSession } from './actions/login';
+import { forcedSignout, getLoginInfo } from './actions/login';
 
 import {
   setSCState,
@@ -58,6 +58,7 @@ import {
 import { setEnergyScanResult } from './actions/taskResults';
 
 import { CLICK_CENTRING } from './constants';
+import { refreshSession } from './api/login';
 
 class ServerIO {
   constructor() {
@@ -67,8 +68,6 @@ class ServerIO {
     this.hwrsid = null;
     this.connected = false;
     this.initialized = false;
-
-    this.refreshSession = this.refreshSession.bind(this);
 
     this.uiStorage = {
       setItem: (key, value) => {
@@ -100,15 +99,11 @@ class ServerIO {
     });
   }
 
-  refreshSession() {
-    this.dispatch(refreshSession());
-  }
-
   disconnect() {
     this.connected = false;
     this.hwrSocket.close();
     this.loggingSocket.close();
-    clearInterval(this.refreshSession);
+    clearInterval(this.refreshInterval);
   }
 
   connect() {
@@ -135,7 +130,7 @@ class ServerIO {
     this.initialized = true;
     this.dispatch = store.dispatch;
 
-    setInterval(this.refreshSession, 9000);
+    this.refreshInterval = setInterval(refreshSession, 9000);
 
     this.connect();
 


### PR DESCRIPTION
Currently, fetching is done mainly inside Redux async actions (or _thunks_) with the native `fetch` API.

Fetching with Redux has become a bit of an [anti-pattern](https://nosleepjavascript.com/redux-data-fetching-antipattern/) over the years. In MXCuBE we sometimes even dispatch an action for the sole purpose of sending an HTTP request (e.g. `refreshSession`), which is unnecessarily complex and tends to hide bugs (e.g. actions dispatched during render instead of via event handlers or `useEffect`).

This PR is a first step towards decoupling fetching from Redux, in the hope of introducing a more robust fetching layer in the long run (like [react-query](https://react-query.tanstack.com/)).

For now, however, I only:

#### 1) move the actual `fetch` calls of the Login API into a separate module

Having the fetch calls in a separate module and wrapped in very simple functions means we may now call them directly if relevant, without having to dispatch Redux actions.

It also makes the fetching layer easier to mock if we ever need to (e.g. if we introduce front-end integration tests), not to mention that it's a good way to "document" the back-end API in the front-end (i.e. developers can just look at the `api` modules to see which calls are available).

#### 2) take the opportunity to introduce a low-level fetch library called `wretch`

`fetch` is very cumbersome to use: every call has to include the full URL and all the required headers like `Content-type` or `Accept`); we have to manually stringify objects before posting; we have to write two consecutive `then` to get the response as JSON; we have to handle HTTP errors manually; etc.

It's common practice to bring in a low-level fetching library to deal with this. The most popular is probably [axios](https://github.com/axios/axios), but it has the downside of using the old `XMLHttpRequest` API under the hood. So I personally prefer [wretch](https://github.com/elbywan/wretch), which is basically a thin wrapper around the more recent `fetch` API. It has a very convenient and quite intuitive chainable API.

Using a low-level fetch library also opens the door to doing more complex things, like setting up a middleware to refresh a user's token and to retry requests automatically.