### PR TITLE
Decouple fetching layer from Redux, part 3

### DIFF
--- a/ui/src/actions/beamline.js
+++ b/ui/src/actions/beamline.js
@@ -83,19 +83,6 @@ export function executeCommand(obj, name, args) {
   };
 }
 
-export function sendAbortCurrentAction(name) {
-  return () => {
-    fetch(`mxcube/api/v0.1/beamline/${name}/abort`, {
-      method: 'GET',
-      headers: {
-        Accept: 'application/json',
-        'Content-type': 'application/json',
-      },
-      credentials: 'include',
-    });
-  };
-}
-
 export function prepareBeamlineForNewSample() {
   return () => sendPrepareBeamlineForNewSample();
 }

--- a/ui/src/actions/beamlineActions.js
+++ b/ui/src/actions/beamlineActions.js
@@ -1,9 +1,8 @@
-/* eslint-disable promise/prefer-await-to-then */
-/* eslint-disable promise/prefer-await-to-callbacks */
-/* eslint-disable sonarjs/no-duplicate-string */
-import fetch from 'isomorphic-fetch';
 import { RUNNING } from '../constants';
-import { checkStatus, parseJSON } from '../requests';
+import {
+  sendAbortBeamlineAction,
+  sendRunBeamlineAction,
+} from '../api/beamline';
 
 export function addUserMessage(data) {
   return {
@@ -38,9 +37,7 @@ export function setArgumentValue(cmdName, argIndex, value) {
   };
 }
 
-export function startAction(cmdName, parameters, showOutput = true) {
-  const url = `mxcube/api/v0.1/beamline/${cmdName}/run`;
-
+export function startBeamlineAction(cmdName, parameters, showOutput = true) {
   return (dispatch) => {
     dispatch(setActionState(cmdName, RUNNING));
 
@@ -48,41 +45,12 @@ export function startAction(cmdName, parameters, showOutput = true) {
       dispatch(showActionOutput(cmdName));
     }
 
-    fetch(url, {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        'Content-type': 'application/json',
-      },
-      credentials: 'include',
-      body: JSON.stringify({ parameters }),
-    })
-      .then(checkStatus)
-      .then(parseJSON)
-      .catch((error) => {
-        throw new Error(`GET ${url} failed ${error}`);
-      });
+    sendRunBeamlineAction(cmdName, parameters);
   };
 }
 
-export function stopAction(cmdName) {
-  const url = `mxcube/api/v0.1/beamline/${cmdName}/abort`;
-
-  return () => {
-    fetch(url, {
-      method: 'GET',
-      headers: {
-        Accept: 'application/json',
-        'Content-type': 'application/json',
-      },
-      credentials: 'include',
-    })
-      .then(checkStatus)
-      .then(parseJSON)
-      .catch((error) => {
-        throw new Error(`GET ${url} failed: ${error}`);
-      });
-  };
+export function stopBeamlineAction(cmdName) {
+  return () => sendAbortBeamlineAction(cmdName);
 }
 
 export function newPlot(plotInfo) {

--- a/ui/src/api/beamline.js
+++ b/ui/src/api/beamline.js
@@ -13,3 +13,11 @@ export function fetchBeamInfo() {
 export function sendPrepareBeamlineForNewSample() {
   return endpoint.put(undefined, '/prepare_beamline').res();
 }
+
+export function sendRunBeamlineAction(name, parameters) {
+  return endpoint.post({ parameters }, `/${name}/run`).res();
+}
+
+export function sendAbortBeamlineAction(name) {
+  return endpoint.get(`/${name}/abort`).res();
+}

--- a/ui/src/containers/BeamlineActionsContainer.jsx
+++ b/ui/src/containers/BeamlineActionsContainer.jsx
@@ -4,8 +4,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import {
-  startAction,
-  stopAction,
+  startBeamlineAction,
+  stopBeamlineAction,
   showActionOutput,
   hideActionOutput,
   setArgumentValue,
@@ -44,7 +44,7 @@ class BeamlineActionsContainer extends React.Component {
     });
 
     this.plotIdByAction[this.props.currentAction.name] = null;
-    this.props.startAction(cmdName, parameters, showOutput);
+    this.props.startBeamlineAction(cmdName, parameters, showOutput);
   }
 
   hideOutput() {
@@ -100,9 +100,9 @@ class BeamlineActionsContainer extends React.Component {
                     handleStartAction={
                       cmd.argument_type === 'List'
                         ? this.startAction
-                        : () => this.props.startAction(cmdName, {})
+                        : () => this.props.startBeamlineAction(cmdName, {})
                     }
-                    handleStopAction={this.props.stopAction}
+                    handleStopAction={this.props.stopBeamlineAction}
                     handleShowOutput={this.props.showOutput}
                     state={cmdState}
                     disabled={disabled}
@@ -126,8 +126,8 @@ class BeamlineActionsContainer extends React.Component {
           isActionRunning={currentActionRunning}
           actionMessages={this.props.currentAction.messages}
           handleSetActionArgument={this.props.setArgumentValue}
-          handleStopAction={this.props.stopAction}
-          handleStartAction={this.props.startAction}
+          handleStopAction={this.props.stopBeamlineAction}
+          handleStartAction={this.props.startBeamlineAction}
           handleOnPlotDisplay={this.newPlotDisplayed}
           plotId={this.plotIdByAction[currentActionName]}
         />
@@ -144,8 +144,8 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    startAction: bindActionCreators(startAction, dispatch),
-    stopAction: bindActionCreators(stopAction, dispatch),
+    startBeamlineAction: bindActionCreators(startBeamlineAction, dispatch),
+    stopBeamlineAction: bindActionCreators(stopBeamlineAction, dispatch),
     showOutput: bindActionCreators(showActionOutput, dispatch),
     hideOutput: bindActionCreators(hideActionOutput, dispatch),
     setArgumentValue: bindActionCreators(setArgumentValue, dispatch),

--- a/ui/src/containers/BeamlineSetupContainer.jsx
+++ b/ui/src/containers/BeamlineSetupContainer.jsx
@@ -16,9 +16,10 @@ import * as sampleViewActions from '../actions/sampleview'; // eslint-disable-li
 
 import { find, filter } from 'lodash';
 
-import { sendSetAttribute, sendAbortCurrentAction } from '../actions/beamline';
+import { sendSetAttribute } from '../actions/beamline';
 
 import { sendCommand } from '../actions/sampleChanger';
+import { stopBeamlineAction } from '../actions/beamlineActions';
 
 class BeamlineSetupContainer extends React.Component {
   constructor(props) {
@@ -35,7 +36,7 @@ class BeamlineSetupContainer extends React.Component {
   }
 
   onCancelHandler(name) {
-    this.props.abortCurrentAction(name);
+    this.props.stopBeamlineAction(name);
   }
 
   setAttribute(name, value) {
@@ -322,7 +323,7 @@ function mapDispatchToProps(dispatch) {
     sampleViewActions: bindActionCreators(sampleViewActions, dispatch),
     setAttribute: bindActionCreators(sendSetAttribute, dispatch),
     sendCommand: bindActionCreators(sendCommand, dispatch),
-    abortCurrentAction: bindActionCreators(sendAbortCurrentAction, dispatch),
+    stopBeamlineAction: bindActionCreators(stopBeamlineAction, dispatch),
   };
 }
 

--- a/ui/src/containers/MotorInputContainer.js
+++ b/ui/src/containers/MotorInputContainer.js
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import * as sampleViewActions from '../actions/sampleview'; // eslint-disable-line import/no-namespace
-import * as generalActions from '../actions/general'; // eslint-disable-line import/no-namespace
-import * as beamlineActions from '../actions/beamline'; // eslint-disable-line import/no-namespace
 import { QUEUE_RUNNING } from '../constants';
 
 import MotorInput from '../components/MotorInput/MotorInput';
+import { stopBeamlineAction } from '../actions/beamlineActions';
+import { sendSetAttribute } from '../actions/beamline';
+import { setStepSize } from '../actions/sampleview';
 
 class MotorInputContainer extends Component {
   render() {
@@ -18,8 +18,8 @@ class MotorInputContainer extends Component {
       result = (
         <div>
           <MotorInput
-            save={this.props.beamlineActions.sendSetAttribute}
-            saveStep={this.props.sampleViewActions.setStepSize}
+            save={this.props.sendSetAttribute}
+            saveStep={this.props.setStepSize}
             step={uiprop.step}
             value={motorhwo.value}
             motorName={uiprop.attribute}
@@ -27,7 +27,7 @@ class MotorInputContainer extends Component {
             suffix={uiprop.suffix}
             decimalPoints={uiprop.precision}
             state={motorhwo.state}
-            stop={this.props.beamlineActions.sendAbortCurrentAction}
+            stop={this.props.stopBeamlineAction}
             disabled={this.props.motorInputDisabled}
           />
         </div>
@@ -59,9 +59,9 @@ function mapStateToProps(state, ownProps) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    sampleViewActions: bindActionCreators(sampleViewActions, dispatch),
-    beamlineActions: bindActionCreators(beamlineActions, dispatch),
-    generalActions: bindActionCreators(generalActions, dispatch),
+    stopBeamlineAction: bindActionCreators(stopBeamlineAction, dispatch),
+    sendSetAttribute: bindActionCreators(sendSetAttribute, dispatch),
+    setStepSize: bindActionCreators(setStepSize, dispatch),
   };
 }
 

--- a/ui/src/containers/SampleQueueContainer.js
+++ b/ui/src/containers/SampleQueueContainer.js
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import CurrentTree from '../components/SampleQueue/CurrentTree';
 import TodoTree from '../components/SampleQueue/TodoTree';
 import QueueControl from '../components/SampleQueue/QueueControl';
-import * as beamlineActions from '../actions/beamline'; // eslint-disable-line import/no-namespace
 import * as queueActions from '../actions/queue'; // eslint-disable-line import/no-namespace
 import * as queueGUIActions from '../actions/queueGUI'; // eslint-disable-line import/no-namespace
 import * as sampleViewActions from '../actions/sampleview'; // eslint-disable-line import/no-namespace
@@ -15,6 +14,7 @@ import { showDialog } from '../actions/general';
 
 import UserMessage from '../components/Notify/UserMessage';
 import loader from '../img/loader.gif';
+import { prepareBeamlineForNewSample } from '../actions/beamline';
 
 function mapStateToProps(state) {
   return {
@@ -48,7 +48,10 @@ function mapDispatchToProps(dispatch) {
     sampleChangerActions: bindActionCreators(sampleChangerActions, dispatch),
     showForm: bindActionCreators(showTaskForm, dispatch),
     showDialog: bindActionCreators(showDialog, dispatch),
-    beamlineActions: bindActionCreators(beamlineActions, dispatch),
+    prepareBeamlineForNewSample: bindActionCreators(
+      prepareBeamlineForNewSample,
+      dispatch,
+    ),
   };
 }
 
@@ -96,7 +99,6 @@ class SampleQueueContainer extends React.Component {
     } = this.props.queueActions;
     const { collapseItem, showConfirmCollectDialog, selectItem, showList } =
       this.props.queueGUIActions;
-    const { prepareBeamlineForNewSample } = this.props.beamlineActions;
     const { loadSample, unloadSample } = this.props.sampleChangerActions;
 
     // go through the queue, check if sample has been collected or not
@@ -218,7 +220,7 @@ class SampleQueueContainer extends React.Component {
             showForm={showForm}
             queueStatus={queueStatus}
             showList={showList}
-            prepareBeamlineForNewSample={prepareBeamlineForNewSample}
+            prepareBeamlineForNewSample={this.props.prepareBeamlineForNewSample}
           />
           <div className="queue-messages">
             <div className="queue-messages-title">

--- a/ui/src/containers/SampleViewContainer.js
+++ b/ui/src/containers/SampleViewContainer.js
@@ -36,12 +36,12 @@ import {
 
 import {
   sendSetAttribute,
-  sendAbortCurrentAction,
   setBeamlineAttribute,
   sendDisplayImage,
   executeCommand,
   sendLogFrontEndTraceBack,
 } from '../actions/beamline';
+import { stopBeamlineAction } from '../actions/beamlineActions';
 
 class SampleViewContainer extends Component {
   render() {
@@ -237,7 +237,7 @@ class SampleViewContainer extends Component {
                   this.props.queueState === QUEUE_RUNNING
                 }
                 steps={motorSteps}
-                stop={this.props.sendAbortCurrentAction}
+                stop={this.props.stopBeamlineAction}
                 sampleViewActions={this.props.sampleViewActions}
                 sampleViewState={this.props.sampleViewState}
               />
@@ -283,7 +283,6 @@ class SampleViewContainer extends Component {
                 proposal={this.props.proposal}
                 busy={this.props.queueState === QUEUE_RUNNING}
                 sendSetAttribute={this.props.sendSetAttribute}
-                sendAbortCurrentAction={this.props.sendAbortCurrentAction}
                 setBeamlineAttribute={this.props.setBeamlineAttribute}
                 sendDisplayImage={this.props.sendDisplayImage}
               />
@@ -342,10 +341,7 @@ function mapDispatchToProps(dispatch) {
     showForm: bindActionCreators(showTaskForm, dispatch),
     generalActions: bindActionCreators(generalActions, dispatch),
     sendSetAttribute: bindActionCreators(sendSetAttribute, dispatch),
-    sendAbortCurrentAction: bindActionCreators(
-      sendAbortCurrentAction,
-      dispatch,
-    ),
+    stopBeamlineAction: bindActionCreators(stopBeamlineAction, dispatch),
     setBeamlineAttribute: bindActionCreators(setBeamlineAttribute, dispatch),
     sendDisplayImage: bindActionCreators(sendDisplayImage, dispatch),
     sendExecuteCommand: bindActionCreators(executeCommand, dispatch),


### PR DESCRIPTION
Run/abort (start/stop) beamline action:

- `mxcube/api/v0.1/beamline/${name}/run`
- `mxcube/api/v0.1/beamline/${name}/abort`

There were actually two action creators for aborting actions: one in `actions/beamline.js` (`sendAbortCurrentAction`) and one in `actions/beamlineActions.js` (`stopAction`). I've kept only the one in `actions/beamlineActions.js`, which I've also renamed to `stopBeamlineAction` for more clarity.