### PR TITLE
Queue - Making sure queue is update on observer

### DIFF
--- a/mxcubeweb/core/components/samplechanger.py
+++ b/mxcubeweb/core/components/samplechanger.py
@@ -37,6 +37,10 @@ class SampleChanger(ComponentBase):
                 "globalStateChanged", signals.sc_maintenance_update
             )
 
+            HWR.beamline.sample_changer_maintenance.connect(
+                "gripperChanged", self._gripper_changed
+            )
+
     def get_sample_list(self):
         samples_list = HWR.beamline.sample_changer.get_sample_list()
         samples = {}
@@ -384,6 +388,16 @@ class SampleChanger(ComponentBase):
         except Exception:
             logging.getLogger("MX3.HWR").exception("Could not get crystal List")
             return {"xtal_list": xtal_list}
+
+    def _gripper_changed(self):
+        from mxcubeweb.routes import signals
+
+        self.app.queue.queue_clear()
+        self.app.server.emit(
+            "queue", {"Signal": "update", "message": "all"}, namespace="/hwr"
+        )
+
+        # self.app.sample_changer.get_sample_list()
 
 
 # Disabling C901 function is too complex (19)

--- a/mxcubeweb/core/components/samplechanger.py
+++ b/mxcubeweb/core/components/samplechanger.py
@@ -390,15 +390,10 @@ class SampleChanger(ComponentBase):
             return {"xtal_list": xtal_list}
 
     def _gripper_changed(self):
-        from mxcubeweb.routes import signals
-
         self.app.queue.queue_clear()
         self.app.server.emit(
             "queue", {"Signal": "update", "message": "all"}, namespace="/hwr"
         )
-
-        # self.app.sample_changer.get_sample_list()
-
 
 # Disabling C901 function is too complex (19)
 def queue_mount_sample(view, data_model, centring_done_cb, async_result):  # noqa: C901

--- a/mxcubeweb/core/components/samplechanger.py
+++ b/mxcubeweb/core/components/samplechanger.py
@@ -395,6 +395,7 @@ class SampleChanger(ComponentBase):
             "queue", {"Signal": "update", "message": "all"}, namespace="/hwr"
         )
 
+
 # Disabling C901 function is too complex (19)
 def queue_mount_sample(view, data_model, centring_done_cb, async_result):  # noqa: C901
     from mxcubeweb.routes import signals

--- a/mxcubeweb/routes/queue.py
+++ b/mxcubeweb/routes/queue.py
@@ -174,7 +174,9 @@ def init_route(app, server, url_prefix):  # noqa: C901
         )
         resp.status_code = 200
 
-        server.emit("queue", {"Signal": "update"}, namespace="/hwr")
+        server.emit(
+            "queue", {"Signal": "update", "message": "observers"}, namespace="/hwr"
+        )
 
         return resp
 
@@ -189,7 +191,9 @@ def init_route(app, server, url_prefix):  # noqa: C901
         resp = jsonify(app.queue.queue_to_dict([model]))
         resp.status_code = 200
 
-        server.emit("queue", {"Signal": "update"}, namespace="/hwr")
+        server.emit(
+            "queue", {"Signal": "update", "message": "observers"}, namespace="/hwr"
+        )
 
         return resp
 
@@ -200,7 +204,9 @@ def init_route(app, server, url_prefix):  # noqa: C901
         item_pos_list = request.get_json()
 
         app.queue.delete_entry_at(item_pos_list)
-        server.emit("queue", {"Signal": "update"}, namespace="/hwr")
+        server.emit(
+            "queue", {"Signal": "update", "message": "observers"}, namespace="/hwr"
+        )
 
         return Response(status=200)
 
@@ -212,7 +218,9 @@ def init_route(app, server, url_prefix):  # noqa: C901
         qid_list = params.get("qidList", None)
         enabled = params.get("enabled", False)
         app.queue.queue_enable_item(qid_list, enabled)
-        server.emit("queue", {"Signal": "update"}, namespace="/hwr")
+        server.emit(
+            "queue", {"Signal": "update", "message": "observers"}, namespace="/hwr"
+        )
 
         return Response(status=200)
 
