### PR TITLE
Remove obsolete 4xx checks + add missing try/catch blocks

### DIFF
--- a/ui/src/actions/harvester.js
+++ b/ui/src/actions/harvester.js
@@ -32,127 +32,110 @@ export function setHarvesterCommandResponse(response) {
 
 export function refresh() {
   return async (dispatch) => {
-    const response = await sendRefresh();
-
-    if (response.status >= 400) {
-      throw new Error('Error refreshing harvester contents');
+    try {
+      const contents = await sendRefresh();
+      dispatch(setContents(contents));
+    } catch {
+      throw new TypeError('Error refreshing harvester contents');
     }
-
-    const contents = await response.json();
-    dispatch(setContents(contents));
   };
 }
 
 export function harvestCrystal(xtalUUID, successCb = null) {
   return async (dispatch) => {
-    const response = await sendHarvestCrystal(xtalUUID);
+    try {
+      const contents = await sendHarvestCrystal(xtalUUID);
+      dispatch(setContents(contents));
 
-    if (response.status >= 400) {
-      dispatch(showErrorPanel(true, response.headers.get('message')));
+      if (successCb) {
+        successCb();
+      }
+    } catch (error) {
+      dispatch(showErrorPanel(true, error.response.headers.get('message')));
       throw new Error('Server refused to Harveste Crystal');
-    }
-
-    const contents = await response.json();
-    dispatch(setContents(contents));
-
-    if (successCb) {
-      successCb();
     }
   };
 }
 
 export function harvestAndLoadCrystal(xtalUUID, successCb = null) {
   return async (dispatch) => {
-    const response = await sendHarvestAndLoadCrystal(xtalUUID);
+    try {
+      const contents = await sendHarvestAndLoadCrystal(xtalUUID);
+      dispatch(setContents(contents));
 
-    if (response.status >= 400) {
-      dispatch(showErrorPanel(true, response.headers.get('message')));
+      if (successCb) {
+        successCb();
+      }
+    } catch (error) {
+      dispatch(showErrorPanel(true, error.response.headers.get('message')));
       throw new Error('Server refused to Harveste or Load Crystal');
-    }
-
-    const contents = await response.json();
-    dispatch(setContents(contents));
-
-    if (successCb) {
-      successCb();
     }
   };
 }
 
 export function sendDataCollectionToCrims() {
   return async (dispatch) => {
-    const response = await sendDCToCrims();
+    try {
+      const contents = await sendDCToCrims();
+      dispatch(setContents(contents));
 
-    if (response.status >= 400) {
-      dispatch(showErrorPanel(true, response.headers.get('message')));
+      // temporary use ErrorPanel to display success message
+      dispatch(showErrorPanel(true, 'Succesfully Send DC to Crims'));
+    } catch (error) {
+      dispatch(showErrorPanel(true, error.response.headers.get('message')));
       throw new Error('Server refused to Harveste or Load Crystal');
     }
-
-    // temporary use ErrorPanel to display success message
-    dispatch(showErrorPanel(true, 'Succesfully Send DC to Crims'));
-
-    const contents = await response.json();
-    dispatch(setContents(contents));
   };
 }
 
 export function calibratePin(successCb = null) {
   return async (dispatch) => {
-    const response = await sendCalibratePin();
+    try {
+      const contents = await sendCalibratePin();
+      dispatch(setContents(contents));
 
-    if (response.status >= 400) {
-      dispatch(showErrorPanel(true, response.headers.get('message')));
+      if (successCb) {
+        successCb();
+      }
+    } catch (error) {
+      dispatch(showErrorPanel(true, error.response.headers.get('message')));
       throw new Error('Calibration Procedure Failed');
-    }
-
-    const contents = await response.json();
-    dispatch(setContents(contents));
-
-    if (successCb) {
-      successCb();
     }
   };
 }
 
 export function validateCalibration(validated, successCb = null) {
   return async (dispatch) => {
-    const response = await sendValidateCalibration(validated);
+    try {
+      const contents = await sendValidateCalibration(validated);
+      dispatch(setContents(contents));
 
-    if (response.status >= 400) {
-      dispatch(showErrorPanel(true, response.headers.get('message')));
+      if (successCb) {
+        successCb();
+      }
+    } catch (error) {
+      dispatch(showErrorPanel(true, error.response.headers.get('message')));
       throw new Error('Calibration Procedure Failed');
-    }
-
-    const contents = await response.json();
-    dispatch(setContents(contents));
-
-    if (successCb) {
-      successCb();
     }
   };
 }
 
 export function abort() {
   return async (dispatch) => {
-    const response = await sendAbort();
-
-    if (response.status < 400) {
-      dispatch(showErrorPanel(true, 'action aborted'));
-    }
+    await sendAbort();
+    dispatch(showErrorPanel(true, 'action aborted'));
   };
 }
 
 export function sendCommand(cmdparts, args) {
   return async (dispatch) => {
-    const response = await sendCmd(cmdparts, args);
-
-    if (response.status >= 400) {
-      dispatch(showErrorPanel(true, response.headers.get('message')));
+    try {
+      const answer = await sendCmd(cmdparts, args);
+      dispatch(setHarvesterCommandResponse(answer.response));
+      dispatch(setContents(answer.contents));
+    } catch (error) {
+      dispatch(showErrorPanel(true, error.response.headers.get('message')));
       throw new Error(`Error while  sending command @ ${cmdparts}`);
     }
-
-    const answer = await response.json();
-    dispatch(setHarvesterCommandResponse(answer.response));
-    dispatch(setContents(answer.contents));
   };
 }

--- a/ui/src/actions/login.js
+++ b/ui/src/actions/login.js
@@ -65,11 +65,9 @@ export function selectProposal(number, navigate) {
       await sendSelectProposal(number);
       navigate('/');
       dispatch(selectProposalAction(number));
-    } catch (error) {
-      if (error.status >= 400) {
-        dispatch(showErrorPanel(true, 'Server refused to select proposal'));
-        navigate('/login');
-      }
+    } catch {
+      dispatch(showErrorPanel(true, 'Server refused to select proposal'));
+      navigate('/login');
     }
   };
 }

--- a/ui/src/actions/queue.js
+++ b/ui/src/actions/queue.js
@@ -97,10 +97,8 @@ export function addSamplesToQueue(sampleDataList) {
     try {
       const json = await sendAddQueueItem(sampleDataList);
       dispatch(setQueue(json));
-    } catch (error) {
-      if (error.status >= 400) {
-        dispatch(showErrorPanel(true, 'Server refused to add sample'));
-      }
+    } catch {
+      dispatch(showErrorPanel(true, 'Server refused to add sample'));
     }
 
     dispatch(queueLoading(false));
@@ -117,10 +115,8 @@ export function addSampleAndMount(sampleData) {
           const json = await sendAddQueueItem([sampleData]);
           dispatch(setQueue(json));
           dispatch(selectSamplesAction([sampleData.sampleID]));
-        } catch (error) {
-          if (error.status >= 400) {
-            dispatch(showErrorPanel(true, 'Server refused to add sample'));
-          }
+        } catch {
+          dispatch(showErrorPanel(true, 'Server refused to add sample'));
         }
 
         dispatch(queueLoading(false));
@@ -162,11 +158,9 @@ export function moveTask(sampleID, oldIndex, newIndex) {
 
     try {
       await sendMoveTask(sampleID, oldIndex, newIndex);
-    } catch (error) {
-      if (error.status >= 400) {
-        dispatch(changeTaskOrderAction(sampleID, newIndex, oldIndex));
-        dispatch(showErrorPanel(true, 'Could not move task'));
-      }
+    } catch {
+      dispatch(changeTaskOrderAction(sampleID, newIndex, oldIndex));
+      dispatch(showErrorPanel(true, 'Could not move task'));
     }
 
     dispatch(queueLoading(false));
@@ -201,10 +195,8 @@ export function runSample(sampleID, taskIndex) {
     try {
       await sendRunSample(sampleID, taskIndex);
       dispatch({ type: 'RUN_SAMPLE', queueID: sampleID });
-    } catch (error) {
-      if (error.status >= 400) {
-        throw new Error('Server refused to run sample');
-      }
+    } catch {
+      throw new Error('Server refused to run sample');
     }
   };
 }
@@ -244,12 +236,8 @@ export function setEnabledSample(sampleIDList, value) {
       if (!value) {
         dispatch(removeSamplesFromQueueAction(sampleIDList));
       }
-    } catch (error) {
-      if (error.status >= 400) {
-        dispatch(
-          showErrorPanel(true, 'Server refused to set item enabled flag'),
-        );
-      }
+    } catch {
+      dispatch(showErrorPanel(true, 'Server refused to set item enabled flag'));
     }
 
     dispatch(queueLoading(false));
@@ -270,10 +258,8 @@ export function deleteTask(sampleID, taskIndex) {
     try {
       await sendDeleteQueueItem([[sampleID, taskIndex]]);
       dispatch(removeTaskAction(sampleID, taskIndex, task.queueID));
-    } catch (error) {
-      if (error.status >= 400) {
-        dispatch(showErrorPanel(true, 'Server refused to delete task'));
-      }
+    } catch {
+      dispatch(showErrorPanel(true, 'Server refused to delete task'));
     }
 
     dispatch(queueLoading(false));
@@ -302,10 +288,8 @@ export function deleteTaskList(sampleIDList) {
     try {
       await sendDeleteQueueItem(itemPosList);
       dispatch(removeTaskListAction(taskList, queueIDList));
-    } catch (error) {
-      if (error.status >= 400) {
-        dispatch(showErrorPanel(true, 'Server refused to delete task'));
-      }
+    } catch {
+      dispatch(showErrorPanel(true, 'Server refused to delete task'));
     }
 
     dispatch(queueLoading(false));
@@ -342,12 +326,10 @@ export function updateTask(sampleID, taskIndex, params, runNow) {
       if (runNow) {
         dispatch(runSample(sampleID, taskIndex));
       }
-    } catch (error) {
-      if (error.status >= 400) {
-        dispatch(
-          showErrorPanel(true, 'The task could not be modified on the server'),
-        );
-      }
+    } catch {
+      dispatch(
+        showErrorPanel(true, 'The task could not be modified on the server'),
+      );
     }
 
     dispatch(queueLoading(false));
@@ -359,7 +341,6 @@ export function addDiffractionPlanAction(tasks) {
 }
 
 export function addTask(sampleIDs, parameters, runNow) {
-  // eslint-disable-next-line sonarjs/cognitive-complexity
   return async (dispatch, getState) => {
     const state = getState();
     const samples = [];
@@ -430,12 +411,10 @@ export function addTask(sampleIDs, parameters, runNow) {
           sl[sampleIDs[0]].tasks[sl[sampleIDs[0]].tasks.length - 1];
         dispatch(runSample(sampleIDs[0], taskIndex));
       }
-    } catch (error) {
-      if (error.status >= 400) {
-        dispatch(
-          showErrorPanel(true, 'The task could not be added to the server'),
-        );
-      }
+    } catch {
+      dispatch(
+        showErrorPanel(true, 'The task could not be added to the server'),
+      );
     }
 
     dispatch(queueLoading(false));
@@ -483,10 +462,8 @@ export function deleteSamplesFromQueue(sampleIDList) {
     try {
       await sendDeleteQueueItem(itemPostList);
       dispatch(removeSamplesFromQueueAction(sampleIDList));
-    } catch (error) {
-      if (error.status >= 400) {
-        dispatch(showErrorPanel(true, 'Server refused to delete sample'));
-      }
+    } catch {
+      dispatch(showErrorPanel(true, 'Server refused to delete sample'));
     }
 
     dispatch(queueLoading(false));
@@ -507,10 +484,8 @@ export function setAutoMountSample(automount) {
           json.automount === undefined ? false : json.automount,
         ),
       );
-    } catch (error) {
-      if (error.status >= 400) {
-        dispatch(showErrorPanel(true, 'Could not set/unset automount'));
-      }
+    } catch {
+      dispatch(showErrorPanel(true, 'Could not set/unset automount'));
     }
   };
 }
@@ -525,10 +500,8 @@ export function setAutoAddDiffPlan(autoadddiffplan) {
       const json = await sendSetAutoAddDiffPlan(autoadddiffplan);
       const a = json.auto_add_diffplan;
       dispatch(setAutoAddDiffPlanAction(a));
-    } catch (error) {
-      if (error.status >= 400) {
-        dispatch(showErrorPanel(true, 'Could not set/unset automount'));
-      }
+    } catch {
+      dispatch(showErrorPanel(true, 'Could not set/unset automount'));
     }
   };
 }

--- a/ui/src/actions/sampleChanger.js
+++ b/ui/src/actions/sampleChanger.js
@@ -118,9 +118,7 @@ export function unmountSample(sample) {
 
       dispatch(clearCurrentSample());
     } catch (error) {
-      if (error.status >= 400) {
-        dispatch(showErrorPanel(true, error.response.headers.get('message')));
-      }
+      dispatch(showErrorPanel(true, error.response.headers.get('message')));
     }
   };
 }
@@ -137,9 +135,7 @@ export function sendCommand(cmdparts, args) {
     try {
       await sendSampleChangerCommand(cmdparts, args);
     } catch (error) {
-      if (error.status >= 400) {
-        dispatch(showErrorPanel(true, error.response.headers.get('message')));
-      }
+      dispatch(showErrorPanel(true, error.response.headers.get('message')));
     }
   };
 }

--- a/ui/src/actions/sampleGrid.js
+++ b/ui/src/actions/sampleGrid.js
@@ -94,17 +94,15 @@ export function syncSamples() {
       dispatch(setQueue(json));
       dispatch(setLoading(false));
     } catch (error) {
-      if (error.status >= 400) {
-        dispatch(setLoading(false));
-        dispatch(
-          showErrorPanel(
-            true,
-            `Synchronization with ISPyB failed ${error.response.headers.get(
-              'message',
-            )}`,
-          ),
-        );
-      }
+      dispatch(setLoading(false));
+      dispatch(
+        showErrorPanel(
+          true,
+          `Synchronization with ISPyB failed ${error.response.headers.get(
+            'message',
+          )}`,
+        ),
+      );
     }
   };
 }
