### PR TITLE
setting exceptions logged in user_level_log

### DIFF
--- a/mxcubeweb/core/adapter/actuator_adapter.py
+++ b/mxcubeweb/core/adapter/actuator_adapter.py
@@ -49,10 +49,7 @@ class ActuatorAdapter(ActuatorAdapterBase):
             RuntimeError: Timeout while setting the value.
             StopItteration: When a value change was interrupted (abort/cancel).
         """
-        try:
-            self._ho.set_value(float(value.value))
-        except Exception:
-            raise
+        self._ho.set_value(float(value.value))
 
     @export
     def _get_value(self) -> FloatValueModel:


### PR DESCRIPTION
This PR logs exceptions from setting values to `user_level_log` and returns a 400(Bad request) status code. (see #1404 and #1406)
![Screenshot from 2024-09-19 17-26-11](https://github.com/user-attachments/assets/49af70f2-777d-4596-96f8-94a9bdc0efd2)
While at it added the following clean-ups:
- removal of unused imports
- removal of unnecessary try-except block