### PR TITLE
connect SocketIO first when logged in

### DIFF
--- a/ui/src/components/App.js
+++ b/ui/src/components/App.js
@@ -85,12 +85,18 @@ function App(props) {
 
   useEffect(() => {
     getLoginInfo();
-    serverIO.listen();
 
-    return () => {
-      serverIO.disconnect();
-    };
-  }, [getLoginInfo]);
+    if (loggedIn) {
+      serverIO.listen();
+
+      return () => {
+        serverIO.disconnect();
+      };
+    }
+
+    // no clean-up required, until we connect to serverIO
+    return undefined;
+  }, [loggedIn, getLoginInfo]);
 
   if (loggedIn === null) {
     // Fetching login info

--- a/ui/src/components/Login/Login.jsx
+++ b/ui/src/components/Login/Login.jsx
@@ -7,7 +7,6 @@ import logo from '../../img/mxcube_logo20.png';
 import loader from '../../img/loader.gif';
 import withRouter from '../WithRouter';
 import styles from './Login.module.css';
-import { serverIO } from '../../serverIO';
 
 function LoginComponent(props) {
   const { router, loading, logIn, showError, errorMessage } = props;
@@ -20,7 +19,6 @@ function LoginComponent(props) {
 
   async function handleSubmit(data) {
     await logIn(data.username.toLowerCase(), data.password, router.navigate);
-    serverIO.listen();
   }
 
   return (

--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -131,16 +131,15 @@ class ServerIO {
 
   // eslint-disable-next-line sonarjs/cognitive-complexity
   listen() {
+    this.refreshInterval = setInterval(sendRefreshSession, 9000);
+    this.connect();
+
     if (this.initialized) {
       return;
     }
 
     this.initialized = true;
     this.dispatch = store.dispatch;
-
-    this.refreshInterval = setInterval(sendRefreshSession, 9000);
-
-    this.connect();
 
     this.loggingSocket.on('log_record', (record) => {
       if (record.severity !== 'DEBUG') {


### PR DESCRIPTION
Start connecting to SocketIO after user have successfully logged in.

You need to be authenticated before back-end allows you to open a SocketIO connection. Trying to establish a connection before will fail. This leads to an endless retry loop while the user is on the login page.