### PR TITLE
Remove `cancel-in-progress` in `pages` workflow

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -5,7 +5,6 @@ name: "Pages"
 
 concurrency:
   group: "pages"
-  cancel-in-progress: true
 
 on:
   pull_request:


### PR DESCRIPTION
This should prevent cancelled workflows to be considered as failed from the point of view of the pull requests checks.