### PR TITLE
Separated login and login_info routes

### DIFF
--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -181,8 +181,6 @@ class BaseUserManager(ComponentBase):
             msg = "User %s signed in" % user.username
             logging.getLogger("MX3.HWR").info(msg)
 
-            return login_res["status"]
-
     # Abstract method to be implemented by concrete implementation
     def _signout(self):
         pass
@@ -212,6 +210,7 @@ class BaseUserManager(ComponentBase):
 
         self.app.server.user_datastore.deactivate_user(user)
         flask_security.logout_user()
+
         self.emit_observers_changed()
 
     def is_authenticated(self):
@@ -227,22 +226,6 @@ class BaseUserManager(ComponentBase):
             self.app.server.emit("forceSignout", room=socketio_sid, namespace="/hwr")
 
     def login_info(self):
-        res = {
-            "synchrotronName": HWR.beamline.session.synchrotron_name,
-            "beamlineName": HWR.beamline.session.beamline_name,
-            "loggedIn": False,
-            "loginType": HWR.beamline.lims.loginType.title(),
-            "proposalList": [],
-            "user": {
-                "username": "",
-                "email": "",
-                "isstaff": False,
-                "nickname": "",
-                "inControl": False,
-                "ip": "",
-            },
-        }
-
         if not current_user.is_anonymous:
             login_info = convert_to_dict(json.loads(current_user.limsdata))
 
@@ -275,8 +258,10 @@ class BaseUserManager(ComponentBase):
             )
 
             res["selectedProposalID"] = HWR.beamline.session.proposal_id
+        else:
+            raise Exception("Not logged in")
 
-        return current_user, res
+        return res
 
     def update_user(self, user):
         self.app.server.user_datastore.put(user)

--- a/mxcubeweb/core/models/configmodels.py
+++ b/mxcubeweb/core/models/configmodels.py
@@ -17,7 +17,6 @@ class FlaskConfigModel(BaseModel):
     SECURITY_TRACKABLE: bool = Field(True, description="")
     USER_DB_PATH: str = Field("/tmp/mxcube-user.db", description="")
     PERMANENT_SESSION_LIFETIME: datetime.timedelta
-    SESSION_PERMANENT: bool = Field(True, description="")
     CERT_KEY: str = Field("", description="Full path to signed certficate key file")
     CERT_PEM: str = Field("", description="Full path to signed certificate pem file")
 

--- a/mxcubeweb/core/util/networkutils.py
+++ b/mxcubeweb/core/util/networkutils.py
@@ -11,9 +11,14 @@ from email.utils import make_msgid
 
 import flask
 import flask_socketio
+import flask_security
 
 from flask_login import current_user, login_required
 from mxcubecore import HardwareRepository as HWR
+
+
+def auth_required(fun):
+    return flask_security.auth_required("session", within=-1, grace=None)(fun)
 
 
 def RateLimited(maxPerSecond):

--- a/mxcubeweb/routes/login.py
+++ b/mxcubeweb/routes/login.py
@@ -83,7 +83,7 @@ def init_route(app, server, url_prefix):
             res = app.usermanager.login_info()
             response = jsonify(res)
         except Exception:
-            response = make_response(jsonify(""), 401)
+            response = make_response(jsonify({"loggedIn": False}), 200)
 
         return response
 

--- a/mxcubeweb/routes/login.py
+++ b/mxcubeweb/routes/login.py
@@ -10,10 +10,6 @@ from mxcubeweb.core.util import networkutils
 from flask_login import current_user
 
 
-def deny_access(msg):
-    return make_response(jsonify({"msg": msg}), 200)
-
-
 def init_route(app, server, url_prefix):
     bp = Blueprint("login", __name__, url_prefix=url_prefix)
 
@@ -49,7 +45,7 @@ def init_route(app, server, url_prefix):
             )
             logging.getLogger("MX3.HWR").exception("")
             logging.getLogger("MX3.HWR").info(msg)
-            res = deny_access("Could not authenticate")
+            res = make_response(jsonify({"msg": "Could not authenticate"}), 200)
         else:
             res = make_response(jsonify({"msg": ""}), 200)
 

