### PR TITLE
Don't disconnect sockets twice on logout

### DIFF
--- a/ui/src/actions/login.js
+++ b/ui/src/actions/login.js
@@ -95,10 +95,9 @@ export function logIn(proposal, password) {
 
 export function signOut() {
   return async (dispatch) => {
-    await sendSignOut();
-    dispatch({ type: 'SIGNOUT' });
     dispatch(resetLoginInfo());
     dispatch(applicationFetched(false));
+    await sendSignOut();
   };
 }
 

--- a/ui/src/components/MXNavbar/MXNavbar.jsx
+++ b/ui/src/components/MXNavbar/MXNavbar.jsx
@@ -4,7 +4,6 @@ import { BsList } from 'react-icons/bs';
 import { NavLink, useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { showProposalsForm, signOut } from '../../actions/login';
-import { serverIO } from '../../serverIO';
 import styles from './MXNavbar.module.css';
 
 function MXNavbar() {
@@ -106,10 +105,7 @@ function MXNavbar() {
             <button
               className={styles.navBtn}
               type="button"
-              onClick={() => {
-                serverIO.disconnect();
-                dispatch(signOut());
-              }}
+              onClick={() => dispatch(signOut())}
             >
               <span className="me-2 fas fa-lg fa-sign-out-alt" />
               Sign out

--- a/ui/src/containers/SelectProposalContainer.jsx
+++ b/ui/src/containers/SelectProposalContainer.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { signOut, selectProposal, hideProposalsForm } from '../actions/login';
 import SelectProposal from '../components/LoginForm/SelectProposal';
-import { serverIO } from '../serverIO';
 import { useNavigate } from 'react-router-dom';
 
 function SelectProposalContainer() {
@@ -13,7 +12,6 @@ function SelectProposalContainer() {
   function handleHide() {
     if (login.selectedProposalID === null) {
       dispatch(signOut());
-      serverIO.disconnect();
     } else {
       dispatch(hideProposalsForm());
     }


### PR DESCRIPTION
When the `loggedIn` state in the Redux store changes to `false`, we already run a clean-up effect in `App.jsx` that disconnects the sockets. So we shouldn't ever need to call `serverIO.disconnect()` after dispatching the `signOut` action. It should just works.

In practice, however, removing the extra `disconnect()` calls would lead to an unauthorised network error. This was due to the `/signout` endpoint being called _before_ resetting the `loggedIn` state (and therefore disconnecting the sockets). We would get the following:

1. dispatch `signOut` action
2. call `/signout` endpoint
3. server notifies all clients that a user/observer has logged out
4. clients (including the one who just logged out) receive the `observersChanged` socket event and try to refetch the remote-access state => ERROR on the client that just logged out...
5. disconnect sockets

The fix is simple: reset the `loggedIn` state (and `applicationFetched` state) before calling the `/signout` endpoint.

> If the `/signout` endpoint errors (i.e. if the client remains connected), everything still works: we see the login screen for a split second before being redirected to `/datacollection` as a logged in user. That's thanks to the `getLoginInfo` action that gets dispatched from `App.jsx` whenever the `loggedIn` state changes (and `getInitialState` action in `Main`).