### PR TITLE
Fixes  issue #1389 (Saving grid crashes front end)

### DIFF
--- a/ui/src/components/SampleView/DrawGridPlugin.jsx
+++ b/ui/src/components/SampleView/DrawGridPlugin.jsx
@@ -375,7 +375,7 @@ export default class DrawGridPlugin {
     let color = gridData.selected
       ? 'rgba(136, 255, 91, 1)'
       : 'rgba(228, 255, 9, 0.5)';
-    color = gridData.result.length > 0 ? 'rgba(228, 255, 9, 1)' : color;
+    color = gridData.result?.length > 0 ? 'rgba(228, 255, 9, 1)' : color;
     const lineColor = gridData.selected
       ? 'rgba(136, 255, 91, 0.5)'
       : 'rgba(228, 255, 9, 0)';


### PR DESCRIPTION
Closes #1389 

Returning `false` when result is `null` using optional chaining operator.

@meguiraun, would that work for you ? 