### PR TITLE
Inconsistent Log messages

### DIFF
--- a/ui/src/components/Notify/style.css
+++ b/ui/src/components/Notify/style.css
@@ -9,7 +9,6 @@
   border-top: 5px solid #4e677b;
   background-color: rgba(91, 141, 180, 0.8);
   border-radius: 2px;
-  margin-top: 0.5em;
 }
 
 .messageWARNING {


### PR DESCRIPTION
There was some inconsistency regarding the style of different log messages. (info messages had a top margin while other messages where shown right next to each other)
I deleted the top margin of the info messages , so that all messages will be shown at uniform distance to each other.