### PR TITLE
prevent confusing log message

### DIFF
--- a/mxcubeweb/core/components/beamline.py
+++ b/mxcubeweb/core/components/beamline.py
@@ -42,7 +42,6 @@ class Beamline(ComponentBase):
                         "commandReplyArrived",
                         signals.beamline_action_done,
                     )
-                    cmd.connect("commandReady", signals.beamline_action_done)
                     cmd.connect(
                         "commandFailed",
                         signals.beamline_action_failed,


### PR DESCRIPTION
This PR closes #1319. It prevents to call `beamline_actions_done` method to be called after failure resp. to be called twice.