### PR TITLE
Tame Cypress tests

### DIFF
--- a/ui/.env
+++ b/ui/.env
@@ -1,8 +1,12 @@
 #####
-# UI ENVIRONMENT VARIABLEs
+# UI ENVIRONMENT VARIABLES
 # Copy and configure the variables below in your own `.env.local` or `.env.[mode].local` file
 # https://vitejs.dev/guide/env-and-mode.html#env-files
 #####
 
 # Redux logger ('true' to enable)
 VITE_REDUX_LOGGER_ENABLED=
+
+# Disable WebSockets ('true' to disable)
+# Useful when running Cypress tests locally to match CI (where WebSockets currently don't work)
+VITE_DISABLE_WEBSOCKETS=

--- a/ui/cypress.config.js
+++ b/ui/cypress.config.js
@@ -1,10 +1,14 @@
 import { defineConfig } from 'cypress';
+import installLogsPrinter from 'cypress-terminal-report/src/installLogsPrinter.js';
 
 export default defineConfig({
   e2e: {
     baseUrl: 'http://localhost:5173',
     supportFile: 'cypress/support.js',
     screenshotsFolder: 'cypress/debug',
+    setupNodeEvents(on) {
+      installLogsPrinter(on);
+    },
   },
   viewportWidth: 1200,
   viewportHeight: 800,

--- a/ui/cypress/e2e/app.cy.js
+++ b/ui/cypress/e2e/app.cy.js
@@ -24,8 +24,7 @@ describe('login', () => {
 
 describe('app', () => {
   beforeEach(() => {
-    cy.login();
-    cy.findByRole('heading', { name: 'MXCuBE-Web (OSC)' }).should('be.visible');
+    cy.loginWithControl();
   });
 
   it('displays collection page', () => {

--- a/ui/cypress/e2e/queue.cy.js
+++ b/ui/cypress/e2e/queue.cy.js
@@ -2,9 +2,7 @@
 
 describe('queue', () => {
   beforeEach(() => {
-    cy.login();
-    cy.findByRole('heading', { name: 'MXCuBE-Web (OSC)' }).should('be.visible');
-    cy.takeControl();
+    cy.loginWithControl();
   });
 
   it('mount a test sample', () => {

--- a/ui/cypress/e2e/sampleControls.cy.js
+++ b/ui/cypress/e2e/sampleControls.cy.js
@@ -15,12 +15,18 @@ describe('3-click centring', () => {
     );
   });
 
-  it.skip('Each click is rotating the sample by 90 degrees', () => {
+  it('Each click is rotating the sample by 90 degrees', () => {
     cy.mountSample();
     cy.findByRole('button', { name: 'Sample: test - test' }).should(
       'be.visible',
     );
+
     cy.findByRole('button', { name: '3-click centring' }).click();
+    cy.findByRole('button', { name: '3-click centring' }).should(
+      'have.class',
+      'active',
+    );
+
     cy.get('.form-control[name="diffractometer.phi"]')
       .invoke('val')
       .then((value) => {

--- a/ui/cypress/e2e/sampleControls.cy.js
+++ b/ui/cypress/e2e/sampleControls.cy.js
@@ -2,13 +2,13 @@
 
 describe('3-click centring', () => {
   beforeEach(() => {
-    cy.login();
-    cy.findByRole('heading', { name: 'MXCuBE-Web (OSC)' }).should('be.visible');
-    cy.takeControl();
+    cy.loginWithControl();
   });
 
   it('3-click centring should not work without sample', () => {
-    cy.clearSamples();
+    cy.clearSamples(); // another test may have mounted a sample
+    cy.findByRole('link', { name: /Data collection/u, hidden: true }).click();
+
     cy.findByRole('button', { name: '3-click centring' }).click();
     cy.findByRole('alert', 'Error: There is no sample mounted').should(
       'be.visible',

--- a/ui/cypress/support.js
+++ b/ui/cypress/support.js
@@ -13,9 +13,7 @@ Cypress.Commands.add('takeControl', (returnPage = '/datacollection') => {
   /* firefox (only firefox) throws an unhandled promise error when executing
      this function. Hence, we tell cypress to ignore this, otherwise the tests
      fail, when we try to click the observer mode dialog away. */
-  Cypress.on('uncaught:exception', (err, runnable) => {
-    return false;
-  });
+  Cypress.on('uncaught:exception', () => false);
 
   // control only needs to be taken, when observer mode is present
   cy.get('body').then(($body) => {
@@ -23,18 +21,23 @@ Cypress.Commands.add('takeControl', (returnPage = '/datacollection') => {
       cy.findByRole('button', { name: 'Continue' }).click();
       cy.findByRole('link', { name: /Remote/u, hidden: true }).click();
       cy.findByRole('button', { name: 'Take control' }).click();
-      cy.visit(returnPage);
     }
   });
 
   // tell cypress to listen to any uncaught:execptions again
-  Cypress.on('uncaught:exception', (err, runnable) => {
-    return true;
-  });
+  Cypress.on('uncaught:exception', () => true);
+});
+
+Cypress.Commands.add('loginWithControl', () => {
+  cy.login();
+  cy.findByRole('heading', { name: 'MXCuBE-Web (OSC)' }).should('be.visible');
+
+  cy.takeControl();
+  cy.findByRole('link', { name: /Data collection/u, hidden: true }).click();
+  cy.findByRole('button', { name: 'Run Queue' }).should('be.visible');
 });
 
 Cypress.Commands.add('mountSample', (sample = 'test', protein = 'test') => {
-  cy.visit('/datacollection');
   cy.findByRole('button', { name: /Queued Samples/u }).click();
   cy.findByRole('button', { name: 'Create new sample' }).click();
   cy.findByLabelText('Sample name').type(sample);
@@ -44,9 +47,8 @@ Cypress.Commands.add('mountSample', (sample = 'test', protein = 'test') => {
   cy.reload();
 });
 
-Cypress.Commands.add('clearSamples', (returnPage = '/datacollection') => {
+Cypress.Commands.add('clearSamples', () => {
   cy.findByText('Samples').click();
   cy.findByRole('button', { name: /Clear sample list/u }).click('left');
   cy.findByRole('button', { name: 'Ok' }).click();
-  cy.visit(returnPage);
 });

--- a/ui/cypress/support.js
+++ b/ui/cypress/support.js
@@ -1,5 +1,8 @@
 /* global Cypress, cy */
 import '@testing-library/cypress/add-commands';
+import installLogsCollector from 'cypress-terminal-report/src/installLogsCollector.js';
+
+installLogsCollector();
 
 Cypress.Commands.add('login', (username = 'idtest0', password = '0000') => {
   cy.visit('/');

--- a/ui/cypress/support.js
+++ b/ui/cypress/support.js
@@ -46,7 +46,14 @@ Cypress.Commands.add('mountSample', (sample = 'test', protein = 'test') => {
   cy.findByLabelText('Sample name').type(sample);
   cy.findByLabelText('Protein acronym').type(protein);
   cy.findByRole('button', { name: 'Mount' }).click();
-  // reload for button changes to take effect
+
+  // Wait for "Queued Samples" tab to no longer be selected to ensure that mount command has been sent
+  cy.findByRole('button', { name: /Queued Samples/u }).should(
+    'not.have.class',
+    'active',
+  );
+
+  // Reload to see mounted sample (until WebSockets are fixed on CI)
   cy.reload();
 });
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,7 +16,7 @@
     "prettier": "prettier . --cache --check",
     "eslint": "eslint \"**/*.{js,jsx}\"",
     "e2e": "cypress run --e2e --browser firefox",
-    "cypress": "cypress open --e2e --browser firefox"
+    "cypress": "VITE_DISABLE_WEBSOCKETS=true cypress open --e2e --browser firefox"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",

--- a/ui/package.json
+++ b/ui/package.json
@@ -69,6 +69,7 @@
     "@types/react-redux": "7.1.33",
     "@vitejs/plugin-react-swc": "3.7.0",
     "cypress": "13.13.2",
+    "cypress-terminal-report": "6.1.2",
     "eslint": "8.42.0",
     "eslint-config-galex": "4.5.2",
     "prettier": "3.0.0",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       cypress:
         specifier: 13.13.2
         version: 13.13.2
+      cypress-terminal-report:
+        specifier: 6.1.2
+        version: 6.1.2(cypress@13.13.2)
       eslint:
         specifier: 8.42.0
         version: 8.42.0
@@ -1548,6 +1551,11 @@ packages:
   csstype@3.1.2:
     resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
 
+  cypress-terminal-report@6.1.2:
+    resolution: {integrity: sha512-lGYLyy/fB2j3ZSfwGCZAh9z6Xmc5hompUFdAWxXgDimPZwsilQS9w7WI7QG/UoAAnLrl2P1zu+dX38HThQiSgg==}
+    peerDependencies:
+      cypress: '>=10.0.0'
+
   cypress@13.13.2:
     resolution: {integrity: sha512-PvJQU33933NvS1StfzEb8/mu2kMy4dABwCF+yd5Bi7Qly1HOVf+Bufrygee/tlmty/6j5lX+KIi8j9Q3JUMbhA==}
     engines: {node: ^16.0.0 || ^18.0.0 || >=20.0.0}
@@ -2191,6 +2199,10 @@ packages:
   fragment-cache@0.2.1:
     resolution: {integrity: sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==}
     engines: {node: '>=0.10.0'}
+
+  fs-extra@10.1.0:
+    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
+    engines: {node: '>=12'}
 
   fs-extra@9.1.0:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
@@ -4124,6 +4136,10 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
+  tv4@1.3.0:
+    resolution: {integrity: sha512-afizzfpJgvPr+eDkREK4MxJ/+r8nEEHcmitwgnPUqpaP+FpwQyadnxNoSACbgc/b1LsZYtODGoPiFxQrgJgjvw==}
+    engines: {node: '>= 0.8.0'}
+
   tweetnacl@0.14.5:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
 
@@ -5910,6 +5926,15 @@ snapshots:
 
   csstype@3.1.2: {}
 
+  cypress-terminal-report@6.1.2(cypress@13.13.2):
+    dependencies:
+      chalk: 4.1.2
+      cypress: 13.13.2
+      fs-extra: 10.1.0
+      process: 0.11.10
+      semver: 7.5.4
+      tv4: 1.3.0
+
   cypress@13.13.2:
     dependencies:
       '@cypress/request': 3.0.1
@@ -6329,9 +6354,9 @@ snapshots:
       eslint-config-prettier: 8.8.0(eslint@8.42.0)
       eslint-import-resolver-jsconfig: 1.1.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0))(eslint@8.42.0)
+      eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5)(eslint@8.42.0)
       eslint-plugin-etc: 2.0.2(eslint@8.42.0)(typescript@5.0.3)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0))(eslint@8.42.0))(eslint@8.42.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-typescript@3.5.4)(eslint@8.42.0)
       eslint-plugin-jest: 27.2.1(@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0)(typescript@5.0.3)
       eslint-plugin-jest-dom: 4.0.3(eslint@8.42.0)
       eslint-plugin-jest-formatting: 3.1.0(eslint@8.42.0)
@@ -6382,12 +6407,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0))(eslint@8.42.0):
+  eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5)(eslint@8.42.0):
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       enhanced-resolve: 5.17.1
       eslint: 8.42.0
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0))(eslint@8.42.0))(eslint@8.42.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-typescript@3.5.4)(eslint@8.42.0)
       get-tsconfig: 4.7.6
       globby: 13.2.2
       is-core-module: 2.15.0
@@ -6396,14 +6421,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0))(eslint@8.42.0))(eslint@8.42.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5)(eslint@8.42.0))(eslint@8.42.0):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
       '@typescript-eslint/parser': 5.56.0(eslint@8.42.0)(typescript@5.0.3)
       eslint: 8.42.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0))(eslint@8.42.0)
+      eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5)(eslint@8.42.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6420,7 +6445,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0))(eslint@8.42.0))(eslint@8.42.0):
+  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-typescript@3.5.4)(eslint@8.42.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.flat: 1.3.2
@@ -6429,7 +6454,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.42.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0))(eslint@8.42.0))(eslint@8.42.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5)(eslint@8.42.0))(eslint@8.42.0)
       has: 1.0.3
       is-core-module: 2.15.0
       is-glob: 4.0.3
@@ -6854,6 +6879,12 @@ snapshots:
   fragment-cache@0.2.1:
     dependencies:
       map-cache: 0.2.2
+
+  fs-extra@10.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.0
 
   fs-extra@9.1.0:
     dependencies:
@@ -8986,6 +9017,8 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  tv4@1.3.0: {}
 
   tweetnacl@0.14.5: {}
 

--- a/ui/src/actions/queue.js
+++ b/ui/src/actions/queue.js
@@ -106,22 +106,18 @@ export function addSamplesToQueue(sampleDataList) {
 }
 
 export function addSampleAndMount(sampleData) {
-  return (dispatch) => {
-    dispatch(
-      mountSample(sampleData, async () => {
-        dispatch(queueLoading(true));
+  return async (dispatch) => {
+    await dispatch(mountSample(sampleData));
 
-        try {
-          const json = await sendAddQueueItem([sampleData]);
-          dispatch(setQueue(json));
-          dispatch(selectSamplesAction([sampleData.sampleID]));
-        } catch {
-          dispatch(showErrorPanel(true, 'Server refused to add sample'));
-        }
-
-        dispatch(queueLoading(false));
-      }),
-    );
+    dispatch(queueLoading(true));
+    try {
+      const json = await sendAddQueueItem([sampleData]);
+      dispatch(setQueue(json));
+      dispatch(selectSamplesAction([sampleData.sampleID]));
+    } catch {
+      dispatch(showErrorPanel(true, 'Server refused to add sample'));
+    }
+    dispatch(queueLoading(false));
   };
 }
 

--- a/ui/src/actions/sampleChanger.js
+++ b/ui/src/actions/sampleChanger.js
@@ -87,7 +87,7 @@ export function scan(address) {
   };
 }
 
-export function mountSample(sampleData, successCb = null) {
+export function mountSample(sampleData) {
   return async (dispatch, getState) => {
     const state = getState();
     if (state.sampleChanger.loadedSample.address === sampleData.location) {
@@ -96,10 +96,6 @@ export function mountSample(sampleData, successCb = null) {
 
     try {
       await sendMountSample(sampleData);
-
-      if (successCb) {
-        successCb();
-      }
     } catch (error) {
       dispatch(showErrorPanel(true, error.response.headers.get('message')));
     }

--- a/ui/src/actions/sampleChanger.js
+++ b/ui/src/actions/sampleChanger.js
@@ -98,6 +98,7 @@ export function mountSample(sampleData) {
       await sendMountSample(sampleData);
     } catch (error) {
       dispatch(showErrorPanel(true, error.response.headers.get('message')));
+      throw error;
     }
   };
 }

--- a/ui/src/components/App.jsx
+++ b/ui/src/components/App.jsx
@@ -75,7 +75,7 @@ function App() {
   useEffect(() => {
     dispatch(getLoginInfo());
 
-    if (loggedIn) {
+    if (loggedIn && import.meta.env.VITE_DISABLE_WEBSOCKETS !== 'true') {
       serverIO.listen();
 
       return () => {

--- a/ui/src/components/Tasks/AddSample.jsx
+++ b/ui/src/components/Tasks/AddSample.jsx
@@ -45,11 +45,12 @@ function AddSample(props) {
     }
   }, [setFocus, show]);
 
-  function addAndMount(params) {
+  async function addAndMount(params) {
     const sampleData = getSampleData(params);
     addSamplesToList([sampleData]);
-    addSampleAndMount(sampleData);
     hide();
+
+    await addSampleAndMount(sampleData);
 
     if (pathname === '/' || pathname === '/datacollection') {
       // Switch to mounted sample tab


### PR DESCRIPTION
Our E2E tests are currently limited by the fact that **WebSockets don't seem to work on the CI**. The front-end tries to connect but the connection is never established. It is a very hard issue to debug. I've tried with Chrome and Electron browsers instead of Firefox; I've played with the WebSocket URL; I've refactored the `ServerIO` class ; ... nothing worked.

I did find [this issue](https://github.com/cypress-io/cypress/issues/22556), which is still open and suggests a workaround, but before I dig into this, I thought I'd first try to **stabilise the tests** with the knowledge that WebSockets don't work on the CI.

---

### 1) Run tests locally with WebSockets disabled

I add an environment variable called `VITE_DISABLE_WEBSOCKETS` that I set to `true` before launching the Cypress UI locally (in the `cypress` script in `package.json`). This allows me to run the E2E tests locally more like how they are run on the CI.

### 2) Make tests easier to debug on the CI

Debugging tests that fail on the CI is challenging because we can't inspect the DOM or see `console.log()` messages, and Cypress' output is generally quite sparse. I fix this by installing a Cypress plugin called [cypress-terminal-report](https://github.com/archfz/cypress-terminal-report), which logs all the commands and `console` messages for failing tests.

### 3) Refetch local state only when needed

Basically, without WebSockets, any UI change that relies on a server-sent update must be expected **after refetching the Redux state**. This can be done in three ways: by reloading the page (`cy.reload()`), by performing a full browser navigation (`cy.visit(...)`), or by signing out and logging back in.

I noticed that not all calls to `cy.reload()` or `cy.visit(...)` were necessary in our current tests. For instance, after taking control, we can navigate back to "Data collection" instantly by simply clicking on the corresponding navigation link in the top bar. So I replace all the unnecessary calls, which should speed up the tests a bit.

Two tests remain with calls to `cy.reload()`. Ideally, I would prefer to log out and back in, but this has a number of side effects that are incompatible with our tests, including unmounting the current sample. So I've left them as is.

### 4) Stabilise flaky tests

The two tests calling `cy.reload()` were particularly flaky, to the point that we had to skip one of them. This happened because `cy.reload()` was called before the browser had time to send the preceding command to the server.

The solution consists in awaiting the API call and expecting a UI change to confirm that the call went through successfully before reloading.