### PR TITLE
Task creation  - Fixing nested "run_number" directories

### DIFF
--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -1117,6 +1117,30 @@ class Queue(ComponentBase):
                 sample_model
             )
 
+        run_number_dir_parts = (
+            params.get("subdir", "").strip("/").split("/")[-1].split("_")
+        )
+
+        # When duplicating an item the "run number" directory of the original
+        # item is already part of the data subfolder, so we need to strip ita
+        # to avoid nesting.
+
+        # Sub directory is a run number directory if it starts
+        # with run folowed by a number and a tag spereated by a
+        # underscore (_) for instance, run_01_datacollection
+        # The run number directory is passed as the last folder of the
+        # data sub direecotry when and item is duplicated. We strip
+        # the run number folder in this case to remove duplication
+        if (
+            len(run_number_dir_parts) == 3
+            and run_number_dir_parts[0] == "run"
+            and run_number_dir_parts[1].isnumeric()
+            and run_number_dir_parts[2] == self.get_folder_tag(params)
+        ):
+            params["subdir"] = "/".join(
+                params.get("subdir", "").strip("/").split("/")[0:-1]
+            )
+
         full_path, process_path = HWR.beamline.session.get_full_path(
             params.get("subdir", ""), self.get_folder_tag(params)
         )


### PR DESCRIPTION
When duplicating an item the "run number" directory of the original item is already part of the data sub-folder, so we need to strip it to avoid nesting before the sub folder of the copy is created