### PR TITLE
Remove build deps: `setuptools`, `setuptools-scm`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ exclude = '''
 '''
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "setuptools>=45", "setuptools_scm[toml]>=6.2"]
+requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
`setuptools` and `setuptools-scm` were listed as build dependencies in `pyproject.toml`'s  `build-system.requires`.
But this was non-sense, since the build backend is `poetry-core`.