### PR TITLE
[TaskDialog] - Fix for JSForm getting cleard when store update

### DIFF
--- a/ui/src/components/Tasks/fields.js
+++ b/ui/src/components/Tasks/fields.js
@@ -12,8 +12,14 @@ export function getLastUsedParameters(type, newParams) {
   return lastParameters === null ? newParams : JSON.parse(lastParameters);
 }
 
-export function saveToLastUsedParameters(formName, parameters) {
-  localStorage.setItem(`last${formName}Parameters`, JSON.stringify(parameters));
+export function saveToLastUsedParameters(formName, parameters, exclude = []) {
+  const params = { ...parameters };
+
+  exclude.forEach((paramName) => {
+    delete params[paramName];
+  });
+
+  localStorage.setItem(`last${formName}Parameters`, JSON.stringify(params));
 }
 
 export function clearAllLastUsedParameters() {

--- a/ui/src/containers/TaskContainer.js
+++ b/ui/src/containers/TaskContainer.js
@@ -205,6 +205,7 @@ class TaskContainer extends React.Component {
             apertureList={this.props.apertureList}
             availableElements={this.props.beamline.energyScanElements}
             rootPath={this.props.path}
+            defaultParameters={this.props.defaultParameters}
           />
         );
       }


### PR DESCRIPTION
This fixes a few issues with the generic task dialog.

 - The "current" values of the JSForm is saved in local storage so that they are not cleared by updates to the redux store (as the redux form gets re-rendered when the store is updated)
 
 - Reset to default fixed

 - Added missing title