### PR TITLE
use correct motor for horizontal sample movements

### DIFF
--- a/ui/src/components/SampleView/MotorControls.js
+++ b/ui/src/components/SampleView/MotorControls.js
@@ -29,7 +29,7 @@ export default class MotorControls extends React.Component {
     });
 
     const sample_horizontal_uiprop = find(this.props.uiproperties.components, {
-      role: 'sample_vertical',
+      role: 'sample_horizontal',
     });
 
     const sample_vertical =


### PR DESCRIPTION
For the sample position UI controls, i.e. the arrows in the left column, pick correct horizontal motor.

Use component with 'sample_horizontal' role for horizontal sample moves.

![image](https://github.com/mxcube/mxcubeweb/assets/77584583/91c38f8e-bd3f-4da4-b96b-7b7785282e5b)
