### PR TITLE
added 3-click centring tests

### DIFF
--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -62,6 +62,8 @@ module.exports = createConfig({
         'testing-library/prefer-screen-queries': 'off', // Cypress provides `cy` object instead of `screen`
         'sonarjs/no-duplicate-string': 'off', // incompatible with Cypress testing syntax
         'unicorn/numeric-separators-style': 'off', // not supported
+        'promise/prefer-await-to-then': 'off', // Cypress has its own `then` command
+        'promise/catch-or-return': 'off', // Cypress has its own `then` command
       },
     },
   ],

--- a/ui/cypress/e2e/app.cy.js
+++ b/ui/cypress/e2e/app.cy.js
@@ -32,16 +32,3 @@ describe('app', () => {
     cy.findByRole('button', { name: /Beamline Actions/u }).should('be.visible');
   });
 });
-
-describe('queue', () => {
-  beforeEach(() => {
-    cy.login();
-    cy.findByRole('link', { name: 'MXCuBE-Web (OSC)' }).should('be.visible');
-    cy.takeControl();
-  });
-
-  it('mount a test sample', () => {
-    cy.mountSample('test', 'test');
-    cy.findByText('Sample: test - test').should('be.visible');
-  });
-});

--- a/ui/cypress/e2e/queue.cy.js
+++ b/ui/cypress/e2e/queue.cy.js
@@ -1,0 +1,14 @@
+/* global cy, it, describe, beforeEach */
+
+describe('queue', () => {
+  beforeEach(() => {
+    cy.login();
+    cy.findByRole('link', { name: 'MXCuBE-Web (OSC)' }).should('be.visible');
+    cy.takeControl();
+  });
+
+  it('mount a test sample', () => {
+    cy.mountSample('test', 'test');
+    cy.findByText('Sample: test - test').should('be.visible');
+  });
+});

