### PR TITLE
yaml: revert back detector config to XML

### DIFF
--- a/test/HardwareObjectsMockup.xml/beamline_config.yml
+++ b/test/HardwareObjectsMockup.xml/beamline_config.yml
@@ -23,7 +23,7 @@ objects:
   # on one object that require the other to be already loaded.
   #
   # Hardware:
-  - detector: detector.yml
+  - detector: detector.xml
   - session: session.xml
   - data_publisher: data_publisher.xml
   - machine_info: machine_info.xml


### PR DESCRIPTION
The detector.yml is missing, let's go back to detector.xml for now.