### PR TITLE
Fix various minor UI issues

### DIFF
--- a/ui/src/components/Main.jsx
+++ b/ui/src/components/Main.jsx
@@ -122,20 +122,20 @@ class Main extends React.Component {
         <Stack className="mb-4" gap={2}>
           <Outlet />
         </Stack>
-        <div className="chat-widget-dragable">
-          <Draggable>
-            <div onClick={this.onChatContainerClick}>
-              {this.props.remoteAccess.observers.length > 0 ? (
+        {this.props.remoteAccess.observers.length > 0 ? (
+          <div className="chat-widget-dragable">
+            <Draggable>
+              <div onClick={this.onChatContainerClick}>
                 <Widget
                   title="Chat"
                   subtitle=""
                   badge={this.props.remoteAccess.chatMessageCount}
                   handleNewUserMessage={this.handleNewUserMessage}
                 />
-              ) : null}
-            </div>
-          </Draggable>
-        </div>
+              </div>
+            </Draggable>
+          </div>
+        ) : null}
       </div>
     );
   }

--- a/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
+++ b/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
@@ -397,7 +397,7 @@ export default class TaskItem extends Component {
                         >
                           <i
                             style={{ marginLeft: '0px' }}
-                            className="fa fa-clipboard"
+                            className="fa fa-copy"
                             aria-hidden="true"
                           />
                         </Button>

--- a/ui/src/components/SampleQueue/TaskItem.jsx
+++ b/ui/src/components/SampleQueue/TaskItem.jsx
@@ -355,7 +355,7 @@ export default class TaskItem extends Component {
                         >
                           <i
                             style={{ marginLeft: '0px' }}
-                            className="fa fa-clipboard"
+                            className="fa fa-copy"
                             aria-hidden="true"
                           />
                         </Button>

--- a/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
+++ b/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
@@ -265,7 +265,7 @@ export default class WorkflowTaskItem extends Component {
                     >
                       <i
                         style={{ marginLeft: '0px' }}
-                        className="fa fa-clipboard"
+                        className="fa fa-copy"
                         aria-hidden="true"
                       />
                     </Button>

--- a/ui/src/components/SampleQueue/app.css
+++ b/ui/src/components/SampleQueue/app.css
@@ -218,7 +218,6 @@
 }
 .task-body button {
   font-weight: bold;
-  border-radius: 0;
   width: 33%;
 }
 .task-information {

--- a/ui/src/containers/BeamlineActionsContainer.jsx
+++ b/ui/src/containers/BeamlineActionsContainer.jsx
@@ -61,6 +61,10 @@ class BeamlineActionsContainer extends React.Component {
 
     const defaultDialogPosition = { x: -100, y: 100 };
 
+    if (this.props.actionsList.length === 0) {
+      return null;
+    }
+
     return (
       <>
         <Dropdown

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -810,8 +810,16 @@ class SampleListViewContainer extends React.Component {
           hide={this.props.confirmClearQueueHide}
         />
         {this.props.loading ? (
-          <div className="center-in-box" style={{ zIndex: 1200 }}>
-            <img src={loader} className="img-centerd img-responsive" alt="" />
+          <div
+            className="center-in-box"
+            style={{ zIndex: 1200, position: 'fixed' }}
+          >
+            <img
+              src={loader}
+              className="img-centerd img-responsive"
+              width="10rem"
+              alt=""
+            />
           </div>
         ) : null}
         <Card className="samples-grid-table-card">

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -901,7 +901,7 @@ class SampleListViewContainer extends React.Component {
                 </Dropdown>
               </Col>
               <Col sm={5} className="d-flex me-auto">
-                <Form>
+                <Form onSubmit={(evt) => evt.preventDefault()}>
                   <Form.Group as={Row} className="d-flex">
                     <Form.Label
                       style={{ whiteSpace: 'nowrap' }}

--- a/ui/src/containers/SampleQueueContainer.js
+++ b/ui/src/containers/SampleQueueContainer.js
@@ -138,7 +138,12 @@ class SampleQueueContainer extends React.Component {
           </Nav>
           {loading ? (
             <div className="center-in-box" style={{ zIndex: '1000' }}>
-              <img src={loader} className="img-responsive" alt="" />
+              <img
+                src={loader}
+                className="img-responsive"
+                width="10rem"
+                alt=""
+              />
             </div>
           ) : null}
           <CurrentTree


### PR DESCRIPTION
- Use correct copy icon for copying paths – fix #1308 
- Restore border radius on copy path buttons

![image](https://github.com/mxcube/mxcubeweb/assets/2936402/9dff03e6-7940-4954-80cd-c03ebeaebe4b)

---

- Hide beamline actions drop-down when empty – fix #1305 

![image](https://github.com/mxcube/mxcubeweb/assets/2936402/d1b01d84-84ca-4e55-83f5-674bec58c771)

---

- Fix size and positioning of spinner on sample list view – fix #1303

![Peek 2024-07-11 13-43](https://github.com/mxcube/mxcubeweb/assets/2936402/09456f80-d92c-40b2-978f-ca43051fd404)

---

- Reduce size of spinner on sample queue

<img src="https://github.com/mxcube/mxcubeweb/assets/2936402/46660566-c796-4e43-9ae2-708312b3592e" alt="" width="400">

---

- Prevent submitting filter form on sample list view – fix #1302 
- Fix chat widget not fully hidden and preventing interactions when there are no observers