### PR TITLE
Refactor remote access components

### DIFF
--- a/ui/src/actions/remoteAccess.js
+++ b/ui/src/actions/remoteAccess.js
@@ -1,5 +1,6 @@
 import {
   fetchRemoteAccessState,
+  sendCancelControlRequest,
   sendGiveControl,
   sendLogoutUser,
   sendRequestControl,
@@ -30,13 +31,12 @@ export function updateNickname(name) {
   };
 }
 
-export function requestControl(
-  control = true,
-  message = '',
-  name = '',
-  userInfo = {},
-) {
-  return () => sendRequestControl(control, message, name, userInfo);
+export function requestControl(message) {
+  return () => sendRequestControl(message);
+}
+
+export function cancelControlRequest() {
+  return () => sendCancelControlRequest();
 }
 
 export function takeControl() {

--- a/ui/src/api/remoteAccess.js
+++ b/ui/src/api/remoteAccess.js
@@ -18,10 +18,12 @@ export function sendUpdateNickname(name) {
   return endpoint.post({ name }, '/update_user_nickname').res();
 }
 
-export function sendRequestControl(control, message, name, userInfo) {
-  return endpoint
-    .post({ control, message, name, userInfo }, '/request_control')
-    .res();
+export function sendRequestControl(message) {
+  return endpoint.post({ message }, '/request_control').res();
+}
+
+export function sendCancelControlRequest() {
+  return endpoint.post(undefined, '/cancel_request').res();
 }
 
 export function sendRespondToControlRequest(giveControl, message) {

--- a/ui/src/components/RemoteAccess/RequestControlForm.jsx
+++ b/ui/src/components/RemoteAccess/RequestControlForm.jsx
@@ -1,102 +1,62 @@
-/* eslint-disable react/jsx-handler-names */
 import React from 'react';
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { Form, Button, Card } from 'react-bootstrap';
-import { requestControl, takeControl } from '../../actions/remoteAccess';
+import {
+  cancelControlRequest,
+  requestControl,
+  takeControl,
+} from '../../actions/remoteAccess';
 import { showWaitDialog } from '../../actions/waitDialog';
 
-class RequestControlForm extends React.Component {
-  constructor(props) {
-    super(props);
-    this.askForControl = this.askForControl.bind(this);
-    this.cancelControlRequest = this.cancelControlRequest.bind(this);
-    this.getTakeControlOption = this.getTakeControlOption.bind(this);
-    this.takeControlOnClick = this.takeControlOnClick.bind(this);
-  }
+function RequestControlForm() {
+  const dispatch = useDispatch();
+  const nickname = useSelector((state) => state.login.user.nickname);
 
-  getTakeControlOption() {
-    return (
-      <span style={{ marginLeft: '1em' }}>
-        <Button
-          size="sm"
-          variant="outline-secondary"
-          onClick={this.takeControlOnClick}
-        >
-          Take control
-        </Button>
-      </span>
+  function handleAskForControl(evt) {
+    evt.preventDefault();
+    const formData = new FormData(evt.target);
+
+    dispatch(
+      showWaitDialog(
+        'Asking for control',
+        'Please wait while asking for control',
+        true,
+        () => dispatch(cancelControlRequest()),
+      ),
     );
+
+    dispatch(requestControl(formData.get('message')));
   }
 
-  takeControlOnClick() {
-    this.props.takeControl();
-  }
-
-  askForControl() {
-    this.props.showWaitDialog(
-      'Asking for control',
-      'Please wait while asking for control',
-      true,
-      this.cancelControlRequest,
-    );
-    const message = this.message.value;
-    const name = this.props.login.user.nickname;
-    this.props.requestControl(true, message, name, this.props.login.user);
-  }
-
-  cancelControlRequest() {
-    const message = this.message.value;
-    const name = this.props.login.user.nickname;
-
-    this.props.requestControl(false, message, name, this.props.login.user);
-  }
-
-  render() {
-    return (
-      <Card>
-        <Card.Header>Request control</Card.Header>
-        <Card.Body>
-          <Form>
-            <Form.Group className="mb-3">
-              <Form.Label>Message</Form.Label>
-              <Form.Control
-                ref={(ref) => {
-                  this.message = ref;
-                }}
-                as="textarea"
-                defaultValue={`Hi it's ${this.props.login.user.nickname}, Please give me control`}
-                rows={3}
-              />
-            </Form.Group>
+  return (
+    <Card>
+      <Card.Header>Request control</Card.Header>
+      <Card.Body>
+        <Form onSubmit={handleAskForControl}>
+          <Form.Group className="mb-3">
+            <Form.Label>Message</Form.Label>
+            <Form.Control
+              name="message"
+              as="textarea"
+              defaultValue={`Hi, it's ${nickname}, please give me control.`}
+              rows={3}
+            />
+          </Form.Group>
+          <Button type="submit" variant="outline-secondary">
+            Ask for control
+          </Button>
+          <span style={{ marginLeft: '1em' }}>
             <Button
               variant="outline-secondary"
-              size="sm"
-              onClick={this.askForControl}
+              onClick={() => dispatch(takeControl())}
             >
-              Ask for control
+              Take control
             </Button>
-            {this.getTakeControlOption()}
-          </Form>
-        </Card.Body>
-      </Card>
-    );
-  }
+          </span>
+        </Form>
+      </Card.Body>
+    </Card>
+  );
 }
 
-function mapStateToProps(state) {
-  return {
-    remoteAccess: state.remoteAccess,
-    login: state.login,
-  };
-}
-
-function mapDispatchToProps(dispatch) {
-  return {
-    showWaitDialog: bindActionCreators(showWaitDialog, dispatch),
-    requestControl: bindActionCreators(requestControl, dispatch),
-    takeControl: bindActionCreators(takeControl, dispatch),
-  };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(RequestControlForm);
+export default RequestControlForm;

--- a/ui/src/components/RemoteAccess/UserList.jsx
+++ b/ui/src/components/RemoteAccess/UserList.jsx
@@ -12,7 +12,9 @@ class UserList extends React.Component {
       observers.push(
         <Row key={observer.username} className="mt-3">
           <Col sm={4}>
-            <span style={{ lineHeight: '24px' }}>{observer.nickname}</span>
+            <span style={{ lineHeight: '24px' }}>
+              {observer.nickname || <em>Not provided</em>}
+            </span>
           </Col>
           <Col sm={3}>
             <span style={{ lineHeight: '24px' }}>{observer.ip}</span>

--- a/ui/src/components/RemoteAccess/UserList.jsx
+++ b/ui/src/components/RemoteAccess/UserList.jsx
@@ -1,90 +1,65 @@
 import React from 'react';
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { Row, Col, Button, Card } from 'react-bootstrap';
 import { giveControl, logoutUser } from '../../actions/remoteAccess';
 
-class UserList extends React.Component {
-  getObservers() {
-    const observers = [];
+function UserList() {
+  const dispatch = useDispatch();
 
-    for (const observer of this.props.remoteAccess.observers) {
-      observers.push(
-        <Row key={observer.username} className="mt-3">
+  const user = useSelector((state) => state.login.user);
+  const observers = useSelector((state) => state.remoteAccess.observers);
+
+  return (
+    <Card className="mb-3">
+      <Card.Header>Users</Card.Header>
+      <Card.Body>
+        <Row>
           <Col sm={4}>
-            <span style={{ lineHeight: '24px' }}>
-              {observer.nickname || <em>Not provided</em>}
-            </span>
+            <b>Name</b>
           </Col>
-          <Col sm={3}>
-            <span style={{ lineHeight: '24px' }}>{observer.ip}</span>
+          <Col sm={4}>
+            <b>Host</b>
           </Col>
-          {this.props.login.user.inControl && (
-            <Col sm={5}>
-              <Button
-                size="sm"
-                variant="outline-secondary"
-                className="me-3"
-                onClick={() => this.props.giveControl(observer.username)}
-              >
-                Give control
-              </Button>
-              {this.props.login.user.isstaff && (
-                <span>
-                  &nbsp;
+          <Col sm={4}>
+            <span>&nbsp;</span>
+          </Col>
+        </Row>
+        {observers.map((observer) => (
+          <Row key={observer.username} className="mt-3">
+            <Col sm={4}>
+              <span style={{ lineHeight: '24px' }}>
+                {observer.nickname || <em>Not provided</em>}
+              </span>
+            </Col>
+            <Col sm={3}>
+              <span style={{ lineHeight: '24px' }}>{observer.ip}</span>
+            </Col>
+            {user.inControl && (
+              <Col sm={5}>
+                <Button
+                  size="sm"
+                  variant="outline-secondary"
+                  className="me-3"
+                  onClick={() => dispatch(giveControl(observer.username))}
+                >
+                  Give control
+                </Button>
+                {user.isstaff && (
                   <Button
                     size="sm"
                     variant="outline-secondary"
-                    onClick={() => this.props.logoutUser(observer.username)}
+                    onClick={() => dispatch(logoutUser(observer.username))}
                   >
                     Logout
                   </Button>
-                </span>
-              )}
-            </Col>
-          )}
-        </Row>,
-      );
-    }
-
-    return observers;
-  }
-
-  render() {
-    return (
-      <Card className="mb-3">
-        <Card.Header>Users</Card.Header>
-        <Card.Body>
-          <Row>
-            <Col sm={4}>
-              <b>Name</b>
-            </Col>
-            <Col sm={4}>
-              <b>Host</b>
-            </Col>
-            <Col sm={4}>
-              <span>&nbsp;</span>
-            </Col>
+                )}
+              </Col>
+            )}
           </Row>
-          {this.getObservers()}
-        </Card.Body>
-      </Card>
-    );
-  }
+        ))}
+      </Card.Body>
+    </Card>
+  );
 }
 
-function mapStateToProps(state) {
-  return {
-    remoteAccess: state.remoteAccess,
-    login: state.login,
-  };
-}
-
-function mapDispatchToProps(dispatch) {
-  return {
-    giveControl: bindActionCreators(giveControl, dispatch),
-    logoutUser: bindActionCreators(logoutUser, dispatch),
-  };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(UserList);
+export default UserList;

--- a/ui/src/components/RemoteAccess/UserList.jsx
+++ b/ui/src/components/RemoteAccess/UserList.jsx
@@ -10,16 +10,15 @@ class UserList extends React.Component {
 
     for (const observer of this.props.remoteAccess.observers) {
       observers.push(
-        <Row key={observer.username}>
+        <Row key={observer.username} className="mt-3">
           <Col sm={4}>
             <span style={{ lineHeight: '24px' }}>{observer.nickname}</span>
           </Col>
           <Col sm={3}>
             <span style={{ lineHeight: '24px' }}>{observer.ip}</span>
           </Col>
-          <Col sm={5} />
-          {this.props.login.user.inControl ? (
-            <Col className="mt-3" sm={5}>
+          {this.props.login.user.inControl && (
+            <Col sm={5}>
               <Button
                 size="sm"
                 variant="outline-secondary"
@@ -28,7 +27,7 @@ class UserList extends React.Component {
               >
                 Give control
               </Button>
-              {this.props.login.user.isstaff ? (
+              {this.props.login.user.isstaff && (
                 <span>
                   &nbsp;
                   <Button
@@ -39,11 +38,7 @@ class UserList extends React.Component {
                     Logout
                   </Button>
                 </span>
-              ) : null}
-            </Col>
-          ) : (
-            <Col sm={4}>
-              <span>&nbsp;</span>
+              )}
             </Col>
           )}
         </Row>,


### PR DESCRIPTION
Before doing what I mentioned in https://github.com/mxcube/mxcubeweb/pull/1348#issuecomment-2296489048, I start by: refactoring all the remote access components to function components; adding an endpoint to cancel control requests (instead of handling that in `/request_control`); and improving a couple more things in the UI as follows:

1. Show _Not provided_ as a fallback while an observer is entering their name:

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/7ffc3b40-d908-41f7-9bda-252d0801fc73) | ![image](https://github.com/user-attachments/assets/a8dd7691-1ed2-4a48-95ac-0109f266381d) |

2. Fix `UserList` layout when in control

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/53aa52cb-2ba6-4bff-834b-6d3492b438ef) | ![image](https://github.com/user-attachments/assets/4b0e3708-0396-4b7b-9d4b-ce6c9b683624) |