@@ -221,7 +229,9 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.restrict
     def queue_swap_task_item(sid, ti1, ti2):
         app.queue.swap_task_entry(sid, int(ti1), int(ti2))
-        server.emit("queue", {"Signal": "update"}, namespace="/hwr")
+        server.emit(
+            "queue", {"Signal": "update", "message": "observers"}, namespace="/hwr"
+        )
 
         return Response(status=200)
 
@@ -229,7 +239,9 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.require_control
     def queue_move_task_item(sid, ti1, ti2):
         app.queue.move_task_entry(sid, int(ti1), int(ti2))
-        server.emit("queue", {"Signal": "update"}, namespace="/hwr")
+        server.emit(
+            "queue", {"Signal": "update", "message": "observers"}, namespace="/hwr"
+        )
 
         return Response(status=200)
 
@@ -239,7 +251,9 @@ def init_route(app, server, url_prefix):  # noqa: C901
     def queue_set_sample_order():
         sample_order = request.get_json().get("sampleOrder", [])
         app.queue.set_sample_order(sample_order)
-        server.emit("queue", {"Signal": "update"}, namespace="/hwr")
+        server.emit(
+            "queue", {"Signal": "update", "message": "observers"}, namespace="/hwr"
+        )
 
         return Response(status=200)
 

--- a/mxcubeweb/routes/signals.py
+++ b/mxcubeweb/routes/signals.py
@@ -200,7 +200,7 @@ def set_current_sample(sample_id):
 
 
 def sc_contents_update():
-    server.emit("sc_contents_update")
+    server.emit("sc_contents_update", {}, namespace="/hwr")
 
 
 def sc_maintenance_update(*args):
@@ -655,6 +655,7 @@ def beam_changed(*args, **kwargs):
 
 def beamline_action_start(name):
     msg = {"name": name, "state": RUNNING}
+
     try:
         server.emit("beamline_action", msg, namespace="/hwr")
     except Exception:

--- a/ui/src/actions/taskForm.js
+++ b/ui/src/actions/taskForm.js
@@ -1,26 +1,19 @@
-export function showForm(
-  formName,
-  sampleQueueID = [],
-  taskData = {},
-  pointQueueID = -1,
-) {
-  return {
-    type: 'SHOW_FORM',
-    name: formName,
-    sampleIDs: sampleQueueID,
-    taskData,
-    pointID: pointQueueID,
-  };
-}
-
 export function showTaskForm(
   formName,
   sampleQueueID = -1,
   taskData = {},
   pointQueueID = -1,
+  origin = 'sampleview',
 ) {
   return (dispatch) => {
-    dispatch(showForm(formName, sampleQueueID, taskData, pointQueueID));
+    dispatch({
+      type: 'SHOW_FORM',
+      name: formName,
+      sampleIDs: sampleQueueID,
+      taskData,
+      pointID: pointQueueID,
+      origin,
+    });
   };
 }
 

