### PR TITLE
fix wrong json format for automount and autoadddiffplan

### DIFF
--- a/mxcubeweb/routes/queue.py
+++ b/mxcubeweb/routes/queue.py
@@ -325,11 +325,10 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.require_control
     @server.restrict
     def set_autmount():
-        automount = request.get_json()
-        app.queue.set_auto_mount_sample(automount)
-        resp = jsonify({"automount": automount})
+        data = request.get_json()
+        app.queue.set_auto_mount_sample(data.get("automount", False))
+        resp = jsonify(data)
         resp.status_code = 200
-
         return resp
 
     @bp.route("/num_snapshots", methods=["PUT"])
@@ -366,9 +365,9 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.require_control
     @server.restrict
     def set_autoadd():
-        autoadd = request.get_json()
-        app.queue.set_auto_add_diffplan(autoadd)
-        resp = jsonify({"auto_add_diffplan": autoadd})
+        data = request.get_json()
+        app.queue.set_auto_add_diffplan(data.get("autoadddiffplan", False))
+        resp = jsonify(data)
         resp.status_code = 200
         return resp
 

--- a/test/test_queue_routes.py
+++ b/test/test_queue_routes.py
@@ -454,7 +454,7 @@ def test_set_automount(client):
 
     resp = client.post(
         "/mxcube/api/v0.1/queue/automount",
-        data=json.dumps(True),
+        data=json.dumps({"automount": True}),
         content_type="application/json",
     )
     assert resp.status_code == 200 and json.loads(resp.data).get("automount") == True
@@ -484,10 +484,9 @@ def test_set_group_folder(client):
 def test_set_autoadd(client):
     resp = client.post(
         "/mxcube/api/v0.1/queue/auto_add_diffplan",
-        data=json.dumps(True),
+        data=json.dumps({"autoadddiffplan": True}),
         content_type="application/json",
     )
     assert (
-        resp.status_code == 200
-        and json.loads(resp.data).get("auto_add_diffplan") == True
+        resp.status_code == 200 and json.loads(resp.data).get("autoadddiffplan") == True
     )

--- a/ui/src/actions/queue.js
+++ b/ui/src/actions/queue.js
@@ -498,7 +498,7 @@ export function setAutoAddDiffPlan(autoadddiffplan) {
   return async (dispatch) => {
     try {
       const json = await sendSetAutoAddDiffPlan(autoadddiffplan);
-      const a = json.auto_add_diffplan;
+      const a = json.autoadddiffplan;
       dispatch(setAutoAddDiffPlanAction(a));
     } catch {
       dispatch(showErrorPanel(true, 'Could not set/unset automount'));

--- a/ui/src/api/queue.js
+++ b/ui/src/api/queue.js
@@ -61,11 +61,11 @@ export function sendMoveTask(sampleID, oldIndex, newIndex) {
 }
 
 export function sendSetAutoMountSample(automount) {
-  return endpoint.post(automount, '/automount').json();
+  return endpoint.post({ automount }, '/automount').json();
 }
 
 export function sendSetAutoAddDiffPlan(autoadddiffplan) {
-  return endpoint.post(autoadddiffplan, '/auto_add_diffplan').json();
+  return endpoint.post({ autoadddiffplan }, '/auto_add_diffplan').json();
 }
 
 export function sendSetNumSnapshots(numSnapshots) {


### PR DESCRIPTION
I was getting:

```
415 Unsupported Media Type: Did not attempt to load JSON data because the request Content-Type was not 'application/json'.
```

When setting "Automount next sample" and "Auto add diff plan" in the queue settings