### PR TITLE
Make checkboxes clickable

### DIFF
--- a/ui/src/containers/QueueSettings.jsx
+++ b/ui/src/containers/QueueSettings.jsx
@@ -80,6 +80,7 @@ class QueueSettings extends React.Component {
               onChange={this.autoMountNextOnClick}
               checked={this.props.queueState.autoMountNext}
               label="Automount next sample"
+              id="auto-mount-next"
             />
           </Dropdown.Item>
           <Dropdown.Item>
@@ -91,6 +92,7 @@ class QueueSettings extends React.Component {
                 this.props.queueState.centringMethod === AUTO_LOOP_CENTRING
               }
               label="Auto loop centring"
+              id="auto-loop-centring"
             />
           </Dropdown.Item>
           <Dropdown.Item>
@@ -100,6 +102,7 @@ class QueueSettings extends React.Component {
               onChange={this.setAutoAddDiffPlan}
               checked={this.props.queueState.autoAddDiffplan}
               label="Auto add diffraction plan"
+              id="auto-add-diff-plan"
             />
           </Dropdown.Item>
           <Dropdown.Item>
@@ -114,6 +117,7 @@ class QueueSettings extends React.Component {
               }}
               checked={this.props.queueState.rememberParametersBetweenSamples}
               label="Remember parameters between samples"
+              id="remember-params"
             />
           </Dropdown.Item>
           <Dropdown.Divider />

--- a/ui/src/containers/RemoteAccessContainer.jsx
+++ b/ui/src/containers/RemoteAccessContainer.jsx
@@ -1,81 +1,57 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
-
 import { Container, Card, Form, Row, Col } from 'react-bootstrap';
-
-import RequestControlForm from '../components/RemoteAccess/RequestControlForm';
-import UserList from '../components/RemoteAccess/UserList';
+import { useDispatch, useSelector } from 'react-redux';
 
 import {
   updateAllowRemote,
   updateTimeoutGivesControl,
 } from '../actions/remoteAccess';
+import RequestControlForm from '../components/RemoteAccess/RequestControlForm';
+import UserList from '../components/RemoteAccess/UserList';
 
-export class RemoteAccessContainer extends React.Component {
-  getRAOptions() {
-    return (
-      <Col sm={4}>
-        <Card className="mb-3">
-          <Card.Header>RA Options</Card.Header>
-          <Card.Body>
-            <Form.Check
-              type="checkbox"
-              onChange={(e) => this.props.updateAllowRemote(e.target.checked)}
-              checked={this.props.remoteAccess.allowRemote}
-              label="Enable remote access"
-            />
-            <Form.Check
-              type="checkbox"
-              onChange={(e) =>
-                this.props.updateTimeoutGivesControl(e.target.checked)
-              }
-              checked={this.props.remoteAccess.timeoutGivesControl}
-              label="Timeout gives control"
-            />
-          </Card.Body>
-        </Card>
-      </Col>
-    );
-  }
+function RemoteAccessContainer() {
+  const dispatch = useDispatch();
 
-  render() {
-    return (
-      <Container fluid className="mt-4">
-        <Row sm={12} className="d-flex">
-          {!this.props.login.user.inControl ? (
-            <Col sm={4} className="col-xs-4">
-              <RequestControlForm />
-            </Col>
-          ) : null}
-          <Col sm={4} className="mb-3">
-            <UserList />
+  const remoteAccess = useSelector((state) => state.remoteAccess);
+  const inControl = useSelector((state) => state.login.user.inControl);
+
+  return (
+    <Container fluid className="mt-4">
+      <Row sm={12} className="d-flex">
+        {!inControl && (
+          <Col sm={4} className="col-xs-4">
+            <RequestControlForm />
           </Col>
-          {this.getRAOptions()}
-        </Row>
-      </Container>
-    );
-  }
+        )}
+        <Col sm={4} className="mb-3">
+          <UserList />
+        </Col>
+        <Col sm={4}>
+          <Card className="mb-3">
+            <Card.Header>Options</Card.Header>
+            <Card.Body>
+              <Form.Check
+                type="checkbox"
+                onChange={(e) => dispatch(updateAllowRemote(e.target.checked))}
+                checked={remoteAccess.allowRemote}
+                label="Enable remote access"
+                id="allow-remote"
+              />
+              <Form.Check
+                type="checkbox"
+                onChange={(e) =>
+                  dispatch(updateTimeoutGivesControl(e.target.checked))
+                }
+                checked={remoteAccess.timeoutGivesControl}
+                label="Timeout gives control"
+                id="timeout-gives-control"
+              />
+            </Card.Body>
+          </Card>
+        </Col>
+      </Row>
+    </Container>
+  );
 }
 
-function mapStateToProps(state) {
-  return {
-    remoteAccess: state.remoteAccess,
-    login: state.login,
-  };
-}
-
-function mapDispatchToProps(dispatch) {
-  return {
-    updateAllowRemote: bindActionCreators(updateAllowRemote, dispatch),
-    updateTimeoutGivesControl: bindActionCreators(
-      updateTimeoutGivesControl,
-      dispatch,
-    ),
-  };
-}
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(RemoteAccessContainer);
+export default RemoteAccessContainer;


### PR DESCRIPTION
Fix #1279 

Bootstrap's `<Form.Check>` with a `label` prop requires an `id` for the label to be properly associated with the checkbox and become clickable. This is now fixed for checkboxes in the remote access options and queue settings .

<details>
<summary>Reverted changes</summary>

On `localhost` or `127.0.0.1`, I match the server's behaviour (cf. `usermanager.py`, [line 390](https://github.com/mxcube/mxcubeweb/blob/develop/mxcubeweb/core/components/user/usermanager.py#L390)) by forcing the checkbox to be ticked and by disabling it so it can't be unticked:

![image](https://github.com/user-attachments/assets/d2dd3e4a-b06a-409a-81c0-7da72c2fd2cb)

For completeness, I also change the `/ra/allow_remote` endpoint to respond with a 400 when the client is on localhost (whether trying to enable to disable remote access; either way it doesn't make sense to call the endpoint since the setting is ignored).

</details>