### PR TITLE
Refactor equipment maintenance components

### DIFF
--- a/ui/src/components/Equipment/ActionButton.jsx
+++ b/ui/src/components/Equipment/ActionButton.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Button } from 'react-bootstrap';
+
+function ActionButton(props) {
+  const { label, disabled, onSend } = props;
+  return (
+    <Button
+      className="me-2"
+      size="sm"
+      variant="outline-secondary"
+      disabled={disabled}
+      onClick={() => onSend()}
+    >
+      {label}
+    </Button>
+  );
+}
+
+export default ActionButton;

--- a/ui/src/components/Equipment/ActionField.jsx
+++ b/ui/src/components/Equipment/ActionField.jsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import { Button, Card, Form, InputGroup } from 'react-bootstrap';
+
+function ActionField(props) {
+  const { headerMsg, label, inputType = 'text', btnLabel, onSubmit } = props;
+
+  const [inputValue, setInputValue] = useState('');
+
+  function handleInputChange(evt) {
+    const { value } = evt.target;
+
+    if (inputType === 'number') {
+      setInputValue(value && Number(value));
+    } else {
+      setInputValue(value);
+    }
+  }
+
+  return (
+    <Card className="mb-2">
+      <Card.Header>{headerMsg}</Card.Header>
+      <Card.Body>
+        <Form
+          onSubmit={(evt) => {
+            evt.preventDefault();
+            onSubmit(inputValue);
+          }}
+        >
+          <Form.Group>
+            <Form.Label>{label}</Form.Label>
+            <InputGroup>
+              <Form.Control
+                type={inputType}
+                value={inputValue}
+                required
+                size="sm"
+                style={{ width: '13em', flex: 'none' }}
+                onChange={(e) => handleInputChange(e)}
+              />
+              <Button type="submit" variant="outline-secondary">
+                {btnLabel}
+              </Button>
+            </InputGroup>
+          </Form.Group>
+        </Form>
+      </Card.Body>
+    </Card>
+  );
+}
+
+export default ActionField;

--- a/ui/src/components/Equipment/ActionGroup.jsx
+++ b/ui/src/components/Equipment/ActionGroup.jsx
@@ -1,91 +1,16 @@
-import React, { useState } from 'react';
-import { Button, InputGroup, ButtonGroup, Card, Form } from 'react-bootstrap';
+import React from 'react';
+import { ButtonGroup, Card } from 'react-bootstrap';
 
