### PR TITLE
drop 'adapter_properties' from server.yaml

### DIFF
--- a/mxcubeweb/app.py
+++ b/mxcubeweb/app.py
@@ -142,7 +142,6 @@ class MXCUBECore:
 
     @staticmethod
     def adapt_hardware_objects(app):
-        adapter_config = app.CONFIG.app.adapter_properties
         hwobject_list = [item for item in MXCUBECore.hwr.hardware_objects]
 
         for ho_name in hwobject_list:
@@ -162,7 +161,7 @@ class MXCUBECore:
 
             if adapter_cls:
                 try:
-                    adapter_instance = adapter_cls(ho, _id, app, **dict(adapter_config))
+                    adapter_instance = adapter_cls(ho, _id, app)
                     logging.getLogger("MX3.HWR").info("Added adapter for %s" % _id)
                 except Exception:
                     logging.getLogger("MX3.HWR").exception(

--- a/mxcubeweb/core/adapter/actuator_adapter.py
+++ b/mxcubeweb/core/adapter/actuator_adapter.py
@@ -14,12 +14,12 @@ class ActuatorAdapter(ActuatorAdapterBase):
     information on longer running processes.
     """
 
-    def __init__(self, ho, *args, **kwargs):
+    def __init__(self, ho, *args):
         """
         Args:
             (object): Hardware object.
         """
-        super(ActuatorAdapter, self).__init__(ho, *args, **kwargs)
+        super(ActuatorAdapter, self).__init__(ho, *args)
         self._event_rate = 4
 
         @RateLimited(self._event_rate)

--- a/mxcubeweb/core/adapter/adapter_base.py
+++ b/mxcubeweb/core/adapter/adapter_base.py
@@ -20,7 +20,7 @@ class AdapterBase:
     ATTRIBUTES = []
     METHODS = []
 
-    def __init__(self, ho, role, app, **kwargs):
+    def __init__(self, ho, role, app):
         """
         Args:
             (object): Hardware object to mediate for.
@@ -335,13 +335,14 @@ class AdapterBase:
 
 
 class ActuatorAdapterBase(AdapterBase):
-    def __init__(self, ho, *args, **kwargs):
+    def __init__(self, ho, *args):
         """
         Args:
             (object): Hardware object to mediate for.
             (str): The name of the object.
         """
-        super(ActuatorAdapterBase, self).__init__(ho, *args, **kwargs)
+        super(ActuatorAdapterBase, self).__init__(ho, *args)
+
         self._unique = False
 
         try:

--- a/mxcubeweb/core/adapter/beam_adapter.py
+++ b/mxcubeweb/core/adapter/beam_adapter.py
@@ -7,8 +7,8 @@ from mxcubeweb.core.models.adaptermodels import (
 
 
 class BeamAdapter(ActuatorAdapterBase):
-    def __init__(self, ho, *args, **kwargs):
-        super(BeamAdapter, self).__init__(ho, *args, **kwargs)
+    def __init__(self, ho, *args):
+        super(BeamAdapter, self).__init__(ho, *args)
 
     def limits(self):
         """ """

--- a/mxcubeweb/core/adapter/data_publisher_adapter.py
+++ b/mxcubeweb/core/adapter/data_publisher_adapter.py
@@ -8,12 +8,12 @@ from mxcubeweb.core.adapter.adapter_base import AdapterBase
 class DataPublisherAdapter(AdapterBase):
     ATTRIBUTES = ["current_data", "all_data", "current"]
 
-    def __init__(self, ho, *args, **kwargs):
+    def __init__(self, ho, *args):
         """
         Args:
             (object): Hardware object.
         """
-        super(DataPublisherAdapter, self).__init__(ho, *args, **kwargs)
+        super(DataPublisherAdapter, self).__init__(ho, *args)
         self._all_data_list = []
         self._current_data_list = []
         self._current_info = {}

--- a/mxcubeweb/core/adapter/detector_adapter.py
+++ b/mxcubeweb/core/adapter/detector_adapter.py
@@ -2,12 +2,12 @@ from mxcubeweb.core.adapter.adapter_base import AdapterBase
 
 
 class DetectorAdapter(AdapterBase):
-    def __init__(self, ho, *args, **kwargs):
+    def __init__(self, ho, *args):
         """
         Args:
             (object): Hardware object.
         """
-        super(DetectorAdapter, self).__init__(ho, *args, **kwargs)
+        super(DetectorAdapter, self).__init__(ho, *args)
         ho.connect("stateChanged", self._state_change)
 
     def _state_change(self, *args, **kwargs):

--- a/mxcubeweb/core/adapter/diffractometer_adapter.py
+++ b/mxcubeweb/core/adapter/diffractometer_adapter.py
@@ -5,12 +5,12 @@ class DiffractometerAdapter(AdapterBase):
     ATTRIBUTES = ["head_configuration"]
     METHODS = ["set_chip_layout"]
 
-    def __init__(self, ho, *args, **kwargs):
+    def __init__(self, ho, *args):
         """
         Args:
             (object): Hardware object.
         """
-        super(DiffractometerAdapter, self).__init__(ho, *args, **kwargs)
+        super(DiffractometerAdapter, self).__init__(ho, *args)
         ho.connect("stateChanged", self._state_change)
         ho.connect("valueChanged", self._state_change)
         ho.connect("phaseChanged", self._diffractometer_phase_changed)

--- a/mxcubeweb/core/adapter/energy_adapter.py
+++ b/mxcubeweb/core/adapter/energy_adapter.py
@@ -8,11 +8,11 @@ class EnergyAdapter(ActuatorAdapter):
     information on longer running processes.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args):
         """
         Args:
             (object): Hardware object.
         """
-        super(EnergyAdapter, self).__init__(*args, **kwargs)
+        super(EnergyAdapter, self).__init__(*args)
         self._add_adapter("wavelength", self._ho, WavelengthAdapter)
         self._type = "MOTOR"

--- a/mxcubeweb/core/adapter/machine_info_adapter.py
+++ b/mxcubeweb/core/adapter/machine_info_adapter.py
@@ -6,12 +6,12 @@ from mxcubeweb.core.util.networkutils import RateLimited
 
 
 class MachineInfoAdapter(ActuatorAdapterBase):
-    def __init__(self, ho, *args, **kwargs):
+    def __init__(self, ho, *args):
         """
         Args:
             (object): Hardware object.
         """
-        super(MachineInfoAdapter, self).__init__(ho, *args, **kwargs)
+        super(MachineInfoAdapter, self).__init__(ho, *args)
         ho.connect("valueChanged", self._value_change)
         self._unique = True
 

--- a/mxcubeweb/core/adapter/motor_adapter.py
+++ b/mxcubeweb/core/adapter/motor_adapter.py
@@ -8,12 +8,12 @@ from mxcubeweb.core.models.adaptermodels import (
 
 
 class MotorAdapter(ActuatorAdapterBase):
-    def __init__(self, ho, *args, **kwargs):
+    def __init__(self, ho, *args):
         """
         Args:
             (object): Hardware object.
         """
-        super(MotorAdapter, self).__init__(ho, *args, **kwargs)
+        super(MotorAdapter, self).__init__(ho, *args)
         ho.connect("valueChanged", self._value_change)
         ho.connect("stateChanged", self.state_change)
 

--- a/mxcubeweb/core/adapter/nstate_adapter.py
+++ b/mxcubeweb/core/adapter/nstate_adapter.py
@@ -10,12 +10,12 @@ from mxcubeweb.core.models.adaptermodels import (
 
 
 class NStateAdapter(ActuatorAdapterBase):
-    def __init__(self, ho, *args, **kwargs):
+    def __init__(self, ho, *args):
         """
         Args:
             (object): Hardware object.
         """
-        super(NStateAdapter, self).__init__(ho, *args, **kwargs)
+        super(NStateAdapter, self).__init__(ho, *args)
         self._value_change_model = HOActuatorValueChangeModel
 
         ho.connect("valueChanged", self._value_change)

--- a/mxcubeweb/core/adapter/wavelength_adapter.py
+++ b/mxcubeweb/core/adapter/wavelength_adapter.py
@@ -13,12 +13,12 @@ class WavelengthAdapter(ActuatorAdapterBase):
     information on longer running processes.
     """
 
-    def __init__(self, ho, *args, **kwargs):
+    def __init__(self, ho, *args):
         """
         Args:
             (object): Hardware object.
         """
-        super(WavelengthAdapter, self).__init__(ho, *args, **kwargs)
+        super(WavelengthAdapter, self).__init__(ho, *args)
         self._type = "MOTOR"
 
         try:

--- a/mxcubeweb/core/models/configmodels.py
+++ b/mxcubeweb/core/models/configmodels.py
@@ -122,7 +122,6 @@ class MXCUBEAppConfigModel(BaseModel):
     mode: ModeEnum = Field(ModeEnum.OSC, description="MXCuBE mode SSX or OSC")
     usermanager: UserManagerConfigModel
     ui_properties: Dict[str, UIPropertiesModel] = {}
-    adapter_properties: List = []
 
 
 class AppConfigModel(BaseModel):


### PR DESCRIPTION
According to [config model](https://github.com/mxcube/mxcubeweb/blob/develop/mxcubeweb/core/models/configmodels.py#L103) for server.yaml you can add `adapter_properties' in mxcube section.

However, I don't see how it can be used to configure adapters. As far as I can tell, non of the adapter implementations read any of these values. If it's not used, let's remove this code.

Otherwise, I want to know it is supposed to be used :)
