### PR TITLE
Refactor and improve `ObserverDialog`

### DIFF
--- a/ui/cypress/support.js
+++ b/ui/cypress/support.js
@@ -20,7 +20,7 @@ Cypress.Commands.add('takeControl', (returnPage = '/datacollection') => {
   // control only needs to be taken, when observer mode is present
   cy.get('body').then(($body) => {
     if ($body.text().includes('Observer mode')) {
-      cy.findByRole('button', { name: 'OK' }).click();
+      cy.findByRole('button', { name: 'Continue' }).click();
       cy.findByRole('link', { name: /Remote/u, hidden: true }).click();
       cy.findByRole('button', { name: 'Take control' }).click();
       cy.visit(returnPage);

--- a/ui/src/actions/remoteAccess.js
+++ b/ui/src/actions/remoteAccess.js
@@ -15,10 +15,6 @@ import { showErrorPanel } from './general';
 import { getLoginInfo } from './login';
 import { showWaitDialog } from './waitDialog';
 
-export function showObserverDialog(show = true) {
-  return { type: 'SHOW_OBSERVER_DIALOG', show };
-}
-
 export function getRaState() {
   return async (dispatch) => {
     const data = await fetchRemoteAccessState();

--- a/ui/src/components/RemoteAccess/PassControlDialog.jsx
+++ b/ui/src/components/RemoteAccess/PassControlDialog.jsx
@@ -66,21 +66,22 @@ function PassControlDialog() {
           {requestingObs?.requestsControlMsg && (
             <Alert>{requestingObs.requestsControlMsg}</Alert>
           )}
-          <Form.Label>Your response:</Form.Label>
-          <Form.Control
-            type="textarea"
-            {...register('message')}
-            placeholder="Message"
-            rows="4"
-            isValid={isSubmitted && !errors.message}
-            isInvalid={isSubmitted && !!errors.message}
-          />
-          <Form.Control.Feedback type="invalid">
-            {errors.message?.message}
-          </Form.Control.Feedback>
+          <Form.Group controlId="passControlResponse">
+            <Form.Label>Your response:</Form.Label>
+            <Form.Control
+              {...register('message')}
+              type="textarea"
+              placeholder="Message"
+              rows="4"
+              isValid={isSubmitted && !errors.message}
+              isInvalid={isSubmitted && !!errors.message}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.message?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
         </Modal.Body>
         <Modal.Footer>
-          <br />
           <Button type="submit" name="allow" variant="success">
             Give control
           </Button>

--- a/ui/src/reducers/remoteAccess.js
+++ b/ui/src/reducers/remoteAccess.js
@@ -4,7 +4,6 @@ const INITIAL_STATE = {
   observers: [],
   allowRemote: false,
   timeoutGivesControl: false,
-  showObserverDialog: false,
   chatMessageCount: 0,
 };
 
@@ -23,9 +22,6 @@ function remoteAccessReducer(state = INITIAL_STATE, action = {}) {
     }
     case 'SET_OBSERVERS': {
       return { ...state, observers: action.observers };
-    }
-    case 'SHOW_OBSERVER_DIALOG': {
-      return { ...state, showObserverDialog: action.show };
     }
     case 'SET_ALLOW_REMOTE': {
       return { ...state, allowRemote: action.allow };


### PR DESCRIPTION
- Remove unused `showObserverDialog` action and state flag.
- Convert to function component.
- Use React Hook Form to manage form (there's no validation whatsoever since the `name` is optional, but it provides a cleaner way to retrieve the value of the `name` field in the `submit` handler, and to provide a reactive `defaultValue` for the field).
- Clean up design slightly (size of modal, button colour, etc.)
- Autofocus `name` field when dialog appears so users can type and press Enter right away.
- Label the field and make sure the field receives focus when the label is clicked (and do the same in `PassModalDialog`).

![image](https://github.com/user-attachments/assets/20df8a39-55ab-4152-9ed5-bb90ac01483a)
