### PR TITLE
Remove Whitespace in queue and adjust layout to fit different sizes

### DIFF
--- a/ui/src/components/SampleQueue/CurrentTree.js
+++ b/ui/src/components/SampleQueue/CurrentTree.js
@@ -146,7 +146,7 @@ export default class CurrentTree extends React.Component {
     }
     return (
       <div>
-        <div style={{ top: 'initial' }} className="list-body">
+        <div style={{ top: '5%', height: '70%' }} className="list-body">
           {sampleTasks.map((taskData, i) => {
             let task = null;
             const displayData = this.props.displayData[taskData.queueID] || {};

--- a/ui/src/components/SampleQueue/app.css
+++ b/ui/src/components/SampleQueue/app.css
@@ -131,6 +131,13 @@
   margin-top: 10px;
   margin-bottom: 10px;
 }
+.queue-nav {
+  height: 5%;
+}
+.queue-nav-link {
+  height: 100%;
+  padding: 0.4em 0 0;
+}
 .list-head {
   padding: 1rem 1rem;
   border: 0px;

--- a/ui/src/containers/SampleQueueContainer.js
+++ b/ui/src/containers/SampleQueueContainer.js
@@ -120,9 +120,10 @@ class SampleQueueContainer extends React.Component {
             defaultActiveKey="current"
             activeKey={visibleList}
             onSelect={this.handleSelect}
+            className="queue-nav"
           >
             <Nav.Item>
-              <Nav.Link eventKey="current">
+              <Nav.Link eventKey="current" className="queue-nav-link">
                 <b>
                   {currentSampleID
                     ? `Sample: ${proteinAcronym} ${sampleName}`
@@ -131,7 +132,7 @@ class SampleQueueContainer extends React.Component {
               </Nav.Link>
             </Nav.Item>
             <Nav.Item>
-              <Nav.Link eventKey="todo">
+              <Nav.Link eventKey="todo" className="queue-nav-link">
                 <b>Queued Samples ({todo.length})</b>
               </Nav.Link>
             </Nav.Item>


### PR DESCRIPTION
This PR closes #1299.
The changes removes an unnecessary whitespace in the queue and adjust queue layout to adjust to different window sizes.
Result:
![Screenshot from 2024-07-12 18-22-06](https://github.com/user-attachments/assets/83e6e686-0151-48fe-badf-0deaf846ac16)
