### PR TITLE
Adjust SampleView for different window sizes

### DIFF
--- a/ui/src/components/SampleQueue/CurrentTree.js
+++ b/ui/src/components/SampleQueue/CurrentTree.js
@@ -146,7 +146,7 @@ export default class CurrentTree extends React.Component {
     }
     return (
       <div>
-        <div style={{ top: '5%', height: '70%' }} className="list-body">
+        <div style={{ top: '6%', height: '69%' }} className="list-body">
           {sampleTasks.map((taskData, i) => {
             let task = null;
             const displayData = this.props.displayData[taskData.queueID] || {};

--- a/ui/src/components/SampleQueue/TodoTree.js
+++ b/ui/src/components/SampleQueue/TodoTree.js
@@ -52,6 +52,7 @@ export default class TodoTree extends React.Component {
               className="form-control"
               placeholder="Search Upcoming"
               onChange={this.setSearchWord}
+              style={{ width: '90%' }}
             />
           </div>
           <div>

--- a/ui/src/components/SampleQueue/app.css
+++ b/ui/src/components/SampleQueue/app.css
@@ -132,7 +132,7 @@
   margin-bottom: 10px;
 }
 .queue-nav {
-  height: 5%;
+  height: 6%;
 }
 .queue-nav-link {
   height: 100%;

--- a/ui/src/components/SampleView/SampleControls.module.css
+++ b/ui/src/components/SampleView/SampleControls.module.css
@@ -14,6 +14,12 @@
   min-width: 60px;
 }
 
+@media (max-width: 1400px) {
+  .controls > .controlWrapper {
+    max-width: 60px;
+  }
+}
+
 .controlWrapper {
   position: relative;
 }

--- a/ui/src/containers/SampleViewContainer.js
+++ b/ui/src/containers/SampleViewContainer.js
@@ -36,6 +36,8 @@ import {
 import { stopBeamlineAction } from '../actions/beamlineActions';
 import { find } from 'lodash';
 
+import styles from './SampleViewContainer.module.css';
+
 class SampleViewContainer extends Component {
   constructor(props) {
     super(props);
@@ -125,7 +127,7 @@ class SampleViewContainer extends Component {
           </Col>
         </Row>
         <Row className="gx-3 mt-2 pt-1">
-          <Col sm={1}>
+          <Col sm={2} xxl={1} className={styles.controllers}>
             <DefaultErrorBoundary>
               <div>
                 <p className="motor-name">Phase Control:</p>
@@ -253,7 +255,12 @@ class SampleViewContainer extends Component {
               />
             </DefaultErrorBoundary>
           </Col>
-          <Col sm={5} style={{ display: 'flex' }}>
+          <Col
+            sm={4}
+            xxl={5}
+            className={styles.queue}
+            style={{ display: 'flex' }}
+          >
             <DefaultErrorBoundary>
               <SampleQueueContainer />
             </DefaultErrorBoundary>

--- a/ui/src/containers/SampleViewContainer.module.css
+++ b/ui/src/containers/SampleViewContainer.module.css
@@ -1,0 +1,8 @@
+@media screen and (min-width: 1300px) and (max-width: 1920px) {
+  .controllers {
+    width: 12%;
+  }
+  .queue {
+    width: 38%;
+  }
+}


### PR DESCRIPTION
This PR gradually increase the screen proportion of the motors for smaller screens and decreases the proportion of the queue. It also includes some smaller adjustment to queue head elements and sample control buttons. Previously the video would overlap parts of the motor controls on smaller screens. 
This had some smaller issues:
 - the alignment of the motor arrow controls was disrupted
 - Some parts were less visible
 - Buttons were partially unclickable/ which might also be an issue for possible e2e tests

Below you can compare the changes at different screen sizes:
Before:
![small-before](https://github.com/user-attachments/assets/ee4dd6b4-cd57-4bfc-ade3-9f86fcca38fa)
![medium-before1](https://github.com/user-attachments/assets/c43d7f40-68c1-41b0-b668-edce1c662b28)
![big-before](https://github.com/user-attachments/assets/96af71ac-9c11-4143-9812-55ed5b1b7e62)

Now:
![small-now](https://github.com/user-attachments/assets/acd44a80-f76b-4c24-8711-7d2029cd0d9c)
![medium-now](https://github.com/user-attachments/assets/18833035-48db-48b2-9f33-243aa2992406)
![big-now](https://github.com/user-attachments/assets/f5e4ccb8-cbb1-4da7-b578-6426f31e1591)

