### PR TITLE
Improve UX of requesting/approving/denying control

### DIFF
--- a/mxcubeweb/core/models/usermodels.py
+++ b/mxcubeweb/core/models/usermodels.py
@@ -63,6 +63,7 @@ class User(Base, UserMixin):
     fs_uniquifier = Column(String(255), unique=True, nullable=False)
     confirmed_at = Column(DateTime())
     requests_control = Column(Boolean(False))
+    requests_control_msg = Column(String(255))
     in_control = Column(Boolean(False))
     selected_proposal = Column(String(255), unique=False)
     proposal_list = Column(JSON, unique=False)
@@ -106,4 +107,5 @@ class User(Base, UserMixin):
             "ip": self.current_login_ip,
             "currentLoginAt": current_login_at_str,
             "requestsControl": self.requests_control,
+            "requestsControlMsg": self.requests_control_msg,
         }

--- a/mxcubeweb/routes/ra.py
+++ b/mxcubeweb/routes/ra.py
@@ -44,7 +44,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
 
         data = request.get_json()
         current_user.requests_control = True
-        current_user.requests_control_msg = data['message']
+        current_user.requests_control_msg = data["message"]
         app.usermanager.update_user(current_user)
 
         server.emit("observersChanged", namespace="/hwr")
@@ -189,7 +189,12 @@ def init_route(app, server, url_prefix):  # noqa: C901
             new_op.requests_control = False
             new_op.requests_control_msg = None
             app.usermanager.update_user(new_op)
-            server.emit("userChanged", data["message"], room=new_op.socketio_session_id, namespace="/hwr")
+            server.emit(
+                "userChanged",
+                data["message"],
+                room=new_op.socketio_session_id,
+                namespace="/hwr",
+            )
             server.emit("observersChanged", namespace="/hwr")
 
         return make_response("", 200)

--- a/ui/src/actions/remoteAccess.js
+++ b/ui/src/actions/remoteAccess.js
@@ -11,6 +11,7 @@ import {
   sendUpdateTimeoutGivesControl,
 } from '../api/remoteAccess';
 import { getLoginInfo } from './login';
+import { showWaitDialog } from './waitDialog';
 
 export function showObserverDialog(show = true) {
   return { type: 'SHOW_OBSERVER_DIALOG', show };
@@ -34,7 +35,16 @@ export function updateNickname(name) {
 export function requestControl(message) {
   return async (dispatch) => {
     await sendRequestControl(message);
+
     dispatch(getLoginInfo());
+    dispatch(
+      showWaitDialog(
+        'Asking for control',
+        'Please wait while asking for control',
+        true,
+        () => dispatch(cancelControlRequest()),
+      ),
+    );
   };
 }
 

--- a/ui/src/components/RemoteAccess/PassControlDialog.jsx
+++ b/ui/src/components/RemoteAccess/PassControlDialog.jsx
@@ -35,9 +35,9 @@ function PassControlDialog() {
             {requestingObs?.nickname} is asking for control
           </Modal.Title>
         </Modal.Header>
-        <Modal.Body>
-          User "{requestingObs?.nickname}" is asking for control:
-        </Modal.Body>
+        {requestingObs?.requestsControlMsg && (
+          <Modal.Body>{requestingObs.requestsControlMsg}</Modal.Body>
+        )}
         <Modal.Footer>
           <Form.Control
             name="message"

--- a/ui/src/components/RemoteAccess/RequestControlForm.jsx
+++ b/ui/src/components/RemoteAccess/RequestControlForm.jsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Form, Button, Card } from 'react-bootstrap';
-import {
-  cancelControlRequest,
-  requestControl,
-  takeControl,
-} from '../../actions/remoteAccess';
-import { showWaitDialog } from '../../actions/waitDialog';
+import { requestControl, takeControl } from '../../actions/remoteAccess';
 
 function RequestControlForm() {
   const dispatch = useDispatch();
@@ -15,16 +10,6 @@ function RequestControlForm() {
   function handleAskForControl(evt) {
     evt.preventDefault();
     const formData = new FormData(evt.target);
-
-    dispatch(
-      showWaitDialog(
-        'Asking for control',
-        'Please wait while asking for control',
-        true,
-        () => dispatch(cancelControlRequest()),
-      ),
-    );
-
     dispatch(requestControl(formData.get('message')));
   }
 
@@ -38,7 +23,9 @@ function RequestControlForm() {
             <Form.Control
               name="message"
               as="textarea"
-              defaultValue={`Hi, it's ${nickname}, please give me control.`}
+              defaultValue={
+                nickname && `Hi, it's ${nickname}, please give me control.`
+              }
               rows={3}
             />
           </Form.Group>

--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -377,18 +377,20 @@ class ServerIO {
     });
 
     this.hwrSocket.on('userChanged', async (message) => {
-      const prevState = store.getState();
-      const { inControl: wasInControl } = prevState.login.user;
+      const { inControl: wasInControl, requestsControl: wasRequestingControl } =
+        store.getState().login.user;
 
       await this.dispatch(getLoginInfo());
 
       const newState = store.getState();
-      const { inControl } = newState.login.user;
+      const { inControl, requestsControl } = newState.login.user;
 
       if (!wasInControl && inControl) {
         this.dispatch(showWaitDialog('You were given control', message));
       } else if (wasInControl && !inControl) {
         this.dispatch(showWaitDialog('You lost control'));
+      } else if (wasRequestingControl && !requestsControl && !inControl) {
+        this.dispatch(showWaitDialog('You were denied control', message));
       }
     });
 


### PR DESCRIPTION
Multiple fixes and improvements:

1. At last, I fix #1280 by making sure that the "Asking for control" modal closes after the request is denied by the user in control.
2. I also address [@fabcor-maxiv's comment](https://github.com/mxcube/mxcubeweb/pull/1348#issuecomment-2293614365) by showing the requester's message to the user in control. Note that this required adding a field to the `user` database table, so you'll need to **delete your local database** with `rm /tmp/mxcube-user.db` so it gets recreated the next time you start the server.
3. Finally, I improve the design and UX of the `PassControlDialog` ("[observer] is asking for control"), notably to ensure that the user in control changes the default message ("Here you go!") when denying a request.

Here is a screen recording of the entire flow:

![Peek 2024-08-20 15-37](https://github.com/user-attachments/assets/0b0c44f4-6b66-4ee9-b35f-83fc19a8f5fe)