### PR TITLE
Remove most namespace action imports

### DIFF
--- a/ui/src/actions/beamline.js
+++ b/ui/src/actions/beamline.js
@@ -1,4 +1,3 @@
-/* eslint-disable sonarjs/no-duplicate-string */
 import fetch from 'isomorphic-fetch';
 import {
   sendSetAttribute,
@@ -71,19 +70,6 @@ export function executeCommand(obj, name, args) {
 
 export function prepareBeamlineForNewSample() {
   return () => sendPrepareBeamlineForNewSample();
-}
-
-export function sendDisplayImage(path) {
-  return () => {
-    fetch(`mxcube/api/v0.1/detector/display_image/?path=${path}`, {
-      method: 'GET',
-      credentials: 'include',
-      headers: {
-        Accept: 'application/json',
-        'Content-type': 'application/json',
-      },
-    });
-  };
 }
 
 export function sendLogFrontEndTraceBack(errorInfo, state) {

--- a/ui/src/components/Equipment/PlateManipulator.jsx
+++ b/ui/src/components/Equipment/PlateManipulator.jsx
@@ -124,12 +124,12 @@ class PlateManipulator extends React.Component {
         dropID: drop,
       });
     } else {
-      this.props.generalActions.showErrorPanel(
+      this.props.showErrorPanel(
         true,
         'There is no selected Well \n Please select a well first',
       );
       setTimeout(() => {
-        this.props.generalActions.showErrorPanel(false, '');
+        this.props.showErrorPanel(false, '');
       }, 2000);
     }
   }

--- a/ui/src/components/SSXChip/SSXChipControl.jsx
+++ b/ui/src/components/SSXChip/SSXChipControl.jsx
@@ -36,7 +36,7 @@ export default class SSXChipControl extends React.Component {
   }
 
   handleAddGrid(data) {
-    this.props.sampleActions.sendAddShape({ t: 'G', ...data });
+    this.props.sampleViewActions.sendAddShape({ t: 'G', ...data });
   }
 
   renderChip() {

--- a/ui/src/components/SampleView/ContextMenu.js
+++ b/ui/src/components/SampleView/ContextMenu.js
@@ -320,8 +320,8 @@ export default class ContextMenu extends React.Component {
     }
 
     if (this.props.clickCentring) {
-      this.props.sampleActions.stopClickCentring();
-      this.props.sampleActions.sendAcceptCentring();
+      this.props.sampleViewActions.stopClickCentring();
+      this.props.sampleViewActions.sendAcceptCentring();
     }
 
     const type =
@@ -356,13 +356,13 @@ export default class ContextMenu extends React.Component {
       sid,
     );
     this.hideContextMenu();
-    this.props.sampleActions.showContextMenu(false);
+    this.props.sampleViewActions.showContextMenu(false);
   }
 
   createCollectionOnCell() {
     const { cellCenter } = this.props.shape;
     this.createPoint(cellCenter[0], cellCenter[1]);
-    this.props.sampleActions.showContextMenu(false);
+    this.props.sampleViewActions.showContextMenu(false);
   }
 
   showContextMenu(x, y) {
@@ -375,7 +375,7 @@ export default class ContextMenu extends React.Component {
   }
 
   createPoint(x, y, cb = null) {
-    this.props.sampleActions.sendAddShape(
+    this.props.sampleViewActions.sendAddShape(
       { screenCoord: [x, y], t: '2DP', state: 'SAVED' },
       cb,
     );
@@ -383,10 +383,10 @@ export default class ContextMenu extends React.Component {
 
   savePoint() {
     if (this.props.clickCentring) {
-      this.props.sampleActions.stopClickCentring();
+      this.props.sampleViewActions.stopClickCentring();
     }
 
-    this.props.sampleActions.sendAcceptCentring();
+    this.props.sampleViewActions.sendAcceptCentring();
     // associate the newly saved shape to an existing task with -1 shape.
     // Fixes issues when the task is added before a shape
     const { tasks } = this.props.sampleData;
@@ -405,52 +405,55 @@ export default class ContextMenu extends React.Component {
       });
     }
 
-    this.props.sampleActions.showContextMenu(false);
+    this.props.sampleViewActions.showContextMenu(false);
   }
 
   goToPoint() {
-    this.props.sampleActions.showContextMenu(false);
-    this.props.sampleActions.sendGoToPoint(this.props.shape.id);
+    this.props.sampleViewActions.showContextMenu(false);
+    this.props.sampleViewActions.sendGoToPoint(this.props.shape.id);
   }
 
   goToBeam() {
     const { x, y, imageRatio } = this.props;
-    this.props.sampleActions.showContextMenu(false);
-    this.props.sampleActions.sendGoToBeam(x / imageRatio, y / imageRatio);
+    this.props.sampleViewActions.showContextMenu(false);
+    this.props.sampleViewActions.sendGoToBeam(x / imageRatio, y / imageRatio);
   }
 
   removeShape() {
     if (this.props.clickCentring) {
-      this.props.sampleActions.sendAbortCentring();
+      this.props.sampleViewActions.sendAbortCentring();
     }
 
-    // eslint-disable-next-line promise/prefer-await-to-then, promise/catch-or-return
-    this.props.sampleActions.sendDeleteShape(this.props.shape.id).then(() => {
-      this.props.sampleActions.showContextMenu(false);
-    });
+    // eslint-disable-next-line promise/catch-or-return
+    this.props.sampleViewActions
+      .sendDeleteShape(this.props.shape.id)
+      // eslint-disable-next-line promise/prefer-await-to-then
+      .then(() => {
+        this.props.sampleViewActions.showContextMenu(false);
+      });
   }
 
   measureDistance() {
-    this.props.sampleActions.showContextMenu(false);
-    this.props.sampleActions.measureDistance(true);
+    this.props.sampleViewActions.showContextMenu(false);
+    this.props.sampleViewActions.measureDistance(true);
   }
 
   toggleDrawGrid() {
-    this.props.sampleActions.showContextMenu(false);
-    this.props.sampleActions.toggleDrawGrid();
+    this.props.sampleViewActions.showContextMenu(false);
+    this.props.sampleViewActions.toggleDrawGrid();
   }
 
   saveGrid() {
-    this.props.sampleActions.showContextMenu(false);
+    this.props.sampleViewActions.showContextMenu(false);
 
     const gd = { ...this.props.shape.gridData };
-    this.props.sampleActions.sendAddShape({ t: 'G', ...gd });
-    this.props.sampleActions.toggleDrawGrid();
+    this.props.sampleViewActions.sendAddShape({ t: 'G', ...gd });
+    this.props.sampleViewActions.toggleDrawGrid();
   }
 
   createPointAndShowModal(name, extraParams = {}) {
     const { x, y, imageRatio } = this.props;
-    this.props.sampleActions.showContextMenu(false);
+    this.props.sampleViewActions.showContextMenu(false);
     this.createPoint(x / imageRatio, y / imageRatio, (shape) =>
       this.showModal(name, {}, shape, extraParams),
     );
@@ -468,10 +471,13 @@ export default class ContextMenu extends React.Component {
       lines.map((x) => sid.splice(sid.indexOf(x), 1));
     }
 
-    this.props.sampleActions.showContextMenu(false);
-    this.props.sampleActions.sendAddShape({ t: 'L', refs: shape.id }, (s) => {
-      this.showModal(modal, wf, s);
-    });
+    this.props.sampleViewActions.showContextMenu(false);
+    this.props.sampleViewActions.sendAddShape(
+      { t: 'L', refs: shape.id },
+      (s) => {
+        this.showModal(modal, wf, s);
+      },
+    );
   }
 
   hideContextMenu() {

--- a/ui/src/components/SampleView/SampleControls.js
+++ b/ui/src/components/SampleView/SampleControls.js
@@ -40,16 +40,13 @@ export default class SampleControls extends React.Component {
   toggleDrawGrid() {
     // Cancel click centering before draw grid is started
     if (this.props.current.sampleID === '') {
-      this.props.generalActions.showErrorPanel(
-        true,
-        'There is no sample mounted',
-      );
+      this.props.showErrorPanel(true, 'There is no sample mounted');
     } else {
       if (this.props.clickCentring) {
-        this.props.sampleActions.sendAbortCentring();
+        this.props.sampleViewActions.sendAbortCentring();
       }
 
-      this.props.sampleActions.toggleDrawGrid();
+      this.props.sampleViewActions.toggleDrawGrid();
     }
   }
 
@@ -88,12 +85,12 @@ export default class SampleControls extends React.Component {
 
   toggleCentring() {
     const { sendStartClickCentring, sendAbortCentring } =
-      this.props.sampleActions;
+      this.props.sampleViewActions;
     const { clickCentring } = this.props;
 
     // If draw grid tool enabled, disable it before starting centering
     if (this.props.drawGrid) {
-      this.props.sampleActions.toggleDrawGrid();
+      this.props.sampleViewActions.toggleDrawGrid();
     }
 
     if (clickCentring) {
@@ -123,7 +120,7 @@ export default class SampleControls extends React.Component {
           key={`${size[0]} x ${size[1]}`}
           eventKey="1"
           onClick={() =>
-            this.props.sampleActions.setVideoSize(size[0], size[1])
+            this.props.sampleViewActions.setVideoSize(size[0], size[1])
           }
         >
           <span className={`fa ${sizeGClass}`} /> {`${size[0]} x ${size[1]}`}
@@ -141,7 +138,7 @@ export default class SampleControls extends React.Component {
         key="auto scale"
         onClick={() => {
           const { clientWidth } = document.querySelector('#outsideWrapper');
-          this.props.sampleActions.toggleAutoScale(clientWidth);
+          this.props.sampleViewActions.toggleAutoScale(clientWidth);
         }}
       >
         <span className={`fa ${autoScaleGClass}`} /> Auto Scale
@@ -151,7 +148,7 @@ export default class SampleControls extends React.Component {
         key="reset"
         onClick={() => {
           window.initJSMpeg();
-          this.props.sampleActions.setVideoSize(
+          this.props.sampleViewActions.setVideoSize(
             this.props.width,
             this.props.height,
           );

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -212,13 +212,13 @@ export default class SampleImage extends React.Component {
   }
 
   setGridResultType(resultType) {
-    this.props.sampleActions.setGridResultType(resultType);
+    this.props.sampleViewActions.setGridResultType(resultType);
   }
 
   setImageRatio() {
     if (this.props.autoScale) {
       const { clientWidth } = document.querySelector('#outsideWrapper');
-      this.props.sampleActions.setImageRatio(clientWidth);
+      this.props.sampleViewActions.setImageRatio(clientWidth);
     }
   }
 
@@ -237,7 +237,7 @@ export default class SampleImage extends React.Component {
         gridData.cellHSpace,
         value,
       );
-      this.props.sampleActions.sendUpdateShapes([gd]);
+      this.props.sampleViewActions.sendUpdateShapes([gd]);
     } else if (this.props.drawGrid) {
       this.drawGridPlugin.setCurrentCellSpace(
         null,
@@ -263,7 +263,7 @@ export default class SampleImage extends React.Component {
         value,
         gridData.cellVSpace,
       );
-      this.props.sampleActions.sendUpdateShapes([gd]);
+      this.props.sampleViewActions.sendUpdateShapes([gd]);
     } else if (this.props.drawGrid) {
       this.drawGridPlugin.setCurrentCellSpace(
         value,
@@ -282,7 +282,7 @@ export default class SampleImage extends React.Component {
     }
 
     this.drawGridPlugin.setGridOverlay(value);
-    this.props.sampleActions.setOverlay(value);
+    this.props.sampleViewActions.setOverlay(value);
     this.drawGridPlugin.repaint(this.canvas);
     this.renderSampleView(this.props);
   }
@@ -338,11 +338,11 @@ export default class SampleImage extends React.Component {
 
       if (this._keyPressed === 'Escape') {
         if (this.props.clickCentring) {
-          this.props.sampleActions.sendAbortCentring();
+          this.props.sampleViewActions.sendAbortCentring();
         }
 
         if (this.props.drawGrid) {
-          this.props.sampleActions.toggleDrawGrid();
+          this.props.sampleViewActions.toggleDrawGrid();
         }
       }
     }
@@ -350,11 +350,11 @@ export default class SampleImage extends React.Component {
 
   removeShapes() {
     if (this.props.clickCentring) {
-      this.props.sampleActions.sendAbortCentring();
+      this.props.sampleViewActions.sendAbortCentring();
     }
 
     this.props.selectedShapes.forEach((shapeID) => {
-      this.props.sampleActions.sendDeleteShape(shapeID);
+      this.props.sampleViewActions.sendDeleteShape(shapeID);
     });
   }
 
@@ -363,8 +363,8 @@ export default class SampleImage extends React.Component {
   }
 
   goToBeam(e) {
-    const { sampleActions, imageRatio } = this.props;
-    const { sendGoToBeam } = sampleActions;
+    const { sampleViewActions, imageRatio } = this.props;
+    const { sendGoToBeam } = sampleViewActions;
 
     // Only move to beam if the click was done directly on the canvas.
     if (e.target.tagName === 'CANVAS' && e.shiftKey) {
@@ -396,8 +396,7 @@ export default class SampleImage extends React.Component {
   rightClick(e) {
     e.preventDefault();
 
-    const { sampleActions } = this.props;
-    const { showContextMenu } = sampleActions;
+    const { showContextMenu } = this.props.sampleViewActions;
 
     const group = this.canvas.getActiveObject();
     const clickPoint = new fabric.Point(e.offsetX, e.offsetY);
@@ -547,7 +546,7 @@ export default class SampleImage extends React.Component {
       objectFound = option.target;
     }
     const {
-      sampleActions,
+      sampleViewActions,
       clickCentring,
       measureDistance,
       imageRatio,
@@ -557,16 +556,16 @@ export default class SampleImage extends React.Component {
     } = this.props;
 
     if (contextMenuVisible) {
-      sampleActions.showContextMenu(false);
+      sampleViewActions.showContextMenu(false);
     }
 
     if (clickCentring) {
-      sampleActions.sendCentringPoint(
+      sampleViewActions.sendCentringPoint(
         option.e.layerX / imageRatio,
         option.e.layerY / imageRatio,
       );
     } else if (measureDistance) {
-      sampleActions.addDistancePoint(
+      sampleViewActions.addDistancePoint(
         option.e.layerX / imageRatio,
         option.e.layerY / imageRatio,
       );
@@ -598,9 +597,7 @@ export default class SampleImage extends React.Component {
 
       const { resultDataPath } = shapeData;
       if (resultDataPath.length > 0) {
-        this.props.generalActions.sendDisplayImage(
-          `${resultDataPath}&img_num=${imgNum}`,
-        );
+        this.props.sendDisplayImage(`${resultDataPath}&img_num=${imgNum}`);
       }
     }
   }
@@ -609,8 +606,8 @@ export default class SampleImage extends React.Component {
   wheel(e) {
     e.preventDefault();
     e.stopPropagation();
-    const { sampleActions, motorSteps, hardwareObjects } = this.props;
-    const { sendMotorPosition, sendZoomPos } = sampleActions;
+    const { sampleViewActions, motorSteps, hardwareObjects } = this.props;
+    const { sendMotorPosition, sendZoomPos } = sampleViewActions;
     const keyPressed = this._keyPressed;
 
     const phi = hardwareObjects['diffractometer.phi'];
@@ -705,7 +702,7 @@ export default class SampleImage extends React.Component {
     });
 
     if (updatedShapes.length > 0) {
-      this.props.sampleActions.sendUpdateShapes(updatedShapes);
+      this.props.sampleViewActions.sendUpdateShapes(updatedShapes);
     }
   }
 
@@ -724,7 +721,7 @@ export default class SampleImage extends React.Component {
     });
 
     if (updatedShapes.length > 0) {
-      this.props.sampleActions.sendUpdateShapes(updatedShapes);
+      this.props.sampleViewActions.sendUpdateShapes(updatedShapes);
     }
   }
 
@@ -750,7 +747,7 @@ export default class SampleImage extends React.Component {
     });
 
     if (updatedShapes.length > 0) {
-      this.props.sampleActions.sendUpdateShapes(updatedShapes);
+      this.props.sampleViewActions.sendUpdateShapes(updatedShapes);
     }
   }
 
@@ -775,7 +772,7 @@ export default class SampleImage extends React.Component {
     const gd = this.drawGridPlugin.saveGrid(
       this.drawGridPlugin.currentGridData(),
     );
-    this.props.sampleActions.sendAddShape({ t: 'G', ...gd });
+    this.props.sampleViewActions.sendAddShape({ t: 'G', ...gd });
     this.drawGridPlugin.reset();
   }
 
@@ -788,7 +785,7 @@ export default class SampleImage extends React.Component {
       grid.state = 'HIDDEN';
     }
 
-    this.props.sampleActions.sendUpdateShapes([grid]);
+    this.props.sampleViewActions.sendUpdateShapes([grid]);
   }
 
   centringMessage() {
@@ -977,10 +974,10 @@ export default class SampleImage extends React.Component {
               setVCellSpacing={this.setVCellSpacing}
               gridList={this.props.grids}
               currentGrid={this.drawGridPlugin.currentGridData()}
-              removeGrid={this.props.sampleActions.sendDeleteShape}
+              removeGrid={this.props.sampleViewActions.sendDeleteShape}
               saveGrid={this.saveGrid}
               toggleVisibility={this.toggleGridVisibility}
-              rotateTo={this.props.sampleActions.sendRotateToShape}
+              rotateTo={this.props.sampleViewActions.sendRotateToShape}
               selectGrid={this.selectShape}
               selectedGrids={this.props.selectedGrids.map((grid) => grid.id)}
               setGridResultType={this.setGridResultType}
@@ -988,7 +985,7 @@ export default class SampleImage extends React.Component {
             />
             {this.createVideoPlayerContainer(this.props.videoFormat)}
             <SampleControls
-              generalActions={this.props.generalActions}
+              showErrorPanel={this.props.showErrorPanel}
               {...this.props}
               canvas={this.canvas}
               imageRatio={this.props.imageRatio}

--- a/ui/src/containers/EquipmentContainer.jsx
+++ b/ui/src/containers/EquipmentContainer.jsx
@@ -17,7 +17,7 @@ import {
   selectDrop,
 } from '../actions/sampleChanger';
 
-import * as generalActions from '../actions/general'; // eslint-disable-line import/no-namespace
+import { showErrorPanel } from '../actions/general';
 
 import { syncWithCrims } from '../actions/sampleGrid';
 
@@ -64,7 +64,7 @@ class EquipmentContainer extends React.Component {
                       selectDrop={this.props.selectDrop}
                       crystalList={this.props.crystalList}
                       syncSamplesCrims={this.props.syncSamplesCrims}
-                      generalActions={this.props.generalActions}
+                      showErrorPanel={this.props.showErrorPanel}
                       global_state={this.props.global_state}
                       state={this.props.sampleChangerState}
                     />
@@ -167,7 +167,7 @@ function mapDispatchToProps(dispatch) {
     abort: () => dispatch(abort()),
     sendCommand: (cmd, args) => dispatch(sendCommand(cmd, args)),
     executeCommand: bindActionCreators(executeCommand, dispatch),
-    generalActions: bindActionCreators(generalActions, dispatch),
+    showErrorPanel: bindActionCreators(showErrorPanel, dispatch),
     selectWell: (row, col) => dispatch(selectWell(row, col)),
     setPlate: (address) => dispatch(setPlate(address)),
     selectDrop: (address) => dispatch(selectDrop(address)),

--- a/ui/src/containers/GroupFolderInput.jsx
+++ b/ui/src/containers/GroupFolderInput.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { Form, Button } from 'react-bootstrap';
-import * as queueActions from '../actions/queue'; // eslint-disable-line import/no-namespace
+import { sendSetGroupFolder } from '../actions/queue';
 
 class GroupFolderInput extends React.Component {
   constructor(props) {
@@ -17,7 +17,7 @@ class GroupFolderInput extends React.Component {
   setGroupFolderInput() {
     this.setState({ validationState: 'success' });
     /* eslint-enable react/no-set-state */
-    this.props.queueActions.sendSetGroupFolder(this.inputValue.value);
+    this.props.sendSetGroupFolder(this.inputValue.value);
   }
 
   inputOnSelectHandler(e) {
@@ -76,7 +76,7 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    queueActions: bindActionCreators(queueActions, dispatch),
+    sendSetGroupFolder: bindActionCreators(sendSetGroupFolder, dispatch),
   };
 }
 

--- a/ui/src/containers/QueueSettings.jsx
+++ b/ui/src/containers/QueueSettings.jsx
@@ -10,7 +10,13 @@ import { AUTO_LOOP_CENTRING, CLICK_CENTRING } from '../constants';
 import GroupFolderInput from './GroupFolderInput.jsx';
 import NumSnapshotsDropDown from './NumSnapshotsDropDown.jsx';
 
-import * as queueActions from '../actions/queue'; // eslint-disable-line import/no-namespace
+import {
+  sendSetCentringMethod,
+  sendSetGroupFolder,
+  sendSetQueueSettings,
+  setAutoAddDiffPlan,
+  setAutoMountSample,
+} from '../actions/queue';
 
 class QueueSettings extends React.Component {
   constructor(props) {
@@ -28,11 +34,11 @@ class QueueSettings extends React.Component {
   setGroupFolderInput() {
     this.setState({ validationState: 'success' });
     /* eslint-enable react/no-set-state */
-    this.props.queueActions.sendSetGroupFolder(this.inputValue.value);
+    this.props.sendSetGroupFolder(this.inputValue.value);
   }
 
   setAutoAddDiffPlan(e) {
-    this.props.queueActions.setAutoAddDiffPlan(e.target.checked);
+    this.props.setAutoAddDiffPlan(e.target.checked);
   }
 
   inputOnChangeHandler() {
@@ -42,7 +48,7 @@ class QueueSettings extends React.Component {
 
   autoMountNextOnClick(e) {
     e.preventDefault();
-    this.props.queueActions.setAutoMountSample(e.target.checked);
+    this.props.setAutoMountSample(e.target.checked);
   }
 
   inputOnSelectHandler(e) {
@@ -52,9 +58,9 @@ class QueueSettings extends React.Component {
 
   autoLoopCentringOnClick(e) {
     if (e.target.checked) {
-      this.props.queueActions.sendSetCentringMethod(AUTO_LOOP_CENTRING);
+      this.props.sendSetCentringMethod(AUTO_LOOP_CENTRING);
     } else {
-      this.props.queueActions.sendSetCentringMethod(CLICK_CENTRING);
+      this.props.sendSetCentringMethod(CLICK_CENTRING);
     }
   }
 
@@ -101,7 +107,7 @@ class QueueSettings extends React.Component {
               type="checkbox"
               name="rememberParametersBetweenSamples"
               onChange={(e) => {
-                this.props.queueActions.sendSetQueueSettings(
+                this.props.sendSetQueueSettings(
                   'rememberParametersBetweenSamples',
                   e.target.checked,
                 );
@@ -132,7 +138,11 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    queueActions: bindActionCreators(queueActions, dispatch),
+    sendSetGroupFolder: bindActionCreators(sendSetGroupFolder, dispatch),
+    setAutoAddDiffPlan: bindActionCreators(setAutoAddDiffPlan, dispatch),
+    setAutoMountSample: bindActionCreators(setAutoMountSample, dispatch),
+    sendSetCentringMethod: bindActionCreators(sendSetCentringMethod, dispatch),
+    sendSetQueueSettings: bindActionCreators(sendSetQueueSettings, dispatch),
   };
 }
 

--- a/ui/src/containers/SampleQueueContainer.js
+++ b/ui/src/containers/SampleQueueContainer.js
@@ -4,10 +4,27 @@ import { connect } from 'react-redux';
 import CurrentTree from '../components/SampleQueue/CurrentTree';
 import TodoTree from '../components/SampleQueue/TodoTree';
 import QueueControl from '../components/SampleQueue/QueueControl';
-import * as queueActions from '../actions/queue'; // eslint-disable-line import/no-namespace
-import * as queueGUIActions from '../actions/queueGUI'; // eslint-disable-line import/no-namespace
-import * as sampleViewActions from '../actions/sampleview'; // eslint-disable-line import/no-namespace
-import * as sampleChangerActions from '../actions/sampleChanger'; // eslint-disable-line import/no-namespace
+import {
+  sendToggleCheckBox,
+  sendPauseQueue,
+  sendUnpauseQueue,
+  sendStopQueue,
+  changeTaskOrderAction,
+  deleteTask,
+  addTask,
+  moveTask,
+  setAutoMountSample,
+  setAutoAddDiffPlan,
+  sendRunSample,
+  sendSetCentringMethod,
+  setEnabledSample,
+} from '../actions/queue';
+import {
+  collapseItem,
+  selectItem,
+  showConfirmCollectDialog,
+  showList,
+} from '../actions/queueGUI';
 import { showTaskForm } from '../actions/taskForm';
 import { Nav } from 'react-bootstrap';
 import { showDialog } from '../actions/general';
@@ -15,45 +32,7 @@ import { showDialog } from '../actions/general';
 import UserMessage from '../components/Notify/UserMessage';
 import loader from '../img/loader.gif';
 import { prepareBeamlineForNewSample } from '../actions/beamline';
-
-function mapStateToProps(state) {
-  return {
-    searchString: state.queueGUI.searchString,
-    current: state.queue.current,
-    visibleList: state.queueGUI.visibleList,
-    queueStatus: state.queue.queueStatus,
-    queue: state.queue.queue,
-    autoMountNext: state.queue.autoMountNext,
-    autoAddDiffPlan: state.queue.autoAddDiffPlan,
-    centringMethod: state.queue.centringMethod,
-    sampleList: state.sampleGrid.sampleList,
-    sampleOrder: state.sampleGrid.order,
-    checked: state.queue.checked,
-    rootPath: state.login.rootPath,
-    displayData: state.queueGUI.displayData,
-    loading: state.queueGUI.loading,
-    logRecords: state.logger.logRecords,
-    plotsData: state.beamline.plotsData,
-    plotsInfo: state.beamline.plotsInfo,
-    selectedShapes: state.sampleview.selectedShapes,
-    shapes: state.shapes,
-  };
-}
-
-function mapDispatchToProps(dispatch) {
-  return {
-    queueActions: bindActionCreators(queueActions, dispatch),
-    queueGUIActions: bindActionCreators(queueGUIActions, dispatch),
-    sampleViewActions: bindActionCreators(sampleViewActions, dispatch),
-    sampleChangerActions: bindActionCreators(sampleChangerActions, dispatch),
-    showForm: bindActionCreators(showTaskForm, dispatch),
-    showDialog: bindActionCreators(showDialog, dispatch),
-    prepareBeamlineForNewSample: bindActionCreators(
-      prepareBeamlineForNewSample,
-      dispatch,
-    ),
-  };
-}
+import { loadSample, unloadSample } from '../actions/sampleChanger';
 
 class SampleQueueContainer extends React.Component {
   constructor(props) {
@@ -62,7 +41,7 @@ class SampleQueueContainer extends React.Component {
   }
 
   handleSelect(selectedKey) {
-    this.props.queueGUIActions.showList(selectedKey);
+    this.props.showList(selectedKey);
   }
 
   render() {
@@ -82,24 +61,6 @@ class SampleQueueContainer extends React.Component {
       autoAddDiffPlan,
       centringMethod,
     } = this.props;
-    const {
-      sendToggleCheckBox,
-      sendPauseQueue,
-      sendUnpauseQueue,
-      sendStopQueue,
-      changeTaskOrderAction,
-      deleteTask,
-      addTask,
-      moveTask,
-      setAutoMountSample,
-      setAutoAddDiffPlan,
-      sendRunSample,
-      sendSetCentringMethod,
-      setEnabledSample,
-    } = this.props.queueActions;
-    const { collapseItem, showConfirmCollectDialog, selectItem, showList } =
-      this.props.queueGUIActions;
-    const { loadSample, unloadSample } = this.props.sampleChangerActions;
 
     // go through the queue, check if sample has been collected or not
     // to make todo and history lists
@@ -133,24 +94,24 @@ class SampleQueueContainer extends React.Component {
           historyLength={history.length}
           queueLength={queue.length}
           queue={queue}
-          setEnabledSample={setEnabledSample}
+          setEnabledSample={this.props.setEnabledSample}
           todoLength={todo.length}
           queueStatus={queueStatus}
-          runQueue={showConfirmCollectDialog}
-          stopQueue={sendStopQueue}
-          pause={sendPauseQueue}
-          unpause={sendUnpauseQueue}
-          setAutoMountSample={setAutoMountSample}
+          runQueue={this.props.showConfirmCollectDialog}
+          stopQueue={this.props.sendStopQueue}
+          pause={this.props.sendPauseQueue}
+          unpause={this.props.sendUnpauseQueue}
+          setAutoMountSample={this.props.setAutoMountSample}
           autoMountNext={autoMountNext}
-          setAutoAddDiffPlan={setAutoAddDiffPlan}
+          setAutoAddDiffPlan={this.props.setAutoAddDiffPlan}
           autoAddDiffPlan={autoAddDiffPlan}
           mounted={current.sampleID}
-          runSample={sendRunSample}
-          sendSetCentringMethod={sendSetCentringMethod}
+          runSample={this.props.sendRunSample}
+          sendSetCentringMethod={this.props.sendSetCentringMethod}
           centringMethod={centringMethod}
           todoList={todo}
           sampleList={sampleList}
-          sendUnmountSample={unloadSample}
+          sendUnmountSample={this.props.unloadSample}
         />
         <div className="m-tree queue-body">
           <Nav
@@ -182,28 +143,28 @@ class SampleQueueContainer extends React.Component {
             </div>
           ) : null}
           <CurrentTree
-            changeOrder={changeTaskOrderAction}
+            changeOrder={this.props.changeTaskOrderAction}
             show={visibleList === 'current'}
             mounted={current.sampleID}
             queue={queue}
             sampleList={sampleList}
-            toggleCheckBox={sendToggleCheckBox}
+            toggleCheckBox={this.props.sendToggleCheckBox}
             checked={checked}
-            deleteTask={deleteTask}
-            pause={sendPauseQueue}
-            unpause={sendUnpauseQueue}
-            stop={sendStopQueue}
+            deleteTask={this.props.deleteTask}
+            pause={this.props.sendPauseQueue}
+            unpause={this.props.sendUnpauseQueue}
+            stop={this.props.sendStopQueue}
             showForm={showForm}
-            unmount={unloadSample}
+            unmount={this.props.unloadSample}
             queueStatus={queueStatus}
             rootPath={rootPath}
-            collapseItem={collapseItem}
-            selectItem={selectItem}
+            collapseItem={this.props.collapseItem}
+            selectItem={this.props.selectItem}
             displayData={displayData}
-            runSample={sendRunSample}
+            runSample={this.props.sendRunSample}
             todoList={todo}
-            moveTask={moveTask}
-            addTask={addTask}
+            moveTask={this.props.moveTask}
+            addTask={this.props.addTask}
             plotsData={this.props.plotsData}
             plotsInfo={this.props.plotsInfo}
             shapes={this.props.shapes}
@@ -214,12 +175,12 @@ class SampleQueueContainer extends React.Component {
             list={todo}
             queue={queue}
             sampleList={sampleList}
-            collapseItem={collapseItem}
+            collapseItem={this.props.collapseItem}
             displayData={displayData}
-            mount={loadSample}
+            mount={this.props.loadSample}
             showForm={showForm}
             queueStatus={queueStatus}
-            showList={showList}
+            showList={this.props.showList}
             prepareBeamlineForNewSample={this.props.prepareBeamlineForNewSample}
           />
           <div className="queue-messages">
@@ -239,6 +200,69 @@ class SampleQueueContainer extends React.Component {
       </div>
     );
   }
+}
+
+function mapStateToProps(state) {
+  return {
+    searchString: state.queueGUI.searchString,
+    current: state.queue.current,
+    visibleList: state.queueGUI.visibleList,
+    queueStatus: state.queue.queueStatus,
+    queue: state.queue.queue,
+    autoMountNext: state.queue.autoMountNext,
+    autoAddDiffPlan: state.queue.autoAddDiffPlan,
+    centringMethod: state.queue.centringMethod,
+    sampleList: state.sampleGrid.sampleList,
+    sampleOrder: state.sampleGrid.order,
+    checked: state.queue.checked,
+    rootPath: state.login.rootPath,
+    displayData: state.queueGUI.displayData,
+    loading: state.queueGUI.loading,
+    logRecords: state.logger.logRecords,
+    plotsData: state.beamline.plotsData,
+    plotsInfo: state.beamline.plotsInfo,
+    selectedShapes: state.sampleview.selectedShapes,
+    shapes: state.shapes,
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    // Queue actions
+    sendToggleCheckBox: bindActionCreators(sendToggleCheckBox, dispatch),
+    sendPauseQueue: bindActionCreators(sendPauseQueue, dispatch),
+    sendUnpauseQueue: bindActionCreators(sendUnpauseQueue, dispatch),
+    sendStopQueue: bindActionCreators(sendStopQueue, dispatch),
+    changeTaskOrderAction: bindActionCreators(changeTaskOrderAction, dispatch),
+    deleteTask: bindActionCreators(deleteTask, dispatch),
+    addTask: bindActionCreators(addTask, dispatch),
+    moveTask: bindActionCreators(moveTask, dispatch),
+    setAutoMountSample: bindActionCreators(setAutoMountSample, dispatch),
+    setAutoAddDiffPlan: bindActionCreators(setAutoAddDiffPlan, dispatch),
+    sendRunSample: bindActionCreators(sendRunSample, dispatch),
+    sendSetCentringMethod: bindActionCreators(sendSetCentringMethod, dispatch),
+    setEnabledSample: bindActionCreators(setEnabledSample, dispatch),
+
+    // Queue GUI actions
+    collapseItem: bindActionCreators(collapseItem, dispatch),
+    showConfirmCollectDialog: bindActionCreators(
+      showConfirmCollectDialog,
+      dispatch,
+    ),
+    selectItem: bindActionCreators(selectItem, dispatch),
+    showList: bindActionCreators(showList, dispatch),
+
+    // Sample changer actions
+    loadSample: bindActionCreators(loadSample, dispatch),
+    unloadSample: bindActionCreators(unloadSample, dispatch),
+
+    showForm: bindActionCreators(showTaskForm, dispatch),
+    showDialog: bindActionCreators(showDialog, dispatch),
+    prepareBeamlineForNewSample: bindActionCreators(
+      prepareBeamlineForNewSample,
+      dispatch,
+    ),
+  };
 }
 
 export default connect(

--- a/ui/src/containers/SampleViewContainer.js
+++ b/ui/src/containers/SampleViewContainer.js
@@ -17,7 +17,7 @@ import SSXChipControl from '../components/SSXChip/SSXChipControl';
 import PlateManipulator from '../components/Equipment/PlateManipulator';
 import ContextMenu from '../components/SampleView/ContextMenu';
 import * as sampleViewActions from '../actions/sampleview'; // eslint-disable-line import/no-namespace
-import * as generalActions from '../actions/general'; // eslint-disable-line import/no-namespace
+import { showErrorPanel, sendDisplayImage } from '../actions/general';
 import { updateTask } from '../actions/queue';
 import { showTaskForm } from '../actions/taskForm';
 import BeamlineSetupContainer from './BeamlineSetupContainer';
@@ -36,7 +36,6 @@ import {
 
 import {
   setBeamlineAttribute,
-  sendDisplayImage,
   executeCommand,
   sendLogFrontEndTraceBack,
   setAttribute,
@@ -145,7 +144,7 @@ class SampleViewContainer extends Component {
                   groupFolder={this.props.groupFolder}
                   hardwareObjects={this.props.hardwareObjects}
                   uiproperties={uiproperties.sample_view}
-                  sampleActions={this.props.sampleViewActions}
+                  sampleViewActions={this.props.sampleViewActions}
                   grids={grids}
                   selectedGrids={selectedGrids}
                   setAttribute={this.props.setAttribute}
@@ -181,7 +180,7 @@ class SampleViewContainer extends Component {
                             selectDrop={this.props.selectDrop}
                             crystalList={this.props.crystalList}
                             syncSamplesCrims={this.props.syncSamplesCrims}
-                            generalActions={this.props.generalActions}
+                            showErrorPanel={this.props.showErrorPanel}
                             global_state={this.props.global_state}
                             state={this.props.sampleChangerState}
                             inPopover
@@ -247,7 +246,7 @@ class SampleViewContainer extends Component {
             <DefaultErrorBoundary>
               <ContextMenu
                 {...this.props.contextMenu}
-                sampleActions={this.props.sampleViewActions}
+                sampleViewActions={this.props.sampleViewActions}
                 updateTask={this.props.updateTask}
                 availableMethods={this.props.availableMethods}
                 showForm={this.props.showForm}
@@ -262,8 +261,8 @@ class SampleViewContainer extends Component {
                 taskForm={this.props.taskForm}
               />
               <SampleImage
-                generalActions={this.props.generalActions}
-                sampleActions={this.props.sampleViewActions}
+                showErrorPanel={this.props.showErrorPanel}
+                sampleViewActions={this.props.sampleViewActions}
                 {...this.props.sampleViewState}
                 uiproperties={uiproperties.sample_view}
                 hardwareObjects={this.props.hardwareObjects}
@@ -339,7 +338,7 @@ function mapDispatchToProps(dispatch) {
     sampleViewActions: bindActionCreators(sampleViewActions, dispatch),
     updateTask: bindActionCreators(updateTask, dispatch),
     showForm: bindActionCreators(showTaskForm, dispatch),
-    generalActions: bindActionCreators(generalActions, dispatch),
+    showErrorPanel: bindActionCreators(showErrorPanel, dispatch),
     setAttribute: bindActionCreators(setAttribute, dispatch),
     stopBeamlineAction: bindActionCreators(stopBeamlineAction, dispatch),
     setBeamlineAttribute: bindActionCreators(setBeamlineAttribute, dispatch),


### PR DESCRIPTION
Those namespace imports make it that little bit harder to find where each action creator is used, and to trace back where it's bound from the Redux store.

I managed to remove all of them (as recommended by ESLint) except for `sampleViewActions` in `SampleViewContainer`, which wraps tens of action creators, which are used in multiple child components... However, I did rename the prop that is used to pass it down to child components from `sampleActions` to `sampleViewActions` so it's consistent and easier to search for.