### PR TITLE
Change currentAperture type to str

### DIFF
--- a/mxcubeweb/core/models/adaptermodels.py
+++ b/mxcubeweb/core/models/adaptermodels.py
@@ -42,16 +42,16 @@ class HOActuatorValueChangeModel(BaseModel):
 
 class HOBeamRawValueModel(BaseModel):
     apertureList: List[str] = Field([0], description="List of available apertures")
-    currentAperture: float = Field(0, description="Current aperture size")
+    currentAperture: str = Field(0, description="Current aperture label")
     position: Tuple[float, float] = Field((0, 0), description="Beam position on OAV")
     shape: str = Field("ellipse", descrption="Beam shape")
     size_x: float = Field(
         0.01,
-        description="Current aperture x size (width) in millimieters",
+        description="Current beam x size (width) in millimieters",
     )
     size_y: float = Field(
         0.01,
-        description="Current aperture y size (height) in millimieters",
+        description="Current beam y size (height) in millimieters",
     )
 
     class Config:


### PR DESCRIPTION
currentAperture is a string as it represents beam size label, not just the size any more. Corresponds to any beam definer.