### PR TITLE
Fix two React errors

### DIFF
--- a/ui/src/components/Equipment/SampleChanger.jsx
+++ b/ui/src/components/Equipment/SampleChanger.jsx
@@ -42,7 +42,7 @@ function renderSampleChangerTreeNode(props) {
   const inputId = getUniqueId();
 
   return (
-    <div>
+    <div key={props.label}>
       <li className={styles.treeLi}>
         <input // eslint-disable-line jsx-a11y/control-has-associated-label
           type="checkbox"

--- a/ui/src/reducers/sampleGrid.js
+++ b/ui/src/reducers/sampleGrid.js
@@ -32,8 +32,7 @@ const INITIAL_STATE = {
     notCollected: false,
     cellFilter: '',
     puckFilter: '',
-    limsFilter: false,
-    useFilter: false,
+    limsSamples: false,
   },
 };
 


### PR DESCRIPTION
Fixing two React errors that became more visible with `redux-logger` disabled:

1. Missing `key` in `SampleChanger`
2. Checkbox going from uncontrolled to controlled in `SampleListViewContainer` when syncing with LIMS (`checked` prop going from `undefined` to defined due to a mismatch between the component code and the Redux store).