### PR TITLE
Clean-up `ServerIO`

### DIFF
--- a/ui/src/components/App.jsx
+++ b/ui/src/components/App.jsx
@@ -19,6 +19,9 @@ import LoadingScreen from './LoadingScreen/LoadingScreen';
 import { serverIO } from '../serverIO';
 import { getLoginInfo } from '../actions/login';
 import PrivateOutlet from './PrivateOutlet';
+import { sendRefreshSession } from '../api/login';
+
+const REFRESH_INTERVAL = 9000;
 
 const router = createBrowserRouter([
   {
@@ -77,8 +80,10 @@ function App() {
 
     if (loggedIn && import.meta.env.VITE_DISABLE_WEBSOCKETS !== 'true') {
       serverIO.listen();
+      const refreshInterval = setInterval(sendRefreshSession, REFRESH_INTERVAL);
 
       return () => {
+        clearInterval(refreshInterval);
         serverIO.disconnect();
       };
     }

--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -64,7 +64,6 @@ import {
 import { setEnergyScanResult } from './actions/taskResults';
 
 import { CLICK_CENTRING } from './constants';
-import { sendRefreshSession } from './api/login';
 import { store } from './store';
 import { hideWaitDialog, showWaitDialog } from './actions/waitDialog';
 
@@ -72,46 +71,14 @@ class ServerIO {
   constructor() {
     this.hwrSocket = null;
     this.loggingSocket = null;
-    this.uiStateSocket = null;
-    this.hwrsid = null;
     this.connected = false;
     this.initialized = false;
-
-    this.uiStorage = {
-      setItem: (key, value) => {
-        this.uiStateSocket.emit('ui_state_set', [key, value]);
-      },
-      getItem: (key, cb) => {
-        this.uiStateSocket.emit('ui_state_get', key, (value) => {
-          cb(false, value);
-        });
-      },
-      removeItem: (key) => {
-        this.uiStateSocket.emit('ui_state_rm', key);
-      },
-      getAllKeys: (cb) => {
-        this.uiStateSocket.emit('ui_state_getkeys', null, (value) => {
-          cb(false, value);
-        });
-      },
-    };
-  }
-
-  connectStateSocket(statePersistor) {
-    this.uiStateSocket = io.connect(
-      `//${document.domain}:${window.location.port}/ui_state`,
-    );
-
-    this.uiStateSocket.on('state_update', (newState) => {
-      statePersistor.rehydrate(JSON.parse(newState));
-    });
   }
 
   disconnect() {
     this.connected = false;
     this.hwrSocket.close();
     this.loggingSocket.close();
-    clearInterval(this.refreshInterval);
   }
 
   connect() {
@@ -125,7 +92,7 @@ class ServerIO {
       this.loggingSocket = io.connect(
         `//${document.domain}:${window.location.port}/logging`,
       );
-      this.hwrSocket.on('connect', () => {
+      this.loggingSocket.on('connect', () => {
         console.log('loggingSocket connected!'); // eslint-disable-line no-console
       });
     } else {
@@ -136,7 +103,6 @@ class ServerIO {
 
   // eslint-disable-next-line sonarjs/cognitive-complexity
   listen() {
-    this.refreshInterval = setInterval(sendRefreshSession, 9000);
     this.connect();
 
     if (this.initialized) {
@@ -154,6 +120,8 @@ class ServerIO {
     });
 
     this.loggingSocket.on('disconnect', (reason) => {
+      console.log('loggingSocket disconnected!'); // eslint-disable-line no-console
+
       if (reason === 'io server disconnect') {
         const socket = this.loggingSocket;
         setTimeout(() => {
@@ -353,12 +321,15 @@ class ServerIO {
     });
 
     this.hwrSocket.on('disconnect', (reason) => {
+      console.log('hwrSocket disconnected!'); // eslint-disable-line no-console
+
       if (reason === 'io server disconnect') {
         const socket = this.hwrSocket;
         setTimeout(() => {
           socket.connect();
         }, 500);
       }
+
       if (this.connected) {
         this.connected = false;
         setTimeout(() => {


### PR DESCRIPTION
- Move "refresh interval" initialisation and clean-up to `App.jsx`.
- Remove unused `ServerIO` class members.
- Log to the console when sockets are disconnected.
- Fix `connect` listener registered on wrong socket.