@@ -120,17 +118,14 @@ export function syncWithCrims() {
       const crystalList = await sendSyncWithCrims();
       dispatch(updateCrystalList(crystalList));
     } catch (error) {
-      if (error.status >= 400) {
-        // throw new Error('Error while scanning sample changer');
-        dispatch(
-          showErrorPanel(
-            true,
-            `Synchronization with Crims failed ${error.response.headers.get(
-              'message',
-            )}`,
-          ),
-        );
-      }
+      dispatch(
+        showErrorPanel(
+          true,
+          `Synchronization with Crims failed ${error.response.headers.get(
+            'message',
+          )}`,
+        ),
+      );
     }
   };
 }

--- a/ui/src/actions/sampleview.js
+++ b/ui/src/actions/sampleview.js
@@ -159,10 +159,8 @@ export function rotateToShape(sid) {
   return async (dispatch) => {
     try {
       await sendRotateToShape(sid);
-    } catch (error) {
-      if (error.status >= 400) {
-        dispatch(showErrorPanel(true, 'Server refused to rotate grid.'));
-      }
+    } catch {
+      dispatch(showErrorPanel(true, 'Server refused to rotate grid.'));
     }
   };
 }
@@ -207,10 +205,8 @@ export function addShape(shapeData = {}, successCb = null) {
       if (successCb) {
         successCb(shape);
       }
-    } catch (error) {
-      if (error.status >= 400) {
-        throw new Error('Server refused to add shape');
-      }
+    } catch {
+      throw new Error('Server refused to add shape');
     }
   };
 }
