### PR TITLE
Improve wait dialog

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -59,10 +59,14 @@
     "wretch": "2.7.0"
   },
   "devDependencies": {
+    "@babel/preset-react": "7.24.7",
     "@testing-library/cypress": "10.0.1",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",
+    "@types/react": "17.0.60",
+    "@types/react-dom": "17.0.20",
+    "@types/react-redux": "7.1.33",
     "@vitejs/plugin-react-swc": "3.7.0",
     "cypress": "13.13.2",
     "eslint": "8.42.0",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
         specifier: 2.7.0
         version: 2.7.0
     devDependencies:
+      '@babel/preset-react':
+        specifier: 7.24.7
+        version: 7.24.7(@babel/core@7.21.4)
       '@testing-library/cypress':
         specifier: 10.0.1
         version: 10.0.1(cypress@13.13.2)
@@ -135,6 +138,15 @@ importers:
       '@testing-library/user-event':
         specifier: ^13.5.0
         version: 13.5.0(@testing-library/dom@9.3.3)
+      '@types/react':
+        specifier: 17.0.60
+        version: 17.0.60
+      '@types/react-dom':
+        specifier: 17.0.20
+        version: 17.0.20
+      '@types/react-redux':
+        specifier: 7.1.33
+        version: 7.1.33
       '@vitejs/plugin-react-swc':
         specifier: 3.7.0
         version: 3.7.0(@swc/helpers@0.4.14)(vite@5.4.0(@types/node@20.2.5)(sass@1.62.1)(terser@5.17.7))
@@ -175,10 +187,6 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
-
-  '@babel/code-frame@7.21.4':
-    resolution: {integrity: sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/code-frame@7.24.7':
     resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
@@ -233,10 +241,6 @@ packages:
     resolution: {integrity: sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-identifier@7.22.20':
-    resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-validator-identifier@7.24.7':
     resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
     engines: {node: '>=6.9.0'}
@@ -247,10 +251,6 @@ packages:
 
   '@babel/helpers@7.25.0':
     resolution: {integrity: sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/highlight@7.18.6':
-    resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/highlight@7.24.7':
@@ -294,6 +294,12 @@ packages:
 
   '@babel/preset-react@7.18.6':
     resolution: {integrity: sha512-zXr6atUmyYdiWRVLOZahakYmOBHtWc2WGCkP8PYTgZi0iJXDY2CN180TdrIW4OGOAdLc7TifzDIvtx6izaRIzg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/preset-react@7.24.7':
+    resolution: {integrity: sha512-AAH4lEkpmzFWrGVlHaxJB7RLH21uPQ9+He+eFLWHmF9IuFQVugz8eAsamaW0DXRrTfco5zj1wWtpdcXJUOfsag==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -895,14 +901,17 @@ packages:
   '@types/react-dom@17.0.20':
     resolution: {integrity: sha512-4pzIjSxDueZZ90F52mU3aPoogkHIoSIDG+oQ+wQK7Cy2B9S+MvOqY0uEA/qawKz381qrEDkvpwyt8Bm31I8sbA==}
 
-  '@types/react-redux@7.1.25':
-    resolution: {integrity: sha512-bAGh4e+w5D8dajd6InASVIyCo4pZLJ66oLb80F9OBLO1gKESbZcRCJpTT6uLXX+HAB57zw1WTdwJdAsewuTweg==}
+  '@types/react-redux@7.1.33':
+    resolution: {integrity: sha512-NF8m5AjWCkert+fosDsN3hAlHzpjSiXlVy9EgQEmLoBhaNXbmyeGs/aj5dQzKuF+/q+S7JQagorGDW8pJ28Hmg==}
 
   '@types/react-transition-group@4.4.6':
     resolution: {integrity: sha512-VnCdSxfcm08KjsJVQcfBmhEQAPnLB8G08hAxn39azX1qYBQ/5RVQuoHuKIcfKOdncuaUvEpFKFzEvbtIMsfVew==}
 
   '@types/react@17.0.60':
     resolution: {integrity: sha512-pCH7bqWIfzHs3D+PDs3O/COCQJka+Kcw3RnO9rFA2zalqoXg7cNjJDh6mZ7oRtY1wmY4LVwDdAbA1F7Z8tv3BQ==}
+
+  '@types/react@18.3.3':
+    resolution: {integrity: sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==}
 
   '@types/scheduler@0.16.3':
     resolution: {integrity: sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==}
@@ -4447,10 +4456,6 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@babel/code-frame@7.21.4':
-    dependencies:
-      '@babel/highlight': 7.18.6
-
   '@babel/code-frame@7.24.7':
     dependencies:
       '@babel/highlight': 7.24.7
@@ -4461,7 +4466,7 @@ snapshots:
   '@babel/core@7.21.4':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.21.4
+      '@babel/code-frame': 7.24.7
       '@babel/generator': 7.25.0
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-module-transforms': 7.25.2(@babel/core@7.21.4)
@@ -4533,8 +4538,6 @@ snapshots:
 
   '@babel/helper-string-parser@7.24.8': {}
 
-  '@babel/helper-validator-identifier@7.22.20': {}
-
   '@babel/helper-validator-identifier@7.24.7': {}
 
   '@babel/helper-validator-option@7.24.8': {}
@@ -4543,12 +4546,6 @@ snapshots:
     dependencies:
       '@babel/template': 7.25.0
       '@babel/types': 7.25.2
-
-  '@babel/highlight@7.18.6':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.22.20
-      chalk: 2.4.2
-      js-tokens: 4.0.0
 
   '@babel/highlight@7.24.7':
     dependencies:
@@ -4596,6 +4593,18 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/preset-react@7.18.6(@babel/core@7.21.4)':
+    dependencies:
+      '@babel/core': 7.21.4
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-validator-option': 7.24.8
+      '@babel/plugin-transform-react-display-name': 7.24.7(@babel/core@7.21.4)
+      '@babel/plugin-transform-react-jsx': 7.25.2(@babel/core@7.21.4)
+      '@babel/plugin-transform-react-jsx-development': 7.24.7(@babel/core@7.21.4)
+      '@babel/plugin-transform-react-pure-annotations': 7.24.7(@babel/core@7.21.4)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/preset-react@7.24.7(@babel/core@7.21.4)':
     dependencies:
       '@babel/core': 7.21.4
       '@babel/helper-plugin-utils': 7.24.8
@@ -5078,7 +5087,7 @@ snapshots:
 
   '@testing-library/dom@8.20.1':
     dependencies:
-      '@babel/code-frame': 7.21.4
+      '@babel/code-frame': 7.24.7
       '@babel/runtime': 7.22.3
       '@types/aria-query': 5.0.1
       aria-query: 5.1.3
@@ -5089,7 +5098,7 @@ snapshots:
 
   '@testing-library/dom@9.3.3':
     dependencies:
-      '@babel/code-frame': 7.21.4
+      '@babel/code-frame': 7.24.7
       '@babel/runtime': 7.22.3
       '@types/aria-query': 5.0.1
       aria-query: 5.1.3
@@ -5139,7 +5148,7 @@ snapshots:
 
   '@types/hoist-non-react-statics@3.3.1':
     dependencies:
-      '@types/react': 17.0.60
+      '@types/react': 18.3.3
       hoist-non-react-statics: 3.3.2
 
   '@types/istanbul-lib-coverage@2.0.4': {}
@@ -5171,21 +5180,26 @@ snapshots:
     dependencies:
       '@types/react': 17.0.60
 
-  '@types/react-redux@7.1.25':
+  '@types/react-redux@7.1.33':
     dependencies:
       '@types/hoist-non-react-statics': 3.3.1
-      '@types/react': 17.0.60
+      '@types/react': 18.3.3
       hoist-non-react-statics: 3.3.2
       redux: 4.1.2
 
   '@types/react-transition-group@4.4.6':
     dependencies:
-      '@types/react': 17.0.60
+      '@types/react': 18.3.3
 
   '@types/react@17.0.60':
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.3
+      csstype: 3.1.2
+
+  '@types/react@18.3.3':
+    dependencies:
+      '@types/prop-types': 15.7.5
       csstype: 3.1.2
 
   '@types/scheduler@0.16.3': {}
@@ -6315,9 +6329,9 @@ snapshots:
       eslint-config-prettier: 8.8.0(eslint@8.42.0)
       eslint-import-resolver-jsconfig: 1.1.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5)(eslint@8.42.0)
+      eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0))(eslint@8.42.0)
       eslint-plugin-etc: 2.0.2(eslint@8.42.0)(typescript@5.0.3)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-typescript@3.5.4)(eslint@8.42.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0))(eslint@8.42.0))(eslint@8.42.0)
       eslint-plugin-jest: 27.2.1(@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0)(typescript@5.0.3)
       eslint-plugin-jest-dom: 4.0.3(eslint@8.42.0)
       eslint-plugin-jest-formatting: 3.1.0(eslint@8.42.0)
