### PR TITLE
drop 'mach_info_changed' SocketIO event code

### DIFF
--- a/mxcubeweb/routes/signals.py
+++ b/mxcubeweb/routes/signals.py
@@ -687,15 +687,6 @@ def beamline_action_failed(name):
         logging.getLogger("user_level_log").error("Action %s failed !", name)
 
 
-def mach_info_changed(values):
-    try:
-        server.emit("mach_info_changed", values, namespace="/hwr")
-    except Exception:
-        logging.getLogger("HWR").error(
-            "error sending mach_info_changed signal: &s" % values
-        )
-
-
 def new_plot(plot_info):
     try:
         server.emit("new_plot", plot_info, namespace="/hwr")

--- a/ui/src/actions/beamline.js
+++ b/ui/src/actions/beamline.js
@@ -22,7 +22,6 @@ export const BL_UPDATE_HARDWARE_OBJECT_STATE =
   'BL_UPDATE_HARDWARE_OBJECT_STATE';
 export const BL_ATTR_MOV_SET_STATE = 'BL_ATTR_MOV_SET_STATE';
 export const BL_ATTR_ACT_SET_STATE = 'BL_ATTR_ACT_SET_STATE';
-export const BL_MACH_INFO = 'BL_MACH_INFO';
 export const BL_ATTR_MOV_SET = 'BL_ATTR_MOV_SET';
 export const BL_ATTR_ACT_SET = 'BL_ATTR_ACT_SET';
 
@@ -40,10 +39,6 @@ export function updateBeamlineHardwareObjectValueAction(data) {
 
 export function getBeamlineAttrsAction(data) {
   return { type: BL_ATTR_GET_ALL, data };
-}
-
-export function setMachInfo(info) {
-  return { type: BL_MACH_INFO, info };
 }
 
 export function updateBeamlineHardwareObjectStateAction(data) {

--- a/ui/src/reducers/beamline.js
+++ b/ui/src/reducers/beamline.js
@@ -285,12 +285,6 @@ function beamlineReducer(state = INITIAL_STATE, action = {}) {
         energyScanElements: action.data.beamlineSetup.energyScanElements,
       };
     }
-    case 'BL_MACH_INFO': {
-      return {
-        ...state,
-        machinfo: { ...state.machinfo, ...action.info },
-      };
-    }
     case 'ACTION_SET_STATE': {
       const beamlineActionsList = JSON.parse(
         JSON.stringify(state.beamlineActionsList),

--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -17,7 +17,6 @@ import {
   updateBeamlineHardwareObjectAction,
   updateBeamlineHardwareObjectValueAction,
   updateBeamlineHardwareObjectAttributeAction,
-  setMachInfo,
 } from './actions/beamline';
 import {
   setActionState,
@@ -185,10 +184,6 @@ class ServerIO {
 
     this.hwrSocket.on('beam_changed', (record) => {
       this.dispatch(setBeamInfo(record.data));
-    });
-
-    this.hwrSocket.on('mach_info_changed', (info) => {
-      this.dispatch(setMachInfo(info));
     });
 
     this.hwrSocket.on('hardware_object_changed', (data) => {


### PR DESCRIPTION
Drop the code that was sending and receiving 'mach_info_changed' SocketIO event. This code is not used anymore.

It have been replaced with generic 'hardware_object_value_changed' event.