### PR TITLE
UI: make mesh grid drawing more performant

### DIFF
--- a/ui/src/components/SampleView/DrawGridPlugin.jsx
+++ b/ui/src/components/SampleView/DrawGridPlugin.jsx
@@ -307,8 +307,8 @@ export default class DrawGridPlugin {
      */
     const fillingMatrix = this.initializeCellFilling(gd, col, row);
 
-    // Asume flat result object to remain compatible with old format only
-    // suporting one type of results
+    // Assume flat result object to remain compatible with old format only
+    // supporting one type of results
     let { result } = gd;
 
     // Use selected result type if it exists

--- a/ui/src/components/SampleView/DrawGridPlugin.jsx
+++ b/ui/src/components/SampleView/DrawGridPlugin.jsx
@@ -293,7 +293,7 @@ export default class DrawGridPlugin {
 
   initializeCellFilling(gd, col, row) {
     const level = this.overlayLevel || 0.2;
-    const fill = `rgba(0, 0, 200, ${level}`;
+    const fill = `rgba(0, 0, 200, ${level})`;
     return Array.from({ length: col }).map(() =>
       Array.from({ length: row }).fill(fill),
     );


### PR DESCRIPTION
Replace per-cell result ellipse fabric objects with one single custom fabric object. When the cells are handful pixels large,    switch to drawing the results as a rectangle. It does not make a visual difference, but is faster.
    
These changes reduces UI latency to usable levels, when drawing meshes with 100k+ cells in `RGB` mode.
    
Also, this PR skips drawing the dashed inner lines, when cells are small. This does not affect performance in any noticeable way, but IMHO makes the display of results easier to comprehend.