### PR TITLE
Change onClick prop to onChange

### DIFF
--- a/ui/src/components/SampleView/GridForm.jsx
+++ b/ui/src/components/SampleView/GridForm.jsx
@@ -192,7 +192,7 @@ export default class GridForm extends React.Component {
                   <Form.Check
                     name="resultType"
                     type="radio"
-                    onClick={() => this.props.setGridResultType('heatmap')}
+                    onChange={() => this.props.setGridResultType('heatmap')}
                     checked={this.props.gridResultType === 'heatmap'}
                   />
                 </Col>
@@ -207,7 +207,7 @@ export default class GridForm extends React.Component {
                   <Form.Check
                     name="resultType"
                     type="radio"
-                    onClick={() => this.props.setGridResultType('crystalmap')}
+                    onChange={() => this.props.setGridResultType('crystalmap')}
                     checked={this.props.gridResultType === 'crystalmap'}
                   />
                 </Col>


### PR DESCRIPTION
Changing the onClick prop from radio buttons to onChange prevents unnecessary function calls (multiple click on already selected button), avoids update race conditions and ensures the correct behaviour