### PR TITLE
queue: read precision setting via PathTemplate class

### DIFF
--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -1104,9 +1104,7 @@ class Queue(ComponentBase):
         acq.path_template.start_num = params["first_image"]
         acq.path_template.num_files = params["num_images"]
         acq.path_template.suffix = ftype
-        acq.path_template.precision = "0" + str(
-            HWR.beamline.session["file_info"].get_property("precision", 4)
-        )
+        acq.path_template.precision = "0" + str(qmo.PathTemplate.precision)
 
         self.app.lims.apply_template(params, sample_model, acq.path_template)
 


### PR DESCRIPTION
Accessing session precision config via 'session["file_info"]' syntax is not supported when YAML configuration file is used. Use the PathTemplate class instead.

Without this change, it's not possible to add vanilla data collection tasks to the queue, when Session HWOBJ is configured with a YAML file.