### PR TITLE
FIX  #1304 Context menu on samples list stays open

### DIFF
--- a/ui/src/components/GenericContextMenu/MXContextMenu.css
+++ b/ui/src/components/GenericContextMenu/MXContextMenu.css
@@ -1,14 +1,3 @@
-@keyframes fadeIn {
-  0% {
-    opacity: 0;
-    transform: translateY(3rem);
-  }
-  100% {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
 @keyframes fadeOut {
   0% {
     opacity: 1;
@@ -20,10 +9,23 @@
   }
 }
 
+@keyframes growDown {
+  0% {
+    transform: scaleY(0);
+  }
+  80% {
+    transform: scaleY(1.1);
+  }
+  100% {
+    transform: scaleY(1);
+  }
+}
+
 .generic-context-menu {
-  animation: fadeIn 0.2s ease-in-out;
+  animation: growDown 0.2s ease-in-out forwards;
+  transform-origin: top center;
 }
 
 .generic-context-menu-close {
-  animation: fadeOut 0.2s ease-i;
+  animation: fadeOut 0.2s ease-in;
 }

--- a/ui/src/components/GenericContextMenu/MXContextMenu.js
+++ b/ui/src/components/GenericContextMenu/MXContextMenu.js
@@ -12,10 +12,11 @@ export default class MXContextMenu extends React.Component {
 
   componentDidMount() {
     this.showContextMenu(this.props.x, this.props.y);
+    document.addEventListener('click', this.hideContextMenu);
   }
 
   componentWillUnmount() {
-    this.hideContextMenu();
+    document.removeEventListener('click', this.hideContextMenu);
   }
 
   showContextMenu(x, y) {

--- a/ui/src/components/GenericContextMenu/MXContextMenu.js
+++ b/ui/src/components/GenericContextMenu/MXContextMenu.js
@@ -40,6 +40,7 @@ export default class MXContextMenu extends React.Component {
     if (ctxMenu) {
       ctxMenu.classList.add('generic-context-menu-close');
     }
+    this.props.showGenericContextMenu(false, null, 0, 0);
   }
 
   render() {

--- a/ui/src/components/SampleView/ContextMenu.js
+++ b/ui/src/components/SampleView/ContextMenu.js
@@ -9,6 +9,7 @@ export default class ContextMenu extends React.Component {
     super(props);
     this.toggleDrawGrid = this.toggleDrawGrid.bind(this);
     this.menuOptions = this.menuOptions.bind(this);
+    this.hideContextMenu = this.hideContextMenu.bind(this);
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
@@ -17,6 +18,10 @@ export default class ContextMenu extends React.Component {
     } else {
       this.hideContextMenu();
     }
+  }
+
+  componentWillUnmount() {
+    this.hideContextMenu();
   }
 
   // eslint-disable-next-line sonarjs/cognitive-complexity
@@ -496,8 +501,9 @@ export default class ContextMenu extends React.Component {
 
   hideContextMenu() {
     const ctxMenu = document.querySelector('#contextMenu');
-    if (ctxMenu) {
+    if (ctxMenu && this.props.show) {
       ctxMenu.style.display = 'none';
+      this.props.sampleViewActions.showContextMenu(false);
     }
   }
 

--- a/ui/src/components/SampleView/ContextMenu.js
+++ b/ui/src/components/SampleView/ContextMenu.js
@@ -12,6 +12,10 @@ export default class ContextMenu extends React.Component {
     this.hideContextMenu = this.hideContextMenu.bind(this);
   }
 
+  componentDidMount() {
+    document.addEventListener('click', this.hideContextMenu);
+  }
+
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.show) {
       this.showContextMenu(nextProps.x, nextProps.y);
@@ -21,7 +25,7 @@ export default class ContextMenu extends React.Component {
   }
 
   componentWillUnmount() {
-    this.hideContextMenu();
+    document.removeEventListener('click', this.hideContextMenu);
   }
 
   // eslint-disable-next-line sonarjs/cognitive-complexity

--- a/ui/src/containers/SampleGridTableContainer.jsx
+++ b/ui/src/containers/SampleGridTableContainer.jsx
@@ -1296,6 +1296,7 @@ class SampleGridTableContainer extends React.Component {
             show={this.props.contextMenu.show}
             x={this.props.contextMenu.x}
             y={this.props.contextMenu.y}
+            showGenericContextMenu={this.props.showGenericContextMenu}
           >
             {this.renderContextMenu(this.props.contextMenu.id)}
           </MXContextMenu>

--- a/ui/src/containers/SampleGridTableContainer.jsx
+++ b/ui/src/containers/SampleGridTableContainer.jsx
@@ -77,7 +77,6 @@ class SampleGridTableContainer extends React.Component {
     this.onMouseDown = this.onMouseDown.bind(this);
     this.onMouseUp = this.onMouseUp.bind(this);
     this.onMouseMove = this.onMouseMove.bind(this);
-    this.onKeyDown = this.onKeyDown.bind(this);
 
     this.sampleGridItemsSelectedHandler =
       this.sampleGridItemsSelectedHandler.bind(this);
@@ -114,11 +113,6 @@ class SampleGridTableContainer extends React.Component {
     this.unmount = this.unmount.bind(this);
   }
 
-  componentDidMount() {
-    document.addEventListener('keydown', this.onKeyDown, false);
-    document.addEventListener('click', this.onClick, false);
-  }
-
   shouldComponentUpdate(nextProps) {
     return (
       this.props.queue.queue !== nextProps.queue.queue ||
@@ -126,11 +120,6 @@ class SampleGridTableContainer extends React.Component {
         Object.keys(nextProps.sampleList) ||
       this.props.order !== nextProps.order
     );
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('keydown', this.onKeyDown);
-    document.removeEventListener('click', this.onClick);
   }
 
   /**

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -62,7 +62,6 @@ import '../components/SampleGrid/SampleGridTable.css';
 class SampleListViewContainer extends React.Component {
   constructor(props) {
     super(props);
-    this.onMouseDown = this.onMouseDown.bind(this);
     this.syncSamples = this.syncSamples.bind(this);
     this.mutualExclusiveFilterOption =
       this.mutualExclusiveFilterOption.bind(this);
@@ -107,17 +106,6 @@ class SampleListViewContainer extends React.Component {
   componentDidMount() {
     const localStorageViewMode = localStorage.getItem('view-mode');
     this.setViewMode(localStorageViewMode || this.props.viewMode.mode);
-  }
-
-  /**
-   * If Context menu is showed set it to false'
-   *
-   * @param {MouseEvent} e
-   */
-  onMouseDown(e) {
-    if (this.props.contextMenu.show) {
-      this.props.showGenericContextMenu(false, null, 0, 0);
-    }
   }
 
   setViewMode(mode) {
@@ -823,10 +811,7 @@ class SampleListViewContainer extends React.Component {
           </div>
         ) : null}
         <Card className="samples-grid-table-card">
-          <Card.Header
-            onMouseDown={this.onMouseDown}
-            className="samples-grid-table-card-header"
-          >
+          <Card.Header className="samples-grid-table-card-header">
             <Row className="samples-grid-table-row-header">
               <Col sm={5} className="d-flex">
                 <SplitButton


### PR DESCRIPTION
Hide context menu when unmounted  component  