### PR TITLE
Clean-up of unmount methods

### DIFF
--- a/mxcubeweb/routes/samplechanger.py
+++ b/mxcubeweb/routes/samplechanger.py
@@ -89,25 +89,6 @@ def init_route(app, server, url_prefix):  # noqa: C901
 
         return resp
 
-    @bp.route("/unmount", methods=["POST"])
-    @server.require_control
-    @server.restrict
-    def unmount_sample():
-        try:
-            resp = jsonify(
-                app.sample_changer.unmount_sample(request.get_json()["sample"])
-            )
-        except Exception as ex:
-            return (
-                "Cannot unload sample",
-                409,
-                {
-                    "Content-Type": "application/json",
-                    "message": str(ex),
-                },
-            )
-        return resp
-
     @bp.route("/capacity", methods=["GET"])
     @server.restrict
     def get_sc_capacity():

--- a/ui/src/actions/sampleChanger.js
+++ b/ui/src/actions/sampleChanger.js
@@ -9,7 +9,6 @@ import {
   sendScanSampleChanger,
   sendSelectContainer,
   sendUnmountCurrentSample,
-  sendUnmountSample,
 } from '../api/sampleChanger';
 
 export function setContents(contents) {
@@ -107,15 +106,10 @@ export function mountSample(sampleData, successCb = null) {
   };
 }
 
-export function unmountSample(sample) {
+export function unmountSample() {
   return async (dispatch) => {
     try {
-      if (sample) {
-        await sendUnmountSample(sample);
-      } else {
-        await sendUnmountCurrentSample();
-      }
-
+      await sendUnmountCurrentSample();
       dispatch(clearCurrentSample());
     } catch (error) {
       dispatch(showErrorPanel(true, error.response.headers.get('message')));

--- a/ui/src/api/sampleChanger.js
+++ b/ui/src/api/sampleChanger.js
@@ -30,10 +30,6 @@ export function sendMountSample(sampleData) {
   return endpoint.post(sampleData, '/mount').res();
 }
 
-export function sendUnmountSample(sample) {
-  return endpoint.post({ sample: { location: sample } }, '/unmount').res();
-}
-
 export function sendUnmountCurrentSample() {
   return endpoint.post(undefined, '/unmount_current').res();
 }

--- a/ui/src/components/SampleQueue/QueueControl.jsx
+++ b/ui/src/components/SampleQueue/QueueControl.jsx
@@ -114,7 +114,7 @@ export default class QueueControl extends React.Component {
     if (this.props.queue[idx + 1]) {
       this.props.runSample(this.props.queue[idx + 1]);
     } else {
-      this.props.unmountSample(this.props.sampleList[this.props.queue[idx]]);
+      this.props.unmountSample();
     }
   }
 

--- a/ui/src/containers/EquipmentContainer.jsx
+++ b/ui/src/containers/EquipmentContainer.jsx
@@ -216,7 +216,7 @@ function mapDispatchToProps(dispatch) {
   return {
     select: (address) => dispatch(select(address)),
     mountSample: (address) => dispatch(mountSample(address)),
-    unmountSample: (address) => dispatch(unmountSample(address)),
+    unmountSample: () => dispatch(unmountSample()),
     scan: (container) => dispatch(scan(container)),
     refresh: () => dispatch(refresh()),
     abort: () => dispatch(abort()),


### PR DESCRIPTION
Simplified the un-mount logic slightly. I guess someone took a tumble in the logical garden at some point (probably me ;). There was a method that unmounts a sample with a given address/position. However that obviously does not  make any sense since we only can have one sample mounted at a time :)

Removed the function `unmountSample` that took the sample address and replaced it with the method that unmounts the currently mounted sample ;)

Closes #1363 