### PR TITLE
Remove unused FontAwesome deps and init code

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -18,11 +18,7 @@
     "cypress": "cypress open --e2e --browser firefox"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^1.2.36",
-    "@fortawesome/free-brands-svg-icons": "^5.15.4",
-    "@fortawesome/free-regular-svg-icons": "^5.15.4",
-    "@fortawesome/free-solid-svg-icons": "^5.15.4",
-    "@fortawesome/react-fontawesome": "^0.1.17",
+    "@fortawesome/fontawesome-free": "^5.15.4",
     "@rjsf/core": "5.13.1",
     "@rjsf/utils": "5.13.1",
     "@rjsf/validator-ajv8": "5.13.1",
@@ -74,7 +70,6 @@
     "ws": "^8.5.0"
   },
   "devDependencies": {
-    "@fortawesome/fontawesome-free": "^5.15.4",
     "@testing-library/cypress": "10.0.1",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.2",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -8,21 +8,9 @@ importers:
 
   .:
     dependencies:
-      '@fortawesome/fontawesome-svg-core':
-        specifier: ^1.2.36
-        version: 1.2.36
-      '@fortawesome/free-brands-svg-icons':
+      '@fortawesome/fontawesome-free':
         specifier: ^5.15.4
         version: 5.15.4
-      '@fortawesome/free-regular-svg-icons':
-        specifier: ^5.15.4
-        version: 5.15.4
-      '@fortawesome/free-solid-svg-icons':
-        specifier: ^5.15.4
-        version: 5.15.4
-      '@fortawesome/react-fontawesome':
-        specifier: ^0.1.17
-        version: 0.1.19(@fortawesome/fontawesome-svg-core@1.2.36)(react@17.0.2)
       '@rjsf/core':
         specifier: 5.13.1
         version: 5.13.1(@rjsf/utils@5.13.1(react@17.0.2))(react@17.0.2)
@@ -171,9 +159,6 @@ importers:
         specifier: ^8.5.0
         version: 8.13.0
     devDependencies:
-      '@fortawesome/fontawesome-free':
-        specifier: ^5.15.4
-        version: 5.15.4
       '@testing-library/cypress':
         specifier: 10.0.1
         version: 10.0.1(cypress@13.12.0)
@@ -1158,35 +1143,9 @@ packages:
     resolution: {integrity: sha512-6SWlXpWU5AvId8Ac7zjzmIOqMOba/JWY8XZ4A7q7Gn1Vlfg/SFFIlrtHXt9nPn4op9ZPAkl91Jao+QQv3r/ukw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@fortawesome/fontawesome-common-types@0.2.36':
-    resolution: {integrity: sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==}
-    engines: {node: '>=6'}
-
   '@fortawesome/fontawesome-free@5.15.4':
     resolution: {integrity: sha512-eYm8vijH/hpzr/6/1CJ/V/Eb1xQFW2nnUKArb3z+yUWv7HTwj6M7SP957oMjfZjAHU6qpoNc2wQvIxBLWYa/Jg==}
     engines: {node: '>=6'}
-
-  '@fortawesome/fontawesome-svg-core@1.2.36':
-    resolution: {integrity: sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==}
-    engines: {node: '>=6'}
-
-  '@fortawesome/free-brands-svg-icons@5.15.4':
-    resolution: {integrity: sha512-f1witbwycL9cTENJegcmcZRYyawAFbm8+c6IirLmwbbpqz46wyjbQYLuxOc7weXFXfB7QR8/Vd2u5R3q6JYD9g==}
-    engines: {node: '>=6'}
-
-  '@fortawesome/free-regular-svg-icons@5.15.4':
-    resolution: {integrity: sha512-9VNNnU3CXHy9XednJ3wzQp6SwNwT3XaM26oS4Rp391GsxVYA+0oDR2J194YCIWf7jNRCYKjUCOduxdceLrx+xw==}
-    engines: {node: '>=6'}
-
-  '@fortawesome/free-solid-svg-icons@5.15.4':
-    resolution: {integrity: sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==}
-    engines: {node: '>=6'}
-
-  '@fortawesome/react-fontawesome@0.1.19':
-    resolution: {integrity: sha512-Hyb+lB8T18cvLNX0S3llz7PcSOAJMLwiVKBuuzwM/nI5uoBw+gQjnf9il0fR1C3DKOI5Kc79pkJ4/xB0Uw9aFQ==}
-    peerDependencies:
-      '@fortawesome/fontawesome-svg-core': ~1 || ~6
-      react: '>=16.x'
 
   '@hapi/hoek@9.3.0':
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
@@ -9641,31 +9600,7 @@ snapshots:
 
   '@eslint/js@8.42.0': {}
 
-  '@fortawesome/fontawesome-common-types@0.2.36': {}
-
   '@fortawesome/fontawesome-free@5.15.4': {}
-
-  '@fortawesome/fontawesome-svg-core@1.2.36':
-    dependencies:
-      '@fortawesome/fontawesome-common-types': 0.2.36
-
-  '@fortawesome/free-brands-svg-icons@5.15.4':
-    dependencies:
-      '@fortawesome/fontawesome-common-types': 0.2.36
-
-  '@fortawesome/free-regular-svg-icons@5.15.4':
-    dependencies:
-      '@fortawesome/fontawesome-common-types': 0.2.36
-
-  '@fortawesome/free-solid-svg-icons@5.15.4':
-    dependencies:
-      '@fortawesome/fontawesome-common-types': 0.2.36
-
-  '@fortawesome/react-fontawesome@0.1.19(@fortawesome/fontawesome-svg-core@1.2.36)(react@17.0.2)':
-    dependencies:
-      '@fortawesome/fontawesome-svg-core': 1.2.36
-      prop-types: 15.8.1
-      react: 17.0.2
 
   '@hapi/hoek@9.3.0': {}
 

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -8,13 +8,6 @@ import { store } from './store';
 import DefaultErrorBoundary from './containers/DefaultErrorBoundary';
 
 import '@fortawesome/fontawesome-free/css/all.min.css';
-import { library } from '@fortawesome/fontawesome-svg-core';
-import { fas } from '@fortawesome/free-solid-svg-icons';
-import { far } from '@fortawesome/free-regular-svg-icons';
-import { fab } from '@fortawesome/free-brands-svg-icons';
-
-// Add all icons to the library so you can use it in your page
-library.add(fas, far, fab);
 
 if (module.hot) {
   // Enable Webpack hot module replacement for reducers


### PR DESCRIPTION
There are many, many ways to use FontAwesome. The simplest way, which is used in MXCuBE is to install the `@fortawesome/fontawesome-free` package and import the `@fortawesome/fontawesome-free/css/all.min.css` stylesheet. This basically provides a web font with all of FontAwesome's free icons, which can then be used in HTML with `<i class="fas fa-cog" />`.

This is far from the best way to use FontAwesome since it means all the free icons are loaded even if they're not used, but it has the advantage of being very simple to set up and work with. So I'm not changing it (it would be way to much work anyway).

The problem was that MXCuBE was also kinda trying to set up FontAwesome in two other ways:

- With the React package `@fortawesome/react-fontawesome`, which allows rendering icons in JSX with `<FontAwesomeIcon icon={faHouse} />` — I didn't find any use of this technique, so I've removed the dependency from `package.json`.
- With the [JavaScript API](https://docs.fontawesome.com/apis/javascript/get-started/) provided by the `@fortawesome/fontawesome-svg-core` package, combined with the three free icon packages `@fortawesome/free-<kind>-svg-icons` — the `index.js` file contained some imports and initialisation code for this technique, but the icons registered in this way were not being used anywhere, so I've removed the relevant dependencies and init code.