### PR TITLE
Run Cypress locally against dev server

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -137,6 +137,8 @@ jobs:
 
       - name: Run Cypress
         run: "${MAMBA_EXE} run --name mxcubeweb pnpm --prefix ui e2e"
+        env:
+          CYPRESS_BASE_URL: http://127.0.0.1:8081
 
       - uses: actions/upload-artifact@v3
         if: failure()

--- a/docs/source/dev/environment.md
+++ b/docs/source/dev/environment.md
@@ -159,7 +159,7 @@ _The output should look something like the following:_
 
 #### 9.2. Running the front-end development server
 
-The front end development server, listens for changes on the filesystem and builds (re-builds) the UI when a change is made.
+The front-end development server, listens for changes on the filesystem and builds (re-builds) the UI when a change is made.
 This makes it very easy and fast to see how a change affects the UI and makes debugging much easier.
 The development server listens on port **5173**
 
@@ -171,19 +171,20 @@ conda activate mxcubeweb
 mxcubeweb-server -r $(pwd)/mxcubeweb/test/HardwareObjectsMockup.xml/ --static-folder $(pwd)/mxcubeweb/ui/build/ --log-level debug
 
 # In another terminal, from the root directory of `mxcubeweb`
-pnpm --prefix ui run start
+pnpm --prefix ui start
 ```
 
 The above will automatically open a browser with the URL: <http://localhost:5173>
 
 #### 9.3. Running the end to end (e2e) tests
 
+Keep both the backend and front-end servers running then run the following command in a third terminal, from the root directory of the project:
+
 ```
-# Keep the backend running, and in another terminal from the root directory of `mxcubeweb`:
-pnpm --prefix ui run e2e
+pnpm --prefix ui e2e
 ```
 
-_This should give a result looking something like:_
+The result should look like this:
 ![cypress](assets/cypress.png)
 
 #### 9.4. Ready to develop

--- a/docs/source/dev/front-end.md
+++ b/docs/source/dev/front-end.md
@@ -13,7 +13,7 @@ The front-end package manager is [pnpm](https://pnpm.io/):
 - `pnpm dlx <pkg-name>` - fetch a package from the registry and run its default
   command binary (equivalent to `npx <pkg-name>`)
 
-> You can run all `pnpm` commands above from the root of the repository with `pnpm --prefix ui <cmd>`.
+> You can run all `pnpm` commands from the root of the repository with `pnpm --prefix ui <cmd>`.
 
 [Vite](https://vitejs.dev/) is used to build the project for production:
 

--- a/docs/source/dev/tests.md
+++ b/docs/source/dev/tests.md
@@ -3,8 +3,9 @@
 Testing is a crucial aspect of software development that ensures the reliability, quality, and performance of an application. Additionally, testing facilitates better code design and architecture by encouraging modular and decoupled code. Hence, this document will focus on the different testing frameworks used in this project, explain how to correctly use them and how to contribute to the testing environment.
 
 The tests in this project include two different frameworks, namely [pytest](https://pytest.org/) and [cypress](https://www.cypress.io). The focus of both testing frameworks is slightly different:
- - `pytest` focuses on testing Python code. In the case of MXCuBE-Web the Python code is the back-end server side of the application
- - `cypress` is used for e2e tests. These tests should cover the application's workflow from the user's perspective. They simulate user interaction with the application's interface and ensure the correct functionality of features, integration of components, and overall user experience.
+
+- `pytest` focuses on testing Python code. In the case of MXCuBE-Web the Python code is the back-end server side of the application
+- `cypress` is used for e2e tests. These tests should cover the application's workflow from the user's perspective. They simulate user interaction with the application's interface and ensure the correct functionality of features, integration of components, and overall user experience.
 
 ## Prerequirements
 
@@ -28,15 +29,12 @@ The output should be similar to the following:
 
 ## E2E Tests (Cypress)
 
-The e2e tests are located in the `ui/cypress/e2e` folder and consists of multiple specs represented each by one file. The specs are designed to each contain the tests to their respective component. One exception is the `app.cy.js` which also includes tests regarding login.
+The E2E tests are located in the `ui/cypress/e2e` folder and consist of multiple specs represented each by one file. The specs are designed to each contain the tests to their respective component. One exception is the `app.cy.js` which also includes tests regarding login.
 
-To run all the tests consecutavely in a headless browser environment, you can use the following command:
+To run all the tests consecutively in a headless browser environment, start both the backend and front-end servers in separate terminals, and then run the following command from the root of the project:
 
 ```
