### PR TITLE
Remove `send` prefix from action creators

### DIFF
--- a/ui/src/actions/general.js
+++ b/ui/src/actions/general.js
@@ -52,7 +52,7 @@ export function showConfirmClearQueueDialog(show = true) {
   };
 }
 
-export function sendDisplayImage(path, imgNum) {
+export function displayImage(path, imgNum) {
   return async () => {
     const data = await fetchDisplayImage(path, imgNum);
     window.open(

--- a/ui/src/actions/harvester.js
+++ b/ui/src/actions/harvester.js
@@ -4,9 +4,9 @@ import {
   sendHarvestAndLoadCrystal,
   sendCalibratePin,
   sendValidateCalibration,
-  sendAbort,
-  sendDataCollectionToCrims as sendDCToCrims,
-  sendCommand as sendCmd,
+  sendAbortHarvester,
+  sendDataCollectionInfoToCrims,
+  sendHarvesterCommand,
 } from '../api/harvester';
 
 import { showErrorPanel } from './general';
@@ -52,7 +52,7 @@ export function harvestCrystal(xtalUUID, successCb = null) {
       }
     } catch (error) {
       dispatch(showErrorPanel(true, error.response.headers.get('message')));
-      throw new Error('Server refused to Harveste Crystal');
+      throw new Error('Server refused to harvest crystal');
     }
   };
 }
@@ -68,7 +68,7 @@ export function harvestAndLoadCrystal(xtalUUID, successCb = null) {
       }
     } catch (error) {
       dispatch(showErrorPanel(true, error.response.headers.get('message')));
-      throw new Error('Server refused to Harveste or Load Crystal');
+      throw new Error('Server refused to harvest or load crystal');
     }
   };
 }
@@ -76,14 +76,14 @@ export function harvestAndLoadCrystal(xtalUUID, successCb = null) {
 export function sendDataCollectionToCrims() {
   return async (dispatch) => {
     try {
-      const contents = await sendDCToCrims();
+      const contents = await sendDataCollectionInfoToCrims();
       dispatch(setContents(contents));
 
       // temporary use ErrorPanel to display success message
-      dispatch(showErrorPanel(true, 'Succesfully Send DC to Crims'));
+      dispatch(showErrorPanel(true, 'Succesfully sent DC to Crims'));
     } catch (error) {
       dispatch(showErrorPanel(true, error.response.headers.get('message')));
-      throw new Error('Server refused to Harveste or Load Crystal');
+      throw new Error('Server refused to send DC to Crims');
     }
   };
 }
@@ -99,7 +99,7 @@ export function calibratePin(successCb = null) {
       }
     } catch (error) {
       dispatch(showErrorPanel(true, error.response.headers.get('message')));
-      throw new Error('Calibration Procedure Failed');
+      throw new Error('Calibration procedure failed');
     }
   };
 }
@@ -115,14 +115,14 @@ export function validateCalibration(validated, successCb = null) {
       }
     } catch (error) {
       dispatch(showErrorPanel(true, error.response.headers.get('message')));
-      throw new Error('Calibration Procedure Failed');
+      throw new Error('Calibration procedure failed');
     }
   };
 }
 
 export function abort() {
   return async (dispatch) => {
-    await sendAbort();
+    await sendAbortHarvester();
     dispatch(showErrorPanel(true, 'action aborted'));
   };
 }