--- a/mxcubeweb/routes/login.py
+++ b/mxcubeweb/routes/login.py
@@ -68,7 +68,7 @@ def init_route(app, server, url_prefix):
         {'synchrotron_name': synchrotron_name,
         'beamline_name': beamline_name,
         'loginType': loginType,
-        'loginRes': {'status':{ 'code': 'ok', 'msg': msg },
+        'loggedIn': True,
         'Proposal': proposal, 'session': todays_session,
         'local_contact': local_contact,
         'person': someone,
@@ -76,7 +76,7 @@ def init_route(app, server, url_prefix):
 
         Status code set to:
         200: On success
-        401: Error, could not log in
+        200: Error, could not log in, {"loggedIn": False}
         """
 
         try:

--- a/mxcubeweb/routes/login.py
+++ b/mxcubeweb/routes/login.py
@@ -1,11 +1,6 @@
 import logging
 
-from flask import (
-    Blueprint,
-    request,
-    jsonify,
-    make_response,
-)
+from flask import Blueprint, request, jsonify, make_response, session
 from mxcubeweb.core.util import networkutils
 from flask_login import current_user
 
@@ -48,6 +43,8 @@ def init_route(app, server, url_prefix):
             res = make_response(jsonify({"msg": "Could not authenticate"}), 200)
         else:
             res = make_response(jsonify({"msg": ""}), 200)
+
+        session.permanent = True
 
         return res
 

--- a/mxcubeweb/routes/login.py
+++ b/mxcubeweb/routes/login.py
@@ -43,8 +43,7 @@ def init_route(app, server, url_prefix):
             res = make_response(jsonify({"msg": "Could not authenticate"}), 200)
         else:
             res = make_response(jsonify({"msg": ""}), 200)
-
-        session.permanent = True
+            session.permanent = True
 
         return res
 

--- a/mxcubeweb/routes/login.py
+++ b/mxcubeweb/routes/login.py
@@ -105,7 +105,6 @@ def init_route(app, server, url_prefix):
     @bp.route("/refresh_session", methods=["GET"])
     @server.restrict
     def refresh_session():
-        print("HERE TOOO")
         # Since default value of `SESSION_REFRESH_EACH_REQUEST` config setting is `True`
         # there is no need to do anything to refresh the session.
         logging.getLogger("MX3.HWR").debug("Session refresh")

--- a/mxcubeweb/routes/main.py
+++ b/mxcubeweb/routes/main.py
@@ -58,6 +58,10 @@ def init_route(app, server, url_prefix):
             }
         )
 
+    @server.flask.login_manager.unauthorized_handler
+    def unauth_handler():
+        return jsonify(""), 401
+
     @server.flask.before_request
     def before_request():
         # logging.getLogger("MX3.HWR").debug('Remote Addr: %s', request.remote_addr)

--- a/mxcubeweb/server.py
+++ b/mxcubeweb/server.py
@@ -12,6 +12,7 @@ from flask import Flask, request
 from flask_socketio import SocketIO
 
 import flask_security
+import flask_login
 
 from spectree import SpecTree
 
@@ -105,7 +106,7 @@ class Server:
                 f.write(str(os.getpid()) + " ")
 
             # Make the valid_login_only decorator available on server object
-            Server.restrict = staticmethod(networkutils.login_required)
+            Server.restrict = staticmethod(networkutils.auth_required)
             Server.require_control = staticmethod(networkutils.require_control)
             Server.ws_restrict = staticmethod(networkutils.ws_valid_login_only)
             Server.route = staticmethod(Server.flask.route)
@@ -123,6 +124,10 @@ class Server:
 
     @staticmethod
     def register_routes(mxcube):
+        Server.security = flask_security.Security(
+            Server.flask, Server.user_datastore, register_blueprint=False
+        )
+
         from mxcubeweb.routes.beamline import (
             init_route as init_beamline_route,
         )
@@ -200,8 +205,6 @@ class Server:
         Server._register_route(
             init_workflow_route, mxcube, f"{url_root_prefix}/workflow"
         )
-
-        Server.security = flask_security.Security(Server.flask, Server.user_datastore)
 
     @staticmethod
     def emit(*args, **kwargs):

--- a/mxcubeweb/server.py
+++ b/mxcubeweb/server.py
@@ -26,7 +26,6 @@ from mxcubeweb.core.models.usermodels import User, Role, Message
 class Server:
     init_event = gevent.event.Event()
     flask = None
-    flask_session = None
     security = None
     api = None
     user_datastore = None

--- a/test/HardwareObjectsMockup.xml/mxcube-web/server.yaml
+++ b/test/HardwareObjectsMockup.xml/mxcube-web/server.yaml
@@ -3,7 +3,6 @@ server:
   SECURITY_PASSWORD_SALT: "ASALT"
   SESSION_TYPE: "redis"
   SESSION_KEY_PREFIX: "mxcube:session:"
-  SESSION_PERMANENT: True
   PERMANENT_SESSION_LIFETIME: 60
 
   DEBUG: False
@@ -27,6 +26,5 @@ mxcube:
     class: UserManager
     inhouse_is_staff: True
     users:
-      -
-        username: opid291
+      - username: opid291
         role: staff

--- a/test/test_authn.py
+++ b/test/test_authn.py
@@ -100,7 +100,8 @@ def test_authn_info(client, login_type):
     and true after successful authentication.
     """
     resp = client.get(URL_INFO)
-    assert resp.status_code == 401
+    assert resp.status_code == 200
+    assert resp.json["loggedIn"] == False
 
     client.post(URL_SIGNIN, json=CREDENTIALS_0)
 
@@ -184,7 +185,8 @@ def test_authn_session_timeout(client):
 
     # Check that the session has expired
     resp = client.get(URL_INFO)
-    assert resp.status_code == 401, "Session did not expire"
+    assert resp.status_code == 200
+    assert resp.json["loggedIn"] == False, "Session did not expire"
 
     # Check that it is possible to sign in again
     client.post(URL_SIGNIN, json=CREDENTIALS_0)

--- a/test/test_authn.py
+++ b/test/test_authn.py
@@ -92,7 +92,7 @@ def test_authn_signout(client):
 
     resp = client.get(URL_SIGNOUT)
     assert resp.status_code == 200
-    assert resp.json["msg"] == ""
+    assert resp.json == ""
 
 
 def test_authn_info(client, login_type):

--- a/test/test_authn.py
+++ b/test/test_authn.py
@@ -91,6 +91,7 @@ def test_authn_signout(client):
 
     resp = client.get(URL_SIGNOUT)
     assert resp.status_code == 200
+    assert resp.json["msg"] == ""
 
 
 def test_authn_info(client, login_type):

--- a/test/test_authn.py
+++ b/test/test_authn.py
@@ -77,6 +77,7 @@ def client(make_client):
 def test_authn_signin_good_credentials(client):
     resp = client.post(URL_SIGNIN, json=CREDENTIALS_0)
     assert resp.status_code == 200
+    assert resp.json["msg"] == ""
 
 
 def test_authn_signin_wrong_credentials(client):

--- a/ui/package.json
+++ b/ui/package.json
@@ -58,7 +58,7 @@
     "react-redux": "7.2.6",
     "react-router": "^6.2.1",
     "react-router-bootstrap": "^0.26.1",
-    "react-router-dom": "^6.2.2",
+    "react-router-dom": "^6.19.0",
     "react-slick": "^0.29.0",
     "react-sticky": "^6.0.3",
     "redux": "4.1.2",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -124,10 +124,10 @@ dependencies:
     version: 6.11.2(react@17.0.2)
   react-router-bootstrap:
     specifier: ^0.26.1
-    version: 0.26.2(react-router-dom@6.11.2)(react@17.0.2)
+    version: 0.26.2(react-router-dom@6.19.0)(react@17.0.2)
   react-router-dom:
-    specifier: ^6.2.2
-    version: 6.11.2(react-dom@17.0.2)(react@17.0.2)
+    specifier: ^6.19.0
+    version: 6.19.0(react-dom@17.0.2)(react@17.0.2)
   react-slick:
     specifier: ^0.29.0
     version: 0.29.0(react-dom@17.0.2)(react@17.0.2)
@@ -2724,6 +2724,11 @@ packages:
     dependencies:
       '@swc/helpers': 0.4.14
       react: 17.0.2
+    dev: false
+
+  /@remix-run/router@1.12.0:
+    resolution: {integrity: sha512-2hXv036Bux90e1GXTWSMfNzfDDK8LA8JYEWfyHxzvwdp6GyoWEovKc9cotb3KCKmkdwsIBuFGX7ScTWyiHv7Eg==}
+    engines: {node: '>=14.0.0'}
     dev: false
 
   /@remix-run/router@1.6.2:
@@ -13439,7 +13444,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /react-router-bootstrap@0.26.2(react-router-dom@6.11.2)(react@17.0.2):
+  /react-router-bootstrap@0.26.2(react-router-dom@6.19.0)(react@17.0.2):
     resolution: {integrity: sha512-YlpI9Xi+Uqp6zFAUO8D/wu6P8mr1ujqq+0V5MhJG1kx9dr/95fAMoGk4J+/CsysOkwtR3tYSac4DDWmHwXvC8w==}
     peerDependencies:
       react: '>=16.13.1'
@@ -13447,20 +13452,20 @@ packages:
     dependencies:
       prop-types: 15.8.1
       react: 17.0.2
-      react-router-dom: 6.11.2(react-dom@17.0.2)(react@17.0.2)
+      react-router-dom: 6.19.0(react-dom@17.0.2)(react@17.0.2)
     dev: false
 
-  /react-router-dom@6.11.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-JNbKtAeh1VSJQnH6RvBDNhxNwemRj7KxCzc5jb7zvDSKRnPWIFj9pO+eXqjM69gQJ0r46hSz1x4l9y0651DKWw==}
-    engines: {node: '>=14'}
+  /react-router-dom@6.19.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-N6dWlcgL2w0U5HZUUqU2wlmOrSb3ighJmtQ438SWbhB1yuLTXQ8yyTBMK3BSvVjp7gBtKurT554nCtMOgxCZmQ==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
     dependencies:
-      '@remix-run/router': 1.6.2
+      '@remix-run/router': 1.12.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      react-router: 6.11.2(react@17.0.2)
+      react-router: 6.19.0(react@17.0.2)
     dev: false
 
   /react-router@6.11.2(react@17.0.2):
@@ -13470,6 +13475,16 @@ packages:
       react: '>=16.8'
     dependencies:
       '@remix-run/router': 1.6.2
+      react: 17.0.2
+    dev: false
+
+  /react-router@6.19.0(react@17.0.2):
+    resolution: {integrity: sha512-0W63PKCZ7+OuQd7Tm+RbkI8kCLmn4GPjDbX61tWljPxWgqTKlEpeQUwPkT1DRjYhF8KSihK0hQpmhU4uxVMcdw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.12.0
       react: 17.0.2
     dev: false
 

--- a/ui/src/actions/general.js
+++ b/ui/src/actions/general.js
@@ -1,14 +1,7 @@
 /* eslint-disable promise/catch-or-return */
 /* eslint-disable promise/prefer-await-to-then */
-/* eslint-disable sonarjs/no-duplicate-string */
+
 import fetch from 'isomorphic-fetch';
-import { unselectShapes } from './sampleview'; // eslint-disable-line import/no-cycle
-import { fetchBeamInfo, fetchBeamlineSetup } from '../api/beamline';
-import { fetchDiffractometerInfo } from '../api/diffractometer';
-import { fetchLogMessages } from '../api/log';
-import { fetchApplicationSettings, fetchUIProperties } from '../api/main';
-import { fetchAvailableWorkflows } from '../api/workflow';
-import { fetchAvailableTasks, fetchQueueState } from '../api/queue';
 
 export function addUserMessage(records, target) {
   return {
@@ -24,10 +17,6 @@ export function removeUserMessage(messageID) {
 
 export function clearAllUserMessages() {
   return { type: 'CLEAR_ALL_USER_MESSAGES' };
-}
-
-export function setInitialState(data) {
-  return { type: 'SET_INITIAL_STATE', data };
 }
 
 export function applicationFetched(data) {
@@ -66,184 +55,6 @@ export function showDialog(show, t, title = '', data = null) {
     t,
     title,
     data,
-  };
-}
-
-function parse(response) {
-  if (response.status >= 200 && response.status < 300) {
-    return response.json();
-  }
-  const error = new Error(response.statusText);
-  error.response = response;
-  throw error;
-}
-
-function notify(error) {
-  console.error('REQUEST FAILED', error); // eslint-disable-line no-console
-}
-
-export function getInitialState() {
-  return (dispatch, getState) => {
-    const state = {};
-    const { login } = getState();
-
-    dispatch(applicationFetched(false));
-
-    const sampleVideoInfo = fetch('mxcube/api/v0.1/sampleview/camera', {
-      method: 'GET',
-      credentials: 'include',
-      headers: {
-        Accept: 'application/json',
-        'Content-type': 'application/json',
-      },
-    });
-    const detectorInfo = fetch('mxcube/api/v0.1/detector/', {
-      method: 'GET',
-      credentials: 'include',
-      headers: {
-        Accept: 'application/json',
-        'Content-type': 'application/json',
-      },
-    });
-    const savedShapes = fetch('mxcube/api/v0.1/sampleview/shapes', {
-      method: 'GET',
-      credentials: 'include',
-      headers: {
-        Accept: 'application/json',
-        'Content-type': 'application/json',
-      },
-    });
-    const sampleChangerInitialState = fetch(
-      'mxcube/api/v0.1/sample_changer/get_initial_state',
-      {
-        method: 'GET',
-        credentials: 'include',
-        headers: {
-          Accept: 'application/json',
-          'Content-type': 'application/json',
-        },
-      },
-    );
-    const remoteAccess = fetch('mxcube/api/v0.1/ra/', {
-      method: 'GET',
-      credentials: 'include',
-      headers: {
-        Accept: 'application/json',
-        'Content-type': 'application/json',
-      },
-    });
-
-    const pchains = [
-      fetchUIProperties()
-        .then((json) => {
-          state.uiproperties = json;
-        })
-        .catch(notify),
-      fetchQueueState()
-        .then((json) => {
-          state.queue = json;
-        })
-        .catch(notify),
-      fetchBeamInfo()
-        .then((json) => {
-          state.beamInfo = json;
-        })
-        .catch(notify),
-      fetchBeamlineSetup()
-        .then((json) => {
-          state.beamlineSetup = json;
-          state.datapath = json.path;
-          return json;
-        })
-        .catch(notify),
-      sampleVideoInfo
-        .then(parse)
-        .then((json) => {
-          state.Camera = json;
-        })
-        .catch(notify),
-      fetchDiffractometerInfo()
-        .then((json) => {
-          Object.assign(state, json);
-        })
-        .catch(notify),
-      detectorInfo
-        .then(parse)
-        .then((json) => {
-          state.detector = json;
-        })
-        .catch(notify),
-      fetchAvailableTasks()
-        .then((json) => {
-          state.taskParameters = json;
-        })
-        .catch(notify),
-      savedShapes
-        .then(parse)
-        .then((json) => {
-          state.shapes = json.shapes;
-        })
-        .catch(notify),
-      sampleChangerInitialState
-        .then(parse)
-        .then((json) => {
-          state.sampleChangerState = { state: json.state };
-          return json;
-        })
-        .then((json) => {
-          state.sampleChangerContents = json.contents;
-          return json;
-        })
-        .then((json) => {
-          state.loadedSample = json.loaded_sample;
-          return json;
-        })
-        .then((json) => {
-          state.sampleChangerCommands = json.cmds;
-          return json;
-        })
-        .then((json) => {
-          state.sampleChangerGlobalState = json.global_state;
-          return json;
-        })
-        .catch(notify),
-      remoteAccess
-        .then(parse)
-        .then((json) => {
-          state.remoteAccess = json.data;
-        })
-        .catch(notify),
-      fetchAvailableWorkflows()
-        .then((json) => {
-          state.workflow = json;
-        })
-        .catch(notify),
-      fetchLogMessages()
-        .then((json) => {
-          state.logger = json;
-        })
-        .catch(notify),
-      fetchApplicationSettings()
-        .then((json) => {
-          state.general = json;
-        })
-        .catch(notify),
-    ];
-
-    let prom = Promise.all(pchains).then(() => {
-      dispatch(setInitialState(state));
-    });
-
-    /* don't unselect shapes when in observer mode */
-    if (login.user.userInControl) {
-      prom = prom.then(() => {
-        dispatch(unselectShapes({ shapes: state.shapes }));
-      });
-    }
-
-    prom.then(() => {
-      dispatch(applicationFetched(true));
-    });
   };
 }
 

--- a/ui/src/actions/general.js
+++ b/ui/src/actions/general.js
@@ -82,9 +82,12 @@ function notify(error) {
   console.error('REQUEST FAILED', error); // eslint-disable-line no-console
 }
 
-export function getInitialState(userInControl) {
-  return (dispatch) => {
+export function getInitialState() {
+  return (dispatch, getState) => {
     const state = {};
+    const { login } = getState();
+
+    dispatch(applicationFetched(false));
 
     const sampleVideoInfo = fetch('mxcube/api/v0.1/sampleview/camera', {
       method: 'GET',
@@ -232,7 +235,7 @@ export function getInitialState(userInControl) {
     });
 
     /* don't unselect shapes when in observer mode */
-    if (userInControl) {
+    if (login.user.userInControl) {
       prom = prom.then(() => {
         dispatch(unselectShapes({ shapes: state.shapes }));
       });

--- a/ui/src/actions/login.js
+++ b/ui/src/actions/login.js
@@ -1,10 +1,16 @@
 /* eslint-disable promise/catch-or-return */
-
 /* eslint-disable promise/prefer-await-to-then */
+/* eslint-disable sonarjs/no-duplicate-string */
 
 import fetch from 'isomorphic-fetch';
-import { showErrorPanel, setLoading } from './general';
-import { serverIO } from '../serverIO'; // eslint-disable-line import/no-cycle
+import { fetchBeamInfo, fetchBeamlineSetup } from '../api/beamline';
+import { fetchDiffractometerInfo } from '../api/diffractometer';
+import { fetchLogMessages } from '../api/log';
+import { fetchApplicationSettings, fetchUIProperties } from '../api/main';
+import { fetchAvailableWorkflows } from '../api/workflow';
+import { fetchAvailableTasks, fetchQueueState } from '../api/queue';
+
+import { showErrorPanel, setLoading, applicationFetched } from './general';
 import { fetchLoginInfo, sendLogIn, sendSignOut } from '../api/login';
 
 export function setLoginInfo(loginInfo) {
@@ -47,6 +53,10 @@ export function selectProposal(prop) {
   };
 }
 
+export function setInitialState(data) {
+  return { type: 'SET_INITIAL_STATE', data };
+}
+
 export function postProposal(number) {
   return fetch('mxcube/api/v0.1/lims/proposal', {
     method: 'POST',
@@ -77,6 +87,9 @@ export function getLoginInfo() {
   return async (dispatch) => {
     try {
       const loginInfo = await fetchLoginInfo();
+      if (!loginInfo.loggedIn) {
+        throw new Error('Not authenticated');
+      }
       dispatch(setLoginInfo(loginInfo));
     } catch (error) {
       dispatch(resetLoginInfo());
@@ -88,11 +101,11 @@ export function getLoginInfo() {
 
 export function logIn(proposal, password, navigate) {
   return (dispatch) => {
-    sendLogIn(proposal, password).then(
+    return sendLogIn(proposal, password).then(
       (res) => {
         if (res.msg === '') {
           dispatch(showErrorPanel(false));
-          navigate('/');
+          dispatch(getInitialState(navigate));
         } else {
           dispatch(showErrorPanel(true, res.msg));
           dispatch(setLoading(false));
@@ -108,14 +121,12 @@ export function logIn(proposal, password, navigate) {
 
 export function forcedSignout() {
   return (dispatch) => {
-    serverIO.disconnect();
     dispatch({ type: 'SIGNOUT' });
   };
 }
 
 export function signOut(navigate) {
   return (dispatch) => {
-    serverIO.disconnect();
     return sendSignOut().then(() => {
       dispatch({ type: 'SIGNOUT' });
       dispatch(resetLoginInfo());
@@ -124,4 +135,174 @@ export function signOut(navigate) {
       }
     });
   };
+}
+
+export function getInitialState(navigate) {
+  return async (dispatch) => {
+    const state = {};
+
+    await dispatch(getLoginInfo());
+
+    const sampleVideoInfo = fetch('mxcube/api/v0.1/sampleview/camera', {
+      method: 'GET',
+      credentials: 'include',
+      headers: {
+        Accept: 'application/json',
+        'Content-type': 'application/json',
+      },
+    });
+    const detectorInfo = fetch('mxcube/api/v0.1/detector/', {
+      method: 'GET',
+      credentials: 'include',
+      headers: {
+        Accept: 'application/json',
+        'Content-type': 'application/json',
+      },
+    });
+    const savedShapes = fetch('mxcube/api/v0.1/sampleview/shapes', {
+      method: 'GET',
+      credentials: 'include',
+      headers: {
+        Accept: 'application/json',
+        'Content-type': 'application/json',
+      },
+    });
+    const sampleChangerInitialState = fetch(
+      'mxcube/api/v0.1/sample_changer/get_initial_state',
+      {
+        method: 'GET',
+        credentials: 'include',
+        headers: {
+          Accept: 'application/json',
+          'Content-type': 'application/json',
+        },
+      },
+    );
+    const remoteAccess = fetch('mxcube/api/v0.1/ra/', {
+      method: 'GET',
+      credentials: 'include',
+      headers: {
+        Accept: 'application/json',
+        'Content-type': 'application/json',
+      },
+    });
+
+    const pchains = [
+      fetchUIProperties()
+        .then((json) => {
+          state.uiproperties = json;
+        })
+        .catch(notify),
+      fetchQueueState()
+        .then((json) => {
+          state.queue = json;
+        })
+        .catch(notify),
+      fetchBeamInfo()
+        .then((json) => {
+          state.beamInfo = json;
+        })
+        .catch(notify),
+      fetchBeamlineSetup()
+        .then((json) => {
+          state.beamlineSetup = json;
+          state.datapath = json.path;
+          return json;
+        })
+        .catch(notify),
+      sampleVideoInfo
+        .then(parse)
+        .then((json) => {
+          state.Camera = json;
+        })
+        .catch(notify),
+      fetchDiffractometerInfo()
+        .then((json) => {
+          Object.assign(state, json);
+        })
+        .catch(notify),
+      detectorInfo
+        .then(parse)
+        .then((json) => {
+          state.detector = json;
+        })
+        .catch(notify),
+      fetchAvailableTasks()
+        .then((json) => {
+          state.taskParameters = json;
+        })
+        .catch(notify),
+      savedShapes
+        .then(parse)
+        .then((json) => {
+          state.shapes = json.shapes;
+        })
+        .catch(notify),
+      sampleChangerInitialState
+        .then(parse)
+        .then((json) => {
+          state.sampleChangerState = { state: json.state };
+          return json;
+        })
+        .then((json) => {
+          state.sampleChangerContents = json.contents;
+          return json;
+        })
+        .then((json) => {
+          state.loadedSample = json.loaded_sample;
+          return json;
+        })
+        .then((json) => {
+          state.sampleChangerCommands = json.cmds;
+          return json;
+        })
+        .then((json) => {
+          state.sampleChangerGlobalState = json.global_state;
+          return json;
+        })
+        .catch(notify),
+      remoteAccess
+        .then(parse)
+        .then((json) => {
+          state.remoteAccess = json.data;
+        })
+        .catch(notify),
+      fetchAvailableWorkflows()
+        .then((json) => {
+          state.workflow = json;
+        })
+        .catch(notify),
+      fetchLogMessages()
+        .then((json) => {
+          state.logger = json;
+        })
+        .catch(notify),
+      fetchApplicationSettings()
+        .then((json) => {
+          state.general = json;
+        })
+        .catch(notify),
+    ];
+
+    const prom = Promise.all(pchains).then(() => {
+      dispatch(setInitialState(state));
+    });
+
+    prom.then(() => {
+      dispatch(applicationFetched(true));
+    });
+  };
+}
+
+function parse(response) {
+  if (response.status >= 200 && response.status < 300) {
+    return response.json();
+  }
+  const error = new Error(response.statusText);
+  error.response = response;
+  throw error;
+}
+
+function notify(error) {
+  console.error('REQUEST FAILED', error); // eslint-disable-line no-console
 }

--- a/ui/src/actions/login.js
+++ b/ui/src/actions/login.js
@@ -85,37 +85,26 @@ export function sendSelectProposal(number, navigate) {
 
 export function getLoginInfo() {
   return async (dispatch) => {
-    try {
-      const loginInfo = await fetchLoginInfo();
-      if (!loginInfo.loggedIn) {
-        throw new Error('Not authenticated');
-      }
-      dispatch(setLoginInfo(loginInfo));
-    } catch (error) {
+    const loginInfo = await fetchLoginInfo();
+    if (!loginInfo.loggedIn) {
       dispatch(resetLoginInfo());
-      dispatch(setLoading(false));
-      throw error;
+      throw new Error('Not authenticated');
     }
+    dispatch(setLoginInfo(loginInfo));
   };
 }
 
-export function logIn(proposal, password, navigate) {
+export function logIn(proposal, password) {
   return (dispatch) => {
-    return sendLogIn(proposal, password).then(
-      (res) => {
-        if (res.msg === '') {
-          dispatch(showErrorPanel(false));
-          dispatch(getInitialState(navigate));
-        } else {
-          dispatch(showErrorPanel(true, res.msg));
-          dispatch(setLoading(false));
-        }
-      },
-      () => {
-        dispatch(showErrorPanel(true));
+    return sendLogIn(proposal, password).then((res) => {
+      if (res.msg === '') {
+        dispatch(showErrorPanel(false));
+        dispatch(getInitialState());
+      } else {
+        dispatch(showErrorPanel(true, res.msg));
         dispatch(setLoading(false));
-      },
-    );
+      }
+    });
   };
 }
 
@@ -125,14 +114,11 @@ export function forcedSignout() {
   };
 }
 
-export function signOut(navigate) {
+export function signOut() {
   return (dispatch) => {
     return sendSignOut().then(() => {
       dispatch({ type: 'SIGNOUT' });
       dispatch(resetLoginInfo());
-      if (navigate) {
-        navigate('/');
-      }
     });
   };
 }

--- a/ui/src/actions/login.js
+++ b/ui/src/actions/login.js
@@ -14,6 +14,20 @@ export function setLoginInfo(loginInfo) {
   };
 }
 
+export function resetLoginInfo() {
+  return setLoginInfo({
+    beamlineName: '',
+    synchrotronName: '',
+    loginType: '',
+    user: '',
+    proposalList: [],
+    selectedProposal: '',
+    selectedProposalID: '',
+    loggedIn: false,
+    rootPath: '',
+  });
+}
+
 export function showProposalsForm() {
   return {
     type: 'SHOW_PROPOSALS_FORM',
@@ -72,19 +86,7 @@ export function getLoginInfo() {
       const loginInfo = await fetchLoginInfo();
       dispatch(setLoginInfo(loginInfo));
     } catch (error) {
-      dispatch(
-        setLoginInfo({
-          beamlineName: '',
-          synchrotronName: '',
-          loginType: '',
-          user: '',
-          proposalList: [],
-          selectedProposal: '',
-          selectedProposalID: '',
-          loggedIn: false,
-          rootPath: '',
-        }),
-      );
+      dispatch(resetLoginInfo());
       dispatch(setLoading(false));
       throw error;
     }
@@ -123,7 +125,7 @@ export function signOut(navigate) {
     serverIO.disconnect();
     return sendSignOut().then(() => {
       dispatch({ type: 'SIGNOUT' });
-
+      dispatch(resetLoginInfo());
       if (navigate) {
         navigate('/');
       }

--- a/ui/src/actions/login.js
+++ b/ui/src/actions/login.js
@@ -3,7 +3,7 @@
 /* eslint-disable promise/prefer-await-to-then */
 
 import fetch from 'isomorphic-fetch';
-import { showErrorPanel, setLoading, getInitialState } from './general';
+import { showErrorPanel, setLoading } from './general';
 import { serverIO } from '../serverIO'; // eslint-disable-line import/no-cycle
 import { fetchLoginInfo, sendLogIn, sendSignOut } from '../api/login';
 
@@ -70,13 +70,6 @@ export function sendSelectProposal(number, navigate) {
         dispatch(selectProposal(number));
       }
     });
-  };
-}
-
-export function startSession(userInControl) {
-  return (dispatch) => {
-    dispatch(getInitialState(userInControl));
-    dispatch(setLoading(false));
   };
 }
 

--- a/ui/src/actions/remoteAccess.js
+++ b/ui/src/actions/remoteAccess.js
@@ -1,7 +1,7 @@
 /* eslint-disable promise/catch-or-return */
 /* eslint-disable promise/prefer-await-to-then */
 /* eslint-disable sonarjs/no-duplicate-string */
-import { getLoginInfo } from './login'; // eslint-disable-line import/no-cycle
+import { getLoginInfo } from './login';
 
 export function showObserverDialog(show = true) {
   return { type: 'SHOW_OBSERVER_DIALOG', show };

--- a/ui/src/actions/sampleview.js
+++ b/ui/src/actions/sampleview.js
@@ -2,7 +2,7 @@
 /* eslint-disable promise/prefer-await-to-then */
 /* eslint-disable sonarjs/no-duplicate-string */
 import fetch from 'isomorphic-fetch';
-import { showErrorPanel } from './general'; // eslint-disable-line import/no-cycle
+import { showErrorPanel } from './general';
 import {
   fetchMotorPositions,
   sendUpdateAperture,
@@ -425,16 +425,20 @@ export function sendDeleteShape(id) {
 }
 
 export function unselectShapes(shapes) {
-  return (dispatch) => {
-    const _shapes = [];
-    if (shapes.shapes !== undefined) {
-      const keys = Object.keys(shapes.shapes);
-      keys.forEach((k) => {
-        const aux = shapes.shapes[k];
-        aux.selected = false;
-        _shapes.push(aux);
-      });
-      dispatch(sendUpdateShapes(_shapes));
+  return (dispatch, getState) => {
+    const login = getState();
+
+    if (login.user.userInControl) {
+      const _shapes = [];
+      if (shapes.shapes !== undefined) {
+        const keys = Object.keys(shapes.shapes);
+        keys.forEach((k) => {
+          const aux = shapes.shapes[k];
+          aux.selected = false;
+          _shapes.push(aux);
+        });
+        dispatch(sendUpdateShapes(_shapes));
+      }
     }
   };
 }

--- a/ui/src/api/login.js
+++ b/ui/src/api/login.js
@@ -11,12 +11,7 @@ export function sendSignOut() {
 }
 
 export function fetchLoginInfo() {
-  return endpoint
-    .get('/login_info') // eslint-disable-next-line promise/prefer-await-to-callbacks
-    .unauthorized((err) => {
-      throw err;
-    })
-    .json();
+  return endpoint.get('/login_info').json();
 }
 
 export function sendFeedback(sender, content) {

--- a/ui/src/api/login.js
+++ b/ui/src/api/login.js
@@ -11,7 +11,12 @@ export function sendSignOut() {
 }
 
 export function fetchLoginInfo() {
-  return endpoint.get('/login_info').json();
+  return endpoint
+    .get('/login_info') // eslint-disable-next-line promise/prefer-await-to-callbacks
+    .unauthorized((err) => {
+      throw err;
+    })
+    .json();
 }
 
 export function sendFeedback(sender, content) {

--- a/ui/src/components/App.js
+++ b/ui/src/components/App.js
@@ -103,6 +103,9 @@ function App(props) {
 
   useEffect(() => {
     requireAuth();
+    return () => {
+      serverIO.disconnect();
+    };
   }, []);
 
   if (!applicationFetched) {

--- a/ui/src/components/App.js
+++ b/ui/src/components/App.js
@@ -20,26 +20,23 @@ import LoadingScreen from '../components/LoadingScreen/LoadingScreen';
 
 import { store } from '../store';
 import { serverIO } from '../serverIO';
-
-import { getLoginInfo } from '../actions/login';
-import { getInitialState, applicationFetched } from '../actions/general';
+import { applicationFetched } from '../actions/general';
+import { getInitialState } from '../actions/login';
 
 export async function requireAuth() {
   try {
     store.dispatch(applicationFetched(false));
-    await store.dispatch(getLoginInfo());
+    await store.dispatch(getInitialState());
+    serverIO.listen();
   } catch {
     store.dispatch(applicationFetched(true));
-    return;
   }
-
-  await store.dispatch(getInitialState());
-  serverIO.listen(store);
 }
 
 function PrivateOutlet() {
   const loggedIn = useSelector((state) => state.login.loggedIn);
   const location = useLocation();
+
   return loggedIn ? (
     <Outlet />
   ) : (
@@ -55,10 +52,6 @@ const router = createBrowserRouter([
   {
     path: '/',
     element: <PrivateOutlet />,
-    loader: () => {
-      requireAuth();
-      return true;
-    },
     children: [
       {
         path: '',

--- a/ui/src/components/Login/Login.jsx
+++ b/ui/src/components/Login/Login.jsx
@@ -5,26 +5,11 @@ import { Controller, useForm } from 'react-hook-form';
 
 import logo from '../../img/mxcube_logo20.png';
 import loader from '../../img/loader.gif';
-import SelectProposal from './SelectProposal';
 import withRouter from '../WithRouter';
 import styles from './Login.module.css';
 
 function LoginComponent(props) {
-  const {
-    data,
-    showProposalsForm,
-    hideProposalsForm,
-    selectedProposal,
-    selectProposal,
-    sendSelectProposal,
-    router,
-    loading,
-    setLoading,
-    logIn,
-    signOut,
-    showError,
-    errorMessage,
-  } = props;
+  const { router, loading, logIn, showError, errorMessage } = props;
 
   const {
     control,
@@ -33,102 +18,86 @@ function LoginComponent(props) {
   } = useForm({ defaultValues: { username: '', password: '' } });
 
   function handleSubmit(data) {
-    setLoading(true);
     logIn(data.username.toLowerCase(), data.password, router.navigate);
   }
 
   return (
-    <>
-      {showProposalsForm && (
-        <SelectProposal
-          show
-          hide={hideProposalsForm}
-          data={data}
-          selectedProposal={selectedProposal}
-          selectProposal={selectProposal}
-          sendSelectProposal={(selected) =>
-            sendSelectProposal(selected, router.navigate)
-          }
-          signOut={() => signOut(router.navigate)}
-        />
-      )}
-      <Form
-        className={styles.box}
-        noValidate
-        onSubmit={makeOnSubmit(handleSubmit)}
-      >
-        <h1 className={styles.title}>
-          <img src={logo} width="80" alt="" />
-          MXCuBE
-        </h1>
-        <Form.Group className="mb-3">
-          <InputGroup>
-            <InputGroup.Text>
-              <i className="fas fa-user" />
-            </InputGroup.Text>
-            <Controller
-              name="username"
-              control={control}
-              rules={{ required: 'Login ID is required' }}
-              render={({ field }) => (
-                <Form.Control
-                  type="text"
-                  aria-label="Login ID"
-                  placeholder="Login ID"
-                  autoFocus // eslint-disable-line jsx-a11y/no-autofocus
-                  required
-                  isInvalid={!!errors.username}
-                  {...field}
-                />
-              )}
-            />
-            {errors.username && (
-              <Form.Control.Feedback type="invalid">
-                {errors.username.message}
-              </Form.Control.Feedback>
+    <Form
+      className={styles.box}
+      noValidate
+      onSubmit={makeOnSubmit(handleSubmit)}
+    >
+      <h1 className={styles.title}>
+        <img src={logo} width="80" alt="" />
+        MXCuBE
+      </h1>
+      <Form.Group className="mb-3">
+        <InputGroup>
+          <InputGroup.Text>
+            <i className="fas fa-user" />
+          </InputGroup.Text>
+          <Controller
+            name="username"
+            control={control}
+            rules={{ required: 'Login ID is required' }}
+            render={({ field }) => (
+              <Form.Control
+                type="text"
+                aria-label="Login ID"
+                placeholder="Login ID"
+                autoFocus // eslint-disable-line jsx-a11y/no-autofocus
+                required
+                isInvalid={!!errors.username}
+                {...field}
+              />
             )}
-          </InputGroup>
-        </Form.Group>
-        <Form.Group className="mb-3">
-          <InputGroup>
-            <InputGroup.Text>
-              <i className="fas fa-lock" />
-            </InputGroup.Text>
-            <Controller
-              name="password"
-              control={control}
-              rules={{ required: 'Password is required' }}
-              render={({ field }) => (
-                <Form.Control
-                  type="password"
-                  aria-label="Password"
-                  placeholder="Password"
-                  required
-                  isInvalid={!!errors.password}
-                  {...field}
-                />
-              )}
-            />
-            {errors.password && (
-              <Form.Control.Feedback type="invalid">
-                {errors.password.message}
-              </Form.Control.Feedback>
-            )}
-          </InputGroup>
-        </Form.Group>
-        <Button type="submit" size="lg" className={styles.btn}>
-          {loading && (
-            <img className={styles.loader} src={loader} width="25" alt="" />
+          />
+          {errors.username && (
+            <Form.Control.Feedback type="invalid">
+              {errors.username.message}
+            </Form.Control.Feedback>
           )}
-          Sign in
-        </Button>
-        {!loading && showError && (
-          <Alert className="mt-3" variant="danger">
-            <pre className={styles.errorMsg}>{errorMessage}</pre>
-          </Alert>
+        </InputGroup>
+      </Form.Group>
+      <Form.Group className="mb-3">
+        <InputGroup>
+          <InputGroup.Text>
+            <i className="fas fa-lock" />
+          </InputGroup.Text>
+          <Controller
+            name="password"
+            control={control}
+            rules={{ required: 'Password is required' }}
+            render={({ field }) => (
+              <Form.Control
+                type="password"
+                aria-label="Password"
+                placeholder="Password"
+                required
+                isInvalid={!!errors.password}
+                {...field}
+              />
+            )}
+          />
+          {errors.password && (
+            <Form.Control.Feedback type="invalid">
+              {errors.password.message}
+            </Form.Control.Feedback>
+          )}
+        </InputGroup>
+      </Form.Group>
+      <Button type="submit" size="lg" className={styles.btn}>
+        {loading && (
+          <img className={styles.loader} src={loader} width="25" alt="" />
         )}
-      </Form>
-    </>
+        Sign in
+      </Button>
+      {!loading && showError && (
+        <Alert className="mt-3" variant="danger">
+          <pre className={styles.errorMsg}>{errorMessage}</pre>
+        </Alert>
+      )}
+    </Form>
   );
 }
 

--- a/ui/src/components/Login/Login.jsx
+++ b/ui/src/components/Login/Login.jsx
@@ -7,6 +7,7 @@ import logo from '../../img/mxcube_logo20.png';
 import loader from '../../img/loader.gif';
 import withRouter from '../WithRouter';
 import styles from './Login.module.css';
+import { serverIO } from '../../serverIO';
 
 function LoginComponent(props) {
   const { router, loading, logIn, showError, errorMessage } = props;
@@ -17,8 +18,9 @@ function LoginComponent(props) {
     formState: { errors },
   } = useForm({ defaultValues: { username: '', password: '' } });
 
-  function handleSubmit(data) {
-    logIn(data.username.toLowerCase(), data.password, router.navigate);
+  async function handleSubmit(data) {
+    await logIn(data.username.toLowerCase(), data.password, router.navigate);
+    serverIO.listen();
   }
 
   return (

--- a/ui/src/components/Login/SelectProposal.js
+++ b/ui/src/components/Login/SelectProposal.js
@@ -23,12 +23,10 @@ class SelectProposal extends React.Component {
 
   sendProposal() {
     this.props.sendSelectProposal(this.state.pNumber);
-    this.props.hide();
   }
 
   handleCancel() {
-    this.props.signOut();
-    this.props.hide();
+    this.props.handleHide();
   }
 
   render() {
@@ -76,7 +74,7 @@ class SelectProposal extends React.Component {
         </Modal.Body>
         <Modal.Footer>
           <Button variant="outline-secondary" onClick={this.handleCancel}>
-            Sign Out
+            Cancel
           </Button>
           <Button
             variant="primary"

--- a/ui/src/components/MXNavbar/MXNavbar.jsx
+++ b/ui/src/components/MXNavbar/MXNavbar.jsx
@@ -20,8 +20,9 @@ class MXNavbar extends React.Component {
   }
 
   handleSignOutClick() {
-    this.props.signOut(this.props.router.navigate);
+    this.props.signOut();
     serverIO.disconnect();
+    this.props.router.navigate('/');
   }
 
   render() {

--- a/ui/src/components/MXNavbar/MXNavbar.jsx
+++ b/ui/src/components/MXNavbar/MXNavbar.jsx
@@ -19,8 +19,7 @@ class MXNavbar extends React.Component {
   }
 
   handleSignOutClick() {
-    this.props.signOut();
-    this.props.router.navigate('/login', { replace: true });
+    this.props.signOut(this.props.router.navigate);
   }
 
   render() {
@@ -28,6 +27,11 @@ class MXNavbar extends React.Component {
     const numObservers = this.props.remoteAccess.observers.length;
 
     document.title = `MxCuBE-Web Proposal: ${this.props.selectedProposal}`;
+
+    const username =
+      this.props.loginType === 'User'
+        ? `(${this.props.user.username})`
+        : `(${this.props.selectedProposal})`;
 
     return (
       <Navbar
@@ -77,6 +81,17 @@ class MXNavbar extends React.Component {
                   Remote
                 </Nav.Item>
               </LinkContainer>
+              {this.props.loginType === 'User' && (
+                <Button
+                  as={Nav.Link}
+                  className="nav-link pe-0"
+                  variant="Light"
+                  onClick={this.props.handleShowProposalForm}
+                >
+                  <span className="me-1 fas fa-lg fa-bars" />
+                  Select proposal {`(${this.props.selectedProposal})`}
+                </Button>
+              )}
               <Button
                 as={Nav.Link}
                 className="nav-link pe-0"
@@ -84,7 +99,7 @@ class MXNavbar extends React.Component {
                 onClick={this.handleSignOutClick}
               >
                 <span className="me-1 fas fa-lg fa-sign-out-alt" />
-                Sign out {`(${this.props.selectedProposal})`}
+                Sign out {username}
               </Button>
             </Nav>
           </Navbar.Collapse>

--- a/ui/src/components/MXNavbar/MXNavbar.jsx
+++ b/ui/src/components/MXNavbar/MXNavbar.jsx
@@ -3,6 +3,7 @@ import { Container, Navbar, Nav, Button } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 import withRouter from '../WithRouter';
 import './MXNavbar.css';
+import { serverIO } from '../../serverIO';
 
 class MXNavbar extends React.Component {
   constructor(props) {
@@ -20,6 +21,7 @@ class MXNavbar extends React.Component {
 
   handleSignOutClick() {
     this.props.signOut(this.props.router.navigate);
+    serverIO.disconnect();
   }
 
   render() {

--- a/ui/src/components/Main.jsx
+++ b/ui/src/components/Main.jsx
@@ -18,7 +18,7 @@ import PassControlDialog from './RemoteAccess/PassControlDialog';
 import ConfirmCollectDialog from '../containers/ConfirmCollectDialog';
 import WorkflowParametersDialog from '../containers/WorkflowParametersDialog';
 import GphlWorkflowParametersDialog from '../containers/GphlWorkflowParametersDialog';
-
+import SelectProposalContainer from '../containers/SelectProposalContainer';
 import diagonalNoise from '../img/diagonal-noise.png';
 import {
   sendChatMessage,
@@ -99,6 +99,7 @@ class Main extends React.Component {
             }}
           />
         ) : null}
+        <SelectProposalContainer />
         <TaskContainer />
         <PleaseWaitDialog />
         <ErrorNotificationPanel />

--- a/ui/src/components/Main.jsx
+++ b/ui/src/components/Main.jsx
@@ -33,6 +33,8 @@ import styles from './Main.module.css';
 
 import 'react-chat-widget/lib/styles.css';
 import './rachat.css';
+import { store } from '../store';
+import { getInitialState } from '../actions/login';
 
 class Main extends React.Component {
   constructor(props) {
@@ -43,6 +45,10 @@ class Main extends React.Component {
   }
 
   componentDidMount() {
+    if (!this.props.applicationFetched) {
+      store.dispatch(getInitialState());
+    }
+
     // eslint-disable-next-line promise/prefer-await-to-then, promise/catch-or-return
     getAllChatMessages().then((json) => {
       json.messages.forEach((entry) => {

--- a/ui/src/containers/LoginContainer.js
+++ b/ui/src/containers/LoginContainer.js
@@ -1,13 +1,7 @@
 import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import {
-  logIn,
-  signOut,
-  selectProposal,
-  sendSelectProposal,
-  hideProposalsForm,
-} from '../actions/login';
+import { logIn } from '../actions/login';
 import { setLoading } from '../actions/general';
 import Login from '../components/Login/Login';
 
@@ -22,20 +16,14 @@ function mapStateToProps(state) {
     loading: state.general.loading,
     showError: state.general.showErrorPanel,
     errorMessage: state.general.errorMessage,
-    showProposalsForm: state.login.showProposalsForm,
     data: state.login,
-    selectedProposal: state.login.selectedProposal,
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
     logIn: bindActionCreators(logIn, dispatch),
-    signOut: bindActionCreators(signOut, dispatch),
     setLoading: bindActionCreators(setLoading, dispatch),
-    selectProposal: bindActionCreators(selectProposal, dispatch),
-    sendSelectProposal: bindActionCreators(sendSelectProposal, dispatch),
-    hideProposalsForm: bindActionCreators(hideProposalsForm, dispatch),
   };
 }
 

--- a/ui/src/containers/LoginContainer.js
+++ b/ui/src/containers/LoginContainer.js
@@ -1,14 +1,19 @@
-import React, { Component } from 'react';
+import React from 'react';
+import { useLocation, Navigate } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { logIn } from '../actions/login';
 import { setLoading } from '../actions/general';
 import Login from '../components/Login/Login';
 
-class LoginContainer extends Component {
-  render() {
-    return <Login {...this.props} />;
-  }
+function LoginContainer(props) {
+  const location = useLocation();
+
+  return props.data.loggedIn === false ? (
+    <Login {...props} />
+  ) : (
+    <Navigate to="/" state={{ from: location }} replace />
+  );
 }
 
 function mapStateToProps(state) {

--- a/ui/src/containers/MXNavbarContainer.js
+++ b/ui/src/containers/MXNavbarContainer.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import MXNavbar from '../components/MXNavbar/MXNavbar';
-import { signOut } from '../actions/login';
+import { signOut, showProposalsForm } from '../actions/login';
 
 class MXNavbarContainer extends React.Component {
   render() {
@@ -9,6 +9,8 @@ class MXNavbarContainer extends React.Component {
       <MXNavbar
         user={this.props.user}
         selectedProposal={this.props.selectedProposal}
+        handleShowProposalForm={this.props.showProposalsForm}
+        loginType={this.props.loginType}
         signOut={this.props.signOut}
         loggedIn={this.props.loggedIn}
         location={this.props.location}
@@ -23,6 +25,7 @@ class MXNavbarContainer extends React.Component {
 function mapStateToProps(state) {
   return {
     user: state.login.user,
+    loginType: state.login.loginType,
     loggedIn: state.login.loggedIn,
     selectedProposal: state.login.selectedProposal,
     mode: state.general.mode,
@@ -33,6 +36,7 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
   return {
     signOut: (navigate) => dispatch(signOut(navigate)),
+    showProposalsForm: () => dispatch(showProposalsForm()),
   };
 }
 

--- a/ui/src/containers/SelectProposalContainer.js
+++ b/ui/src/containers/SelectProposalContainer.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import {
@@ -10,30 +10,34 @@ import {
 import { setLoading } from '../actions/general';
 import SelectProposal from '../components/Login/SelectProposal';
 import withRouter from '../components/WithRouter';
+import { serverIO } from '../serverIO';
 
-class SelectProposalContainer extends Component {
-  render() {
-    const show =
-      (this.props.login.loginType === 'User' &&
-        this.props.login.selectedProposalID === null) ||
-      this.props.login.showProposalsForm;
-
-    return (
-      <SelectProposal
-        show={show}
-        handleHide={
-          this.props.login.selectedProposalID === null
-            ? () => this.props.signOut(this.props.router.navigate)
-            : this.props.hideProposalsForm
-        }
-        data={this.props.login}
-        selectProposal={this.props.selectProposal}
-        sendSelectProposal={(selected) =>
-          this.props.sendSelectProposal(selected, this.props.router.navigate)
-        }
-      />
-    );
+function SelectProposalContainer(props) {
+  function handleLogout() {
+    props.signOut(props.router.navigate);
+    serverIO.disconnect();
   }
+
+  const show =
+    (props.login.loginType === 'User' &&
+      props.login.selectedProposalID === null) ||
+    props.login.showProposalsForm;
+
+  return (
+    <SelectProposal
+      show={show}
+      handleHide={
+        props.login.selectedProposalID === null
+          ? () => handleLogout()
+          : props.hideProposalsForm
+      }
+      data={props.login}
+      selectProposal={props.selectProposal}
+      sendSelectProposal={(selected) =>
+        props.sendSelectProposal(selected, props.router.navigate)
+      }
+    />
+  );
 }
 
 function mapStateToProps(state) {

--- a/ui/src/containers/SelectProposalContainer.js
+++ b/ui/src/containers/SelectProposalContainer.js
@@ -14,8 +14,9 @@ import { serverIO } from '../serverIO';
 
 function SelectProposalContainer(props) {
   function handleLogout() {
-    props.signOut(props.router.navigate);
+    props.signOut();
     serverIO.disconnect();
+    props.router.navigate('/');
   }
 
   const show =

--- a/ui/src/containers/SelectProposalContainer.js
+++ b/ui/src/containers/SelectProposalContainer.js
@@ -1,0 +1,58 @@
+import React, { Component } from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import {
+  signOut,
+  selectProposal,
+  sendSelectProposal,
+  hideProposalsForm,
+} from '../actions/login';
+import { setLoading } from '../actions/general';
+import SelectProposal from '../components/Login/SelectProposal';
+import withRouter from '../components/WithRouter';
+
+class SelectProposalContainer extends Component {
+  render() {
+    const show =
+      (this.props.login.loginType === 'User' &&
+        this.props.login.selectedProposalID === null) ||
+      this.props.login.showProposalsForm;
+
+    return (
+      <SelectProposal
+        show={show}
+        handleHide={
+          this.props.login.selectedProposalID === null
+            ? () => this.props.signOut(this.props.router.navigate)
+            : this.props.hideProposalsForm
+        }
+        data={this.props.login}
+        selectProposal={this.props.selectProposal}
+        sendSelectProposal={(selected) =>
+          this.props.sendSelectProposal(selected, this.props.router.navigate)
+        }
+      />
+    );
+  }
+}
+
+function mapStateToProps(state) {
+  return {
+    login: state.login,
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    signOut: bindActionCreators(signOut, dispatch),
+    setLoading: bindActionCreators(setLoading, dispatch),
+    selectProposal: bindActionCreators(selectProposal, dispatch),
+    sendSelectProposal: bindActionCreators(sendSelectProposal, dispatch),
+    hideProposalsForm: bindActionCreators(hideProposalsForm, dispatch),
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(withRouter(SelectProposalContainer));

--- a/ui/src/reducers/index.js
+++ b/ui/src/reducers/index.js
@@ -40,10 +40,6 @@ const mxcubeReducer = combineReducers({
 });
 
 const rootReducer = (state, action) => {
-  if (action.type === 'SIGNOUT') {
-    state = undefined; // eslint-disable-line no-param-reassign
-  }
-
   return mxcubeReducer(state, action);
 };
 

--- a/ui/src/reducers/login.js
+++ b/ui/src/reducers/login.js
@@ -12,10 +12,6 @@ const INITIAL_STATE = {
 function loginReducer(state = INITIAL_STATE, action = {}) {
   switch (action.type) {
     case 'SET_LOGIN_INFO': {
-      if (action.loginInfo.user.username !== '') {
-        localStorage.setItem('currentUser', action.loginInfo.user.username);
-      }
-
       return {
         ...state,
         beamlineName: action.loginInfo.beamlineName,
@@ -48,6 +44,7 @@ function loginReducer(state = INITIAL_STATE, action = {}) {
         ...state,
         selectedProposal: action.proposal,
         selectedProposalID: propId,
+        showProposalsForm: false,
       };
     }
     case 'HIDE_PROPOSALS_FORM': {

--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -45,7 +45,7 @@ import {
   showGphlWorkflowParametersDialog,
 } from './actions/workflow';
 
-import { incChatMessageCount, getRaState } from './actions/remoteAccess'; // eslint-disable-line import/no-cycle
+import { incChatMessageCount, getRaState } from './actions/remoteAccess';
 
 import { forcedSignout, getLoginInfo } from './actions/login';
 
@@ -60,6 +60,7 @@ import { setEnergyScanResult } from './actions/taskResults';
 
 import { CLICK_CENTRING } from './constants';
 import { sendRefreshSession } from './api/login';
+import { store } from './store';
 
 class ServerIO {
   constructor() {
@@ -128,7 +129,7 @@ class ServerIO {
   }
 
   // eslint-disable-next-line sonarjs/cognitive-complexity
-  listen(store) {
+  listen() {
     if (this.initialized) {
       return;
     }
@@ -428,6 +429,7 @@ class ServerIO {
 
     this.hwrSocket.on('forceSignout', () => {
       this.dispatch(forcedSignout());
+      serverIO.disconnect();
     });
 
     this.hwrSocket.on('workflowParametersDialog', (data) => {

--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -127,7 +127,12 @@ class ServerIO {
     }
   }
 
+  // eslint-disable-next-line sonarjs/cognitive-complexity
   listen(store) {
+    if (this.initialized) {
+      return;
+    }
+
     this.initialized = true;
     this.dispatch = store.dispatch;
 


### PR DESCRIPTION
Separated `login` and `login_info` routes. Returning `401 - Unauthorized` from login_info instead of redirect. Removed the call to `requireAuth` from the `PrivateOutlet` component as it runs during rendering. 

`requireAuth` is now executed on page load (`useEffect` of `App`) and on change of route using the loader functionality of `react-router`. The later makes the transition from login to application much smoother, as no reload of the page is needed. 

The proposal selection dialog was also separated from the Login component and displayed at login when there is no proposal already selected. The user can select a proposal from the menu in the top right corner. 

![Peek 2023-11-22 16-29](https://github.com/mxcube/mxcubeweb/assets/4331447/9c050c94-30e8-4def-a590-fca2d94deaaf)
