### PR TITLE
Fix grid scan results issue

### DIFF
--- a/ui/src/components/SampleView/DrawGridPlugin.js
+++ b/ui/src/components/SampleView/DrawGridPlugin.js
@@ -316,12 +316,11 @@ export default class DrawGridPlugin {
       result = gd.result[this.resultType];
     }
 
-    const result_length = Object.values(result).length;
     if (
       result !== undefined &&
       result !== null &&
       gd.id !== null &&
-      result_length > 0
+      Object.values(result).length > 0
     ) {
       for (let nh = 0; nh < row; nh++) {
         for (let nw = 0; nw < col; nw++) {
@@ -407,10 +406,7 @@ export default class DrawGridPlugin {
       }
 
       if (!this.drawing) {
-        if (
-          this.gridResultFormat === 'PNG' ||
-          this.gridResultFormat === 'RGB'
-        ) {
+        if (this.gridResultFormat === 'RGB') {
           const fillingMatrix = this.cellFillingFromData(
             gridData,
             gridData.numCols,

--- a/ui/src/components/SampleView/DrawGridPlugin.js
+++ b/ui/src/components/SampleView/DrawGridPlugin.js
@@ -316,7 +316,8 @@ export default class DrawGridPlugin {
       result = gd.result[this.resultType];
     }
 
-    if (result !== undefined && result !== null && gd.id !== null) {
+    const result_length = Object.values(result).length;
+    if (result !== undefined && result !== null && gd.id !== null && result_length > 0) {
       for (let nh = 0; nh < row; nh++) {
         for (let nw = 0; nw < col; nw++) {
           const index = nw + nh * col + 1;
@@ -401,7 +402,7 @@ export default class DrawGridPlugin {
       }
 
       if (!this.drawing) {
-        if (this.gridResultFormat === 'RGB') {
+        if (this.gridResultFormat === 'PNG' || this.gridResultFormat === 'RGB') {
           const fillingMatrix = this.cellFillingFromData(
             gridData,
             gridData.numCols,

--- a/ui/src/components/SampleView/DrawGridPlugin.js
+++ b/ui/src/components/SampleView/DrawGridPlugin.js
@@ -317,7 +317,12 @@ export default class DrawGridPlugin {
     }
 
     const result_length = Object.values(result).length;
-    if (result !== undefined && result !== null && gd.id !== null && result_length > 0) {
+    if (
+      result !== undefined &&
+      result !== null &&
+      gd.id !== null &&
+      result_length > 0
+    ) {
       for (let nh = 0; nh < row; nh++) {
         for (let nw = 0; nw < col; nw++) {
           const index = nw + nh * col + 1;
@@ -402,7 +407,10 @@ export default class DrawGridPlugin {
       }
 
       if (!this.drawing) {
-        if (this.gridResultFormat === 'PNG' || this.gridResultFormat === 'RGB') {
+        if (
+          this.gridResultFormat === 'PNG' ||
+          this.gridResultFormat === 'RGB'
+        ) {
           const fillingMatrix = this.cellFillingFromData(
             gridData,
             gridData.numCols,


### PR DESCRIPTION
The `gridResultFormat` of the `DrawGridPlugin` defaults to PNG. To fix the UI display issue, the code following the if statement on line 410 must be executed. Additionally, we only plot results when there are results available (length > 0). 

[resolves](https://github.com/AustralianSynchrotron/mxcubeweb/commit/1870cee6d36c7a2172b194fb5b2a1388af2c2d68) https://github.com/mxcube/mxcubeweb/issues/1180 (see the image below)

![grid_scan_mxcube](https://github.com/mxcube/mxcubeweb/assets/49014169/ff3bce92-4596-4032-bfd4-c650ead7d43e)
