### PR TITLE
Fixed name string in HelpContainer

### DIFF
--- a/ui/src/containers/HelpContainer.jsx
+++ b/ui/src/containers/HelpContainer.jsx
@@ -41,7 +41,8 @@ export class HelpContainer extends React.Component {
           </Card.Header>
           <Card.Body>
             <span>
-              Name: `${givenName} ${familyName}`<br />
+              Name: {givenName} {familyName}
+              <br />
               Email: {email}
               <br />
               Tel: {tel} <br />


### PR DESCRIPTION
The name string contained  the unnecessary variable substitution syntax and was rendered \`$ name name \`$