### PR TITLE
Show error when another observer is already asking for control

### DIFF
--- a/ui/src/actions/remoteAccess.js
+++ b/ui/src/actions/remoteAccess.js
@@ -11,6 +11,7 @@ import {
   sendUpdateTimeoutGivesControl,
   sendSetAllMessagesRead,
 } from '../api/remoteAccess';
+import { showErrorPanel } from './general';
 import { getLoginInfo } from './login';
 import { showWaitDialog } from './waitDialog';
 
@@ -35,17 +36,26 @@ export function updateNickname(name) {
 
 export function requestControl(message) {
   return async (dispatch) => {
-    await sendRequestControl(message);
+    try {
+      await sendRequestControl(message);
 
-    dispatch(getLoginInfo());
-    dispatch(
-      showWaitDialog(
-        'Asking for control',
-        'Please wait while asking for control',
-        true,
-        () => dispatch(cancelControlRequest()),
-      ),
-    );
+      dispatch(getLoginInfo());
+      dispatch(
+        showWaitDialog(
+          'Asking for control',
+          'Please wait while asking for control',
+          true,
+          () => dispatch(cancelControlRequest()),
+        ),
+      );
+    } catch (error) {
+      if (error.status === 409) {
+        dispatch(showErrorPanel(true, error.text));
+        return;
+      }
+
+      throw error;
+    }
   };
 }
 

--- a/ui/src/components/RemoteAccess/PassControlDialog.jsx
+++ b/ui/src/components/RemoteAccess/PassControlDialog.jsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Modal, Button, Form, Alert } from 'react-bootstrap';
 import { respondToControlRequest } from '../../actions/remoteAccess';
 import { useForm } from 'react-hook-form';
+import { hideWaitDialog } from '../../actions/waitDialog';
 
 function PassControlDialog() {
   const dispatch = useDispatch();
@@ -40,10 +41,12 @@ function PassControlDialog() {
   }
 
   useEffect(() => {
-    if (!showModal) {
+    if (showModal) {
+      dispatch(hideWaitDialog()); // avoid conflict with any yet-to-be-dismissed dialog
+    } else {
       reset(); // make sure form is properly reset if requester cancels
     }
-  }, [showModal, reset]);
+  }, [showModal, reset, dispatch]);
 
   return (
     <Modal

--- a/ui/src/components/RemoteAccess/PassControlDialog.jsx
+++ b/ui/src/components/RemoteAccess/PassControlDialog.jsx
@@ -79,7 +79,7 @@ function PassControlDialog() {
         <Modal.Footer>
           <br />
           <Button type="submit" name="allow" variant="success">
-            Give control to "{requestingObs?.nickname}"
+            Give control
           </Button>
           <Button type="submit" name="deny" variant="danger">
             Deny control

--- a/ui/src/containers/ErrorNotificationPanel.jsx
+++ b/ui/src/containers/ErrorNotificationPanel.jsx
@@ -1,46 +1,32 @@
-/* eslint-disable react/jsx-handler-names */
 import React from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { Modal, Alert } from 'react-bootstrap';
 import { showErrorPanel } from '../actions/general';
 
-export class ErrorNotificationPanel extends React.Component {
-  render() {
-    return (
-      <Modal show={this.props.show} onHide={this.props.hideErrorPanel}>
-        <div style={{ marginBottom: '-20px' }}>
-          <Alert
-            variant="danger"
-            onClose={this.props.hideErrorPanel}
-            dismissible
-          >
-            <strong>Error:&nbsp;</strong>
-            {this.props.message}
-          </Alert>
-        </div>
-      </Modal>
-    );
-  }
+function ErrorNotificationPanel() {
+  const dispatch = useDispatch();
+
+  const show = useSelector((state) => state.general.showErrorPanel);
+  const message = useSelector((state) => state.general.errorMessage);
+
+  return (
+    <Modal
+      show={show}
+      onHide={() => dispatch(showErrorPanel(false))}
+      data-default-styles
+    >
+      <div style={{ marginBottom: '-20px' }}>
+        <Alert
+          variant="danger"
+          onClose={() => dispatch(showErrorPanel(false))}
+          dismissible
+        >
+          <strong>Error:&nbsp;</strong>
+          {message}
+        </Alert>
+      </div>
+    </Modal>
+  );
 }
 
-function mapStateToProps(state) {
-  return {
-    show: state.general.showErrorPanel,
-    message: state.general.errorMessage,
-  };
-}
-
-function mapDispatchToProps(dispatch) {
-  return {
-    hideErrorPanel: bindActionCreators(
-      showErrorPanel.bind(null, false),
-      dispatch,
-    ),
-  };
-}
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(ErrorNotificationPanel);
+export default ErrorNotificationPanel;

--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -384,8 +384,11 @@ class ServerIO {
 
       const newState = store.getState();
       const { inControl, requestsControl } = newState.login.user;
+      const hasIncomingRequest = newState.remoteAccess.observers.some(
+        (o) => o.requestsControl,
+      );
 
-      if (!wasInControl && inControl) {
+      if (!wasInControl && inControl && !hasIncomingRequest) {
         this.dispatch(showWaitDialog('You were given control', message));
       } else if (wasInControl && !inControl) {
         this.dispatch(showWaitDialog('You lost control'));


### PR DESCRIPTION
![Screenshot from 2024-08-22 16-54-59](https://github.com/user-attachments/assets/9492b8fb-6d23-480c-9aa5-2f318f882cec)

I'm also:

- refactoring the `ErrorNotificationPanel` and reducing the width of the error modal;
- fixing a couple of conflicts between the "pass-control dialog" and the "wait dialog" — this happened for instance when taking control while a request for control is in progress (the _[user] is asking for control_ dialog was shown on top of the _You were given control_ dialog visually but not in the DOM, which caused issues);
- removing the name of the user from the "Give control" button:
    
    ![Screenshot from 2024-08-22 16-39-58](https://github.com/user-attachments/assets/91ad167f-b86c-4320-bc6c-df187d5050f9)