### PR TITLE
Removed unused functionality to save and load queue and thus dependency to redis

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,10 +6,6 @@
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 
-# This uses custom commands, because it needs to get a Redis server running
-# which is necessary to get the Flask routes with the `autoflask` directives.
-
-
 version: 2
 
 build:
@@ -26,7 +22,7 @@ build:
     - "mamba env create --file conda-environment.yml --force"
     - "mamba run --name mxcubeweb poetry install --only=docs,main"
     # yamllint disable-line rule:line-length
-    - "(mamba run --name mxcubeweb redis-server &) && mamba run --name mxcubeweb python -m sphinx -T -E -b html -d _build/doctrees -c docs docs/source ${READTHEDOCS_OUTPUT}/html && mamba run --name mxcubeweb redis-cli shutdown"
+    - "mamba run --name mxcubeweb python -m sphinx -T -E -b html -d _build/doctrees -c docs docs/source ${READTHEDOCS_OUTPUT}/html"
 
 
 ...  # EOF

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,4 +13,8 @@
   "[python]": {
     "editor.defaultFormatter": "ms-python.black-formatter"
   }
+  "[yaml]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": false
+  },
 }

--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -1,12 +1,10 @@
 ---
-
 name: mxcubeweb
 
 channels:
   - conda-forge
 
 dependencies:
-
   # ====================
   # Runtime dependencies
   # ====================
@@ -18,8 +16,6 @@ dependencies:
   # with compilation steps that require a compiler and some header files.
   # Installing with conda is much "easier".
   - python-ldap ==3.4.3  # Make sure it matches `poetry.lock`
-
-  - redis-server
 
   # ========================
   # Development dependencies

--- a/mxcubeweb/__init__.py
+++ b/mxcubeweb/__init__.py
@@ -7,7 +7,6 @@ monkey.patch_all(thread=False)
 import argparse  # noqa: E402
 import mock  # noqa: E402
 import os  # noqa: E402
-import redis  # noqa: E402
 import sys  # noqa: E402
 import traceback  # noqa: E402
 
@@ -106,13 +105,6 @@ def parse_args(argv):
 
 def build_server_and_config(test=False, argv=None):
     cmdline_options = parse_args(argv)
-
-    try:
-        db = redis.Redis()
-        db.ping()
-    except redis.RedisError:
-        print("No Redis server is running, exiting")
-        return None, None
 
     try:
         # This refactoring (with other bits) allows you to pass a 'path1:path2' lookup path

--- a/mxcubeweb/app.py
+++ b/mxcubeweb/app.py
@@ -7,7 +7,6 @@ import os
 import sys
 import logging
 import traceback
-import atexit
 import json
 import time
 
@@ -311,12 +310,9 @@ class MXCUBEApplication:
         MXCUBEApplication.harvester = Harvester(MXCUBEApplication, {})
 
         MXCUBEApplication.init_signal_handlers()
-        atexit.register(MXCUBEApplication.app_atexit)
-
         # Install server-side UI state storage
         MXCUBEApplication.init_state_storage()
 
-        # MXCUBEApplication.load_settings()
         msg = "MXCuBE 3 initialized, it took %.1f seconds" % (
             time.time() - MXCUBEApplication.t0
         )
@@ -536,36 +532,3 @@ class MXCUBEApplication:
 
         with open(fname, "w+") as fp:
             json.dump(data, fp)
-
-    @staticmethod
-    def load_settings():
-        """
-        Loads application wide variables from "stored-mxcube-session.json"
-        """
-        with open("/tmp/stored-mxcube-session.json", "r") as f:
-            data = json.load(f)
-
-        MXCUBEApplication.queue.load_queue_from_dict(data.get("QUEUE", {}))
-
-        MXCUBEApplication.CENTRING_METHOD = data.get(
-            "CENTRING_METHOD", queue_entry.CENTRING_METHOD.LOOP
-        )
-        MXCUBEApplication.NODE_ID_TO_LIMS_ID = data.get("NODE_ID_TO_LIMS_ID", {})
-        MXCUBEApplication.SC_CONTENTS = data.get(
-            "SC_CONTENTS", {"FROM_CODE": {}, "FROM_LOCATION": {}}
-        )
-        MXCUBEApplication.SAMPLE_LIST = data.get(
-            "SAMPLE_LIST", {"sampleList": {}, "sampleOrder": []}
-        )
-        MXCUBEApplication.ALLOW_REMOTE = data.get("ALLOW_REMOTE", False)
-        MXCUBEApplication.TIMEOUT_GIVES_CONTROL = data.get(
-            "TIMEOUT_GIVES_CONTROL", False
-        )
-        MXCUBEApplication.AUTO_MOUNT_SAMPLE = data.get("AUTO_MOUNT_SAMPLE", False)
-        MXCUBEApplication.AUTO_ADD_DIFFPLAN = data.get("AUTO_ADD_DIFFPLAN", False)
-        MXCUBEApplication.NUM_SNAPSHOTS = data.get("NUM_SNAPSHOTS", False)
-        MXCUBEApplication.UI_STATE = data.get("UI_STATE", {})
-
-    @staticmethod
-    def app_atexit():
-        MXCUBEApplication.save_settings()

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
 import json
