### PR TITLE
Mesh results

### DIFF
--- a/mxcubeweb/core/components/sampleview.py
+++ b/mxcubeweb/core/components/sampleview.py
@@ -278,11 +278,11 @@ class SampleView(ComponentBase):
 
         return shape
 
-    def shape_add_cell_result(self, sid, cell, result):
+    def shape_add_result(self, sid, result, data_file):
         from mxcubeweb.routes import signals
 
         shape = HWR.beamline.sample_view.get_shape(sid)
-        shape.set_cell_result(cell, result)
+        HWR.beamline.sample_view.set_grid_data(sid, result, data_file)
         signals.grid_result_available(to_camel(shape.as_dict()))
 
     def handle_grid_result(self, shape):

--- a/mxcubeweb/routes/samplecentring.py
+++ b/mxcubeweb/routes/samplecentring.py
@@ -135,20 +135,18 @@ def init_route(app, server, url_prefix):  # noqa: C901
             return Response(status=409)
 
     @bp.route("/shapes/<sid>", methods=["POST"])
-    def shape_add_cell_result(sid):
+    def shape_add_result(sid):
         """
-        Update cell result data.
-            :parameter shape_data: dict with result info (cell number, result value)
+        Update shape result data.
+            :parameter shape_data: dict with result info (result value dict, data file path)
             :response Content-type: application/json, response status.
             :statuscode: 200: no error
             :statuscode: 409: error
         """
         params = request.get_json()
-
-        cell_number = params.get("cell", 0)
-        result = params.get("result", 0)
-
-        app.sample_view.shape_add_cell_result(sid, cell_number, result)
+        result = params.get("result")
+        data_file = params.get("data_file")
+        app.sample_view.shape_add_result(sid, result, data_file)
         return Response(status=200)
 
     @bp.route("/shapes", methods=["POST"])

--- a/ui/src/components/SampleView/DrawGridPlugin.jsx
+++ b/ui/src/components/SampleView/DrawGridPlugin.jsx
@@ -329,7 +329,7 @@ export default class DrawGridPlugin {
       for (let nh = 0; nh < row; nh++) {
         for (let nw = 0; nw < col; nw++) {
           const index = nw + nh * col + 1;
-          if (index < Object.keys(result).length) {
+          if (result[index] != undefined) {
             fillingMatrix[nw][nh] = this.heatMapColorForValue(
               gd,
               result[index],

--- a/ui/src/components/SampleView/DrawGridPlugin.jsx
+++ b/ui/src/components/SampleView/DrawGridPlugin.jsx
@@ -329,7 +329,7 @@ export default class DrawGridPlugin {
       for (let nh = 0; nh < row; nh++) {
         for (let nw = 0; nw < col; nw++) {
           const index = nw + nh * col + 1;
-          if (result[index] != undefined) {
+          if (result[index] !== undefined) {
             fillingMatrix[nw][nh] = this.heatMapColorForValue(
               gd,
               result[index],

--- a/ui/src/components/SampleView/DrawGridPlugin.jsx
+++ b/ui/src/components/SampleView/DrawGridPlugin.jsx
@@ -325,10 +325,12 @@ export default class DrawGridPlugin {
       for (let nh = 0; nh < row; nh++) {
         for (let nw = 0; nw < col; nw++) {
           const index = nw + nh * col + 1;
-          fillingMatrix[nw][nh] = this.heatMapColorForValue(
-            gd,
-            result[index][1],
-          );
+          if (index < Object.keys(result).length) {
+            fillingMatrix[nw][nh] = this.heatMapColorForValue(
+              gd,
+              result[index],
+            );
+          }
         }
       }
     }

--- a/ui/src/components/SampleView/DrawGridPlugin.jsx
+++ b/ui/src/components/SampleView/DrawGridPlugin.jsx
@@ -312,7 +312,11 @@ export default class DrawGridPlugin {
     let { result } = gd;
 
     // Use selected result type if it exists
-    if (gd.result !== null && this.resultType in gd.result) {
+    if (
+      gd.result !== null &&
+      gd.result !== '' &&
+      this.resultType in gd.result
+    ) {
       result = gd.result[this.resultType];
     }
 

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -478,7 +478,11 @@ export default class SampleImage extends React.Component {
             if (obj.type === 'GridGroup') {
               let gridData = this.props.grids[obj.id];
               if (gridData) {
-                const cellCenter = this.getGridCellCenter(obj, clickPoint);
+                const cellCenter = this.drawGridPlugin.getClickedCell(
+                  gridData,
+                  obj,
+                  e,
+                );
                 ctxMenuObj = {
                   type: 'GridGroupSaved',
                   gridData,


### PR DESCRIPTION
Fixing mesh result display when sending via mxcubeweb API. 

Also fixing the call to `getGridCellCenter`, this method no longer exists.

Format of the data: (to be documented in the documentation, not just here in an MR...)
```
{"result": {<cell_number>:  [R, G, B, alpha], ....}, "data_file": <str>}
```
for example:
```
{"result": 
   {
    '44': [255, 255, 255, 0.0], 
    '61': [255, 255, 255, 0.0], 
    '56': [255, 255, 255, 0.0],
    '10': [255, 255, 255, 0.0]},
"data_file": "a/path/to/file"}
```

Anyone else using this functionality?

For PNG format, who is using it, @marcus-oscarsson? Can you give me an example data and I test with this? Do you use this API or you go via workflow?

Related mxcubecore https://github.com/mxcube/mxcubecore/pull/1004

Working with mockups:

change the following: mesh_result_format: RGB in beamline_config.yml

Mock results, assuming grid G1 exists. Update this code with number of cells (the 266 number below)
```
import requests, json, random

url = "http://localhost:8081/mxcube/api/v0.1/sampleview/shapes/G1"
from random import randrange
MAX = 100


SENT = []

def send():
    data = {}
    cells = []
    for i in range(5):
        cells.append(random.randint(1, 266))

    for i in cells:
        if i not in SENT:
            data.update({str(i): 
            [random.randrange(0, 255, 1), 
                random.randrange(0, 255, 1), 
                random.randrange(0, 255, 1), 0.0]
                # [255, 255, 255, 0.0]
            }
            )
            SENT.append(i)
    requests.post(url, json={"result": data, "data_file": "/data/visitors/2132"})


while(True):
    send()
    time.sleep(1)
```

![mesh_display](https://github.com/user-attachments/assets/580f584d-0482-4c97-9a12-1fc0251c4644)
