### PR TITLE
Drop support for fake commissioning proposals in LIMS

### DIFF
--- a/mxcubeweb/core/components/lims.py
+++ b/mxcubeweb/core/components/lims.py
@@ -230,12 +230,6 @@ class Lims(ComponentBase):
                 todays_session = HWR.beamline.lims.get_todays_session(prop)
                 prop["Session"] = [todays_session["session"]]
 
-            if hasattr(
-                HWR.beamline.session, "commissioning_fake_proposal"
-            ) and HWR.beamline.session.is_inhouse(loginID, None):
-                dummy = HWR.beamline.session.commissioning_fake_proposal
-                session["proposal_list"].append(dummy)
-
             login_res["proposalList"] = session["proposal_list"]
             login_res["status"] = {
                 "code": "ok",


### PR DESCRIPTION
We here at MAXIV no longer use this feature with fake commissioning proposals.

As far as we understand, we were the only users of this. Let's get rid of unneeded code.