-import pickle as pickle
 import redis
 import itertools
 import logging
@@ -1810,37 +1809,6 @@ class Queue(ComponentBase):
         HWR.beamline.queue_model.clear_model("plate")
         HWR.beamline.queue_model.select_model("ispyb")
 
-    def save_queue(self, session, redis=redis.Redis()):
-        """
-        Saves the current HWR.beamline.queue_model (HWR.beamline.queue_model) into a redis database.
-        The queue that is saved is the pickled result returned by queue_to_dict
-
-        :param session: Session to save queue for
-        :param redis: Redis database
-
-        """
-        proposal_id = getattr(current_user, "proposal", None)
-
-        if proposal_id is not None:
-            # List of samples dicts (containing tasks) sample and tasks have same
-            # order as the in queue HO
-            queue = self.queue_to_dict(HWR.beamline.queue_model.get_model_root())
-            redis.set("self.app.queue:%d" % proposal_id, pickle.dumps(queue))
-
-    def load_queue(self, session, redis=redis.Redis()):
-        """
-        Loads the queue belonging to session <session> into redis db <redis>
-
-        :param session: Session for queue to load
-        :param redis: Redis database
-        """
-        proposal_id = getattr(current_user, "proposal", None)
-
-        if proposal_id is not None:
-            serialized_queue = redis.get("self.app.queue:%d" % proposal_id)
-            queue = pickle.loads(serialized_queue)
-            self.load_queue_from_dict(queue)
-
     def queue_model_child_added(self, parent, child):
         """
         Listen to the addition of elements to the queue model ('child_added').
@@ -2221,12 +2189,7 @@ class Queue(ComponentBase):
         logging.getLogger("MX3.HWR").info(msg)
 
     def set_queue(self, json_queue, session):
-        # Clear queue
-        # HWR.beamline.queue_model = clear_queue()
-
-        # Set new queue
         self.queue_add_item(json_queue)
-        self.save_queue(session)
 
     def queue_update_item(self, sqid, tqid, data):
         model, entry = self.get_entry(tqid)

--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -168,14 +168,6 @@ class BaseUserManager(ComponentBase):
             if not self.app.sample_changer.get_current_sample() and address:
                 self.app.sample_changer.get_sample_list()
 
-            # For the moment not loading queue from persistent storage (redis),
-            # uncomment to enable loading.
-            # self.app.queue.load_queue(session)
-            # logging.getLogger('MX3.HWR').info('Loaded queue')
-            logging.getLogger("MX3.HWR").info(
-                "[QUEUE] %s " % self.app.queue.queue_to_json()
-            )
-
             self.update_operator(new_login=True)
 
             msg = "User %s signed in" % user.username
@@ -191,7 +183,6 @@ class BaseUserManager(ComponentBase):
 
         # If operator logs out clear queue and sample list
         if self.is_operator():
-            self.app.queue.save_queue(flask.session)
             self.app.queue.clear_queue()
             HWR.beamline.sample_view.clear_all()
             self.app.lims.init_sample_list()


### PR DESCRIPTION
This removes the unused functionality to save and load queue and thus the dependency to `Redis`.

I also wanted to edit `conda-environemnt.yml` but that gives me the following `ymllint` errors:

```
12:24     warning  too few spaces before comment  (comments)
18:25     warning  too few spaces before comment  (comments)
24:24     warning  too few spaces before comment  (comments)
25:16     warning  too few spaces before comment  (comments)
```

It somehow seems wrong because the other comments pass ?, I tried to fix it by adding spaces but that did not seem to fix the issue. Does anyone know whats wrong ?

I'm all for tightening up the linting rules, its perhaps because I don't know the rules yet and the `ymllint` tool but as it is now it start to quite annoying to work with.