### PR TITLE
Draft: automatically load&sync samples upon login

### DIFF
--- a/ui/src/actions/login.js
+++ b/ui/src/actions/login.js
@@ -14,6 +14,7 @@ import { fetchHarvesterInitialState } from '../api/harvester';
 import { fetchImageData, fetchShapes } from '../api/sampleview';
 import { fetchRemoteAccessState } from '../api/remoteAccess';
 import { sendSelectProposal } from '../api/lims';
+import { sendGetandSyncSamples } from './sampleGrid';
 
 export function setLoginInfo(loginInfo) {
   return {
@@ -211,6 +212,7 @@ export function getInitialState(navigate) {
     await Promise.all(pchains);
 
     dispatch(setInitialState(state));
+    dispatch(sendGetandSyncSamples());
     dispatch(applicationFetched(true));
   };
 }

--- a/ui/src/actions/sampleGrid.js
+++ b/ui/src/actions/sampleGrid.js
@@ -103,6 +103,20 @@ export function syncSamples() {
   };
 }
 
+/**
+ * Sends a request to get the sample list and then synchronizes the samples with lims.
+ */
+export function sendGetandSyncSamples() {
+  return async (dispatch) => {
+    try {
+      await dispatch(sendGetSampleList());
+      await dispatch(syncSamples());
+    } catch {
+      dispatch(showErrorPanel(true, 'Could not get and sync samples list'));
+    }
+  };
+}
+
 // update list crystal from crims
 export function updateCrystalList(crystalList) {
   return { type: 'UPDATE_CRYSTAL_LIST', crystalList };


### PR DESCRIPTION
And now a bit of controversy ;)

We would like to populate the samples list and sync with lims automatically (save the user two clicks). Also, if a sample is already loaded in the md3, the todo queue would also be populated.

opinions?