### PR TITLE
Prevent error from holding ctrl on 2D points

### DIFF
--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -511,23 +511,6 @@ export default class SampleImage extends React.Component {
 
     this.drawGridPlugin.clearMouseOverGridLabel(this.canvas);
 
-    if (option.target && option.target.type === 'activeSelection') {
-      const group = this.canvas.getActiveObject();
-      const clickPoint = new fabric.Point(option.e.offsetX, option.e.offsetY);
-
-      // Important to call this for containsPoint to work properly
-      // this.canvas.discardActiveObject();
-
-      group.getObjects().forEach((obj) => {
-        if (!objectFound && obj.containsPoint(clickPoint) && obj.selectable) {
-          objectFound = obj;
-        } else {
-          // this.deSelectShape([obj], option.e.ctrlKey);
-        }
-      });
-    } else if (option.target) {
-      objectFound = option.target;
-    }
     const {
       sampleViewActions,
       clickCentring,
@@ -553,6 +536,19 @@ export default class SampleImage extends React.Component {
     } else if (this.props.drawGrid) {
       this.drawGridPlugin.startDrawing(option, this.canvas, imageRatio);
     } else if (option.target && !(option.e.shiftKey || option.e.ctrlKey)) {
+      if (option.target.type === 'activeSelection') {
+        const group = this.canvas.getActiveObject();
+        const clickPoint = new fabric.Point(option.e.offsetX, option.e.offsetY);
+
+        group.getObjects().forEach((obj) => {
+          if (!objectFound && obj.containsPoint(clickPoint) && obj.selectable) {
+            objectFound = obj;
+          }
+        });
+      } else {
+        objectFound = option.target;
+      }
+
       const shapeData = this.drawGridPlugin.setPixelsPerMM(
         this.props.pixelsPerMm,
         this.props.shapes[objectFound.id],


### PR DESCRIPTION
This PR closes #1301.
By catching the error that is thrown from an undefined function (undefined because of no previously selected points), we can ensure the correct behavior for selecting multiple points on the canvas element. See result below:
![multiple_click_fix](https://github.com/user-attachments/assets/703e740f-d4d8-409f-9810-95b6a6d310f4)
