### PR TITLE
always stop queue with queue_manager.stop()

### DIFF
--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -2174,29 +2174,7 @@ class Queue(ComponentBase):
             logging.getLogger("MX3.HWR").info("[QUEUE] Queue started")
 
     def queue_stop(self):
-        from mxcubeweb.routes import signals
-
-        if HWR.beamline.queue_manager._root_task is not None:
-            HWR.beamline.queue_manager.stop()
-        else:
-            qe = HWR.beamline.queue_manager.get_current_entry()
-            # check if a node/task is executing and stop that one
-            if qe:
-                try:
-                    qe.stop()
-                except Exception:
-                    logging.getLogger("MX3.HWR").exception(
-                        "[QUEUE] Could not stop queue"
-                    )
-                HWR.beamline.queue_manager.set_pause(False)
-                # the next two is to avoid repeating the task
-                # TODO: if you now run the queue it will be enabled and run
-                qe.get_data_model().set_executed(True)
-                qe.get_data_model().set_enabled(False)
-                qe._execution_failed = True
-
-                HWR.beamline.queue_manager._is_stopped = True
-                signals.queue_execution_stopped()
+        HWR.beamline.queue_manager.stop()
 
     def queue_pause(self):
         """


### PR DESCRIPTION
This solves problem with stopping tasks started via 'run now' action.

Note that in current code, else-branch is taken only if you run all your task as 'run now' actions. As soon as you put something on the queue, the `HWR.beamline.queue_manager._root_task` becomes non-None. Thus _all_ future queue stops will take the if-branch. Regardless if they are created via 'run now' or 'add to queue' actions. And it seems to work fine.

Do we need else-branch for something? Does this patch break something I'm not considering?
