### PR TITLE
make 'save last used params' feature work for generic task form

### DIFF
--- a/ui/src/components/Tasks/GenericTaskForm.js
+++ b/ui/src/components/Tasks/GenericTaskForm.js
@@ -71,7 +71,7 @@ class GenericTaskForm extends React.Component {
       'chip_type',
     ];
 
-    saveToLastUsedParameters(this.props.taskData.type, params);
+    saveToLastUsedParameters(this.props.taskData.type, parameters);
     this.props.addTask(parameters, stringFields, runNow);
     this.props.hide();
   }


### PR DESCRIPTION
Fixes issue with saving 'last used parameters' in generic task forms.

With this change, the fields values will be retained between the forms usages.