-export function ActionGroup(props) {
+function ActionGroup(props) {
+  const { label, children } = props;
   return (
     <Card className="mb-2">
-      <Card.Header>{props.name}</Card.Header>
+      <Card.Header>{label}</Card.Header>
       <Card.Body>
-        <ButtonGroup>{props.buttons}</ButtonGroup>
+        <ButtonGroup>{children}</ButtonGroup>
       </Card.Body>
     </Card>
   );
 }
 
-export function ActionButton(props) {
-  let disabled;
-
-  if (props.enabled === true) {
-    disabled = false;
-  } else {
-    disabled = true;
-  }
-
-  return (
-    <Button
-      disabled={disabled}
-      onClick={() => props.sendCommand(props.cmd, props.args)}
-      size="sm"
-      className="me-2"
-      variant={props.variant || 'outline-secondary'}
-    >
-      {props.label}
-    </Button>
-  );
-}
-
-export function ActionField(props) {
-  const [inputValue, setInputValue] = useState(null);
-
-  function handleInputChange(e) {
-    if (props.inputType === 'number') {
-      setInputValue(Number(e.target.value));
-    } else {
-      setInputValue(e.target.value);
-    }
-  }
-
-  function actionComponent() {
-    return (
-      <span>
-        <Form
-          onSubmit={(e) => {
-            e.preventDefault();
-            props.sendCommand(props.cmd, inputValue);
-          }}
-        >
-          <Form.Group size="sm">
-            <Form.Label>{props.label}</Form.Label>
-            <br />
-            <InputGroup>
-              <Form.Control
-                size="sm"
-                required
-                value={inputValue}
-                style={{
-                  maxWidth: '13em',
-                  minWidth: '13em',
-                  marginRight: '0.2em',
-                }}
-                type={props.inputType}
-                onChange={(e) => {
-                  handleInputChange(e);
-                }}
-              />
-              <Button type="submit" size="sm">
-                {props.btn_label}
-              </Button>
-            </InputGroup>
-          </Form.Group>
-        </Form>
-      </span>
-    );
-  }
-
-  return (
-    <ActionGroup
-      name={`${props.header_msg} : ${props.value}`}
-      buttons={actionComponent()}
-    />
-  );
-}
+export default ActionGroup;

--- a/ui/src/components/Equipment/SampleChangerMaintenance.jsx
+++ b/ui/src/components/Equipment/SampleChangerMaintenance.jsx
@@ -1,64 +1,46 @@
 import React from 'react';
 import { Card } from 'react-bootstrap';
+import { useDispatch, useSelector } from 'react-redux';
 
-import { ActionGroup, ActionButton } from './ActionGroup';
-
+import ActionGroup from './ActionGroup';
+import ActionButton from './ActionButton';
+import { sendCommand } from '../../actions/sampleChanger';
 import styles from './equipment.module.css';
 
-export default function SampleChangerMaintenance(props) {
-  function renderActionButton(cmdinfo) {
-    return (
-      <ActionButton
-        label={cmdinfo[1]}
-        cmd={cmdinfo[0]}
-        args={cmdinfo[3]}
-        enabled={props.commands_state[cmdinfo[0]]}
-        sendCommand={props.sendCommand}
-        key={cmdinfo[1]}
-        variant="outline-secondary"
-      />
-    );
-  }
+function SampleChangerMaintenance() {
+  const dispatch = useDispatch();
 
-  function renderActionGroup(grpinfo) {
-    const butgrp = [];
+  const { commands, commands_state, message } = useSelector(
+    (state) => state.sampleChangerMaintenance,
+  );
 
-    for (const cmdinfo of grpinfo[1]) {
-      butgrp.push(renderActionButton(cmdinfo));
-    }
-
-    return <ActionGroup name={grpinfo[0]} buttons={butgrp} key={grpinfo[0]} />;
-  }
-
-  const groups = [];
-  let msg = '';
-
-  if (
-    Object.keys(props.commands).length > 0 &&
-    props.commands.cmds !== 'SC maintenance controller not defined'
-  ) {
-    for (const cmdgrp of props.commands.cmds) {
-      groups.push(renderActionGroup(cmdgrp));
-    }
-  } else {
-    return <div />;
-  }
-
-  if (props.message !== '') {
-    msg = props.message;
-  }
+  const commandGroups = commands.cmds || [];
 
   return (
-    <div>
-      {groups}
-      {msg ? (
+    <>
+      {commandGroups.map(([grpLabel, grpCmds]) => (
+        <ActionGroup key={grpLabel} label={grpLabel}>
+          {grpCmds.map(([cmd, cmdLabel, , cmdArgs]) => (
+            <ActionButton
+              key={cmd}
+              label={cmdLabel}
+              disabled={!commands_state[cmd]}
+              onSend={() => dispatch(sendCommand(cmd, cmdArgs))}
+            />
+          ))}
+        </ActionGroup>
+      ))}
+
+      {message && (
         <Card className="mb-2">
           <Card.Header>Status message</Card.Header>
           <Card.Body>
-            <span className={styles.scMessage}>{msg}</span>
+            <span className={styles.scMessage}>{message}</span>
           </Card.Body>
         </Card>
-      ) : null}
-    </div>
+      )}
+    </>
   );
 }
+
+export default SampleChangerMaintenance;

--- a/ui/src/containers/EquipmentContainer.jsx
+++ b/ui/src/containers/EquipmentContainer.jsx
@@ -19,13 +19,9 @@ import {
 
 import {
   abort as haAbort,
-  sendCommand as haSendCommand,
   refresh as haRefresh,
   harvestCrystal,
   harvestAndLoadCrystal,
-  calibratePin as haCalibratePin,
-  validateCalibration as haValidateCalibration,
-  sendDataCollectionToCrims,
 } from '../actions/harvester';
 
 import { showErrorPanel } from '../actions/general';
@@ -82,14 +78,7 @@ function EquipmentContainer(props) {
                   />
                 </Col>
                 <Col sm={6}>
-                  <PlateManipulatorMaintenance
-                    commands={props.commands}
-                    global_state={props.global_state}
-                    commands_state={props.commands_state}
-                    message={props.message}
-                    sendCommand={props.sendCommand}
-                    contents={props.contents}
-                  />
+                  <PlateManipulatorMaintenance />
                 </Col>
               </Row>
             ) : (
@@ -108,13 +97,7 @@ function EquipmentContainer(props) {
                   />
                 </Col>
                 <Col sm={6}>
-                  <SampleChangerMaintenance
-                    commands={props.commands}
-                    global_state={props.global_state}
-                    commands_state={props.commands_state}
-                    message={props.message}
-                    sendCommand={props.sendCommand}
-                  />
+                  <SampleChangerMaintenance />
                 </Col>
               </Row>
             )}
@@ -137,17 +120,7 @@ function EquipmentContainer(props) {
                   />
                 </Col>
                 <Col sm={3}>
-                  <HarvesterMaintenance
-                    contents={props.haContents}
-                    commands={props.haCommands}
-                    global_state={props.haGlobal_state}
-                    commands_state={props.haCommands_state}
-                    message={props.haMessage}
-                    sendCommand={props.haSendCommand}
-                    calibratePin={props.haCalibratePin}
-                    sendDataCollectionToCrims={props.sendDataCollectionToCrims}
-                    validateCalibration={props.haValidateCalibration}
-                  />
+                  <HarvesterMaintenance />
                 </Col>
               </Row>
             </GenericEquipment>
@@ -194,15 +167,10 @@ function mapStateToProps(state) {
     commands: state.sampleChangerMaintenance.commands,
     commands_state: state.sampleChangerMaintenance.commands_state,
     global_state: state.sampleChangerMaintenance.global_state,
-    message: state.sampleChangerMaintenance.message,
     beamline: state.beamline,
 
     haContents: state.harvester.contents,
     haState: state.harvester.state,
-    haCommands: state.harvesterMaintenance.commands,
-    haCommands_state: state.harvesterMaintenance.commands_state,
-    haGlobal_state: state.harvesterMaintenance.global_state,
-    haMessage: state.harvesterMaintenance.message,
   };
 }
 
@@ -225,13 +193,8 @@ function mapDispatchToProps(dispatch) {
     harvestCrystal: (address) => dispatch(harvestCrystal(address)),
     harvestAndLoadCrystal: (address) =>
       dispatch(harvestAndLoadCrystal(address)),
-    haCalibratePin: () => dispatch(haCalibratePin()),
-    sendDataCollectionToCrims: () => dispatch(sendDataCollectionToCrims()),
-    haValidateCalibration: (validated) =>
-      dispatch(haValidateCalibration(validated)),
     haRefresh: () => dispatch(haRefresh()),
     haAbort: () => dispatch(haAbort()),
-    haSendCommand: (cmd, args) => dispatch(haSendCommand(cmd, args)),
   };
 }
 


### PR DESCRIPTION
This refers to the `SampleChangerMaintenance`, `HarvesterMaintenance` and `PlateManipulatorMaintenance` components rendered on the _Equipment_ page.

- Move `ActionGroup`, `ActionButton`, `ActionField` into separate files and refactor them slightly (notably, `ActionButton` no longer takes care of sending the maintenance command; it just exposes an `onClick` prop).
- Let `PlateManipulatorMaintenance` use those "Action" components (it was using its own duplicated "Action" components).
- Refactor the "Maintenance" components to function components, refactor them to remove unnecessary render methods (`renderActionGroup`, `renderActionButton`, etc.)
- Let the "Maintenance" retrieve the state they need from the Redux store instead of passing it down from `EquipmentContainer`.