### PR TITLE
yaml conf: make 'export yaml config' a user invokable feature

### DIFF
--- a/docs/source/dev/index.rst
+++ b/docs/source/dev/index.rst
@@ -16,3 +16,4 @@ Developer documentation
     sample-changer-changes-and-maintenance.md
     tutorial.md
     deployment.md
+    yaml_conf_migration.md

--- a/docs/source/dev/yaml_conf_migration.md
+++ b/docs/source/dev/yaml_conf_migration.md
@@ -1,0 +1,15 @@
+# YAML configuration migration
+
+Historically MXCuBE used XML files for configuring hardware objects.
+Now it's possible to use YAML files instead of XML files.
+To help with migration to YAML files, MXCuBE-Web can export loaded hardware objects configurations as YAML files.
+
+Use `--export-yaml-config` argument when starting MXCuBE-web to enable YAML export.
+For example, if you use:
+
+```
+    $ mxcubeweb-server --export-yaml-config <my-yaml-dir>
+```
+
+`mxcubeweb-server` will load your hardware object configuration as normal.
+Then it will write the loaded configuration into the `<my-yaml-dir>`.

--- a/mxcubeweb/__init__.py
+++ b/mxcubeweb/__init__.py
@@ -10,6 +10,7 @@ import os  # noqa: E402
 import redis  # noqa: E402
 import sys  # noqa: E402
 import traceback  # noqa: E402
+from pathlib import Path  # noqa: E402
 
 from mxcubeweb.server import Server as server  # noqa: E402
 from mxcubeweb.app import MXCUBEApplication as mxcube  # noqa: E402
@@ -99,6 +100,13 @@ def parse_args(argv):
         default=False,
     )
 
+    opt_parser.add_argument(
+        "--export-yaml-config",
+        dest="yaml_export_directory",
+        type=Path,
+        help="write YAML configuration to specified path",
+    )
+
     # If `argv` is `None`, then `argparse.ArgumentParser.parse_args`
     # will know to read from `sys.argv` instead.
     return opt_parser.parse_args(argv)
@@ -119,7 +127,9 @@ def build_server_and_config(test=False, argv=None):
         # as the hwr_directory. I need it for sensible managing of a multi-beamline test set-up
         # without continuously editing the main config files.
         # Note that the machinery was all there in the core already. rhfogh.
-        HWR.init_hardware_repository(cmdline_options.hwr_directory)
+        HWR.init_hardware_repository(
+            cmdline_options.hwr_directory, cmdline_options.yaml_export_directory
+        )
         config_path = HWR.get_hardware_repository().find_in_repository("mxcube-web")
 
         cfg = Config(config_path)


### PR DESCRIPTION
yaml conf: make 'export yaml config' a user invokable feature

Adds --export-yaml-config command line argument to mxcubeweb-server script. When used, the HWO YAML config files will be written to the specified directory.
    
The aim of this feature is assist in migrating beamline XML configuration to YAML style.

This PR depends on this core PR: https://github.com/mxcube/mxcubecore/pull/956