### PR TITLE
drop unused socket.io emitter for safety shutter

### DIFF
--- a/mxcubeweb/core/components/beamline.py
+++ b/mxcubeweb/core/components/beamline.py
@@ -56,21 +56,6 @@ class Beamline(ComponentBase):
             logging.getLogger("MX3.HWR").exception(msg)
 
         try:
-            safety_shutter = HWR.beamline.safety_shutter
-            if safety_shutter is not None:
-                safety_shutter.connect(
-                    safety_shutter,
-                    "shutterStateChanged",
-                    signals.safety_shutter_state_changed,
-                )
-            else:
-                logging.getLogger("MX3.HWR").error("safety_shutter is not defined")
-        except Exception as ex:
-            logging.getLogger("MX3.HWR").error(
-                "error loading safety_shutter hwo: %s" % str(ex)
-            )
-
-        try:
             HWR.beamline.xrf_spectrum.connect(
                 HWR.beamline.xrf_spectrum,
                 "xrf_task_progress",

--- a/mxcubeweb/routes/signals.py
+++ b/mxcubeweb/routes/signals.py
@@ -686,15 +686,6 @@ def beamline_action_failed(name):
         logging.getLogger("user_level_log").error("Action %s failed !", name)
 
 
-def safety_shutter_state_changed(values):
-    ho = BeamlineAdapter(HWR.beamline).get_object_by_role("safety_shutter")
-    data = ho.dict()
-    try:
-        server.emit("hardware_object_changed", data, namespace="/hwr")
-    except Exception:
-        logging.getLogger("HWR").error("error sending message: %s" + str(data))
-
-
 def mach_info_changed(values):
     try:
         server.emit("mach_info_changed", values, namespace="/hwr")


### PR DESCRIPTION
Remove 'shutterStateChanged' based socket.io emitter for safey shutter hardware object.

The safety_shutter_state_changed() is never invoked, as safey shutter 'shutterStateChanged' signal is not send.

The safety shutter socket.io messages are now send from a generic emitter method AdapterBase.emit_ho_value_changed().