--- a/ui/src/components/Tasks/Workflow.jsx
+++ b/ui/src/components/Tasks/Workflow.jsx
@@ -99,7 +99,7 @@ function Workflow(props) {
           <ButtonToolbar className="float-end">
             <Button
               variant="success"
-              disabled={props.invalid}
+              disabled={props.origin === 'samplelist' || props.invalid}
               onClick={props.handleSubmit((params) => addToQueue(true, params))}
             >
               Run Now
@@ -151,6 +151,7 @@ const WorkflowFormConnect = connect((state) => {
 
   return {
     path: `${state.login.rootPath}/${subdir}`,
+    origin: state.taskForm.origin,
     filename: fname,
     wfname: state.taskForm.taskData.parameters.wfname,
     wfpath: state.taskForm.taskData.parameters.wfpath,

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -281,7 +281,7 @@ class SampleListViewContainer extends React.Component {
           formName,
           selected,
           parameters,
-          [],
+          -1,
           'samplelist',
         );
       }

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -277,7 +277,13 @@ class SampleListViewContainer extends React.Component {
       if (formName === 'AddSample') {
         this.props.showTaskParametersForm('AddSample');
       } else {
-        this.props.showTaskParametersForm(formName, selected, parameters);
+        this.props.showTaskParametersForm(
+          formName,
+          selected,
+          parameters,
+          [],
+          'samplelist',
+        );
       }
     }
   }

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -314,7 +314,7 @@ class SampleListViewContainer extends React.Component {
     } else {
       this.props.syncSamples();
     }
-    this.sampleGridFilterByKey('limsSamples', true);
+    this.props.filter({ limsSamples: true });
   }
 
   /**
@@ -452,10 +452,6 @@ class SampleListViewContainer extends React.Component {
         behavior: 'smooth',
       });
     }
-  }
-
-  sampleGridFilterByKey(key, value) {
-    this.props.filter({ [key]: value });
   }
 
   /**

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -314,7 +314,7 @@ class SampleListViewContainer extends React.Component {
     } else {
       this.props.syncSamples();
     }
-    this.sampleGridFilterByKey("limsSamples", true);
+    this.sampleGridFilterByKey('limsSamples', true);
   }
 
   /**
@@ -455,7 +455,7 @@ class SampleListViewContainer extends React.Component {
   }
 
   sampleGridFilterByKey(key, value) {
-    this.props.filter({[key] : value});
+    this.props.filter({ [key]: value });
   }
 
   /**

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -308,6 +308,7 @@ class SampleListViewContainer extends React.Component {
     } else {
       this.props.syncSamples();
     }
+    this.sampleGridFilterByKey("limsSamples", true);
   }
 
   /**
@@ -445,6 +446,10 @@ class SampleListViewContainer extends React.Component {
         behavior: 'smooth',
       });
     }
+  }
+
+  sampleGridFilterByKey(key, value) {
+    this.props.filter({[key] : value});
   }
 
   /**

--- a/ui/src/reducers/sampleGrid.js
+++ b/ui/src/reducers/sampleGrid.js
@@ -42,10 +42,9 @@ function sampleGridReducer(state = INITIAL_STATE, action = {}) {
   // eslint-disable-next-line sonarjs/max-switch-cases
   switch (action.type) {
     case 'SET_QUEUE': {
-      const sampleList = { ...state.sampleList };
       return {
         ...state,
-        sampleList: Object.assign(sampleList, action.sampleList),
+        sampleList: { ...action.sampleList },
       };
     }
     // Set the list of samples (sampleList), clearing any existing list

--- a/ui/src/reducers/taskForm.js
+++ b/ui/src/reducers/taskForm.js
@@ -25,6 +25,7 @@ function taskFormReducer(state = INITIAL_STATE, action = {}) {
         sampleIds: action.sampleIDs,
         taskData: { ...action.taskData },
         pointID: action.pointID,
+        origin: action.origin,
       };
     }
     case 'UPDATE_TASK': {

--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -265,17 +265,17 @@ class ServerIO {
       this.dispatch(addDiffractionPlanAction(record.tasks));
     });
 
-    this.hwrSocket.on('queue', (record, callback) => {
-      if (callback) {
-        callback();
-      }
-
+    this.hwrSocket.on('queue', (record) => {
       if (record.Signal === 'DisableSample') {
         this.dispatch(setSampleAttribute([record.sampleID], 'checked', false));
       } else if (record.Signal === 'update') {
-        const state = store.getState();
-        if (!state.login.user.inControl) {
+        if (record.message === 'all') {
           this.dispatch(fetchQueue());
+        } else if (record.message === 'observers') {
+          const state = store.getState();
+          if (!state.login.user.inControl) {
+            this.dispatch(fetchQueue());
+          }
         }
       } else {
         this.dispatch(setStatus(record.Signal));


### PR DESCRIPTION
We need to update the queue contents on change as we are no longer using the server side `redis-persist` solution. 

- Emitting queue changes to observer when it changes.
- Disabled run-now from sample list (only makes sense from sample view)
- Clearing queue when gripper changes, queued samples cant be loaded with a different gripper