### PR TITLE
working with sessions

### DIFF
--- a/mxcubeweb/core/components/lims.py
+++ b/mxcubeweb/core/components/lims.py
@@ -226,10 +226,6 @@ class Lims(ComponentBase):
                 )
                 return ERROR_CODE
 
-            for prop in session["proposal_list"]:
-                todays_session = HWR.beamline.lims.get_todays_session(prop)
-                prop["Session"] = [todays_session["session"]]
-
             if hasattr(
                 HWR.beamline.session, "commissioning_fake_proposal"
             ) and HWR.beamline.session.is_inhouse(loginID, None):
@@ -326,7 +322,7 @@ class Lims(ComponentBase):
             )
 
             todays_session = HWR.beamline.lims.get_todays_session(
-                proposal_info, create_session=False
+                proposal_info, create_session=True
             )
             HWR.beamline.session.session_id = todays_session.get("session").get(
                 "sessionId"

--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -383,7 +383,11 @@ class UserManager(BaseUserManager):
             raise Exception("Remote access disabled")
 
         # Only allow remote logins with existing sessions
-        if self.app.lims.lims_valid_login(login_res)
+        if (
+            self.app.lims.lims_valid_login(login_res)
+            and is_local_host()
+            and HWR.beamline.lims.loginType.lower() != "user"
+        ):
         and is_local_host()
         and HWR.beamline.lims.loginType.lower() != "user":
             msg = "[LOGIN] Valid login from local host (%s)" % str(info)

--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -388,7 +388,6 @@ class UserManager(BaseUserManager):
             and is_local_host()
             and HWR.beamline.lims.loginType.lower() != "user"
         ):
-        and is_local_host()
         and HWR.beamline.lims.loginType.lower() != "user":
             msg = "[LOGIN] Valid login from local host (%s)" % str(info)
             logging.getLogger("MX3.HWR").info(msg)

--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -383,7 +383,9 @@ class UserManager(BaseUserManager):
             raise Exception("Remote access disabled")
 
         # Only allow remote logins with existing sessions
-        if self.app.lims.lims_valid_login(login_res) and is_local_host():
+        if self.app.lims.lims_valid_login(login_res)
+        and is_local_host()
+        and HWR.beamline.lims.loginType.lower() != "user":
             msg = "[LOGIN] Valid login from local host (%s)" % str(info)
             logging.getLogger("MX3.HWR").info(msg)
         elif self.app.lims.lims_valid_login(

--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -384,9 +384,6 @@ class UserManager(BaseUserManager):
 
         # Only allow remote logins with existing sessions
         if self.app.lims.lims_valid_login(login_res) and is_local_host():
-            if not self.app.lims.lims_existing_session(login_res):
-                login_res = self.app.lims.create_lims_session(login_res)
-
             msg = "[LOGIN] Valid login from local host (%s)" % str(info)
             logging.getLogger("MX3.HWR").info(msg)
         elif self.app.lims.lims_valid_login(


### PR DESCRIPTION
here at MAXIV we dont necessarily have sessions in LIMS at the time the user logins, so we create on demand, hence [this change](https://github.com/mxcube/mxcubeweb/blob/d2a4464f6ef54972ca89c86fed2b34fc5e4b8b26/mxcubeweb/core/components/lims.py#L325).

However, the current implementation checks (and creates) session for all user's proposals, which feels an unnecessary step (see deleted code in this MR).

does this breaks other peoples' login procedures?



