### PR TITLE
Remote access - take control option avaiable to all users

### DIFF
--- a/mxcubeweb/routes/ra.py
+++ b/mxcubeweb/routes/ra.py
@@ -66,11 +66,6 @@ def init_route(app, server, url_prefix):  # noqa: C901
         if app.usermanager.is_operator():
             return make_response("", 200)
 
-        # Not inhouse user so not allowed to take control by force,
-        # return error code
-        if not current_user.isstaff:
-            return make_response("", 409)
-
         toggle_operator(current_user.username, "You were given control")
 
         return make_response("", 200)

--- a/mxcubeweb/routes/ra.py
+++ b/mxcubeweb/routes/ra.py
@@ -10,7 +10,6 @@ from flask import (
     copy_current_request_context,
 )
 
-from flask_socketio import join_room, leave_room
 from flask_login import current_user
 
 DISCONNECT_HANDLED = True
@@ -106,17 +105,6 @@ def init_route(app, server, url_prefix):  # noqa: C901
         newop.requests_control = False
         app.usermanager.update_user(oldop)
         app.usermanager.update_user(newop)
-
-        join_room(
-            "observers",
-            sid=oldop.socketio_session_id,
-            namespace="/ui_state",
-        )
-        leave_room(
-            "observers",
-            sid=newop.socketio_session_id,
-            namespace="/ui_state",
-        )
 
         app.usermanager.emit_observers_changed(message)
 

--- a/ui/src/components/rachat.css
+++ b/ui/src/components/rachat.css
@@ -1,5 +1,9 @@
 .chat-widget-dragable {
-  position: relative;
+  position: absolute;
+  height: 100px;
+  width: 100px;
+  bottom: 0px;
+  right: 0px;
   z-index: 100002;
 }
 

--- a/ui/src/containers/PleaseWaitDialog.js
+++ b/ui/src/containers/PleaseWaitDialog.js
@@ -27,8 +27,10 @@ export class PleaseWaitDialog extends React.Component {
   render() {
     return (
       <Modal
+        keyboard={false}
         animation={false}
         show={this.props.loading}
+        enforceFocus={false}
         onHide={this.hide}
         data-default-styles
       >

--- a/ui/src/containers/RemoteAccessContainer.jsx
+++ b/ui/src/containers/RemoteAccessContainer.jsx
@@ -14,7 +14,7 @@ import {
 
 export class RemoteAccessContainer extends React.Component {
   getRAOptions() {
-    let content = (
+    return (
       <Col sm={4}>
         <Card className="mb-3">
           <Card.Header>RA Options</Card.Header>
@@ -37,12 +37,6 @@ export class RemoteAccessContainer extends React.Component {
         </Card>
       </Col>
     );
-
-    if (!this.props.login.user.isstaff) {
-      content = null;
-    }
-
-    return content;
   }
 
   render() {


### PR DESCRIPTION
Made the options of taking control and enabling and disabling timeout available to all users (not only staff). Also fixed an issue with the chat dialog overlay not beeing "fousable" when the "ask for control dialog" was displayed.