### PR TITLE
Fixed error in registering highlight colours for IndexingTable popup

### DIFF
--- a/ui/src/containers/GphlWorkflowParametersDialog.jsx
+++ b/ui/src/containers/GphlWorkflowParametersDialog.jsx
@@ -36,8 +36,8 @@ function renderIndexingTable(indexingTable, selected, onSelectRow) {
               key={tdContent}
               data-selected={selected.includes(index) || undefined}
               data-highlight={
-                indexingTable.highlights[index + 1]
-                  ? indexingTable.highlights[index + 1][0]
+                indexingTable.highlights[index]
+                  ? indexingTable.highlights[index][0]
                   : undefined
               }
               onClick={() => onSelectRow(index, tdContent)}


### PR DESCRIPTION
Highlight colours were one line off the correct row; now fixed.
NB is it correct that GphlWorkflowParametersDialog.jsx line 45 says

              <td className="text-center">{index + 1}</td>

or should that '+ 1'   be removed as well? 