### PR TITLE
Aperture changes

### DIFF
--- a/mxcubeweb/routes/signals.py
+++ b/mxcubeweb/routes/signals.py
@@ -646,6 +646,7 @@ def beam_changed(*args, **kwargs):
         "shape": "",
         "size_x": 0,
         "size_y": 0,
+        "aperture": 0,
     }
     _beam = beam_info.get_value()
     beam_info_dict.update(
@@ -654,6 +655,7 @@ def beam_changed(*args, **kwargs):
             "size_x": _beam[0],
             "size_y": _beam[1],
             "shape": _beam[2].value,
+            "aperture": _beam[3],
         }
     )
     try:

--- a/mxcubeweb/routes/signals.py
+++ b/mxcubeweb/routes/signals.py
@@ -646,7 +646,7 @@ def beam_changed(*args, **kwargs):
         "shape": "",
         "size_x": 0,
         "size_y": 0,
-        "aperture": 0,
+        "label": 0,
     }
     _beam = beam_info.get_value()
     beam_info_dict.update(
@@ -655,7 +655,7 @@ def beam_changed(*args, **kwargs):
             "size_x": _beam[0],
             "size_y": _beam[1],
             "shape": _beam[2].value,
-            "aperture": _beam[3],
+            "label": _beam[3],
         }
     )
     try:

--- a/ui/src/reducers/sampleview.js
+++ b/ui/src/reducers/sampleview.js
@@ -129,6 +129,7 @@ function sampleViewReducer(state = INITIAL_STATE, action = {}) {
         beamPosition: action.info.position,
         beamShape: action.info.shape,
         beamSize: { x: action.info.size_x, y: action.info.size_y },
+        currentAperture: action.info.aperture,
       };
     }
     case 'SET_CURRENT_PHASE': {

--- a/ui/src/reducers/sampleview.js
+++ b/ui/src/reducers/sampleview.js
@@ -129,7 +129,7 @@ function sampleViewReducer(state = INITIAL_STATE, action = {}) {
         beamPosition: action.info.position,
         beamShape: action.info.shape,
         beamSize: { x: action.info.size_x, y: action.info.size_y },
-       currentAperture: action.info.label,
+        currentAperture: action.info.label,
       };
     }
     case 'SET_CURRENT_PHASE': {

--- a/ui/src/reducers/sampleview.js
+++ b/ui/src/reducers/sampleview.js
@@ -129,7 +129,7 @@ function sampleViewReducer(state = INITIAL_STATE, action = {}) {
         beamPosition: action.info.position,
         beamShape: action.info.shape,
         beamSize: { x: action.info.size_x, y: action.info.size_y },
-        currentAperture: action.info.aperture,
+       currentAperture: action.info.label,
       };
     }
     case 'SET_CURRENT_PHASE': {


### PR DESCRIPTION
Small fixes:
- When the aperture changes outside mxcube (via MD application) the ui was not getting the most recent value
- When the aperture changes in mxcube, the beam size drawn in the canvas had wrong unit (resulting in the beam not being displayed)
   - this one is making me crazy, is it only me seeing this? It seems there is a unit mismatch (ApertureInput components expects '5', '50' whereas the `makeImageOverlay` has to divide that by 1000...)