### PR TITLE
Refactor remote access messaging

### DIFF
--- a/ui/src/actions/remoteAccess.js
+++ b/ui/src/actions/remoteAccess.js
@@ -32,11 +32,17 @@ export function updateNickname(name) {
 }
 
 export function requestControl(message) {
-  return () => sendRequestControl(message);
+  return async (dispatch) => {
+    await sendRequestControl(message);
+    dispatch(getLoginInfo());
+  };
 }
 
 export function cancelControlRequest() {
-  return () => sendCancelControlRequest();
+  return async (dispatch) => {
+    await sendCancelControlRequest();
+    dispatch(getLoginInfo());
+  };
 }
 
 export function takeControl() {

--- a/ui/src/components/RemoteAccess/PassControlDialog.jsx
+++ b/ui/src/components/RemoteAccess/PassControlDialog.jsx
@@ -41,7 +41,7 @@ function PassControlDialog() {
         <Modal.Footer>
           <Form.Control
             name="message"
-            defaultValue="Here you go !"
+            defaultValue="Here you go!"
             type="textarea"
             placeholder="Message"
             rows="3"


### PR DESCRIPTION
The `observersChanged` websocket message had two responsibilities; it used to let all logged in clients know that:

1. the `observers` state has changed (e.g. because of a change of user in control; because an observer is currently requesting control; ...)
2. the `user` state _may_ have changed (e.g. because _this_ user gained/lost control or is requesting control)

Turns out that notifying all clients that their `user` state may have changed is unnecessary—we only need to notify the client(s) whose `user` state actually changed.

So in this PR, I follow the single responsibility principle by splitting the `observersChanged` message in two and rethinking when the resulting messages, `observersChanged` and `userChanged`, actually need to be emitted (and to which clients).

I also refactor how those messages are handled in the front-end:

- Now each message forces a refetch of its corresponding slice of state independently (`remoteAccess` and `login`).
- The `userChanged` message is now the one responsible for showing the correct "in control" dialog ("You were given control", or "You lost control") and this logic is now based solely on the toggling of the `login.user.inControl` state (instead of relying on the `userChanged` message payload).