@@ -220,10 +216,8 @@ export function updateShapes(shapes) {
     try {
       const json = await sendAddOrUpdateShapes(shapes);
       dispatch(updateShapesAction(json.shapes));
-    } catch (error) {
-      if (error.status >= 400) {
-        throw new Error('Server refused to update shapes');
-      }
+    } catch {
+      throw new Error('Server refused to update shapes');
     }
   };
 }
@@ -233,10 +227,8 @@ export function deleteShape(id) {
     try {
       await sendDeleteShape(id);
       dispatch(deleteShapeAction(id));
-    } catch (error) {
-      if (error.status >= 400) {
-        throw new Error('Server refused to delete shape');
-      }
+    } catch {
+      throw new Error('Server refused to delete shape');
     }
   };
 }
@@ -316,10 +308,8 @@ export function moveToPoint(id) {
   return async (dispatch) => {
     try {
       await sendMoveToPoint(id);
-    } catch (error) {
-      if (error.status >= 400) {
-        dispatch(showErrorPanel(true, 'Server refused to move to point'));
-      }
+    } catch {
+      dispatch(showErrorPanel(true, 'Server refused to move to point'));
     }
   };
 }

--- a/ui/src/api/harvester.js
+++ b/ui/src/api/harvester.js
@@ -7,29 +7,29 @@ export function fetchHarvesterInitialState() {
 }
 
 export function sendRefresh() {
-  return endpoint.get('/contents').res();
+  return endpoint.get('/contents').json();
 }
 
 export function sendHarvestCrystal(xtalUUID) {
-  return endpoint.post(JSON.stringify(xtalUUID), '/harvest').res();
+  return endpoint.post(JSON.stringify(xtalUUID), '/harvest').json();
 }
 
 export function sendHarvestAndLoadCrystal(xtalUUID) {
-  return endpoint.post(JSON.stringify(xtalUUID), '/harvest_and_mount').res();
+  return endpoint.post(JSON.stringify(xtalUUID), '/harvest_and_mount').json();
 }
 
 export function sendCalibratePin() {
-  return endpoint.get('/calibrate').res();
+  return endpoint.get('/calibrate').json();
 }
 
 export function sendDataCollectionToCrims() {
-  return endpoint.get('/send_data_collection_info_to_crims').res();
+  return endpoint.get('/send_data_collection_info_to_crims').json();
 }
 
 export function sendValidateCalibration(validated) {
   return endpoint
     .post(JSON.stringify(validated), '/validate_calibration')
-    .res();
+    .json();
 }
 
 export function sendAbort() {
@@ -37,5 +37,5 @@ export function sendAbort() {
 }
 
 export function sendCommand(cmdparts, args) {
-  return endpoint.get(`/send_command/${cmdparts}/${args}`).res();
+  return endpoint.get(`/send_command/${cmdparts}/${args}`).json();
 }


### PR DESCRIPTION
Reasoning for removing all the `error.status >= 400` checks inside the try/catch blocks:

- Wretch throws errors when `response.ok` is `false`, which happens when the status code is **outside the 2xx range**.
- If they are well-formed, 1xx and 3xx responses are typically **"interim" response codes**; the browser deals with them transparently, which means that in our `catch` blocks, we are likely to see only 4xx or 5xx errors (so the `error.status >= 400` checks are redundant).
- If we do get a 1xx or 3xx error, it's likely a programming error and we need to report it, so we really don't want to exclude them with `error.status >= 400`.