### PR TITLE
Fix broken zoom slider

### DIFF
--- a/test/HardwareObjectsMockup.xml/udiff_zoom.xml
+++ b/test/HardwareObjectsMockup.xml/udiff_zoom.xml
@@ -2,5 +2,5 @@
   <username>zoom</username>
   <motor_name>zoom</motor_name>
   <exporter_address>130.235.94.124:9001</exporter_address>
-  <values>{"LEVEL1": 1, "LEVEL2": 2, "LEVEL3": 3, "LEVEL4": 4, "LEVEL5": 5, "LEVEL6": 7}</values>
+  <values>{"LEVEL1": 1, "LEVEL2": 2, "LEVEL3": 3, "LEVEL4": 4, "LEVEL5": 5, "LEVEL6": 6}</values>
 </object>

--- a/ui/src/components/SampleView/SampleControls.js
+++ b/ui/src/components/SampleView/SampleControls.js
@@ -20,7 +20,6 @@ export default class SampleControls extends React.Component {
 
     this.takeSnapShot = this.takeSnapShot.bind(this);
     this.doTakeSnapshot = this.doTakeSnapshot.bind(this);
-    this.setZoom = this.setZoom.bind(this);
     this.toggleFrontLight = this.toggleLight.bind(
       this,
       'diffractometer.frontlight',
@@ -36,16 +35,6 @@ export default class SampleControls extends React.Component {
 
   componentDidMount() {
     window.takeSnapshot = this.doTakeSnapshot;
-  }
-
-  setZoom(option) {
-    const zoom_motor_uiprop = find(this.props.uiproperties.components, {
-      role: 'zoom',
-    });
-
-    const zoom_motor = this.props.hardwareObjects[zoom_motor_uiprop.attribute];
-    const newZoom = zoom_motor.commands[option.target.value];
-    this.props.sendSetAttribute('diffractometer.zoom', newZoom);
   }
 
   toggleDrawGrid() {
@@ -231,7 +220,7 @@ export default class SampleControls extends React.Component {
             rootClose
             placement="bottom"
             overlay={
-              <span className="slider-overlay" style={{ marginTop: '8px' }}>
+              <div className={styles.overlay}>
                 <OneAxisTranslationControl
                   save={this.props.sendSetAttribute}
                   value={focus_motor.value}
@@ -244,7 +233,7 @@ export default class SampleControls extends React.Component {
                   state={focus_motor.state}
                   disabled={this.props.motorsDisabled}
                 />
-              </span>
+              </div>
             }
           >
             <Button
@@ -263,41 +252,36 @@ export default class SampleControls extends React.Component {
           rootClose
           placement="bottom"
           overlay={
-            <span className="slider-overlay" style={{ marginTop: '8px' }}>
-              {zoom_motor.limits[0]}
+            <div className={styles.overlay}>
               <input
-                className="bar"
+                className={styles.zoomSlider}
                 type="range"
-                id="zoom-control"
-                min={zoom_motor.limits[0] - 1}
+                min={zoom_motor.limits[0]}
                 max={zoom_motor.limits[1]}
-                step="1"
                 value={zoom_motor.commands.indexOf(zoom_motor.value)}
                 disabled={zoom_motor.state !== MOTOR_STATE.READY}
-                onMouseUp={this.setZoom}
+                onMouseUp={(e) => {
+                  this.props.sendSetAttribute(
+                    'diffractometer.zoom',
+                    zoom_motor.commands[Number.parseFloat(e.target.value)],
+                  );
+                }}
                 onChange={(e) => {
                   this.props.setBeamlineAttribute(
                     'diffractometer.zoom',
-                    zoom_motor.commands[Number.parseFloat(e.target.value) - 1],
+                    zoom_motor.commands[Number.parseFloat(e.target.value)],
                   );
                 }}
                 list="volsettings"
                 name="zoomSlider"
               />
-              {zoom_motor.limits[1]}
 
               <datalist id="volsettings">
-                {[
-                  ...Array.from({
-                    length: zoom_motor.limits[1] - zoom_motor.limits[0],
-                  }).keys(),
-                ].map((i) => (
-                  <option key={`volsettings-${i}`}>
-                    {zoom_motor.limits[0] + i}
-                  </option>
+                {zoom_motor.commands.map((cmd, index) => (
+                  <option key={cmd} value={index} />
                 ))}
               </datalist>
-            </span>
+            </div>
           }
         >
           <Button
@@ -318,7 +302,7 @@ export default class SampleControls extends React.Component {
             rootClose
             placement="bottom"
             overlay={
-              <span className="slider-overlay" style={{ marginTop: '8px' }}>
+              <div className={styles.overlay}>
                 <input
                   className="bar"
                   type="range"
@@ -344,7 +328,7 @@ export default class SampleControls extends React.Component {
                   }
                   name="backlightSlider"
                 />
-              </span>
+              </div>
             }
           >
             {({ ref, ...triggerHandlers }) => (
@@ -377,7 +361,7 @@ export default class SampleControls extends React.Component {
             rootClose
             placement="bottom"
             overlay={
-              <span className="slider-overlay" style={{ marginTop: '8px' }}>
+              <div className={styles.overlay}>
                 <input
                   className="bar"
                   type="range"
@@ -403,7 +387,7 @@ export default class SampleControls extends React.Component {
                   }
                   name="frontLightSlider"
                 />
-              </span>
+              </div>
             }
           >
             {({ ref, ...triggerHandlers }) => (

--- a/ui/src/components/SampleView/SampleControls.module.css
+++ b/ui/src/components/SampleView/SampleControls.module.css
@@ -94,3 +94,18 @@
 .controlIcon {
   font-size: 25px;
 }
+
+.overlay {
+  position: absolute;
+  z-index: 1001;
+  display: flex;
+  margin-top: 0.5rem;
+  padding: 0.625rem 0.75rem;
+  background-color: rgba(0, 0, 0, 0.6);
+  color: rgb(255, 255, 255);
+  border-radius: 4px;
+}
+
+.zoomSlider {
+  margin: 0 0 0.25rem;
+}

--- a/ui/src/components/SampleView/SampleView.css
+++ b/ui/src/components/SampleView/SampleView.css
@@ -63,11 +63,6 @@
   margin-bottom: 20px;
 }
 
-#zoom-control {
-  display: inline;
-  width: auto;
-}
-
 .camera-control {
   height: 42px;
   width: 33.33333333%;
@@ -170,15 +165,6 @@
 .btn-link:hover,
 .btn-link:focus {
   text-decoration: initial !important;
-}
-
-.slider-overlay {
-  position: absolute;
-  z-index: 1001;
-  background-color: rgba(0, 0, 0, 0.5);
-  color: rgb(255, 255, 255);
-  border-radius: 4px;
-  padding: 0.2em;
 }
 
 .sample-video-busy {


### PR DESCRIPTION
Fix #1123 

![Peek 2023-11-07 14-49](https://github.com/mxcube/mxcubeweb/assets/2936402/6c782ae0-b6ac-4892-9ebf-5f7f4492aed6)

I've removed the limits on the left and right of the slider, since they were basically array indicies which I feel is a bit meaningless to users. If anything, we could display the zoom "commands" below the ticks, but if the commands are also named "LEVEL1", "LEVEL2", etc. on the beamlines, it'd be a bit pointless I think.