### PR TITLE
fixed: motors do not correctly abort

### DIFF
--- a/mxcubeweb/core/adapter/beamline_adapter.py
+++ b/mxcubeweb/core/adapter/beamline_adapter.py
@@ -56,7 +56,7 @@ class _BeamlineAdapter:
         )
 
     def get_object(self, name):
-        return self.get_attr_from_path(name)
+        return self._ho.get_hardware_object(name)
 
     def dict(self):
         """

--- a/mxcubeweb/core/components/beamline.py
+++ b/mxcubeweb/core/components/beamline.py
@@ -221,11 +221,15 @@ class Beamline(ComponentBase):
         :param str name: Owner / Actuator of the process/action to abort
 
         """
-        try:
+        beamline_action_names = [
+            cmd.name() for cmd in HWR.beamline.beamline_actions.get_commands()
+        ]
+
+        if name in beamline_action_names:
             HWR.beamline.beamline_actions.abort_command(name)
-        except KeyError:
+        else:
             try:
-                ho = BeamlineAdapter(HWR.beamline).get_object(name.lower())
+                ho = HWR.beamline.get_hardware_object(name.lower())
             except AttributeError:
                 pass
             else:


### PR DESCRIPTION
These changes ensure that motor stop is correctly called by clicking the abort button in the UI.