### PR TITLE
[type hint] fix for Python 3.8 incompatible typehints

### DIFF
--- a/mxcubeweb/core/components/harvester.py
+++ b/mxcubeweb/core/components/harvester.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
 import logging
 
 from mxcubecore import HardwareRepository as HWR


### PR DESCRIPTION
@marcus-oscarsson  @woutdenolf As suggest i had the the line to fix the [issue](https://github.com/mxcube/mxcubeweb/issues/1414)