### PR TITLE
link to developer docs from README file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The client is implemented in ECMAScript6 and HTML5. React, Boostrap and FabricJS
 ## Information for developers
 
 - [Contributing guidelines](https://github.com/mxcube/mxcubeweb/blob/master/CONTRIBUTING.md)
+- [Developer documentation](https://mxcubeweb.readthedocs.io/)
 
 ## Information for users
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ MXCuBE-Web is the latest generation of the data acquisition software MXCuBE (Mac
 - [Global Phasing Ltd.](http://www.globalphasing.com/)
 - [ALBA](https://www.cells.es/en)
 - [DESY](https://www.desy.de)
-- [LNLS](https://www.lnls.cnpem.br/)
+- [LNLS](https://lnls.cnpem.br/)
 - [Elettra](https://www.elettra.trieste.it/)
 - [NSRRC](https://www.nsrrc.org.tw/english/index.aspx)
 - [ANSTO](https://www.ansto.gov.au/facilities/australian-synchrotron)


### PR DESCRIPTION
Link to the generated developer docs from the readme file. This way these docs will get some visibility. Right now I suspect most are not aware of the dev docs existance.

Also, updates link to LNLS, as the old one does not work properly anymore.