### PR TITLE
set dynamic queue entry origin to 'MX3'

### DIFF
--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -1470,7 +1470,11 @@ class Queue(ComponentBase):
 
         entry = entry_cls(Mock(), entry_cls.QMO(task_data=data))
         entry.set_enabled(True)
-        return entry.get_data_model(), entry
+
+        model = entry.get_data_model()
+        model.set_origin(ORIGIN_MX3)
+
+        return model, entry
 
     def _create_wf(self, task):
         """


### PR DESCRIPTION
When creating model object for dynamic queue entries, set the origin to 'MX3', same origin as the static queue entries. This way dynamic queue entries are handles the same way as static queue entries in Queue.queue_model_child_added() method.

If we don't set the origin, we'll get following error when adding dynamic queue entries:
```

Traceback (most recent call last):
  File "/<...>/mxcubecore/dispatcher.py", line 27, in __my_robust_apply
    return robustapply._robust_apply(*args, **kwargs)
  File "/<...>/lib/python3.10/site-packages/pydispatch/robustapply.py", line 55, in robustApply
    return receiver(*arguments, **named)
  File "/<...>/mxcubeweb/core/components/queue.py", line 1828, in queue_model_child_added
    self.enable_entry(parent_entry, True)
  File "/<...>/mxcubeweb/core/components/queue.py", line 843, in enable_entry
    model, entry = self.get_entry(id_or_qentry)
  File "/<...>/mxcubeweb/core/components/queue.py", line 788, in get_entry
    model = HWR.beamline.queue_model.get_node(int(_id))
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```