### PR TITLE
add Space Group and Unit Cell parameters to Mesh Scan

### DIFF
--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -1429,7 +1429,7 @@ class Queue(ComponentBase):
         model.set_enabled(task_data["checked"])
         entry.set_enabled(task_data["checked"])
 
-    def _create_dc(self, task):
+    def _create_dc(self):
         """
         Creates a data collection model and its corresponding queue entry from
         a dict with collection parameters.
@@ -1549,7 +1549,7 @@ class Queue(ComponentBase):
         sample_model, sample_entry = self.get_entry(node_id)
         params = task["parameters"]
 
-        refdc_model, refdc_entry = self._create_dc(task)
+        refdc_model, refdc_entry = self._create_dc()
         refdc_model.acquisitions[0].path_template.reference_image_prefix = "ref"
         refdc_model.set_name("refdc")
         char_params = qmo.CharacterisationParameters().set_from_dict(params)
@@ -1596,7 +1596,7 @@ class Queue(ComponentBase):
         :rtype: int
         """
         sample_model, sample_entry = self.get_entry(node_id)
-        dc_model, dc_entry = self._create_dc(task)
+        dc_model, dc_entry = self._create_dc()
         self.set_dc_params(dc_model, dc_entry, task, sample_model)
 
         group_model = qmo.TaskGroup()
@@ -1744,7 +1744,7 @@ class Queue(ComponentBase):
 
         for wedge in task["parameters"]["wedges"]:
             wc = wc + 1
-            dc_model, dc_entry = self._create_dc(wedge)
+            dc_model, dc_entry = self._create_dc()
             self.set_dc_params(dc_model, dc_entry, wedge, sample_model)
 
             # Add wedge prefix to path

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -1094,6 +1094,15 @@ class Queue(ComponentBase):
         params = task_data["parameters"]
         acq.acquisition_parameters.set_from_dict(params)
 
+        processing_params = model.processing_parameters
+        processing_params.space_group = params.get("space_group", "")
+        processing_params.cell_a = params.get("cellA", "")
+        processing_params.cell_alpha = params.get("cellAlpha", "")
+        processing_params.cell_b = params.get("cellB", "")
+        processing_params.cell_beta = params.get("cellBeta", "")
+        processing_params.cell_c = params.get("cellC", "")
+        processing_params.cell_gamma = params.get("cellGamma", "")
+
         ftype = HWR.beamline.detector.get_property("file_suffix")
         ftype = ftype if ftype else ".?"
 
@@ -1616,6 +1625,15 @@ class Queue(ComponentBase):
 
         acq = model.acquisitions[0]
         params = task["parameters"]
+
+        processing_params = model.processing_parameters
+        processing_params.space_group = params.get("space_group", "")
+        processing_params.cell_a = params.get("cellA", "")
+        processing_params.cell_alpha = params.get("cellAlpha", "")
+        processing_params.cell_b = params.get("cellB", "")
+        processing_params.cell_beta = params.get("cellBeta", "")
+        processing_params.cell_c = params.get("cellC", "")
+        processing_params.cell_gamma = params.get("cellGamma", "")
 
         ftype = HWR.beamline.detector.get_property("file_suffix")
         ftype = ftype if ftype else ".?"

--- a/mxcubeweb/routes/mockups.py
+++ b/mxcubeweb/routes/mockups.py
@@ -63,7 +63,7 @@ def init_route(app, server, url_prefix):
         }
 
         sample_model, sample_entry = app.queue.get_entry(sid)
-        dc_model, dc_entry = app.queue._create_dc(task)
+        dc_model, dc_entry = app.queue._create_dc()
         app.queue.set_dc_params(dc_model, dc_entry, task, sample_model)
         pt = dc_model.acquisitions[0].path_template
 

--- a/ui/src/components/Tasks/Mesh.js
+++ b/ui/src/components/Tasks/Mesh.js
@@ -22,6 +22,8 @@ import {
   resetLastUsedParameters,
 } from './fields';
 
+import { SPACE_GROUPS } from '../../constants';
+
 class Mesh extends React.Component {
   constructor(props) {
     super(props);
@@ -188,6 +190,45 @@ class Mesh extends React.Component {
           </Form>
 
           <FieldsHeader title="Processing" />
+          <CollapsableRows>
+            <Form>
+              <SelectField
+                col1="3"
+                col2="3"
+                propName="space_group"
+                label="Space group"
+                list={SPACE_GROUPS}
+              />
+              <Form.Label className="mb-2 mt-3">
+                <b> Unit Cell: </b>
+              </Form.Label>
+              <FieldsRow>
+                <InputField col1="1" col2="5" propName="cellA" label="a" />
+                <InputField col1="1" col2="5" propName="cellB" label="b" />
+                <InputField col1="1" col2="5" propName="cellC" label="c" />
+              </FieldsRow>
+              <FieldsRow>
+                <InputField
+                  col1="1"
+                  col2="5"
+                  propName="cellAlpha"
+                  label="&alpha;"
+                />
+                <InputField
+                  col1="1"
+                  col2="5"
+                  propName="cellBeta"
+                  label="&beta;"
+                />
+                <InputField
+                  col1="1"
+                  col2="5"
+                  propName="cellGamma"
+                  label="&gamma;"
+                />
+              </FieldsRow>
+            </Form>
+          </CollapsableRows>
         </Modal.Body>
         {this.props.taskData.state ? (
           ''


### PR DESCRIPTION
Adds support for specifying **Space Group** and **Unit Cell** parameters for mesh scans.

Add the UI fields to Mesh Scan dialog, see the screen shot below. Propagate the user specified parameters to the queue task model.

Also include a small cleanup, where an unused `task` parameter for `app.queue._create_dc()` is removed.

![image](https://github.com/user-attachments/assets/8238dde9-7503-48d1-991b-3f0eced4d584)

