### PR TITLE
Mockup: show more fields in machine info box

### DIFF
--- a/test/HardwareObjectsMockup.xml/machine_info.xml
+++ b/test/HardwareObjectsMockup.xml/machine_info.xml
@@ -1,2 +1,3 @@
 <object class="MachineInfoMockup">
+    <parameters>["current", "message", "lifetime"]</parameters>
 </object>


### PR DESCRIPTION
When running MXCuBE with mockups, enable more fields in the machine info drop-down box. Let's include 'message' and 'lifetime' fields in addition to 'current', as the MachineInfoMockup implements these fields.

The result looks like this:

![image](https://github.com/mxcube/mxcubeweb/assets/77584583/5350b436-e401-42fa-9692-ebb6890ebc3b)
