### PR TITLE
Fix initial position of chat widget

### DIFF
--- a/ui/src/components/Equipment/GenericEquipment.jsx
+++ b/ui/src/components/Equipment/GenericEquipment.jsx
@@ -20,7 +20,7 @@ export default function GenericEquipment(props) {
         state={props.state}
         equipmentName={props.name}
         style={{
-          margin: '0px 0px 0px 0px',
+          margin: 0,
           width: 'inherit',
           borderBottomLeftRadius: '0%',
           borderBottomRightRadius: '0%',

--- a/ui/src/components/Equipment/GenericEquipmentControl.jsx
+++ b/ui/src/components/Equipment/GenericEquipmentControl.jsx
@@ -121,7 +121,7 @@ export default function GenericEquipmentControl(props) {
         state={props.equipment.state}
         equipmentName={props.equipment.name}
         style={{
-          margin: '0px 0px 0px 0px',
+          margin: 0,
           width: 'inherit',
           borderBottomLeftRadius: '0%',
           borderBottomRightRadius: '0%',

--- a/ui/src/components/Equipment/PlateManipulator.jsx
+++ b/ui/src/components/Equipment/PlateManipulator.jsx
@@ -702,9 +702,7 @@ export default function PlateManipulator(props) {
             <Popover.Header>
               {global_state.plate_info.plate_label}
             </Popover.Header>
-            <Popover.Body style={{ padding: '0px' }}>
-              {renderPlate()}
-            </Popover.Body>
+            <Popover.Body style={{ padding: 0 }}>{renderPlate()}</Popover.Body>
           </Popover>
         }
       >

--- a/ui/src/components/Equipment/equipment.module.css
+++ b/ui/src/components/Equipment/equipment.module.css
@@ -13,7 +13,7 @@
 .treeNodeLabel {
   font-weight: normal;
   cursor: pointer;
-  margin: 0px;
+  margin: 0;
 }
 
 .treeNodeLabel:hover {

--- a/ui/src/components/Equipment/genericEquipmentControl.module.css
+++ b/ui/src/components/Equipment/genericEquipmentControl.module.css
@@ -15,7 +15,7 @@
 }
 
 .command-panel {
-  border: 0px;
+  border: 0;
 }
 
 .generic_equipment_arrow_p {

--- a/ui/src/components/LabeledValue/LabeledValue.jsx
+++ b/ui/src/components/LabeledValue/LabeledValue.jsx
@@ -15,16 +15,16 @@ export default class LabeledValue extends React.Component {
       backgroundColor: 'transparent',
       display: 'block-inline',
       fontSize: '100%',
-      borderRadius: '0px',
+      borderRadius: 0,
       color: '#000',
-      padding: '0px',
+      padding: 0,
       marginBottom: 0,
       whiteSpace: 'nowrap',
     };
 
     if (this.props.look === 'vertical') {
       labelStyle = { display: 'block', marginBottom: '3px' };
-      valueStyle = { display: 'block', fontSize: '100%', borderRadius: '0px' };
+      valueStyle = { display: 'block', fontSize: '100%', borderRadius: 0 };
     }
 
     let value = this.props.value.toFixed(

--- a/ui/src/components/LoginForm/LoginForm.module.css
+++ b/ui/src/components/LoginForm/LoginForm.module.css
@@ -6,7 +6,7 @@
   margin: -10vh auto 0; /* centred with slight vertical offset to feel more centred */
   padding: 50px 60px;
   background-color: #f7f7f7;
-  box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 2px 2px rgba(0, 0, 0, 0.3);
 }
 
 .title {

--- a/ui/src/components/MotorInput/motor.css
+++ b/ui/src/components/MotorInput/motor.css
@@ -1,12 +1,12 @@
 .motor-input-container {
-  padding-right: 0px;
+  padding-right: 0;
   margin-bottom: 1em;
   font-size: 16px !important;
 }
 
 .motor-name {
   font-size: 1em;
-  margin-bottom: 0px;
+  margin-bottom: 0;
   font-weight: bold;
   display: block;
 }
@@ -26,8 +26,8 @@
 .motor-group {
   padding-top: 20px;
   padding-left: 20px;
-  padding-right: 0px;
-  padding-bottom: 0px;
+  padding-right: 0;
+  padding-bottom: 0;
 }
 
 .motor-button {
@@ -54,8 +54,8 @@
 }
 
 .rw-widget input {
-  border-bottom-right-radius: 0px;
-  border-top-right-radius: 0px;
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
 }
 
 input[type='number']::-webkit-inner-spin-button,
@@ -81,15 +81,15 @@ input::-webkit-inner-spin-button {
 }
 
 .rw-widget-no-right-border {
-  border-right: 0px;
-  border-top-right-radius: 0px;
-  border-bottom-right-radius: 0px;
+  border-right: 0;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 .rw-widget-no-left-border {
-  border-left: 0px;
-  border-top-left-radius: 0px;
-  border-bottom-left-radius: 0px;
+  border-left: 0;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
 }
 
 .rw-widget-right-border {
@@ -133,8 +133,8 @@ input::-webkit-inner-spin-button {
 }
 
 .rw-widget input {
-  border-bottom-right-radius: 0px;
-  border-top-right-radius: 0px;
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
 }
 
 .rw-input {
@@ -222,7 +222,7 @@ input::-webkit-inner-spin-button {
 .arrow-control .arrow-small {
   width: 2em;
   height: 2em;
-  padding: 0px;
+  padding: 0;
 }
 
 .arrow-control .arrow-up {
@@ -246,13 +246,13 @@ input::-webkit-inner-spin-button {
 .arrow-control .arrow i {
   font-size: 25px;
   font-weight: bold;
-  margin-left: 0px;
+  margin-left: 0;
 }
 
 .arrow-control .arrow-small i {
   font-size: 21px;
   font-weight: bold;
-  margin-left: 0px;
+  margin-left: 0;
 }
 
 .arrow-control .arrow-settings i {

--- a/ui/src/components/Notify/style.css
+++ b/ui/src/components/Notify/style.css
@@ -40,7 +40,7 @@
   border-radius: 5px;
   border-color: #333;
   opacity: 0;
-  height: 0px;
+  height: 0;
 }
 
 .closebtn {
@@ -67,6 +67,6 @@
 
 .messageContainerInner {
   position: absolute;
-  bottom: 0px;
+  bottom: 0;
   overflow: hidden;
 }

--- a/ui/src/components/SampleGrid/SampleGridTable.css
+++ b/ui/src/components/SampleGrid/SampleGridTable.css
@@ -7,7 +7,7 @@
 }
 
 .samples-grid-table-card {
-  border: 0px !important;
+  border: 0 !important;
 }
 
 .samples-grid-table-card-header {
@@ -33,7 +33,7 @@
 .sample-items-collapsible-header {
   display: flex;
   border: 1px solid #d1d6da !important;
-  border-radius: 3px 3px 0px 0px !important;
+  border-radius: 3px 3px 0 0 !important;
   padding: 4px;
 }
 
@@ -53,7 +53,7 @@
 
 .sample-items-table {
   align-items: center;
-  margin-bottom: 0px;
+  margin-bottom: 0;
   background: #e5e8eb6b;
   width: 100%;
 }
@@ -67,13 +67,13 @@
 }
 
 .sample-items-table-row-header-th {
-  padding: 0px !important;
+  padding: 0 !important;
   text-align: right;
   width: 330px !important;
 }
 
 .sample-items-table > :not(:first-child) {
-  border-top: 0px;
+  border-top: 0;
 }
 
 .sample-items-table > tbody > tr > td {
@@ -82,7 +82,7 @@
 
 .samples-grid-table-li {
   min-width: 283px;
-  margin: auto auto 6px 0px;
+  margin: auto auto 6px 0;
   z-index: 2 !important;
   list-style-type: none;
   height: 70px;
@@ -97,7 +97,7 @@
 
 .samples-grid-table-item {
   list-style-type: none !important;
-  padding: 0px;
+  padding: 0;
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05) !important;
 }
 
@@ -164,7 +164,7 @@ button[disabled] {
 }
 
 .samples-grid-table-item-tasks > .slick-list > .slick-track {
-  margin-left: 0px !important;
+  margin-left: 0 !important;
 }
 
 .samples-grid-table-item-tasks > .slick-next::before,
@@ -187,7 +187,7 @@ button[disabled] {
 }
 
 .new-sample-grid-task-item {
-  margin: 0px !important;
+  margin: 0 !important;
 }
 
 .samples-item-controls-container {
@@ -396,13 +396,13 @@ button[disabled] {
 .cell-cicle:hover {
   stroke: #6cb0f5;
   stroke-width: 9.5;
-  text-shadow: 0px 0px 30px #fdec6e;
+  text-shadow: 0 0 30px #fdec6e;
   transition: all 0.2s ease-in;
 }
 
 .circle-text:hover > .cell-cicle:hover {
   stroke: #63adf7;
-  text-shadow: 0px 0px 30px #fdec6e;
+  text-shadow: 0 0 30px #fdec6e;
   transition: all 0.2s ease-in;
 }
 

--- a/ui/src/components/SampleGrid/TaskItem.jsx
+++ b/ui/src/components/SampleGrid/TaskItem.jsx
@@ -250,7 +250,7 @@ export class TaskItem extends React.Component {
   render() {
     const style = {
       display: 'inline-block',
-      margin: '0px',
+      margin: 0,
       cursor: 'pointer',
       fontSize: '0.7em',
     };

--- a/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
+++ b/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
@@ -287,7 +287,7 @@ export default class TaskItem extends Component {
         <ProgressBar
           variant={pbarBsStyle}
           striped
-          style={{ marginBottom: '0px', height: '18px' }}
+          style={{ marginBottom: 0, height: '18px' }}
           min={0}
           max={1}
           active={this.props.progress < 1}
@@ -396,7 +396,7 @@ export default class TaskItem extends Component {
                           }}
                         >
                           <i
-                            style={{ marginLeft: '0px' }}
+                            style={{ marginLeft: 0 }}
                             className="fa fa-copy"
                             aria-hidden="true"
                           />
@@ -408,7 +408,7 @@ export default class TaskItem extends Component {
                       bordered
                       hover
                       onClick={this.showForm}
-                      style={{ fontSize: 'smaller', marginBottom: '0px' }}
+                      style={{ fontSize: 'smaller', marginBottom: 0 }}
                       className="task-parameters-table"
                     >
                       <thead>

--- a/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
+++ b/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
@@ -214,7 +214,7 @@ export default class EnergyScanTaskItem extends Component {
                     <ProgressBar
                       variant={pbarBsStyle}
                       striped
-                      style={{ marginBottom: '0px', height: '18px' }}
+                      style={{ marginBottom: 0, height: '18px' }}
                       min={0}
                       max={1}
                       active={this.props.progress < 1}

--- a/ui/src/components/SampleQueue/TaskItem.jsx
+++ b/ui/src/components/SampleQueue/TaskItem.jsx
@@ -242,7 +242,7 @@ export default class TaskItem extends Component {
         <ProgressBar
           variant={pbarBsStyle}
           striped
-          style={{ marginBottom: '0px', height: '18px' }}
+          style={{ marginBottom: 0, height: '18px' }}
           min={0}
           max={1}
           active={this.props.progress < 1}
@@ -354,7 +354,7 @@ export default class TaskItem extends Component {
                           }}
                         >
                           <i
-                            style={{ marginLeft: '0px' }}
+                            style={{ marginLeft: 0 }}
                             className="fa fa-copy"
                             aria-hidden="true"
                           />
@@ -366,7 +366,7 @@ export default class TaskItem extends Component {
                       bordered
                       hover
                       onClick={this.showForm}
-                      style={{ fontSize: 'smaller', marginBottom: '0px' }}
+                      style={{ fontSize: 'smaller', marginBottom: 0 }}
                       className="task-parameters-table"
                     >
                       <thead>

--- a/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
+++ b/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
@@ -162,7 +162,7 @@ export default class WorkflowTaskItem extends Component {
         <ProgressBar
           variant={pbarBsStyle}
           striped
-          style={{ marginBottom: '0px', height: '18px' }}
+          style={{ marginBottom: 0, height: '18px' }}
           min={0}
           max={1}
           active={this.props.progress < 1}
@@ -264,7 +264,7 @@ export default class WorkflowTaskItem extends Component {
                       }}
                     >
                       <i
-                        style={{ marginLeft: '0px' }}
+                        style={{ marginLeft: 0 }}
                         className="fa fa-copy"
                         aria-hidden="true"
                       />

--- a/ui/src/components/SampleQueue/XRFTaskItem.jsx
+++ b/ui/src/components/SampleQueue/XRFTaskItem.jsx
@@ -282,7 +282,7 @@ export default class XRFTaskItem extends Component {
                     <ProgressBar
                       variant={pbarBsStyle}
                       striped
-                      style={{ marginBottom: '0px', height: '18px' }}
+                      style={{ marginBottom: 0, height: '18px' }}
                       min={0}
                       max={1}
                       active={this.props.progress < 1}

--- a/ui/src/components/SampleQueue/app.css
+++ b/ui/src/components/SampleQueue/app.css
@@ -140,7 +140,7 @@
 }
 .list-head {
   padding: 1rem 1rem;
-  border: 0px;
+  border: 0;
 }
 .list-body {
   padding: 0.5rem 1rem;
@@ -156,7 +156,7 @@
 .queue-messages {
   height: 25%;
   width: 100%;
-  bottom: 0px;
+  bottom: 0;
   position: absolute;
   overflow-y: auto;
   overflow-x: hidden;

--- a/ui/src/components/SampleView/SampleView.css
+++ b/ui/src/components/SampleView/SampleView.css
@@ -2,7 +2,7 @@
   width: 100%;
   height: auto;
   margin-right: auto;
-  margin-bottom: 0px;
+  margin-bottom: 0;
   margin-left: auto;
 }
 .insideWrapper {
@@ -18,14 +18,14 @@
   width: 100%;
   height: 100%;
   position: absolute;
-  top: 0px;
-  left: 0px;
+  top: 0;
+  left: 0;
 }
 
 #contextMenu {
   position: absolute;
-  top: 0px;
-  left: 0px;
+  top: 0;
+  left: 0;
   display: none;
 }
 
@@ -57,7 +57,7 @@
   background-color: white;
   border: 1px solid #aaa;
   border-radius: 3px;
-  box-shadow: 0px 2px 3px 0px #aaa;
+  box-shadow: 0 2px 3px 0 #aaa;
   min-height: 300px;
   overflow: hidden;
   margin-bottom: 20px;
@@ -69,7 +69,7 @@
 }
 
 .divider {
-  margin-bottom: 0px;
+  margin-bottom: 0;
 }
 
 .canvas-container {
@@ -155,7 +155,7 @@
 }
 
 .step-size .popinput-input-value {
-  min-width: 0px;
+  min-width: 0;
 }
 
 .step-size span {

--- a/ui/src/components/Tasks/Interleaved.jsx
+++ b/ui/src/components/Tasks/Interleaved.jsx
@@ -151,7 +151,7 @@ class Interleaved extends React.Component {
               striped
               bordered
               hover
-              style={{ fontSize: 'smaller', marginBottom: '0px' }}
+              style={{ fontSize: 'smaller', marginBottom: 0 }}
               className="task-parameters-table"
             >
               <thead>
@@ -222,7 +222,7 @@ class Interleaved extends React.Component {
                 striped
                 bordered
                 hover
-                style={{ fontSize: 'smaller', marginBottom: '0px' }}
+                style={{ fontSize: 'smaller', marginBottom: 0 }}
                 className="task-parameters-table mt-3"
               >
                 <thead>

--- a/ui/src/components/rachat.css
+++ b/ui/src/components/rachat.css
@@ -1,9 +1,7 @@
 .chat-widget-dragable {
   position: absolute;
-  height: 100px;
-  width: 100px;
-  bottom: 0px;
-  right: 0px;
+  bottom: 5px;
+  right: 0;
   z-index: 100002;
 }
 
@@ -27,7 +25,7 @@
 .rcw-conversation-container .rcw-header {
   background-color: #f4f7f9;
   color: rgb(90, 85, 85);
-  padding: 0px 0px;
+  padding: 0;
   border-bottom: 1px solid #ddd;
 }
 

--- a/ui/src/containers/BeamlineSetupContainer.jsx
+++ b/ui/src/containers/BeamlineSetupContainer.jsx
@@ -238,7 +238,7 @@ function BeamlineSetupContainer(props) {
                   )}
                   <td
                     style={{
-                      border: '0px',
+                      border: 0,
                       borderLeft: '1px solid #ddd',
                       paddingLeft: '1em',
                     }}

--- a/ui/src/containers/SampleGridTableContainer.jsx
+++ b/ui/src/containers/SampleGridTableContainer.jsx
@@ -212,8 +212,8 @@ class SampleGridTableContainer extends React.Component {
     const selectionRubberBand = document.querySelector('#selectionRubberBand');
     selectionRubberBand.style.top = `${e.clientY}px`;
     selectionRubberBand.style.left = `${e.clientX}px`;
-    selectionRubberBand.style.width = '0px';
-    selectionRubberBand.style.height = '0px';
+    selectionRubberBand.style.width = 0;
+    selectionRubberBand.style.height = 0;
     this.showRubberBand = true;
 
     if (this.props.contextMenu.show) {


### PR DESCRIPTION
The chat widget is now a bit more tucked into the bottom-right corner, as expected (I think):

![image](https://github.com/user-attachments/assets/c7cb27f1-9917-41e4-b072-6daf79e4ffff)

Took the opportunity to replace all occurrences I could find of `0px` in the CSS, which can be written simply as `0`.