### PR TITLE
Fix MXCuBE dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -867,52 +867,6 @@ unicode = ["unicodedata2 (>=15.0.0)"]
 woff = ["brotli (>=1.0.1)", "brotlicffi (>=0.8.0)", "zopfli (>=0.1.4)"]
 
 [[package]]
-name = "frozendict"
-version = "2.3.8"
-description = "A simple immutable dictionary"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "frozendict-2.3.8-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d188d062084fba0e4bf32719ff7380b26c050b932ff164043ce82ab90587c52b"},
-    {file = "frozendict-2.3.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f2a4e818ac457f6354401dcb631527af25e5a20fcfc81e6b5054b45fc245caca"},
-    {file = "frozendict-2.3.8-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9a506d807858fa961aaa5b48dab6154fdc6bd045bbe9310788bbff141bb42d13"},
-    {file = "frozendict-2.3.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:750632cc890d8ee9484fe6d31b261159144b6efacc08e1317fe46accd1410373"},
-    {file = "frozendict-2.3.8-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:7ee5fe2658a8ac9a57f748acaf563f6a47f80b8308cbf0a04fac0ba057d41f75"},
-    {file = "frozendict-2.3.8-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23c4bb46e6b8246e1e7e49b5593c2bc09221db0d8f31f7c092be8dfb42b9e620"},
-    {file = "frozendict-2.3.8-cp310-cp310-win_amd64.whl", hash = "sha256:c31abc8acea309b132dde441856829f6003a3d242da8b54bce4c0f2a3c8c63f0"},
-    {file = "frozendict-2.3.8-cp310-cp310-win_arm64.whl", hash = "sha256:9ea5520e85447ff8d4681e181941e482662817ccba921b7cb3f87922056d892a"},
-    {file = "frozendict-2.3.8-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f83fed36497af9562ead5e9fb8443224ba2781786bd3b92b1087cb7d0ff20135"},
-    {file = "frozendict-2.3.8-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e27c5c1d29d0eda7979253ec88abc239da1313b38f39f4b16984db3b3e482300"},
-    {file = "frozendict-2.3.8-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4c785de7f1a13f15963945f400656b18f057c2fc76c089dacf127a2bb188c03"},
-    {file = "frozendict-2.3.8-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:8cf35ddd25513428ec152614def9696afb93ae5ec0eb54fa6aa6206eda77ac4c"},
-    {file = "frozendict-2.3.8-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:ffc684773de7c88724788fa9787d0016fd75830412d58acbd9ed1a04762c675b"},
-    {file = "frozendict-2.3.8-cp36-cp36m-win_amd64.whl", hash = "sha256:4c258aab9c8488338634f2ec670ef049dbf0ab0e7a2fa9bc2c7b5009cb614801"},
-    {file = "frozendict-2.3.8-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:47fc26468407fdeb428cfc89495b7921419e670355c21b383765482fdf6c5c14"},
-    {file = "frozendict-2.3.8-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ea638228692db2bf94bce40ea4b25f4077588497b516bd16576575560094bd9"},
-    {file = "frozendict-2.3.8-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a75bf87e76c4386caecdbdd02a99e53ad43a6b5c38fb3d5a634a9fc9ce41462"},
-    {file = "frozendict-2.3.8-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:ed5a6c5c7a0f57269577c2a338a6002949aea21a23b7b7d06da7e7dced8b605b"},
-    {file = "frozendict-2.3.8-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d086440328a465dea9bef2dbad7548d75d1a0a0d21f43a08c03e1ec79ac5240e"},
-    {file = "frozendict-2.3.8-cp37-cp37m-win_amd64.whl", hash = "sha256:0bc4767e2f83db5b701c787e22380296977368b0c57e485ca71b2eedfa11c4a3"},
-    {file = "frozendict-2.3.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:638cf363d3cbca31a341503cf2219eac52a5f5140449676fae3d9644cd3c5487"},
-    {file = "frozendict-2.3.8-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:2b2fd8ce36277919b36e3c834d2389f3cd7ac068ae730c312671dd4439a5dd65"},
-    {file = "frozendict-2.3.8-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3957d52f1906b0c85f641a1911d214255873f6408ab4e5ad657cc27a247fb145"},
-    {file = "frozendict-2.3.8-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:72cfe08ab8ae524e54848fa90b22d02c1b1ecfb3064438696bcaa4b953f18772"},
-    {file = "frozendict-2.3.8-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:4742e76c4111bd09198d3ab66cef94be8506212311338f9182d6ef5f5cb60493"},
-    {file = "frozendict-2.3.8-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:313ed8d9ba6bac35d7635cd9580ee5721a0fb016f4d2d20f0efa05dbecbdb1be"},
-    {file = "frozendict-2.3.8-cp38-cp38-win_amd64.whl", hash = "sha256:d3c6ce943946c2a61501c8cf116fff0892d11dd579877eb36e2aea2c27fddfef"},
-    {file = "frozendict-2.3.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f0f573dc4861dd7ec9e055c8cceaf45355e894e749f621f199aab7b311ac4bdb"},
-    {file = "frozendict-2.3.8-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:2b3435e5f1ca5ae68a5e95e64b09d6d5c645cadd6b87569a0b3019dd248c8d00"},
-    {file = "frozendict-2.3.8-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:145afd033ebfade28416093335261b8ec1af5cccc593482309e7add062ec8668"},
-    {file = "frozendict-2.3.8-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da98427de26b5a2865727947480cbb53860089c4d195baa29c539da811cea617"},
-    {file = "frozendict-2.3.8-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:5e82befa7c385a668d569cebbebbdf49cee6fea4083f08e869a1b08cfb640a9f"},
-    {file = "frozendict-2.3.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:80abe81d36e889ceec665e06ec764a7638000fa3e7be09786ac4d3ddc64b76db"},
-    {file = "frozendict-2.3.8-cp39-cp39-win_amd64.whl", hash = "sha256:8ccc94ac781710db44e142e1a11ff9b31d02c032c01c6868d51fcbef73086225"},
-    {file = "frozendict-2.3.8-cp39-cp39-win_arm64.whl", hash = "sha256:e72dbc1bcc2203cef38d205f692396f5505921a5680f66aa9a7e8bb71fd38f28"},
-    {file = "frozendict-2.3.8-py311-none-any.whl", hash = "sha256:ba41a7ed019bd03b62d63ed3f8dea35b8243d1936f7c9ed4b5298ca45a01928e"},
-    {file = "frozendict-2.3.8.tar.gz", hash = "sha256:5526559eca8f1780a4ee5146896f59afc31435313560208dd394a3a5e537d3ff"},
-]
-
-[[package]]
 name = "furo"
 version = "2023.9.10"
 description = "A clean customisable Sphinx documentation theme."
