### PR TITLE
UI: make sure looked up HO values are numbers

### DIFF
--- a/ui/src/components/Tasks/fields.js
+++ b/ui/src/components/Tasks/fields.js
@@ -85,9 +85,11 @@ export function toFixed(state, hoName, parameterName = null) {
     }
   }
 
-  return value
-    ? Number.parseFloat(value).toFixed(precision)
-    : ho.value.toFixed(precision);
+  return Number(
+    value
+      ? Number.parseFloat(value).toFixed(precision)
+      : ho.value.toFixed(precision),
+  );
 }
 
 function validation(error, warning) {


### PR DESCRIPTION
The values returned by toFixed() are used to pre-fill task dialog's common fields. Fields such as resolution, energy, etc. The dialog's schema for these parameters specify that these fields must be of a number types. When we pre-fill these fields as text string, the dialog will show errors such as:

  'Energy' must be a number

Note, this error will be displayed on first validation run of the dialog. That is first when user starts editing the fields.

Converting return values to number solves this problem.

Solves issue: https://github.com/mxcube/mxcubeweb/issues/1231