@@ -130,12 +130,12 @@ export function abort() {
 export function sendCommand(cmdparts, args) {
   return async (dispatch) => {
     try {
-      const answer = await sendCmd(cmdparts, args);
+      const answer = await sendHarvesterCommand(cmdparts, args);
       dispatch(setHarvesterCommandResponse(answer.response));
       dispatch(setContents(answer.contents));
     } catch (error) {
       dispatch(showErrorPanel(true, error.response.headers.get('message')));
-      throw new Error(`Error while  sending command @ ${cmdparts}`);
+      throw new Error(`Error while sending command @ ${cmdparts}`);
     }
   };
 }

--- a/ui/src/actions/sampleGrid.js
+++ b/ui/src/actions/sampleGrid.js
@@ -61,7 +61,7 @@ export function setSamplesInfoAction(sampleInfoList) {
   return { type: 'SET_SAMPLES_INFO', sampleInfoList };
 }
 
-export function sendGetSampleList() {
+export function getSamplesList() {
   return async (dispatch) => {
     dispatch(
       showWaitDialog('Please wait', 'Retrieving sample changer contents', true),

--- a/ui/src/api/harvester.js
+++ b/ui/src/api/harvester.js
@@ -22,7 +22,7 @@ export function sendCalibratePin() {
   return endpoint.get('/calibrate').json();
 }
 
-export function sendDataCollectionToCrims() {
+export function sendDataCollectionInfoToCrims() {
   return endpoint.get('/send_data_collection_info_to_crims').json();
 }
 
@@ -32,10 +32,10 @@ export function sendValidateCalibration(validated) {
     .json();
 }
 
-export function sendAbort() {
+export function sendAbortHarvester() {
   return endpoint.get('/send_command/abort').res();
 }
 
-export function sendCommand(cmdparts, args) {
+export function sendHarvesterCommand(cmdparts, args) {
   return endpoint.get(`/send_command/${cmdparts}/${args}`).json();
 }

--- a/ui/src/components/Equipment/HarvesterMaintenance.jsx
+++ b/ui/src/components/Equipment/HarvesterMaintenance.jsx
@@ -14,7 +14,7 @@ export default function HarvesterMaintenance(props) {
     calibratePin,
     validateCalibration,
     sendCommand,
-    sendDCToCrims,
+    sendDataCollectionToCrims,
     commands,
   } = props;
 
@@ -156,7 +156,7 @@ export default function HarvesterMaintenance(props) {
                 <Button
                   className="mt-1"
                   variant="outline-secondary"
-                  onClick={() => sendDCToCrims()}
+                  onClick={() => sendDataCollectionToCrims()}
                   title="TEST : Send latest Data collection Group and to Crims"
                 >
                   Send Data to Crims

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -570,7 +570,7 @@ export default class SampleImage extends React.Component {
 
       const { resultDataPath } = shapeData;
       if (resultDataPath !== undefined) {
-        this.props.sendDisplayImage(`${resultDataPath}&img_num=${imgNum}`);
+        this.props.displayImage(`${resultDataPath}&img_num=${imgNum}`);
       }
     }
   }

--- a/ui/src/containers/EquipmentContainer.jsx
+++ b/ui/src/containers/EquipmentContainer.jsx
@@ -146,7 +146,9 @@ class EquipmentContainer extends React.Component {
                       message={this.props.haMessage}
                       sendCommand={this.props.haSendCommand}
                       calibratePin={this.props.haCalibratePin}
-                      sendDCToCrims={this.props.sendDataCollectionToCrims}
+                      sendDataCollectionToCrims={
+                        this.props.sendDataCollectionToCrims
+                      }
                       validateCalibration={this.props.haValidateCalibration}
                     />
                   </Col>

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -28,7 +28,7 @@ import { LuSettings2 } from 'react-icons/lu';
 import { QUEUE_RUNNING, isCollected, hasLimsData } from '../constants';
 
 import {
-  sendGetSampleList,
+  getSamplesList,
   setViewModeAction,
   syncSamples,
   syncWithCrims,
@@ -287,7 +287,7 @@ class SampleListViewContainer extends React.Component {
     // because they will be remove from sample List
     await this.props.setEnabledSample(manualSamples, false);
 
-    this.props.getSamples();
+    this.props.getSamplesList();
   }
 
   /**
@@ -1002,7 +1002,7 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    getSamples: () => dispatch(sendGetSampleList()),
+    getSamplesList: () => dispatch(getSamplesList()),
     setViewMode: (mode) => dispatch(setViewModeAction(mode)),
     filter: (filterOptions) => dispatch(filterAction(filterOptions)),
     syncSamples: () => dispatch(syncSamples()),

--- a/ui/src/containers/SampleViewContainer.jsx
+++ b/ui/src/containers/SampleViewContainer.jsx
@@ -10,7 +10,7 @@ import SSXChipControl from '../components/SSXChip/SSXChipControl';
 import PlateManipulator from '../components/Equipment/PlateManipulator';
 import ContextMenu from '../components/SampleView/ContextMenu';
 import * as sampleViewActions from '../actions/sampleview'; // eslint-disable-line import/no-namespace
-import { showErrorPanel, sendDisplayImage } from '../actions/general';
+import { showErrorPanel, displayImage } from '../actions/general';
 import { updateTask } from '../actions/queue';
 import { showTaskForm } from '../actions/taskForm';
 import BeamlineSetupContainer from './BeamlineSetupContainer';
@@ -250,7 +250,7 @@ class SampleViewContainer extends Component {
                 busy={this.props.queueState === QUEUE_RUNNING}
                 setAttribute={this.props.setAttribute}
                 setBeamlineAttribute={this.props.setBeamlineAttribute}
-                sendDisplayImage={this.props.sendDisplayImage}
+                displayImage={this.props.displayImage}
                 meshResultFormat={this.props.meshResultFormat}
               />
             </DefaultErrorBoundary>
@@ -318,7 +318,7 @@ function mapDispatchToProps(dispatch) {
     setAttribute: bindActionCreators(setAttribute, dispatch),
     stopBeamlineAction: bindActionCreators(stopBeamlineAction, dispatch),
     setBeamlineAttribute: bindActionCreators(setBeamlineAttribute, dispatch),
-    sendDisplayImage: bindActionCreators(sendDisplayImage, dispatch),
+    displayImage: bindActionCreators(displayImage, dispatch),
     sendExecuteCommand: bindActionCreators(executeCommand, dispatch),
     logFrontEndTraceBack: bindActionCreators(logFrontEndTraceBack, dispatch),
 


### PR DESCRIPTION
There are a couple of exceptions where the endpoint itself includes the word `send`, like `send_command`. In this case, I've tried to use a more specific name for the fetch function (e.g. `sendHarvesterCommand`). This is what I already had done in other domains, like `sampleChanger`.