### PR TITLE
[bug] FIX potential  TypeError :

### DIFF
--- a/mxcubeweb/routes/lims.py
+++ b/mxcubeweb/routes/lims.py
@@ -28,7 +28,9 @@ def init_route(app, server, url_prefix):  # noqa: C901
         try:
             res = jsonify(app.lims.synch_with_lims())
         except Exception as ex:
-            logging.getLogger("MX3.HWR").exception()
+            logging.getLogger("MX3.HWR").exception(
+                "Could not synchronize with LIMS %s" % str(ex)
+            )
             res = (
                 "Could not synchronize with LIMS",
                 409,


### PR DESCRIPTION
the parameter was forgotten when adding the logger. 

To avoid having a 
Logger.exception() missing 1 required positional argument: 'msg' error 

