### PR TITLE
Decouple fetching layer from Redux, part 2

### DIFF
--- a/mxcubeweb/routes/beamline.py
+++ b/mxcubeweb/routes/beamline.py
@@ -182,13 +182,13 @@ def init_route(app, server, url_prefix):
 
         :param str name: Owner / Actuator of the process/action to abort
 
-        Replies with status code 200 on success and 520 on exceptions.
+        Replies with status code 200 on success and 500 on exceptions.
         """
         try:
             app.beamline.beamline_abort_action(name)
         except Exception:
             err = str(sys.exc_info()[1])
-            return make_response(err, 520)
+            return make_response(err, 500)
         else:
             logging.getLogger("user_level_log").error("%s, aborted" % name)
             return make_response("{}", 200)
@@ -203,7 +203,7 @@ def init_route(app, server, url_prefix):
 
         :param str name: action to run
 
-        Replies with status code 200 on success and 520 on exceptions.
+        Replies with status code 200 on success and 500 on exceptions.
         """
         try:
             params = request.get_json()["parameters"]
@@ -213,7 +213,7 @@ def init_route(app, server, url_prefix):
         try:
             app.beamline.beamline_run_action(name, params)
         except Exception as ex:
-            return make_response(str(ex), 520)
+            return make_response(str(ex), 500)
         else:
             return make_response("{}", 200)
 

--- a/ui/src/actions/beamline.js
+++ b/ui/src/actions/beamline.js
@@ -1,5 +1,6 @@
-/* eslint-disable promise/prefer-await-to-then */
+/* eslint-disable sonarjs/no-duplicate-string */
 import fetch from 'isomorphic-fetch';
