### PR TITLE
fix issues with starting 3-click centering

### DIFF
--- a/ui/src/actions/sampleview.js
+++ b/ui/src/actions/sampleview.js
@@ -426,9 +426,9 @@ export function sendDeleteShape(id) {
 
 export function unselectShapes(shapes) {
   return (dispatch, getState) => {
-    const login = getState();
+    const state = getState();
 
-    if (login.user.userInControl) {
+    if (state.login.user.inControl) {
       const _shapes = [];
       if (shapes.shapes !== undefined) {
         const keys = Object.keys(shapes.shapes);


### PR DESCRIPTION
Currently when clicking '3-click centering' button nothing happens. In the browser's console, you can see that there is an JavaScript error when trying to read 'user in control' flag.

I think the problem is just that the 'path' to the 'in control' flag is wrong. This PR changes that to the one I think is correct.

