### PR TITLE
Use lowest supported Python version for checks

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.8"]
 
     # Skip `pull_request` runs on local PRs for which `push` runs are already triggered
     # yamllint disable-line rule:line-length

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,7 @@
 ---
 
 default_language_version:
-  python: python3.10
-
+  python: python3.8  # This should be set to the lowest Python version that we support.
 
 repos:
 


### PR DESCRIPTION
We should do formatting, linting, testing, and so on against the lowest Python version that we intend to support. We want to make sure we do not introduce unsupported Python syntax. Because Python is generally backwards-compatible this should be good enough to check against lowest version.