### PR TITLE
UI: fix state mapping for Sample Changer widget

### DIFF
--- a/ui/src/components/InOutSwitch/InOutSwitch.jsx
+++ b/ui/src/components/InOutSwitch/InOutSwitch.jsx
@@ -89,6 +89,7 @@ export default function InOutSwitch(props) {
       break;
     }
     case offValue:
+    case 'DISABLED':
     case 'CLOSED': {
       msgBgStyle = 'danger';
       btn = (
@@ -102,7 +103,6 @@ export default function InOutSwitch(props) {
       );
       break;
     }
-    case 'DISABLED':
     case 'UNUSABLE': {
       msgBgStyle = 'warning';
       btn = (


### PR DESCRIPTION
Treat disabled state as closed state in InOutSwitch component.
    
Change logic for handling DISABLED state in the InOutSwitch component. Make the DISABLED state equivalent to CLOSED state.
    
This solves the issue with the 'Sample Changer' InOutSwitch widget. Previously it was not possible to power on a disabled sample changer, as the command for DISABLED state was set to 'PowerOff'. Now when it is in DISABLED state, the command will be 'PowerOn'.
    
Note that for sample changers, the DISABLED state is used when they are in 'powered off' mode.
