### PR TITLE
Documentation URL have to be on the same host ? as the repository.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mxcubeweb"
-version = "4.33.0"
+version = "4.34.0"
 license = "LGPL-3.0-or-later"
 description = "MXCuBE Web user interface"
 authors = ["The MXCuBE collaboration <mxcube@esrf.fr>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ maintainers = [
 readme = "README.md"
 homepage = "https://github.com/mxcube/mxcubeweb"
 repository = "https://github.com/mxcube/mxcubeweb"
-documentation = "https://mxcubeweb.readthedocs.io/"
+documentation = "https://github.com/mxcube/mxcubeweb"
 keywords = ["mxcube", "mxcube3", "mxcubeweb"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
It seems like the documentation URL and the project homepage or repository have to be on the same host otherwise PyPI gives us 404 back, with the very informative error:

```
 HTTP Error 400: '' is not a valid url. See https://packaging.python.org/specifications/core-metadata for more information. | b"<html>\n <head>\n  <title>400 '' is not a valid url. See https://packaging.python.org/specifications/core-metadata for more information.\n \n <body>\n  <h1>400 '' is not a valid url. See https://packaging.python.org/specifications/core-metadata for more information.\n  The server could not comply with the request since it is either malformed or otherwise incorrect.<br/><br/>\n&#x27;&#x27; is not a valid url. See https://packaging.python.org/specifications/core-metadata for more information.\n\n\n \n"
Error: Process completed with exit code 1.
```

I find this a bit odd ?