@@ -1215,25 +1169,6 @@ files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
 ]
-
-[[package]]
-name = "ispyb-client"
-version = "1.0.0"
-description = "py-ISPyB"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "ispyb_client-1.0.0-py3-none-any.whl", hash = "sha256:439759a915559b97ef982f5061013345c6f86fc35e3f512bb5c15c2dfcb986df"},
-    {file = "ispyb_client-1.0.0.tar.gz", hash = "sha256:959a4e4d7ea530b2d33d235a7c4791e7097e1161634914d35f27d99ec451bd20"},
-]
-
-[package.dependencies]
-certifi = ">=14.5.14"
-frozendict = ">=2.3.4,<2.4.0"
-python-dateutil = ">=2.7.0,<2.8.0"
-setuptools = ">=21.0.0"
-typing-extensions = ">=4.3.0,<4.4.0"
-urllib3 = ">=1.26.7,<1.27.0"
 
 [[package]]
 name = "itsdangerous"
@@ -1766,13 +1701,13 @@ test = ["pytest (<5.4)", "pytest-cov"]
 
 [[package]]
 name = "mxcube-video-streamer"
-version = "1.0.0"
+version = "1.2.0"
 description = "FastAPI Based video streamer"
 optional = false
 python-versions = ">=3.7,<3.11"
 files = [
-    {file = "mxcube_video_streamer-1.0.0-py3-none-any.whl", hash = "sha256:b5338a55d4fedef510acdd25d6e8d3482d913c05a497e9749ceac1ffdbca5fbd"},
-    {file = "mxcube_video_streamer-1.0.0.tar.gz", hash = "sha256:c283f6e575e7e97d867cd2f746cc3e1d1b75920b781e736efd68228d667de8e0"},
+    {file = "mxcube_video_streamer-1.2.0-py3-none-any.whl", hash = "sha256:83818fa663a029491a6809ff895b628e12d484953db756a6d0b28bde1a754556"},
+    {file = "mxcube_video_streamer-1.2.0.tar.gz", hash = "sha256:278e1147870af419f338a0423b0cbf977e08d5afa7a606347e25a149e0ab68ac"},
 ]
 
 [package.dependencies]
