### PR TITLE
set content-type to json for beamline get routes

### DIFF
--- a/mxcubeweb/routes/beamline.py
+++ b/mxcubeweb/routes/beamline.py
@@ -26,7 +26,7 @@ def create_get_route(app, server, bp, adapter, attr):
             **{"return": getattr(app.mxcubecore.get_adapter(name), attr)(**args)}
         )
 
-        return make_response(result.json(), 200)
+        return make_response(result.dict(), 200)
 
     route_url = f"{atype}/<string:name>/{attr}"
     endpoint = f"{atype}_{attr}"


### PR DESCRIPTION
For beamline 'get attributes' API routes, make sure Content-Type header is `application/json`. The front-end is now checking the content-type header for replies, and assumes an error unless it is set to `application/json`.

This fixes the issue where changing data collection parameters in the Task Dialog breaks the validation, making it impossible to run the job with non-default parameters.