### PR TITLE
beamline setup - Made it possible to display any hardware object as a `DeviceState`

### DIFF
--- a/ui/src/containers/BeamlineSetupContainer.jsx
+++ b/ui/src/containers/BeamlineSetupContainer.jsx
@@ -198,7 +198,10 @@ function BeamlineSetupContainer(props) {
   const uiprops = uiproperties.beamline_setup.components;
   const uiprop_list = filter(
     uiprops,
-    (o) => o.value_type === 'MOTOR' || o.value_type === 'ACTUATOR',
+    (o) =>
+      o.value_type === 'MOTOR' ||
+      o.value_type === 'ACTUATOR' ||
+      o.value_type === 'ENERGY',
   );
 
   return (

--- a/ui/src/containers/BeamlineSetupContainer.jsx
+++ b/ui/src/containers/BeamlineSetupContainer.jsx
@@ -88,7 +88,7 @@ function BeamlineSetupContainer(props) {
           if (uiprop !== undefined && uiprop.value_type === 'NSTATE') {
             if (uiprop.label === 'Beamstop') {
               acts.push(
-                <Nav.Item key={key}>
+                <Nav.Item key={key} className="ms-3">
                   <InOutSwitch
                     openText={beamline.hardwareObjects[key].commands[0]}
                     offText={beamline.hardwareObjects[key].commands[1]}
@@ -257,10 +257,8 @@ function BeamlineSetupContainer(props) {
               onSave={sendCommand}
             />
           </Nav.Item>
-        </Nav>
-        <Nav className="me-3">{renderActuatorComponent()}</Nav>
-        <Nav className="me-3">
-          <Nav.Item>
+          {renderActuatorComponent()}
+          <Nav.Item className="ms-3">
             <span className="blstatus-item">
               {beamline.hardwareObjects.machine_info && (
                 <MachInfo info={beamline.hardwareObjects.machine_info.value} />

--- a/ui/src/containers/BeamlineSetupContainer.jsx
+++ b/ui/src/containers/BeamlineSetupContainer.jsx
@@ -118,6 +118,21 @@ function BeamlineSetupContainer(props) {
                 </Nav.Item>,
               );
             }
+          } else if (
+            uiprop !== undefined &&
+            uiprop.value_type !== 'NSTATE' &&
+            uiprop.value_type !== 'MOTOR' &&
+            uiprop.value_type !== 'ACTUATOR' &&
+            uiprop.value_type !== 'ENERGY'
+          ) {
+            acts.push(
+              <Nav.Item key={key} className="ms-3">
+                <DeviceState
+                  labelText={uiprop.label}
+                  data={beamline.hardwareObjects[key].state}
+                />
+              </Nav.Item>,
+            );
           }
         }
       }
@@ -244,22 +259,6 @@ function BeamlineSetupContainer(props) {
           </Nav.Item>
         </Nav>
         <Nav className="me-3">{renderActuatorComponent()}</Nav>
-        <Nav className="me-3">
-          <Nav.Item>
-            <DeviceState
-              labelText="Detector"
-              data={beamline.hardwareObjects.detector.state}
-            />
-          </Nav.Item>
-        </Nav>
-        <Nav className="me-3">
-          <Nav.Item>
-            <DeviceState
-              labelText="Diffractometer"
-              data={beamline.hardwareObjects.diffractometer.state}
-            />
-          </Nav.Item>
-        </Nav>
         <Nav className="me-3">
           <Nav.Item>
             <span className="blstatus-item">


### PR DESCRIPTION
- Made it possible to display any hardware object that are not already present (NSTATE, MOTOR, ACTUATOR or ENERGY) as a device state component (as all hardware objects have state)
- Minor layout fix, rendering the state component to the right