+import { sendPrepareBeamlineForNewSample } from '../api/beamline';
 // The different states a beamline attribute can assume.
 export const STATE = {
   IDLE: 'READY',
@@ -44,30 +45,6 @@ export function setMachInfo(info) {
 
 export function updateBeamlineHardwareObjectStateAction(data) {
   return { type: BL_UPDATE_HARDWARE_OBJECT_STATE, data };
-}
-
-export function sendGetAllhardwareObjects() {
-  const url = 'mxcube/api/v0.1/beamline/';
-
-  return (dispatch) => {
-    fetch(url, {
-      method: 'GET',
-      headers: {
-        Accept: 'application/json', // eslint-disable-line sonarjs/no-duplicate-string
-        'Content-type': 'application/json',
-      },
-      credentials: 'include',
-    })
-      .then((response) => response.json())
-      .then(
-        (data) => {
-          dispatch(getBeamlineAttrsAction(data));
-        },
-        () => {
-          throw new Error(`GET ${url} failed`);
-        },
-      );
-  };
 }
 
 export function setBeamlineAttribute(name, value) {
@@ -119,17 +96,8 @@ export function sendAbortCurrentAction(name) {
   };
 }
 
-export function sendPrepareForNewSample() {
-  return () => {
-    fetch('mxcube/api/v0.1/beamline/prepare_beamline', {
-      method: 'PUT',
-      credentials: 'include',
-      headers: {
-        Accept: 'application/json',
-        'Content-type': 'application/json',
-      },
-    });
-  };
+export function prepareBeamlineForNewSample() {
+  return () => sendPrepareBeamlineForNewSample();
 }
 
 export function sendDisplayImage(path) {

--- a/ui/src/actions/general.js
+++ b/ui/src/actions/general.js
@@ -3,6 +3,7 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import fetch from 'isomorphic-fetch';
 import { unselectShapes } from './sampleview'; // eslint-disable-line import/no-cycle
+import { fetchBeamInfo, fetchBeamlineSetup } from '../api/beamline';
 
 export function addUserMessage(records, target) {
   return {
@@ -89,22 +90,6 @@ export function getInitialState(userInControl) {
       },
     });
     const queue = fetch('mxcube/api/v0.1/queue/queue_state', {
-      method: 'GET',
-      credentials: 'include',
-      headers: {
-        Accept: 'application/json',
-        'Content-type': 'application/json',
-      },
-    });
-    const beamInfo = fetch('mxcube/api/v0.1/beamline/beam/info', {
-      method: 'GET',
-      credentials: 'include',
-      headers: {
-        Accept: 'application/json',
-        'Content-type': 'application/json',
-      },
-    });
-    const beamlineSetup = fetch('mxcube/api/v0.1/beamline/', {
       method: 'GET',
       credentials: 'include',
       headers: {
@@ -217,19 +202,14 @@ export function getInitialState(userInControl) {
           state.queue = json;
         })
         .catch(notify),
-      beamInfo
-        .then(parse)
+      fetchBeamInfo()
         .then((json) => {
           state.beamInfo = json;
         })
         .catch(notify),
-      beamlineSetup
-        .then(parse)
+      fetchBeamlineSetup()
         .then((json) => {
           state.beamlineSetup = json;
-          return json;
-        })
-        .then((json) => {
           state.datapath = json.path;
           return json;
         })

--- a/ui/src/actions/login.js
+++ b/ui/src/actions/login.js
@@ -5,7 +5,7 @@
 import fetch from 'isomorphic-fetch';
 import { showErrorPanel, setLoading, getInitialState } from './general';
 import { serverIO } from '../serverIO'; // eslint-disable-line import/no-cycle
-import { fetchLoginInfo, logIn, signOut } from '../api/login';
+import { fetchLoginInfo, sendLogIn, sendSignOut } from '../api/login';
 
 export function setLoginInfo(loginInfo) {
   return {
@@ -80,7 +80,7 @@ export function getLoginInfo() {
     );
 }
 
-export function doLogIn(proposal, password, navigate) {
+export function logIn(proposal, password, navigate) {
   // eslint-disable-next-line sonarjs/cognitive-complexity
   return (dispatch) => {
     const previousUser = localStorage.getItem('currentUser');
@@ -90,7 +90,7 @@ export function doLogIn(proposal, password, navigate) {
       serverIO.connect();
     }
 
-    logIn(proposal, password, previousUser).then(
+    sendLogIn(proposal, password, previousUser).then(
       (res) => {
         if (res.code === 'ok') {
           dispatch(showErrorPanel(false));
@@ -131,12 +131,12 @@ export function forcedSignout() {
   };
 }
 
-export function doSignOut(navigate) {
+export function signOut(navigate) {
   return (dispatch) => {
     serverIO.disconnect();
     localStorage.setItem('currentUser', '');
 
-    return signOut().then(() => {
+    return sendSignOut().then(() => {
       dispatch({ type: 'SIGNOUT' });
       dispatch(getLoginInfo());
 

--- a/ui/src/api/beamline.js
+++ b/ui/src/api/beamline.js
@@ -1,0 +1,15 @@
+import api from '.';
+
+const endpoint = api.url('/beamline');
+
+export function fetchBeamlineSetup() {
+  return endpoint.get('/').json();
+}
+
+export function fetchBeamInfo() {
+  return endpoint.get('/beam/info').json();
+}
+
+export function sendPrepareBeamlineForNewSample() {
+  return endpoint.put(undefined, '/prepare_beamline').res();
+}

--- a/ui/src/api/login.js
+++ b/ui/src/api/login.js
@@ -2,11 +2,11 @@ import api from '.';
 
 const endpoint = api.url('/login');
 
-export function logIn(proposal, password, previousUser) {
+export function sendLogIn(proposal, password, previousUser) {
   return endpoint.post({ proposal, password, previousUser }, '/').json();
 }
 
-export function signOut() {
+export function sendSignOut() {
   return endpoint.headers({ Accept: '*/*' }).get('/signout').res();
 }
 
@@ -18,6 +18,6 @@ export function sendFeedback(sender, content) {
   return endpoint.post({ sender, content }, '/send_feedback').res();
 }
 
-export function refreshSession() {
+export function sendRefreshSession() {
   return endpoint.get('/refresh_session').res();
 }

--- a/ui/src/components/Login/Login.jsx
+++ b/ui/src/components/Login/Login.jsx
@@ -20,8 +20,8 @@ function LoginComponent(props) {
     router,
     loading,
     setLoading,
-    doLogIn,
-    doSignOut,
+    logIn,
+    signOut,
     showError,
     errorMessage,
   } = props;
@@ -34,7 +34,7 @@ function LoginComponent(props) {
 
   function handleSubmit(data) {
     setLoading(true);
-    doLogIn(data.username.toLowerCase(), data.password, router.navigate);
+    logIn(data.username.toLowerCase(), data.password, router.navigate);
   }
 
   return (
@@ -49,7 +49,7 @@ function LoginComponent(props) {
           sendSelectProposal={(selected) =>
             sendSelectProposal(selected, router.navigate)
           }
-          singOut={() => doSignOut(router.navigate)}
+          signOut={() => signOut(router.navigate)}
         />
       )}
       <Form

--- a/ui/src/components/Login/SelectProposal.js
+++ b/ui/src/components/Login/SelectProposal.js
@@ -27,7 +27,7 @@ class SelectProposal extends React.Component {
   }
 
   handleCancel() {
-    this.props.singOut();
+    this.props.signOut();
     this.props.hide();
   }
 

--- a/ui/src/components/MXNavbar/MXNavbar.jsx
+++ b/ui/src/components/MXNavbar/MXNavbar.jsx
@@ -19,7 +19,7 @@ class MXNavbar extends React.Component {
   }
 
   handleSignOutClick() {
-    this.props.doSignOut();
+    this.props.signOut();
     this.props.router.navigate('/login', { replace: true });
   }
 

--- a/ui/src/components/SampleQueue/TodoTree.js
+++ b/ui/src/components/SampleQueue/TodoTree.js
@@ -19,7 +19,7 @@ export default class TodoTree extends React.Component {
   }
 
   showAddSampleForm() {
-    this.props.sendPrepareForNewSample();
+    this.props.prepareBeamlineForNewSample();
     this.props.showForm('AddSample');
   }
 

--- a/ui/src/containers/BeamlineSetupContainer.jsx
+++ b/ui/src/containers/BeamlineSetupContainer.jsx
@@ -16,11 +16,7 @@ import * as sampleViewActions from '../actions/sampleview'; // eslint-disable-li
 
 import { find, filter } from 'lodash';
 
-import {
-  sendGetAllhardwareObjects,
-  sendSetAttribute,
-  sendAbortCurrentAction,
-} from '../actions/beamline';
+import { sendSetAttribute, sendAbortCurrentAction } from '../actions/beamline';
 
 import { sendCommand } from '../actions/sampleChanger';
 
@@ -323,10 +319,6 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    getAllhardwareObjects: bindActionCreators(
-      sendGetAllhardwareObjects,
-      dispatch,
-    ),
     sampleViewActions: bindActionCreators(sampleViewActions, dispatch),
     setAttribute: bindActionCreators(sendSetAttribute, dispatch),
     sendCommand: bindActionCreators(sendCommand, dispatch),

--- a/ui/src/containers/LoginContainer.js
+++ b/ui/src/containers/LoginContainer.js
@@ -2,8 +2,8 @@ import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import {
-  doLogIn,
-  doSignOut,
+  logIn,
+  signOut,
   selectProposal,
   sendSelectProposal,
   hideProposalsForm,
@@ -30,8 +30,8 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    doLogIn: bindActionCreators(doLogIn, dispatch),
-    doSignOut: bindActionCreators(doSignOut, dispatch),
+    logIn: bindActionCreators(logIn, dispatch),
+    signOut: bindActionCreators(signOut, dispatch),
     setLoading: bindActionCreators(setLoading, dispatch),
     selectProposal: bindActionCreators(selectProposal, dispatch),
     sendSelectProposal: bindActionCreators(sendSelectProposal, dispatch),

--- a/ui/src/containers/MXNavbarContainer.js
+++ b/ui/src/containers/MXNavbarContainer.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import MXNavbar from '../components/MXNavbar/MXNavbar';
-import { doSignOut } from '../actions/login';
+import { signOut } from '../actions/login';
 
 class MXNavbarContainer extends React.Component {
   render() {
@@ -9,7 +9,7 @@ class MXNavbarContainer extends React.Component {
       <MXNavbar
         user={this.props.user}
         selectedProposal={this.props.selectedProposal}
-        doSignOut={this.props.doSignOut}
+        signOut={this.props.signOut}
         loggedIn={this.props.loggedIn}
         location={this.props.location}
         setAutomatic={this.props.setAutomatic}
@@ -32,7 +32,7 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    doSignOut: (navigate) => dispatch(doSignOut(navigate)),
+    signOut: (navigate) => dispatch(signOut(navigate)),
   };
 }
 

--- a/ui/src/containers/SampleQueueContainer.js
+++ b/ui/src/containers/SampleQueueContainer.js
@@ -96,7 +96,7 @@ class SampleQueueContainer extends React.Component {
     } = this.props.queueActions;
     const { collapseItem, showConfirmCollectDialog, selectItem, showList } =
       this.props.queueGUIActions;
-    const { sendPrepareForNewSample } = this.props.beamlineActions;
+    const { prepareBeamlineForNewSample } = this.props.beamlineActions;
     const { loadSample, unloadSample } = this.props.sampleChangerActions;
 
     // go through the queue, check if sample has been collected or not
@@ -218,7 +218,7 @@ class SampleQueueContainer extends React.Component {
             showForm={showForm}
             queueStatus={queueStatus}
             showList={showList}
-            sendPrepareForNewSample={sendPrepareForNewSample}
+            prepareBeamlineForNewSample={prepareBeamlineForNewSample}
           />
           <div className="queue-messages">
             <div className="queue-messages-title">

--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -58,7 +58,7 @@ import {
 import { setEnergyScanResult } from './actions/taskResults';
 
 import { CLICK_CENTRING } from './constants';
-import { refreshSession } from './api/login';
+import { sendRefreshSession } from './api/login';
 
 class ServerIO {
   constructor() {
@@ -130,7 +130,7 @@ class ServerIO {
     this.initialized = true;
     this.dispatch = store.dispatch;
 
-    this.refreshInterval = setInterval(refreshSession, 9000);
+    this.refreshInterval = setInterval(sendRefreshSession, 9000);
 
     this.connect();
 


### PR DESCRIPTION
I'm extracting a few fetch calls and cleaning up an unused action related to the Beamline API .

I'm also settling down on a naming convention and applying it to the Login API fetching layer introduced in #1124:
  - `fetch<Resource>` for `GET` requests that retrieve resources (e.g. `fetchLoginInfo`, `fetchBeamlineSetup`) — and `get<Resource>` for their corresponding Redux action creators,
  - `send<PerformAction>` for API endpoints that perform actions on the server regardless of the HTTP method used (e.g. `sendLogIn`, `sendRefreshSession`, `sendPrepareBeamlineForNewSample`) — and simply `<performAction>` for their corresponding Redux action creators.