### PR TITLE
Refactoring GridForm

### DIFF
--- a/ui/src/actions/sampleview.js
+++ b/ui/src/actions/sampleview.js
@@ -151,10 +151,6 @@ export function centringClicksLeft(clicksLeft) {
   return { type: 'CENTRING_CLICKS_LEFT', clicksLeft };
 }
 
-export function setGridResultType(gridResultType) {
-  return { type: 'SET_GRID_RESULT_TYPE', gridResultType };
-}
-
 export function rotateToShape(sid) {
   return async (dispatch) => {
     try {

--- a/ui/src/components/SampleView/GridForm.jsx
+++ b/ui/src/components/SampleView/GridForm.jsx
@@ -13,14 +13,12 @@ export default function GridForm(props) {
   const {
     getGridOverlayOpacity,
     gridList,
-    gridResultType,
     removeGrid,
     rotateTo,
     saveGrid,
     selectedGrids,
     selectGrid,
     setGridOverlayOpacity,
-    setGridResultType,
     show,
     toggleVisibility,
   } = props;
@@ -182,36 +180,6 @@ export default function GridForm(props) {
                   defaultValue={getGridOverlayOpacity()}
                   onChange={setGridOverlayOpacity}
                   name="overlaySlider"
-                />
-              </Col>
-            </Form.Group>
-            <Form.Group className="mb-2" as={Row}>
-              <Col sm="4">
-                {' '}
-                <Form.Label>Heat map</Form.Label>{' '}
-              </Col>
-              <Col sm="1"> : </Col>
-              <Col sm="7">
-                <Form.Check
-                  name="resultType"
-                  type="radio"
-                  onChange={() => setGridResultType('heatmap')}
-                  checked={gridResultType === 'heatmap'}
-                />
-              </Col>
-            </Form.Group>
-            <Form.Group as={Row}>
-              <Col sm="4">
-                {' '}
-                <Form.Label>Crystal map</Form.Label>{' '}
-              </Col>
-              <Col sm="1"> : </Col>
-              <Col sm="7">
-                <Form.Check
-                  name="resultType"
-                  type="radio"
-                  onChange={() => setGridResultType('crystalmap')}
-                  checked={gridResultType === 'crystalmap'}
                 />
               </Col>
             </Form.Group>

--- a/ui/src/components/SampleView/GridForm.jsx
+++ b/ui/src/components/SampleView/GridForm.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-key */
 /* eslint-disable jsx-a11y/control-has-associated-label */
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Row, Col, Form, Button, Table } from 'react-bootstrap';
 import Draggable from 'react-draggable';
 
@@ -30,6 +30,7 @@ export default function GridForm(props) {
   } = props;
 
   const draggableRef = useRef(null);
+  const [position, setPosition] = useState({ x: 20, y: 64 });
 
   useEffect(() => {
     const draggableElement = draggableRef.current;

--- a/ui/src/components/SampleView/GridForm.jsx
+++ b/ui/src/components/SampleView/GridForm.jsx
@@ -72,6 +72,7 @@ export default class GridForm extends React.Component {
           <td>
             <Button
               size="sm"
+              style={{ width: '75%' }}
               variant="outline-secondary"
               onClick={(e) => {
                 e.stopPropagation();
@@ -123,6 +124,7 @@ export default class GridForm extends React.Component {
         <td>
           <Button
             size="sm"
+            style={{ width: '75%' }}
             variant="outline-secondary"
             onClick={() => this.props.saveGrid()}
           >
@@ -192,7 +194,7 @@ export default class GridForm extends React.Component {
                   <Form.Check
                     name="resultType"
                     type="radio"
-                    onClick={() => this.props.setGridResultType('heatmap')}
+                    onChange={() => this.props.setGridResultType('heatmap')}
                     checked={this.props.gridResultType === 'heatmap'}
                   />
                 </Col>
@@ -207,7 +209,7 @@ export default class GridForm extends React.Component {
                   <Form.Check
                     name="resultType"
                     type="radio"
-                    onClick={() => this.props.setGridResultType('crystalmap')}
+                    onChange={() => this.props.setGridResultType('crystalmap')}
                     checked={this.props.gridResultType === 'crystalmap'}
                   />
                 </Col>

--- a/ui/src/components/SampleView/GridForm.jsx
+++ b/ui/src/components/SampleView/GridForm.jsx
@@ -1,10 +1,14 @@
 /* eslint-disable react/jsx-key */
 /* eslint-disable jsx-a11y/control-has-associated-label */
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Row, Col, Form, Button, Table } from 'react-bootstrap';
 import Draggable from 'react-draggable';
 
 import './SampleView.css';
+
+function handleContextMenu(e) {
+  e.stopPropagation();
+}
 
 export default function GridForm(props) {
   const use_advanced_settings = false;
@@ -24,6 +28,21 @@ export default function GridForm(props) {
     show,
     toggleVisibility,
   } = props;
+
+  const draggableRef = useRef(null);
+
+  useEffect(() => {
+    const draggableElement = draggableRef.current;
+    if (draggableElement) {
+      draggableElement.addEventListener('contextmenu', handleContextMenu);
+    }
+
+    return () => {
+      if (draggableElement) {
+        draggableElement.removeEventListener('contextmenu', handleContextMenu);
+      }
+    };
+  }, [show]);
 
   function getGridControls() {
     const gridControlList = [];

--- a/ui/src/components/SampleView/GridForm.jsx
+++ b/ui/src/components/SampleView/GridForm.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-key */
 /* eslint-disable jsx-a11y/control-has-associated-label */
 import React, { useEffect, useRef, useState } from 'react';
 import { Row, Col, Form, Button, Table } from 'react-bootstrap';
@@ -11,7 +10,6 @@ function handleContextMenu(e) {
 }
 
 export default function GridForm(props) {
-  const use_advanced_settings = false;
   const {
     getGridOverlayOpacity,
     gridList,
@@ -23,8 +21,6 @@ export default function GridForm(props) {
     selectGrid,
     setGridOverlayOpacity,
     setGridResultType,
-    setHCellSpacing,
-    setVCellSpacing,
     show,
     toggleVisibility,
   } = props;
@@ -62,12 +58,6 @@ export default function GridForm(props) {
           <td>
             <span style={{ lineHeight: '24px' }}>{grid.name}</span>
           </td>
-          {use_advanced_settings
-            ? [
-                <td>{grid.cellVSpace.toFixed(2)}</td>,
-                <td>{grid.cellHSpace.toFixed(2)}</td>,
-              ]
-            : null}
           <td>
             {vdim} x {hdim}
           </td>
@@ -122,30 +112,6 @@ export default function GridForm(props) {
         <td>
           <span style={{ lineHeight: '24px' }}>*</span>
         </td>
-        {use_advanced_settings
-          ? [
-              <td>
-                <Form>
-                  <Form.Control
-                    style={{ width: '50px' }}
-                    type="text"
-                    defaultValue={0}
-                    onChange={setVCellSpacing}
-                  />
-                </Form>
-              </td>,
-              <td>
-                <Form>
-                  <Form.Control
-                    style={{ width: '50px' }}
-                    type="text"
-                    defaultValue={0}
-                    onChange={setHCellSpacing}
-                  />
-                </Form>
-              </td>,
-            ]
-          : null}
         <td />
         <td />
         <td />
@@ -184,9 +150,6 @@ export default function GridForm(props) {
             <thead>
               <tr>
                 <th>Name</th>
-                {use_advanced_settings
-                  ? [<th>V-Space (µm)</th>, <th>H-Space (µm)</th>]
-                  : null}
                 <th>Dim (µm)</th>
                 <th>#Cells</th>
                 <th>R x C</th>

--- a/ui/src/components/SampleView/GridForm.jsx
+++ b/ui/src/components/SampleView/GridForm.jsx
@@ -26,6 +26,9 @@ export default function GridForm(props) {
   const draggableRef = useRef(null);
   const [position, setPosition] = useState({ x: 20, y: 64 });
 
+  // we use the useEffect function with a ref here, since React's synthetic event
+  // system (onContextMenu) could not stop the propagation
+  // see  https://github.com/mxcube/mxcubeweb/pull/1397 for more details
   useEffect(() => {
     const draggableElement = draggableRef.current;
     if (draggableElement) {

--- a/ui/src/components/SampleView/GridForm.jsx
+++ b/ui/src/components/SampleView/GridForm.jsx
@@ -1,24 +1,35 @@
 /* eslint-disable react/jsx-key */
 /* eslint-disable jsx-a11y/control-has-associated-label */
-/* eslint-disable react/jsx-handler-names */
-import './SampleView.css';
 import React from 'react';
 import { Row, Col, Form, Button, Table } from 'react-bootstrap';
 import Draggable from 'react-draggable';
 
-export default class GridForm extends React.Component {
-  constructor(props) {
-    super(props);
-    this.use_advanced_settings = false;
-  }
+import './SampleView.css';
 
-  getGridControls() {
+export default function GridForm(props) {
+  const use_advanced_settings = false;
+  const {
+    getGridOverlayOpacity,
+    gridList,
+    gridResultType,
+    removeGrid,
+    rotateTo,
+    saveGrid,
+    selectedGrids,
+    selectGrid,
+    setGridOverlayOpacity,
+    setGridResultType,
+    setHCellSpacing,
+    setVCellSpacing,
+    show,
+    toggleVisibility,
+  } = props;
+
+  function getGridControls() {
     const gridControlList = [];
 
-    for (const grid of Object.values(this.props.gridList)) {
-      const selectedStyle = this.props.selectedGrids.includes(grid.id)
-        ? 'selected'
-        : '';
+    for (const grid of Object.values(gridList)) {
+      const selectedStyle = selectedGrids.includes(grid.id) ? 'selected' : '';
       const vdim = grid.numRows * (grid.cellHeight + grid.cellVSpace);
       const hdim = grid.numCols * (grid.cellWidth + grid.cellHSpace);
 
@@ -26,12 +37,12 @@ export default class GridForm extends React.Component {
         <tr
           className={selectedStyle}
           key={grid.name}
-          onClick={(e) => this.props.selectGrid([grid], e.ctrlKey)}
+          onClick={(e) => selectGrid([grid], e.ctrlKey)}
         >
           <td>
             <span style={{ lineHeight: '24px' }}>{grid.name}</span>
           </td>
-          {this.use_advanced_settings
+          {use_advanced_settings
             ? [
                 <td>{grid.cellVSpace.toFixed(2)}</td>,
                 <td>{grid.cellHSpace.toFixed(2)}</td>,
@@ -51,7 +62,7 @@ export default class GridForm extends React.Component {
               variant="outline-secondary"
               onClick={(e) => {
                 e.stopPropagation();
-                this.props.rotateTo(grid.id);
+                rotateTo(grid.id);
               }}
             >
               Rotate to
@@ -63,7 +74,7 @@ export default class GridForm extends React.Component {
               variant="outline-secondary"
               onClick={(e) => {
                 e.stopPropagation();
-                this.props.toggleVisibility(grid.id);
+                toggleVisibility(grid.id);
               }}
             >
               {grid.state === 'HIDDEN' ? 'Show' : 'Hide '}
@@ -76,7 +87,7 @@ export default class GridForm extends React.Component {
               variant="outline-secondary"
               onClick={(e) => {
                 e.stopPropagation();
-                this.props.removeGrid(grid.id);
+                removeGrid(grid.id);
               }}
             >
               -
@@ -91,7 +102,7 @@ export default class GridForm extends React.Component {
         <td>
           <span style={{ lineHeight: '24px' }}>*</span>
         </td>
-        {this.use_advanced_settings
+        {use_advanced_settings
           ? [
               <td>
                 <Form>
@@ -99,7 +110,7 @@ export default class GridForm extends React.Component {
                     style={{ width: '50px' }}
                     type="text"
                     defaultValue={0}
-                    onChange={this.props.setVCellSpacing}
+                    onChange={setVCellSpacing}
                   />
                 </Form>
               </td>,
@@ -109,7 +120,7 @@ export default class GridForm extends React.Component {
                     style={{ width: '50px' }}
                     type="text"
                     defaultValue={0}
-                    onChange={this.props.setHCellSpacing}
+                    onChange={setHCellSpacing}
                   />
                 </Form>
               </td>,
@@ -126,7 +137,7 @@ export default class GridForm extends React.Component {
             size="sm"
             style={{ width: '75%' }}
             variant="outline-secondary"
-            onClick={() => this.props.saveGrid()}
+            onClick={() => saveGrid()}
           >
             +
           </Button>
@@ -137,93 +148,93 @@ export default class GridForm extends React.Component {
     return gridControlList;
   }
 
-  render() {
-    const gridForm = (
-      <Draggable defaultPosition={{ x: 20, y: 64 }} cancel="form">
-        <Row className="gridform">
-          <Col xs={8}>
-            <Table striped hover responsive>
-              <thead>
-                <tr>
-                  <th>Name</th>
-                  {this.use_advanced_settings
-                    ? [<th>V-Space (µm)</th>, <th>H-Space (µm)</th>]
-                    : null}
-                  <th>Dim (µm)</th>
-                  <th>#Cells</th>
-                  <th>R x C</th>
-                  <th>&Omega;</th>
-                  <th />
-                  <th />
-                  <th />
-                </tr>
-              </thead>
-              <tbody>{this.getGridControls()}</tbody>
-            </Table>
-          </Col>
-          <Col xs={4} style={{ marginTop: '20px' }}>
-            <Form>
-              <Form.Group className="mb-2" as={Row}>
-                <Col sm="4">
-                  {' '}
-                  <Form.Label>Opacity</Form.Label>{' '}
-                </Col>
-                <Col sm="1"> : </Col>
-                <Col sm="7">
-                  <Form.Control
-                    style={{ width: '100px', padding: '0' }}
-                    className="bar"
-                    type="range"
-                    id="overlay-control"
-                    min="0"
-                    max="1"
-                    step="0.05"
-                    defaultValue={this.props.getGridOverlayOpacity()}
-                    onChange={this.props.setGridOverlayOpacity}
-                    name="overlaySlider"
-                  />
-                </Col>
-              </Form.Group>
-              <Form.Group className="mb-2" as={Row}>
-                <Col sm="4">
-                  {' '}
-                  <Form.Label>Heat map</Form.Label>{' '}
-                </Col>
-                <Col sm="1"> : </Col>
-                <Col sm="7">
-                  <Form.Check
-                    name="resultType"
-                    type="radio"
-                    onChange={() => this.props.setGridResultType('heatmap')}
-                    checked={this.props.gridResultType === 'heatmap'}
-                  />
-                </Col>
-              </Form.Group>
-              <Form.Group as={Row}>
-                <Col sm="4">
-                  {' '}
-                  <Form.Label>Crystal map</Form.Label>{' '}
-                </Col>
-                <Col sm="1"> : </Col>
-                <Col sm="7">
-                  <Form.Check
-                    name="resultType"
-                    type="radio"
-                    onChange={() => this.props.setGridResultType('crystalmap')}
-                    checked={this.props.gridResultType === 'crystalmap'}
-                  />
-                </Col>
-              </Form.Group>
-            </Form>
-          </Col>
-        </Row>
-      </Draggable>
-    );
-
-    return this.props.show ? gridForm : null;
+  if (!show) {
+    return null;
   }
-}
 
-GridForm.defaultProps = {
-  show: true,
-};
+  return (
+    <Draggable
+      position={position}
+      onDrag={(e, data) => setPosition({ x: data.x, y: data.y })}
+      cancel="form"
+    >
+      <Row className="gridform" ref={draggableRef}>
+        <Col xs={8}>
+          <Table striped hover responsive>
+            <thead>
+              <tr>
+                <th>Name</th>
+                {use_advanced_settings
+                  ? [<th>V-Space (µm)</th>, <th>H-Space (µm)</th>]
+                  : null}
+                <th>Dim (µm)</th>
+                <th>#Cells</th>
+                <th>R x C</th>
+                <th>&Omega;</th>
+                <th />
+                <th />
+                <th />
+              </tr>
+            </thead>
+            <tbody>{getGridControls()}</tbody>
+          </Table>
+        </Col>
+        <Col xs={4} style={{ marginTop: '20px' }}>
+          <Form>
+            <Form.Group className="mb-2" as={Row}>
+              <Col sm="4">
+                {' '}
+                <Form.Label>Opacity</Form.Label>{' '}
+              </Col>
+              <Col sm="1"> : </Col>
+              <Col sm="7">
+                <Form.Control
+                  style={{ width: '100px', padding: '0' }}
+                  className="bar"
+                  type="range"
+                  id="overlay-control"
+                  min="0"
+                  max="1"
+                  step="0.05"
+                  defaultValue={getGridOverlayOpacity()}
+                  onChange={setGridOverlayOpacity}
+                  name="overlaySlider"
+                />
+              </Col>
+            </Form.Group>
+            <Form.Group className="mb-2" as={Row}>
+              <Col sm="4">
+                {' '}
+                <Form.Label>Heat map</Form.Label>{' '}
+              </Col>
+              <Col sm="1"> : </Col>
+              <Col sm="7">
+                <Form.Check
+                  name="resultType"
+                  type="radio"
+                  onChange={() => setGridResultType('heatmap')}
+                  checked={gridResultType === 'heatmap'}
+                />
+              </Col>
+            </Form.Group>
+            <Form.Group as={Row}>
+              <Col sm="4">
+                {' '}
+                <Form.Label>Crystal map</Form.Label>{' '}
+              </Col>
+              <Col sm="1"> : </Col>
+              <Col sm="7">
+                <Form.Check
+                  name="resultType"
+                  type="radio"
+                  onChange={() => setGridResultType('crystalmap')}
+                  checked={gridResultType === 'crystalmap'}
+                />
+              </Col>
+            </Form.Group>
+          </Form>
+        </Col>
+      </Row>
+    </Draggable>
+  );
+}

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -35,8 +35,6 @@ export default class SampleImage extends React.Component {
     this.keyUp = this.keyUp.bind(this);
     this.wheel = this.wheel.bind(this);
     this.goToBeam = this.goToBeam.bind(this);
-    this.setHCellSpacing = this.setHCellSpacing.bind(this);
-    this.setVCellSpacing = this.setVCellSpacing.bind(this);
     this.setGridOverlayOpacity = this.setGridOverlayOpacity.bind(this);
     this.getGridOverlayOpacity = this.getGridOverlayOpacity.bind(this);
     this.saveGrid = this.saveGrid.bind(this);
@@ -209,58 +207,6 @@ export default class SampleImage extends React.Component {
     if (this.props.autoScale) {
       const { clientWidth } = document.querySelector('#outsideWrapper');
       this.props.sampleViewActions.setImageRatio(clientWidth);
-    }
-  }
-
-  setVCellSpacing(e) {
-    let value = Number.parseFloat(e.target.value);
-    if (Number.isNaN(value)) {
-      value = '';
-    }
-
-    const gridData = this.selectedGrid();
-
-    if (gridData) {
-      const gd = this.drawGridPlugin.setCellSpace(
-        gridData,
-        true,
-        gridData.cellHSpace,
-        value,
-      );
-      this.props.sampleViewActions.updateShapes([gd]);
-    } else if (this.props.drawGrid) {
-      this.drawGridPlugin.setCurrentCellSpace(
-        null,
-        value,
-        this.props.imageRatio,
-      );
-      this.drawGridPlugin.repaint(this.canvas);
-    }
-  }
-
-  setHCellSpacing(e) {
-    let value = Number.parseFloat(e.target.value);
-    if (Number.isNaN(value)) {
-      value = '';
-    }
-
-    const gridData = this.selectedGrid();
-
-    if (gridData) {
-      const gd = this.drawGridPlugin.setCellSpace(
-        gridData,
-        true,
-        value,
-        gridData.cellVSpace,
-      );
-      this.props.sampleViewActions.updateShapes([gd]);
-    } else if (this.props.drawGrid) {
-      this.drawGridPlugin.setCurrentCellSpace(
-        value,
-        null,
-        this.props.imageRatio,
-      );
-      this.drawGridPlugin.repaint(this.canvas);
     }
   }
 
@@ -964,8 +910,6 @@ export default class SampleImage extends React.Component {
               getGridOverlayOpacity={this.getGridOverlayOpacity}
               setGridOverlayOpacity={this.setGridOverlayOpacity}
               cellSpacing={this.props.cellSpacing}
-              setHCellSpacing={this.setHCellSpacing}
-              setVCellSpacing={this.setVCellSpacing}
               gridList={this.props.grids}
               currentGrid={this.drawGridPlugin.currentGridData()}
               removeGrid={this.props.sampleViewActions.deleteShape}

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -758,14 +758,6 @@ export default class SampleImage extends React.Component {
     }
   }
 
-  hideGridForm() {
-    const gridForm = document.querySelector('#gridForm');
-
-    if (gridForm) {
-      gridForm.style.display = 'none';
-    }
-  }
-
   saveGrid() {
     const gd = this.drawGridPlugin.saveGrid(
       this.drawGridPlugin.currentGridData(),

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -59,7 +59,6 @@ export default class SampleImage extends React.Component {
     this.player = null;
     this.centringCross = [];
     this.removeShapes = this.removeShapes.bind(this);
-    this.setGridResultType = this.setGridResultType.bind(this);
   }
 
   componentDidMount() {
@@ -197,10 +196,6 @@ export default class SampleImage extends React.Component {
 
   onMouseUp(e) {
     this.drawGridPlugin.endDrawing();
-  }
-
-  setGridResultType(resultType) {
-    this.props.sampleViewActions.setGridResultType(resultType);
   }
 
   setImageRatio() {
@@ -605,8 +600,6 @@ export default class SampleImage extends React.Component {
   updateGridResults() {
     const gd = this.selectedGrid();
 
-    this.drawGridPlugin.resultType = this.props.gridResultType;
-
     if (gd) {
       this.drawGridPlugin.setGridResult(gd.result);
     }
@@ -918,8 +911,6 @@ export default class SampleImage extends React.Component {
               rotateTo={this.props.sampleViewActions.rotateToShape}
               selectGrid={this.selectShape}
               selectedGrids={this.props.selectedGrids.map((grid) => grid.id)}
-              setGridResultType={this.setGridResultType}
-              gridResultType={this.props.gridResultType}
             />
             {this.createVideoPlayerContainer(this.props.videoFormat)}
             <SampleControls

--- a/ui/src/reducers/sampleview.js
+++ b/ui/src/reducers/sampleview.js
@@ -37,7 +37,6 @@ const INITIAL_STATE = {
   cinema: false,
   phaseList: [],
   drawGrid: false,
-  gridResultType: 'heatmap',
   videoMessageOverlay: { show: false, msg: '' },
   savedPointId: '',
   selectedShapes: [],
@@ -79,9 +78,6 @@ function sampleViewReducer(state = INITIAL_STATE, action = {}) {
       }
 
       return { ...state, drawGrid: !state.drawGrid, selectedGrids };
-    }
-    case 'SET_GRID_RESULT_TYPE': {
-      return { ...state, gridResultType: action.gridResultType };
     }
     case 'MEASURE_DISTANCE': {
       return { ...state, measureDistance: action.mode, distancePoints: [] };


### PR DESCRIPTION
This PR includes some refactoring and clean-up on the `GridForm` and `SampleImage` components

Changes include:
  - Some button adujstments: `+` and `-` now have the same size, radio buttons use `onChange` instead of `onClick`
  -  Changed `GridForm` from a class component to a functional component
  -  Previously right-clicking on the `GridForm` would open the `SampleImage` context menu which also happened when the form was moved away from the canvas element
Before:  
   ![Broken_ContextMenu](https://github.com/user-attachments/assets/0d19eacb-5f82-4686-bf23-194501045474)
Now:
   ![Fixed_contextMenu](https://github.com/user-attachments/assets/59f66773-add9-49b3-9f4a-3f6c9be0e617)
  - Previously upon closing and opening the form, it would always cover parts of the video view even when previously dragged 
away. Now it remembers its old position.
Before:
![Broken_position](https://github.com/user-attachments/assets/8894287c-3795-4136-ad1e-170b842a894e)
Now:
![Fixed_position](https://github.com/user-attachments/assets/a240b2ad-ef2a-45bf-bd01-04a2adeeb9e3)
  - removed the `hideGridForm` function from `SampleImage`, which was never used, since this is handled by the GridForm's `show` variable.
  - `GridForm` had some advanced settings, that were not used. These allowed the setting of the Cell space, I removed code from `SampleImage` and `GridForm` related to this.