### PR TITLE
data_publisher uses correct state nomenclature

### DIFF
--- a/mxcubeweb/core/adapter/data_publisher_adapter.py
+++ b/mxcubeweb/core/adapter/data_publisher_adapter.py
@@ -43,7 +43,7 @@ class DataPublisherAdapter(AdapterBase):
         self.emit_ho_changed()
 
     def state(self):
-        return HardwareObjectState.READY.value
+        return HardwareObjectState.READY.name
 
     def current_data(self) -> list:
         return self._current_data_list


### PR DESCRIPTION
To be in sync with other hardwareobjects in the state, this adapter should return the name of the objects state not the value