### PR TITLE
Remove undefined elements in ContextMenu

### DIFF
--- a/ui/src/components/SampleView/ContextMenu.js
+++ b/ui/src/components/SampleView/ContextMenu.js
@@ -512,6 +512,10 @@ export default class ContextMenu extends React.Component {
   }
 
   listOptions(type) {
+    if (type.text === undefined) {
+      return undefined;
+    }
+
     let el = (
       <Dropdown.Item key={`${type.key}_${type.text}`} onClick={type.action}>
         {type.text}


### PR DESCRIPTION
This PR closes #1300.
It prevents undefined dropdown elements to be shown as placeholders in the dropdown menu.