@@ -1786,13 +1721,13 @@ websockets = ">=10.4,<11.0"
 
 [[package]]
 name = "mxcubecore"
-version = "1.54.0"
+version = "1.67.0"
 description = "Core libraries for the MXCuBE application"
 optional = false
 python-versions = ">=3.8,<3.11"
 files = [
-    {file = "mxcubecore-1.54.0-py3-none-any.whl", hash = "sha256:b8a6a9e28c3e8fab2460434a0aa7d0ec9e10bb35fedc6a6d095bf3e517ed1153"},
-    {file = "mxcubecore-1.54.0.tar.gz", hash = "sha256:7897f8bbc9c2fbea113fb6f0fad1e9f43340fd11dca7194624b94fb311c43ee2"},
+    {file = "mxcubecore-1.67.0-py3-none-any.whl", hash = "sha256:6a317602327b582ec14adcd0a83228c74291a4ff9b1358d884a14bcb2da65189"},
+    {file = "mxcubecore-1.67.0.tar.gz", hash = "sha256:9b2b5f2a0963b1f9bee630d058f160c7dda02b01af48098a836902ebcfd7c668"},
 ]
 
 [package.dependencies]
@@ -1801,13 +1736,12 @@ f90nml = "1.4.3"
 gevent = ">=21.12.0,<22.0.0"
 gipc = ">=1.4.0,<2.0.0"
 greenlet = ">=1.1.3,<2.0.0"
-ispyb-client = ">=1.0.0,<2.0.0"
 jsonpickle = ">=2.2.0,<3.0.0"
 jsonschema = ">=4.17.1,<5.0.0"
 lucid3 = ">=3.0.0,<4.0.0"
 lxml = ">=4.9.1,<5.0.0"
-matplotlib = {version = ">=3.6.2,<4.0.0", markers = "python_version >= \"3.8\""}
-numpy = {version = ">=1.23.5,<2.0.0", markers = "python_version >= \"3.8\""}
+matplotlib = ">=3.6.2,<4.0.0"
+numpy = ">=1.23.5,<2.0.0"
 Pillow = ">=9.3.0,<10.0.0"
 psutil = ">=5.9.4,<6.0.0"
 py4j = "0.10.9.7"
@@ -1816,7 +1750,7 @@ PyDispatcher = ">=2.0.6,<3.0.0"
 python-ldap = ">=3.4.0,<4.0.0"
 requests = ">=2.31.0,<3.0.0"
 "ruamel.yaml" = ">=0.17.21,<0.18.0"
-scipy = {version = ">=1.9.3,<2.0.0", markers = "python_version >= \"3.8\""}
+scipy = ">=1.9.3,<2.0.0"
 suds-py3 = "1.4.5.0"
 tomli = {version = ">=2.0.1,<3.0.0", markers = "python_full_version <= \"3.10.0\""}
 typing-extensions = ">=4.3.0,<5.0.0"
@@ -3518,4 +3452,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.11"
-content-hash = "bab93ebd266d4364cd0249993ccd315973745db3b2c2ca3584cf9509893310ab"
+content-hash = "1d634a35ec0eeb3d7cb9f50137b0beaeb026fff0183327e4b15e3115db837dc0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,8 @@ pydantic = "^1.10.2"
 PyDispatcher = "^2.0.6"
 pytz = "^2022.6"
 tzlocal = "^4.2"
-mxcubecore = "1.54.0"
-mxcube_video_streamer = "1.0.0"
+mxcubecore = ">=1.54.0"
+mxcube-video-streamer = ">=1.0.0"
 bcrypt = "^4.0.1"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
The dependencies `mxcubecore` and `mxcube-video-streamer` were pinned to a specific version in `pyproject.toml`. The version constraints in `pyproject.toml` are now more loose, and the lockfile has been updated with the latest versions of those.

The command used to do this was:

```none
poetry add 'mxcubecore>=1.54.0' 'mxcube-video-streamer>=1.0.0'
```

GitHub: fix https://github.com/mxcube/mxcubeweb/issues/1159