@@ -6368,12 +6382,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5)(eslint@8.42.0):
+  eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0))(eslint@8.42.0):
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       enhanced-resolve: 5.17.1
       eslint: 8.42.0
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-typescript@3.5.4)(eslint@8.42.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0))(eslint@8.42.0))(eslint@8.42.0)
       get-tsconfig: 4.7.6
       globby: 13.2.2
       is-core-module: 2.15.0
@@ -6382,14 +6396,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5)(eslint@8.42.0))(eslint@8.42.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0))(eslint@8.42.0))(eslint@8.42.0):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
       '@typescript-eslint/parser': 5.56.0(eslint@8.42.0)(typescript@5.0.3)
       eslint: 8.42.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5)(eslint@8.42.0)
+      eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0))(eslint@8.42.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6406,7 +6420,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-typescript@3.5.4)(eslint@8.42.0):
+  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0))(eslint@8.42.0))(eslint@8.42.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.flat: 1.3.2
@@ -6415,7 +6429,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.42.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5)(eslint@8.42.0))(eslint@8.42.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0))(eslint@8.42.0))(eslint@8.42.0)
       has: 1.0.3
       is-core-module: 2.15.0
       is-glob: 4.0.3
@@ -6534,7 +6548,7 @@ snapshots:
 
   eslint-plugin-unicorn@46.0.0(eslint@8.42.0):
     dependencies:
-      '@babel/helper-validator-identifier': 7.22.20
+      '@babel/helper-validator-identifier': 7.24.7
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.42.0)
       ci-info: 3.8.0
       clean-regexp: 1.0.0
@@ -7414,7 +7428,7 @@ snapshots:
 
   jest-message-util@29.5.0:
     dependencies:
-      '@babel/code-frame': 7.21.4
+      '@babel/code-frame': 7.24.7
       '@jest/types': 29.5.0
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
@@ -7982,7 +7996,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.21.4
+      '@babel/code-frame': 7.24.7
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -8238,7 +8252,7 @@ snapshots:
   react-redux@7.2.6(react-dom@17.0.2(react@17.0.2))(react@17.0.2):
     dependencies:
       '@babel/runtime': 7.22.3
-      '@types/react-redux': 7.1.25
+      '@types/react-redux': 7.1.33
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -9033,7 +9047,7 @@ snapshots:
   uncontrollable@7.2.1(react@17.0.2):
     dependencies:
       '@babel/runtime': 7.22.3
-      '@types/react': 17.0.60
+      '@types/react': 18.3.3
       invariant: 2.2.4
       react: 17.0.2
       react-lifecycles-compat: 3.0.4

--- a/ui/src/actions/general.js
+++ b/ui/src/actions/general.js
@@ -20,23 +20,6 @@ export function applicationFetched(data) {
   return { type: 'APPLICATION_FETCHED', data };
 }
 
