### PR TITLE
[CSS FIX] remove extra padding / margin

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
 
   "eslint.workingDirectories": ["./ui"],

--- a/ui/src/components/SampleQueue/TodoTree.js
+++ b/ui/src/components/SampleQueue/TodoTree.js
@@ -42,7 +42,7 @@ export default class TodoTree extends React.Component {
     return (
       <ListGroup variant="flush">
         <ListGroup.Item
-          className="mt-2 d-flex list-head"
+          className="d-flex list-head"
           style={{ borderBottom: 'none' }}
         >
           <div className="me-auto">
@@ -57,7 +57,7 @@ export default class TodoTree extends React.Component {
           <div>
             <Button
               disabled={this.props.queueStatus === QUEUE_RUNNING}
-              className="me-2 btn-primary"
+              className="btn-primary"
               size="sm"
               onClick={this.showAddSampleForm}
             >

--- a/ui/src/components/SampleQueue/app.css
+++ b/ui/src/components/SampleQueue/app.css
@@ -151,7 +151,7 @@
   margin-bottom: 10px;
 }
 .list-head {
-  padding: 1.5rem 1rem;
+  padding: 1rem 1rem;
   border: 0px;
 }
 .list-body {


### PR DESCRIPTION
- [VsCode] Turns out, VSCode true is set to "explicit" since VSCode 1.85.0.
  https://code.visualstudio.com/updates/v1_85#_code-actions-on-save-and-auto

-  [SMALL CSS FIX] remove extra padding / margin
   I neat solution for later would be to convert /ui/src/components/SampleQueue/app.css
   to css module.  

css Bug when screen is at 100 %
![image](https://github.com/mxcube/mxcubeweb/assets/7275231/50ea0079-6bd2-42eb-9bdd-0abbdd840dad)

Fix
![image](https://github.com/mxcube/mxcubeweb/assets/7275231/db191bb9-1514-400b-a637-b6581461b57c)



