### PR TITLE
Clean up `ServerIO`

### DIFF
--- a/ui/src/containers/SelectProposalContainer.jsx
+++ b/ui/src/containers/SelectProposalContainer.jsx
@@ -14,7 +14,6 @@ function SelectProposalContainer() {
     if (login.selectedProposalID === null) {
       dispatch(signOut());
       serverIO.disconnect();
-      navigate('/');
     } else {
       dispatch(hideProposalsForm());
     }


### PR DESCRIPTION
Just cleaning up the class a bit so it's clearer what's going on and to reduce the risk of misuse:

- Split initialisation of the two sockets into two separate methods, and move `connect` and `disconnect` event registrations at the top.
- Log to the console also on `disconnect` (not just on `connect`) to give us reassurance that we are not leaking socket connections on logout.
- Always clean-up socket instances before (re-)initialisation for safety. Previously, the `listen`/`connect` logic was a bit brittle. After this scenario, for instance, the `hwrSocket` would not be fully initialised (because the socket instance would be recreated but the event listeners would not be registered on this new instance):

    ```js
    socketIO.listen();
    socketIO.hwrSocket = null;
    socketIO.listen();
    ```
    
    I know it's unlikely the class would ever be used in this way, but still, it seems cleaner to recreate everything properly on every `listen()` call.