### PR TITLE
Fix ReadTheDocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,14 +20,9 @@ build:
     python: "mambaforge-22.9"
 
   commands:
-    - "mamba env create --file conda-environment.yml"
+    - "mamba env create --file conda-environment.yml --force"
     - "mamba run --name mxcubeweb poetry install --only=docs,main"
     - "(mamba run --name mxcubeweb redis-server &) && mamba run --name mxcubeweb python -m sphinx -T -E -b html -d _build/doctrees -c docs docs/source ${READTHEDOCS_OUTPUT}/html && mamba run --name mxcubeweb redis-cli shutdown"
 
-# `conda.environment` is probably not used, since we use custom commands only,
-# but it seems to be required (wrongly) by ReadTheDocs config file validation.
-# https://github.com/readthedocs/readthedocs.org/pull/10979#issuecomment-1896036953
-conda:
-  environment: "conda-environment-dev.yml"
 
 ...  # EOF


### PR DESCRIPTION
Use the `--force` flag of `mamba env create` in case environment exists.

Remove the workaround for the unwarranted error about "missing `conda.environment`" configuration setting, because it has been fixed already. See:
* https://github.com/readthedocs/readthedocs.org/pull/10979#issuecomment-1896036953
* https://github.com/readthedocs/readthedocs.org/pull/11040