-export function setLoading(
-  loading,
-  title = '',
-  message = '',
-  blocking = false,
-  abortFun = undefined,
-) {
-  return {
-    type: 'SET_LOADING',
-    loading,
-    title,
-    message,
-    blocking,
-    abortFun,
-  };
-}
-
 export function showErrorPanel(show, message = '') {
   return {
     type: 'SHOW_ERROR_PANEL',

--- a/ui/src/actions/login.js
+++ b/ui/src/actions/login.js
@@ -6,7 +6,7 @@ import { fetchApplicationSettings, fetchUIProperties } from '../api/main';
 import { fetchAvailableWorkflows } from '../api/workflow';
 import { fetchAvailableTasks, fetchQueueState } from '../api/queue';
 
-import { showErrorPanel, setLoading, applicationFetched } from './general';
+import { showErrorPanel, applicationFetched } from './general';
 import { fetchLoginInfo, sendLogIn, sendSignOut } from '../api/login';
 import { fetchDetectorInfo } from '../api/detector';
 import { fetchSampleChangerInitialState } from '../api/sampleChanger';
@@ -81,12 +81,10 @@ export function getLoginInfo() {
 
 export function logIn(proposal, password) {
   return async (dispatch) => {
-    dispatch(setLoading(true));
     const res = await sendLogIn(proposal, password);
 
     if (res.msg !== '') {
       dispatch(showErrorPanel(true, res.msg));
-      dispatch(setLoading(false));
       return;
     }
 
@@ -214,7 +212,6 @@ export function getInitialState(navigate) {
 
     dispatch(setInitialState(state));
     dispatch(applicationFetched(true));
-    dispatch(setLoading(false));
   };
 }
 

--- a/ui/src/actions/sampleGrid.js
+++ b/ui/src/actions/sampleGrid.js
@@ -1,7 +1,8 @@
-import { setLoading, showErrorPanel } from './general';
+import { showErrorPanel } from './general';
 import { setQueue } from './queue'; // eslint-disable-line import/no-cycle
 import { fetchSamplesList, sendSyncWithCrims } from '../api/sampleChanger';
 import { fetchLimsSamples } from '../api/lims';
+import { hideWaitDialog, showWaitDialog } from './waitDialog';
 
 export function updateSampleList(sampleList, order) {
   return { type: 'UPDATE_SAMPLE_LIST', sampleList, order };
@@ -63,12 +64,7 @@ export function setSamplesInfoAction(sampleInfoList) {
 export function sendGetSampleList() {
   return async (dispatch) => {
     dispatch(
-      setLoading(
-        true,
-        'Please wait',
-        'Retrieving sample changer contents',
-        true,
-      ),
+      showWaitDialog('Please wait', 'Retrieving sample changer contents', true),
     );
 
     try {
@@ -80,21 +76,19 @@ export function sendGetSampleList() {
       dispatch(showErrorPanel(true, 'Could not get samples list'));
     }
 
-    dispatch(setLoading(false));
+    dispatch(hideWaitDialog());
   };
 }
 
 export function syncSamples() {
   return async (dispatch) => {
-    dispatch(setLoading(true, 'Please wait', 'Synchronizing with ISPyB', true));
+    dispatch(showWaitDialog('Please wait', 'Synchronizing with ISPyB', true));
 
     try {
       const json = await fetchLimsSamples();
       dispatch(updateSampleList(json.sampleList, json.sampleOrder));
       dispatch(setQueue(json));
-      dispatch(setLoading(false));
     } catch (error) {
-      dispatch(setLoading(false));
       dispatch(
         showErrorPanel(
           true,
@@ -103,6 +97,8 @@ export function syncSamples() {
           )}`,
         ),
       );
+    } finally {
+      dispatch(hideWaitDialog());
     }
   };
 }

--- a/ui/src/actions/waitDialog.js
+++ b/ui/src/actions/waitDialog.js
@@ -1,0 +1,20 @@
+export function showWaitDialog(
+  title = 'Please wait',
+  message = undefined,
+  blocking = false,
+  abortFun = undefined,
+) {
+  return {
+    type: 'SHOW_WAIT_DIALOG',
+    title,
+    message,
+    blocking,
+    abortFun,
+  };
+}
+
+export function hideWaitDialog() {
+  return {
+    type: 'HIDE_WAIT_DIALOG',
+  };
+}

--- a/ui/src/components/Login/Login.jsx
+++ b/ui/src/components/Login/Login.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Form, InputGroup, Alert, Button } from 'react-bootstrap';
 
 import { Controller, useForm } from 'react-hook-form';
@@ -9,7 +9,8 @@ import withRouter from '../WithRouter';
 import styles from './Login.module.css';
 
 function LoginComponent(props) {
-  const { router, loading, logIn, showError, errorMessage } = props;
+  const { router, logIn, showError, errorMessage } = props;
+  const [loading, setLoading] = useState(false);
 
   const {
     control,
@@ -18,7 +19,12 @@ function LoginComponent(props) {
   } = useForm({ defaultValues: { username: '', password: '' } });
 
   async function handleSubmit(data) {
-    await logIn(data.username.toLowerCase(), data.password, router.navigate);
+    setLoading(true);
+    try {
+      await logIn(data.username.toLowerCase(), data.password, router.navigate);
+    } finally {
+      setLoading(false);
+    }
   }
 
   return (

--- a/ui/src/components/RemoteAccess/RequestControlForm.jsx
+++ b/ui/src/components/RemoteAccess/RequestControlForm.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { Form, Button, Card } from 'react-bootstrap';
-import { setLoading } from '../../actions/general';
 import { requestControl, takeControl } from '../../actions/remoteAccess';
+import { showWaitDialog } from '../../actions/waitDialog';
 
 class RequestControlForm extends React.Component {
   constructor(props) {
@@ -34,8 +34,7 @@ class RequestControlForm extends React.Component {
   }
 
   askForControl() {
-    this.props.askForControlDialog(
-      true,
+    this.props.showWaitDialog(
       'Asking for control',
       'Please wait while asking for control',
       true,
@@ -94,7 +93,7 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    askForControlDialog: bindActionCreators(setLoading, dispatch),
+    showWaitDialog: bindActionCreators(showWaitDialog, dispatch),
     requestControl: bindActionCreators(requestControl, dispatch),
     takeControl: bindActionCreators(takeControl, dispatch),
   };

--- a/ui/src/containers/LoginContainer.jsx
+++ b/ui/src/containers/LoginContainer.jsx
@@ -3,7 +3,6 @@ import { useLocation, Navigate } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { logIn } from '../actions/login';
-import { setLoading } from '../actions/general';
 import Login from '../components/Login/Login';
 
 function LoginContainer(props) {
@@ -18,7 +17,6 @@ function LoginContainer(props) {
 
 function mapStateToProps(state) {
   return {
-    loading: state.general.loading,
     showError: state.general.showErrorPanel,
     errorMessage: state.general.errorMessage,
     data: state.login,
@@ -28,7 +26,6 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
   return {
     logIn: bindActionCreators(logIn, dispatch),
-    setLoading: bindActionCreators(setLoading, dispatch),
   };
 }
 

--- a/ui/src/containers/PleaseWaitDialog.jsx
+++ b/ui/src/containers/PleaseWaitDialog.jsx
@@ -1,79 +1,59 @@
-/* eslint-disable react/jsx-handler-names */
 import React from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import { Modal, ProgressBar, Button } from 'react-bootstrap';
 import { setLoading } from '../actions/general';
+import { useDispatch, useSelector } from 'react-redux';
 
-export class PleaseWaitDialog extends React.Component {
-  constructor(props) {
-    super(props);
-    this.hide = this.hide.bind(this);
-    this.abort = this.abort.bind(this);
-  }
+function PleaseWaitDialog() {
+  const dispatch = useDispatch();
 
-  hide() {
-    this.props.setLoading(false);
-  }
+  const loading = useSelector(({ general }) => general.loading);
+  const title = useSelector(({ general }) => general.title);
+  const message = useSelector(({ general }) => general.message);
+  const blocking = useSelector(({ general }) => general.blocking);
+  const abortFun = useSelector(({ general }) => general.abortFun);
 
-  abort() {
-    if (this.props.abortFun) {
-      this.props.abortFun();
-    }
+  return (
+    <Modal
+      keyboard={!blocking}
+      backdrop={!blocking || 'static'}
+      show={loading}
+      onHide={() => dispatch(setLoading(false))}
+      data-default-styles
+    >
+      <Modal.Header closeButton={!blocking}>
+        <Modal.Title>{title || 'Please wait'}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <div>
+          <p>{message || ''}</p>
+          {blocking && <ProgressBar variant="primary" animated now={100} />}
+        </div>
+      </Modal.Body>
+      <Modal.Footer>
+        {blocking ? (
+          <Button
+            variant="outline-secondary"
+            onClick={() => {
+              if (abortFun) {
+                abortFun();
+              }
 
-    this.props.setLoading(false);
-  }
-
-  render() {
-    return (
-      <Modal
-        keyboard={!this.props.blocking}
-        backdrop={!this.props.blocking || 'static'}
-        show={this.props.loading}
-        onHide={this.hide}
-        data-default-styles
-      >
-        <Modal.Header closeButton={!this.props.blocking}>
-          <Modal.Title>{this.props.title || 'Please wait'}</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          <div>
-            <p>{this.props.message || ''}</p>
-            {this.props.blocking && (
-              <ProgressBar variant="primary" animated now={100} />
-            )}
-          </div>
-        </Modal.Body>
-        <Modal.Footer>
-          {this.props.blocking ? (
-            <Button variant="outline-secondary" onClick={this.abort}>
-              Cancel
-            </Button>
-          ) : (
-            <Button variant="outline-secondary" onClick={this.hide}>
-              Hide
-            </Button>
-          )}
-        </Modal.Footer>
-      </Modal>
-    );
-  }
+              dispatch(setLoading(false));
+            }}
+          >
+            Cancel
+          </Button>
+        ) : (
+          <Button
+            variant="outline-secondary"
+            onClick={() => dispatch(setLoading(false))}
+          >
+            Hide
+          </Button>
+        )}
+      </Modal.Footer>
+    </Modal>
+  );
 }
 
-function mapStateToProps(state) {
-  return {
-    loading: state.general.loading,
-    title: state.general.title,
-    message: state.general.message,
-    blocking: state.general.blocking,
-    abortFun: state.general.abortFun,
-  };
-}
-
-function mapDispatchToProps(dispatch) {
-  return {
-    setLoading: bindActionCreators(setLoading, dispatch),
-  };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(PleaseWaitDialog);
+export default PleaseWaitDialog;

--- a/ui/src/containers/PleaseWaitDialog.jsx
+++ b/ui/src/containers/PleaseWaitDialog.jsx
@@ -13,7 +13,7 @@ export class PleaseWaitDialog extends React.Component {
   }
 
   hide() {
-    this.props.setLoading(this.props.blocking);
+    this.props.setLoading(false);
   }
 
   abort() {
@@ -27,10 +27,9 @@ export class PleaseWaitDialog extends React.Component {
   render() {
     return (
       <Modal
-        keyboard={false}
-        animation={false}
+        keyboard={!this.props.blocking}
+        backdrop={!this.props.blocking || 'static'}
         show={this.props.loading}
-        enforceFocus={false}
         onHide={this.hide}
         data-default-styles
       >

--- a/ui/src/containers/PleaseWaitDialog.jsx
+++ b/ui/src/containers/PleaseWaitDialog.jsx
@@ -1,34 +1,34 @@
 import React from 'react';
 import { Modal, ProgressBar, Button } from 'react-bootstrap';
-import { setLoading } from '../actions/general';
 import { useDispatch, useSelector } from 'react-redux';
+import { hideWaitDialog } from '../actions/waitDialog';
 
 function PleaseWaitDialog() {
   const dispatch = useDispatch();
 
-  const loading = useSelector(({ general }) => general.loading);
-  const title = useSelector(({ general }) => general.title);
-  const message = useSelector(({ general }) => general.message);
-  const blocking = useSelector(({ general }) => general.blocking);
-  const abortFun = useSelector(({ general }) => general.abortFun);
+  const { show, title, message, blocking, abortFun } = useSelector(
+    (state) => state.waitDialog,
+  );
 
   return (
     <Modal
       keyboard={!blocking}
       backdrop={!blocking || 'static'}
-      show={loading}
-      onHide={() => dispatch(setLoading(false))}
+      show={show}
+      onHide={() => dispatch(hideWaitDialog())}
       data-default-styles
     >
       <Modal.Header closeButton={!blocking}>
-        <Modal.Title>{title || 'Please wait'}</Modal.Title>
+        <Modal.Title>{title}</Modal.Title>
       </Modal.Header>
-      <Modal.Body>
-        <div>
-          <p>{message || ''}</p>
-          {blocking && <ProgressBar variant="primary" animated now={100} />}
-        </div>
-      </Modal.Body>
+      {(message || blocking) && (
+        <Modal.Body>
+          <div>
+            <p>{message || ''}</p>
+            {blocking && <ProgressBar variant="primary" animated now={100} />}
+          </div>
+        </Modal.Body>
+      )}
       <Modal.Footer>
         {blocking ? (
           <Button
@@ -38,7 +38,7 @@ function PleaseWaitDialog() {
                 abortFun();
               }
 
-              dispatch(setLoading(false));
+              dispatch(hideWaitDialog());
             }}
           >
             Cancel
@@ -46,7 +46,7 @@ function PleaseWaitDialog() {
         ) : (
           <Button
             variant="outline-secondary"
-            onClick={() => dispatch(setLoading(false))}
+            onClick={() => dispatch(hideWaitDialog())}
           >
             Hide
           </Button>

--- a/ui/src/containers/SelectProposalContainer.jsx
+++ b/ui/src/containers/SelectProposalContainer.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { signOut, selectProposal, hideProposalsForm } from '../actions/login';
-import { setLoading } from '../actions/general';
 import SelectProposal from '../components/Login/SelectProposal';
 import withRouter from '../components/WithRouter';
 import { serverIO } from '../serverIO';
@@ -44,7 +43,6 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
   return {
     signOut: bindActionCreators(signOut, dispatch),
-    setLoading: bindActionCreators(setLoading, dispatch),
     selectProposal: bindActionCreators(selectProposal, dispatch),
     hideProposalsForm: bindActionCreators(hideProposalsForm, dispatch),
   };

--- a/ui/src/reducers/general.js
+++ b/ui/src/reducers/general.js
@@ -1,5 +1,4 @@
 const INITIAL_STATE = {
-  loading: false,
   showErrorPanel: false,
   errorMessage: '',
   dialogData: '',
@@ -15,16 +14,6 @@ const INITIAL_STATE = {
 
 function generalReducer(state = INITIAL_STATE, action = {}) {
   switch (action.type) {
-    case 'SET_LOADING': {
-      return {
-        ...state,
-        loading: action.loading,
-        title: action.title,
-        message: action.message,
-        blocking: action.blocking,
-        abortFun: action.abortFun,
-      };
-    }
     case 'SHOW_ERROR_PANEL': {
       return {
         ...state,

--- a/ui/src/reducers/index.js
+++ b/ui/src/reducers/index.js
@@ -19,6 +19,7 @@ import shapes from './shapes';
 import workflow from './workflow';
 import taskResult from './taskResult';
 import uiproperties from './uiproperties';
+import waitDialog from './waitDialog';
 
 const mxcubeReducer = combineReducers({
   login,
@@ -41,6 +42,7 @@ const mxcubeReducer = combineReducers({
   workflow,
   taskResult,
   form: formReducer,
+  waitDialog,
 });
 
 const rootReducer = (state, action) => {

--- a/ui/src/reducers/waitDialog.js
+++ b/ui/src/reducers/waitDialog.js
@@ -1,0 +1,35 @@
+const INITIAL_STATE = {
+  show: false,
+  title: undefined,
+  message: undefined,
+  blocking: false,
+  abortFun: undefined, // not serializable! https://redux.js.org/style-guide/#do-not-put-non-serializable-values-in-state-or-actions
+};
+
+function waitDialogReducer(state = INITIAL_STATE, action = {}) {
+  switch (action.type) {
+    case 'SHOW_WAIT_DIALOG': {
+      return {
+        ...state,
+        show: true,
+        title: action.title,
+        message: action.message,
+        blocking: action.blocking,
+        abortFun: action.abortFun,
+      };
+    }
+    case 'HIDE_WAIT_DIALOG': {
+      return {
+        ...state, // keep title and message while dialog is hiding
+        show: false,
+        blocking: false,
+        abortFun: undefined,
+      };
+    }
+    default: {
+      return state;
+    }
+  }
+}
+
+export default waitDialogReducer;

--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -37,7 +37,7 @@ import {
   getQueue,
 } from './actions/queue';
 import { collapseItem, showResumeQueueDialog } from './actions/queueGUI';
-import { setLoading, showConnectionLostDialog } from './actions/general';
+import { showConnectionLostDialog } from './actions/general';
 
 import {
   showWorkflowParametersDialog,
@@ -66,6 +66,7 @@ import { setEnergyScanResult } from './actions/taskResults';
 import { CLICK_CENTRING } from './constants';
 import { sendRefreshSession } from './api/login';
 import { store } from './store';
+import { hideWaitDialog, showWaitDialog } from './actions/waitDialog';
 
 class ServerIO {
   constructor() {
@@ -286,8 +287,7 @@ class ServerIO {
       switch (record.signal) {
         case 'operatingSampleChanger': {
           this.dispatch(
-            setLoading(
-              true,
+            showWaitDialog(
               'Sample changer in operation',
               record.message,
               true,
@@ -301,8 +301,7 @@ class ServerIO {
         case 'loadingSample':
         case 'loadedSample': {
           this.dispatch(
-            setLoading(
-              true,
+            showWaitDialog(
               `Loading sample ${record.location}`,
               record.message,
               true,
@@ -316,8 +315,7 @@ class ServerIO {
         case 'unLoadingSample':
         case 'unLoadedSample': {
           this.dispatch(
-            setLoading(
-              true,
+            showWaitDialog(
               `Unloading sample ${record.location}`,
               record.message,
               true,
@@ -329,22 +327,12 @@ class ServerIO {
         }
 
         case 'loadReady': {
-          this.dispatch(
-            setLoading(false, 'SC Ready', record.message, true, () =>
-              this.dispatch(stopQueue()),
-            ),
-          );
-
+          this.dispatch(hideWaitDialog());
           break;
         }
 
         case 'inSafeArea': {
-          this.dispatch(
-            setLoading(false, 'SC Safe', record.message, true, () =>
-              this.dispatch(stopQueue()),
-            ),
-          );
-
+          this.dispatch(hideWaitDialog());
           break;
         }
 
@@ -396,7 +384,7 @@ class ServerIO {
         data.operator.username === state.login.user.username &&
         !state.login.user.inControl
       ) {
-        this.dispatch(setLoading(true, 'You were given control', data.message));
+        this.dispatch(showWaitDialog('You were given control', data.message));
       } else if (
         data.observers.length > 0 &&
         state.login.user.inControl &&
@@ -404,7 +392,7 @@ class ServerIO {
           .map((el) => el.username)
           .includes(state.login.user.username)
       ) {
-        this.dispatch(setLoading(true, 'You lost control', 'You lost control'));
+        this.dispatch(showWaitDialog('You lost control'));
       }
 
       this.dispatch(getRaState());


### PR DESCRIPTION
I've made separate commits to fix and refactor multiple aspects of the `PleaseWaitDialog` component and corresponding global state:

1. I fix #1281 by preventing "blocking" modals from being dismissed when their backdrop is clicked. This is done by passing `backdrop="static"` to the Bootstrap modal. In this commit, I also fix keyboard accessibility by notably allowing the modal to be dismissed with <kbd>Escape</kbd> (unless `backdrop="static"` is set). 8720b00c2312db4725fe0f109e22bf3840cfb886
2. I install a few dev dependencies to fix auto-imports, linting, etc., notably in VS Code. 01312af1d678cb418e5a0ec9e0762a099f533987
3. I turn the `PleaseWaitDialog` component into a function component. 12ce793d5793f9da8d09c01ab3d0d67c26daad3f
4. I inline the loading state of the `Login` component (which controls the visibility of the little spinner in the "Sign in" button) so that the `general.loading` state in the Redux store is only used by the wait dialog (in preparation for my fifth commit). 38aaa4c60f73bd98feb7a8cb92945d9397a2a3f7
5. I isolate the wait dialog's state into its own Redux state slice, along with its own reducer and actions. This ensures that I can select the whole `waitDialog` slice without triggering unrelated re-renders. 98077c4dbe4a1405d820981080673168f033bb2e In this commit, I also:
    - replace the generic `setLoading` action with two more intuitive actions: `showWaitDialog` and `hideWaitDialog`;
    - make sure not to reset the `title` and `message` in `hideWaitDialog` to avoid a "Please wait" flash while the dialog is being animated out;
    - hide the entire body of the dialog if there's no message or progress bar to show.