### PR TITLE
Pagination items in system log are now clickable

### DIFF
--- a/ui/src/containers/LoggerContainer.js
+++ b/ui/src/containers/LoggerContainer.js
@@ -49,28 +49,20 @@ export class LoggerContainer extends React.Component {
           >
             <nav>
               <Pagination size="sm" className="pagination">
-                <Pagination.Item>
-                  <span onClick={this.firstPage}>
-                    <span aria-hidden="true">first</span>
-                  </span>
+                <Pagination.Item onClick={this.firstPage}>
+                  <span aria-hidden="true">first</span>
                 </Pagination.Item>
-                <Pagination.Item>
-                  <span onClick={this.backwardPage}>
-                    <span aria-hidden="true">&laquo;</span>
-                  </span>
+                <Pagination.Item onClick={this.backwardPage}>
+                  <span aria-hidden="true">&laquo;</span>
                 </Pagination.Item>
                 <Pagination.Item>
                   <span>{page}</span>
                 </Pagination.Item>
-                <Pagination.Item>
-                  <span onClick={this.forwardPage}>
-                    <span aria-hidden="true">&raquo;</span>
-                  </span>
+                <Pagination.Item onClick={this.forwardPage}>
+                  <span aria-hidden="true">&raquo;</span>
                 </Pagination.Item>
-                <Pagination.Item>
-                  <span onClick={this.lastPage}>
-                    <span aria-hidden="true">last</span>
-                  </span>
+                <Pagination.Item onClick={this.lastPage}>
+                  <span aria-hidden="true">last</span>
                 </Pagination.Item>
               </Pagination>
             </nav>


### PR DESCRIPTION
This PR closes #1318.
Previously only the text inside the buttons was clickable.
Results:
![Log_Navigator_fix](https://github.com/user-attachments/assets/5afb08ec-faa9-4836-a2af-1f0edf156fb1)