--- a/ui/cypress/e2e/sampleControls.cy.js
+++ b/ui/cypress/e2e/sampleControls.cy.js
@@ -9,7 +9,7 @@ describe('3-click centring', () => {
 
   it('3-click centring should not work without sample', () => {
     cy.clearSamples();
-    cy.contains('button', '3-click centring').click();
+    cy.findByRole('button', { name: '3-click centring' }).click();
     cy.findByRole('alert', 'Error: There is no sample mounted').should(
       'be.visible',
     );
@@ -17,7 +17,7 @@ describe('3-click centring', () => {
 
   it('Each click is rotating the sample by 90 degrees', () => {
     cy.mountSample();
-    cy.contains('button', '3-click centring').click();
+    cy.findByRole('button', { name: '3-click centring' }).click();
     cy.get('.form-control[name="diffractometer.phi"]')
       .invoke('val')
       .then((value) => {
@@ -29,7 +29,7 @@ describe('3-click centring', () => {
           cy.wait(1000);
           cy.reload();
           // press the centring button again after reload to stay in the correct mode
-          cy.contains('button', '3-click centring').click();
+          cy.findByRole('button', { name: '3-click centring' }).click();
           cy.get('.form-control[name="diffractometer.phi"]')
             .invoke('val')
             .should('equal', omegaValue.toFixed(2));

--- a/ui/cypress/e2e/sampleControls.cy.js
+++ b/ui/cypress/e2e/sampleControls.cy.js
@@ -1,0 +1,41 @@
+/* global cy, it, describe, beforeEach, Cypress */
+
+describe('3-click centring', () => {
+  beforeEach(() => {
+    cy.login();
+    cy.findByRole('link', { name: 'MXCuBE-Web (OSC)' }).should('be.visible');
+    cy.takeControl();
+  });
+
+  it('3-click centring should not work without sample', () => {
+    cy.clearSamples();
+    cy.contains('button', '3-click centring').click();
+    cy.findByRole('alert', 'Error: There is no sample mounted').should(
+      'be.visible',
+    );
+  });
+
+  it('Each click is rotating the sample by 90 degrees', () => {
+    cy.mountSample();
+    cy.contains('button', '3-click centring').click();
+    /* eslint-disable-next-line promise/catch-or-return */
+    cy.get('.form-control[name="diffractometer.phi"]')
+      .invoke('val')
+      /* eslint-disable-next-line promise/prefer-await-to-then */
+      .then((value) => {
+        let omegaValue = Number.parseFloat(value);
+        Cypress._.times(2, () => {
+          omegaValue += 90;
+          cy.get('.canvas-container').click();
+          // to update the omega value, a small amount of time must be waited and the page reloaded
+          cy.wait(1000);
+          cy.reload();
+          // press the centring button again after reload to stay in the correct mode
+          cy.contains('button', '3-click centring').click();
+          cy.get('.form-control[name="diffractometer.phi"]')
+            .invoke('val')
+            .should('equal', omegaValue.toFixed(2));
+        });
+      });
+  });
+});

--- a/ui/cypress/e2e/sampleControls.cy.js
+++ b/ui/cypress/e2e/sampleControls.cy.js
@@ -18,10 +18,8 @@ describe('3-click centring', () => {
   it('Each click is rotating the sample by 90 degrees', () => {
     cy.mountSample();
     cy.contains('button', '3-click centring').click();
-    /* eslint-disable-next-line promise/catch-or-return */
     cy.get('.form-control[name="diffractometer.phi"]')
       .invoke('val')
-      /* eslint-disable-next-line promise/prefer-await-to-then */
       .then((value) => {
         let omegaValue = Number.parseFloat(value);
         Cypress._.times(2, () => {

--- a/ui/cypress/support.js
+++ b/ui/cypress/support.js
@@ -18,7 +18,6 @@ Cypress.Commands.add('takeControl', () => {
   });
 
   // ensure to click away the observer mode dialog box if present
-  /* eslint-disable-next-line promise/catch-or-return, promise/prefer-await-to-then */
   cy.get('body').then(($body) => {
     if ($body.text().includes('Observer mode')) {
       cy.wrap($body.find('.modal-dialog').find('.form-control')).type('test');

--- a/ui/cypress/support.js
+++ b/ui/cypress/support.js
@@ -9,7 +9,7 @@ Cypress.Commands.add('login', (username = 'idtest0', password = '0000') => {
   cy.findByRole('button', { name: 'Sign in' }).click();
 });
 
-Cypress.Commands.add('takeControl', () => {
+Cypress.Commands.add('takeControl', (returnPage = '/datacollection') => {
   /* firefox (only firefox) throws an unhandled promise error when executing
      this function. Hence, we tell cypress to ignore this, otherwise the tests
      fail, when we try to click the observer mode dialog away. */
@@ -17,34 +17,36 @@ Cypress.Commands.add('takeControl', () => {
     return false;
   });
 
-  // ensure to click away the observer mode dialog box if present
+  // control only needs to be taken, when observer mode is present
   cy.get('body').then(($body) => {
     if ($body.text().includes('Observer mode')) {
-      cy.wrap($body.find('.modal-dialog').find('.form-control')).type('test');
-      cy.findByText('OK').click();
+      cy.findByRole('button', { name: 'OK' }).click();
+      cy.findByText('Remote').click();
+      cy.findByRole('button', { name: 'Take control' }).click();
+      cy.visit(returnPage);
     }
   });
-  cy.request('POST', '/mxcube/api/v0.1/ra/take_control');
 
   // tell cypress to listen to any uncaught:execptions again
   Cypress.on('uncaught:exception', (err, runnable) => {
     return true;
   });
-  cy.reload();
 });
 
 Cypress.Commands.add('mountSample', (sample = 'test', protein = 'test') => {
   cy.visit('/datacollection');
   cy.findByRole('button', { name: /Queued Samples/u }).click();
-  cy.findByText('Create new sample').click();
+  cy.findByRole('button', { name: 'Create new sample' }).click();
   cy.findByLabelText('Sample name').type(sample);
   cy.findByLabelText('Protein acronym').type(protein);
-  cy.findByText('Mount').click();
+  cy.findByRole('button', { name: 'Mount' }).click();
   // reload for button changes to take effect
   cy.reload();
 });
 
-Cypress.Commands.add('clearSamples', () => {
-  cy.request('PUT', '/mxcube/api/v0.1/queue/clear');
-  cy.reload();
+Cypress.Commands.add('clearSamples', (returnPage = '/datacollection') => {
+  cy.findByText('Samples').click();
+  cy.findByRole('button', { name: /Clear sample list/u }).click('left');
+  cy.findByRole('button', { name: 'Ok' }).click();
+  cy.visit(returnPage);
 });

--- a/ui/cypress/support.js
+++ b/ui/cypress/support.js
@@ -19,9 +19,9 @@ Cypress.Commands.add('takeControl', () => {
 
   // ensure to click away the observer mode dialog box if present
   /* eslint-disable-next-line promise/catch-or-return, promise/prefer-await-to-then */
-  cy.findByRole('dialog').then(($dialog) => {
-    if ($dialog.text().includes('Observer mode')) {
-      cy.wrap($dialog.find('.form-control')).type('test');
+  cy.get('body').then(($body) => {
+    if ($body.text().includes('Observer mode')) {
+      cy.wrap($body.find('.modal-dialog').find('.form-control')).type('test');
       cy.findByText('OK').click();
     }
   });
@@ -31,6 +31,7 @@ Cypress.Commands.add('takeControl', () => {
   Cypress.on('uncaught:exception', (err, runnable) => {
     return true;
   });
+  cy.reload();
 });
 
 Cypress.Commands.add('mountSample', (sample = 'test', protein = 'test') => {
@@ -41,5 +42,10 @@ Cypress.Commands.add('mountSample', (sample = 'test', protein = 'test') => {
   cy.findByLabelText('Protein acronym').type(protein);
   cy.findByText('Mount').click();
   // reload for button changes to take effect
+  cy.reload();
+});
+
+Cypress.Commands.add('clearSamples', () => {
+  cy.request('PUT', '/mxcube/api/v0.1/queue/clear');
   cy.reload();
 });

--- a/ui/package.json
+++ b/ui/package.json
@@ -81,7 +81,7 @@
     "@testing-library/user-event": "^13.5.0",
     "babel-preset-react-app": "10.0.1",
     "concurrently": "^7.0.0",
-    "cypress": "13.1.0",
+    "cypress": "13.12.0",
     "eslint": "8.42.0",
     "eslint-config-galex": "4.5.2",
     "eslint-plugin-import": "2.27.5",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -176,7 +176,7 @@ importers:
         version: 5.15.4
       '@testing-library/cypress':
         specifier: 10.0.1
-        version: 10.0.1(cypress@13.1.0)
+        version: 10.0.1(cypress@13.12.0)
       '@testing-library/jest-dom':
         specifier: ^5.16.2
         version: 5.16.5
@@ -193,8 +193,8 @@ importers:
         specifier: ^7.0.0
         version: 7.6.0
       cypress:
-        specifier: 13.1.0
-        version: 13.1.0
+        specifier: 13.12.0
+        version: 13.12.0
       eslint:
         specifier: 8.42.0
         version: 8.42.0
@@ -1730,9 +1730,6 @@ packages:
   '@types/mime@1.3.2':
     resolution: {integrity: sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==}
 
-  '@types/node@16.18.48':
-    resolution: {integrity: sha512-mlaecDKQ7rIZrYD7iiKNdzFb6e/qD5I9U1rAhq+Fd+DWvYVs+G2kv74UFHmSOlg5+i/vF3XxuR522V4u8BqO+Q==}
-
   '@types/node@20.2.5':
     resolution: {integrity: sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==}
 
@@ -3013,8 +3010,8 @@ packages:
   cwise-compiler@1.1.3:
     resolution: {integrity: sha512-WXlK/m+Di8DMMcCjcWr4i+XzcQra9eCdXIJrgh4TUgh0pIS/yJduLxS9JgefsHJ/YVLdgPtXm9r62W92MvanEQ==}
 
-  cypress@13.1.0:
-    resolution: {integrity: sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==}
+  cypress@13.12.0:
+    resolution: {integrity: sha512-udzS2JilmI9ApO/UuqurEwOvThclin5ntz7K0BtnHBs+tg2Bl9QShLISXpSEMDv/u8b6mqdoAdyKeZiSqKWL8g==}
     engines: {node: ^16.0.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
 
@@ -10235,11 +10232,11 @@ snapshots:
     dependencies:
       tslib: 2.5.2
 
-  '@testing-library/cypress@10.0.1(cypress@13.1.0)':
+  '@testing-library/cypress@10.0.1(cypress@13.12.0)':
     dependencies:
       '@babel/runtime': 7.22.3
       '@testing-library/dom': 9.3.3
-      cypress: 13.1.0
+      cypress: 13.12.0
 
   '@testing-library/dom@8.20.1':
     dependencies:
@@ -10424,8 +10421,6 @@ snapshots:
   '@types/json5@0.0.29': {}
 
   '@types/mime@1.3.2': {}
-
-  '@types/node@16.18.48': {}
 
   '@types/node@20.2.5': {}
 
@@ -11936,11 +11931,10 @@ snapshots:
     dependencies:
       uniq: 1.0.1
 
-  cypress@13.1.0:
+  cypress@13.12.0:
     dependencies:
       '@cypress/request': 3.0.0
       '@cypress/xvfb': 1.2.4(supports-color@8.1.1)
-      '@types/node': 16.18.48
       '@types/sinonjs__fake-timers': 8.1.1
       '@types/sizzle': 2.3.3
       arch: 2.2.0


### PR DESCRIPTION
This includes 3 changes to the e2e tests:

- addition of 3-click centring tests
- restructuring app.cy.js into multiple specs, this makes it faster to test specific components in the future
- updating cypress to the latest version: this is necessary to fix a an issue that includees newer firefox versions and running multiple specs after another