### PR TITLE
make test_set_aperture test deterministic

### DIFF
--- a/test/test_diffractometer_routes.py
+++ b/test/test_diffractometer_routes.py
@@ -1,5 +1,8 @@
 import json
 import random
+from gevent.event import Event
+from mxcubecore import HardwareRepository as HWR
+
 
 # Python 2 and 3 compatibility
 try:
@@ -102,7 +105,11 @@ def test_set_aperture(client):
 
     original_aperture = data["currentAperture"]
 
-    ap = data["apertureList"][random.randint(0, len(data["apertureList"]) - 1)]
+    ap = data["apertureList"][0]
+
+    # make sure we are testing a change of aperture
+    assert ap != original_aperture
+
     resp = client.put(
         "/mxcube/api/v0.1/diffractometer/aperture",
         data=json.dumps({"diameter": ap}),
@@ -112,11 +119,19 @@ def test_set_aperture(client):
     resp = client.get("/mxcube/api/v0.1/diffractometer/aperture")
     actual_aperture = json.loads(resp.data)["currentAperture"]
 
+    aperture_value_changed = Event()
+    # listen for 'valueChanged' signal
+    HWR.beamline.beam.aperture.connect(
+        "valueChanged", lambda *_, **__: aperture_value_changed.set()
+    )
+
     resp = client.put(
         "/mxcube/api/v0.1/diffractometer/aperture",
         data=json.dumps({"diameter": original_aperture}),
         content_type="application/json",
     )
+    # wait until aperture changes the value
+    aperture_value_changed.wait()
 
     resp = client.get("/mxcube/api/v0.1/diffractometer/aperture")
     actual_original_aperture = json.loads(resp.data)["currentAperture"]


### PR DESCRIPTION
This fixes the intermittent failures of the `test/test_diffractometer_routes.py::test_set_aperture`.

Don't pick a random aperture size. Always pick first one. Also wait until aperture object have changed the value, before fetching the new value via API.

Solves: https://github.com/mxcube/mxcubeweb/issues/1401