-# Make sure to run this from the root of the project
-cd mxcubeweb
-
-pnpm --prefix ui run e2e
+pnpm --prefix ui e2e
 ```
 
 This should give you a result similar to this:
@@ -45,16 +43,20 @@ This should give you a result similar to this:
 
 The default browser for this process is chosen to be [Firefox](https://www.mozilla.org/en-US/firefox/new/).
 
-Another possibility is to use the [cypress app](https://www.cypress.io/app) to run the tests. This gives you some additional possibilities such as choosing the browser environment, run only specific specs or using an interactive debugging mode. To run the cypress app, you can run the following command:
+Another possibility is to use the [Cypress App](https://www.cypress.io/app) to run the tests. This gives you some additional possibilities such as choosing the browser environment, run only specific specs or using an interactive debugging mode. To run the Cypress App, run the following command:
 
 ```
-# Make sure to run this from the root of the project
-cd mxcubeweb
-
-pnpm --prefix ui run cypress
+pnpm --prefix ui cypress
 ```
 
 ![cypress_app](assets/cypress_client.png)
+
+If you'd like to run Cypress against the front-end production build of MXCuBE-Web, like in the CI, run the following:
+
+```
+pnpm --prefix ui build
+CYPRESS_BASE_URL="http://127.0.0.1:8081" pnpm --prefix ui e2e
+```
 
 ### Best Practices
 
@@ -84,9 +86,9 @@ The cypress tests are configured to act according to human behavior, hence durin
 
 Contribution to the testing environment is always welcomed and appreciated. To do so please follow a few simple guidelines:
 
- - Follow the test structure and add your tests to the corresponding spec or add a spec if necessary
- ![Structure](assets/cypress_structure.png)
-    The current structure envisages to use one spec for every larger component in the project, for example the queue or the sample controls field. Each spec then contains smaller group of tests for each functionality, this could be the 3-click-centring method of the sample control field or the login feature for instance. Each group of tests is restricted by the same `beforEach` and `afterEach` part which can help to prepare for everything that is needed for the tests (i.e. navigating to the correct page, remove observer mode, etc...)
- - Use an approach that simulates human behavior. This includes the preference of using function like `cy.findByText` or `cy.findByRole` over functions like `cy.get` (Use the latter only when there is no other possibility) as well as using a clicking procedure rather than using the api directly.
- - Make sure that your tests do not run in _Observer mode_ when accessing elements by using `cy.takeControl()`. Your test might not run in _Observer mode_ when called seperately, but when running in a spec of a few tests, this might be possible.
- - To keep the codebase tidy, you can add auxiliary functions in `ui/cypress/support.js`. These commands are used for clicking procedures that will be repeated by many different tests for example login, or sample mounting. Feel free to add necessary helper functions and check out the current commands.
+- Follow the test structure and add your tests to the corresponding spec or add a spec if necessary
+  ![Structure](assets/cypress_structure.png)
+  The current structure envisages to use one spec for every larger component in the project, for example the queue or the sample controls field. Each spec then contains smaller group of tests for each functionality, this could be the 3-click-centring method of the sample control field or the login feature for instance. Each group of tests is restricted by the same `beforEach` and `afterEach` part which can help to prepare for everything that is needed for the tests (i.e. navigating to the correct page, remove observer mode, etc...)
+- Use an approach that simulates human behavior. This includes the preference of using function like `cy.findByText` or `cy.findByRole` over functions like `cy.get` (Use the latter only when there is no other possibility) as well as using a clicking procedure rather than using the api directly.
+- Make sure that your tests do not run in _Observer mode_ when accessing elements by using `cy.takeControl()`. Your test might not run in _Observer mode_ when called seperately, but when running in a spec of a few tests, this might be possible.
+- To keep the codebase tidy, you can add auxiliary functions in `ui/cypress/support.js`. These commands are used for clicking procedures that will be repeated by many different tests for example login, or sample mounting. Feel free to add necessary helper functions and check out the current commands.

--- a/ui/cypress.config.js
+++ b/ui/cypress.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    baseUrl: 'http://127.0.0.1:8081',
+    baseUrl: 'http://localhost:5173',
     supportFile: 'cypress/support.js',
     screenshotsFolder: 'cypress/debug',
   },


### PR DESCRIPTION
Previously, one had to rebuild the front-end with `pnpm --prefix ui build` on every change for Cypress to "see them", which made it tedious to debug failing tests.