### PR TITLE
Extract and refactor clear queue dialog

### DIFF
--- a/ui/cypress/support.js
+++ b/ui/cypress/support.js
@@ -57,5 +57,5 @@ Cypress.Commands.add('mountSample', (sample = 'test', protein = 'test') => {
 Cypress.Commands.add('clearSamples', () => {
   cy.findByText('Samples').click();
   cy.findByRole('button', { name: /Clear sample list/u }).click('left');
-  cy.findByRole('button', { name: 'Ok' }).click();
+  cy.findByRole('button', { name: 'Clear' }).click();
 });

--- a/ui/src/components/DraggableModal.jsx
+++ b/ui/src/components/DraggableModal.jsx
@@ -2,17 +2,19 @@ import React from 'react';
 import { Modal } from 'react-bootstrap';
 import Draggable from 'react-draggable';
 
-class DraggableModalDialog extends React.Component {
-  render() {
-    return (
-      <Draggable handle=".modal-header" defaultPosition={this.props.defaultpos}>
-        <Modal.Dialog {...this.props} />
-      </Draggable>
-    );
-  }
+function DraggableModalDialog(props) {
+  const { defaultpos } = props;
+
+  return (
+    <Draggable handle=".modal-header" defaultPosition={defaultpos}>
+      <Modal.Dialog {...props} />
+    </Draggable>
+  );
 }
 
 export function DraggableModal(props) {
+  const { children } = props;
+
   return (
     <Modal
       dialogAs={DraggableModalDialog}
@@ -20,7 +22,7 @@ export function DraggableModal(props) {
       backdrop="static"
       {...props}
     >
-      {props.children}
+      {children}
     </Modal>
   );
 }

--- a/ui/src/components/GenericDialog/ConfirmActionDialog.jsx
+++ b/ui/src/components/GenericDialog/ConfirmActionDialog.jsx
@@ -1,56 +1,46 @@
-/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import { Modal, Button } from 'react-bootstrap';
 
-export default class ConfirmActionDialog extends React.Component {
-  constructor(props) {
-    super(props);
-    this.onOkClick = this.onOkClick.bind(this);
-    this.onCancelClick = this.onCancelClick.bind(this);
-  }
+function ConfirmActionDialog(props) {
+  const {
+    title,
+    okBtnLabel = 'OK',
+    cancelBtnLabel = 'Cancel',
+    show = false,
+    children,
+    onHide,
+    onOk,
+    onCancel,
+  } = props;
 
-  onOkClick() {
-    if (this.props.onOk) {
-      this.props.onOk();
-    }
-
-    this.props.hide();
-  }
-
-  onCancelClick() {
-    if (this.props.onCancel) {
-      this.props.onCancel();
-    }
-
-    this.props.hide();
-  }
-
-  render() {
-    return (
-      <Modal show={this.props.show}>
-        <Modal.Header>
-          <Modal.Title>{this.props.title}</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>{this.props.message}</Modal.Body>
-        <Modal.Footer>
-          <Button variant="outline-secondary" onClick={this.onCancelClick}>
-            {this.props.cancelButtonText}
-          </Button>
-          <Button variant="outline-secondary" onClick={this.onOkClick}>
-            {this.props.okButtonText}
-          </Button>
-        </Modal.Footer>
-      </Modal>
-    );
-  }
+  return (
+    <Modal show={show} data-default-styles onHide={onHide}>
+      <Modal.Header>
+        <Modal.Title>{title}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>{children}</Modal.Body>
+      <Modal.Footer>
+        <Button
+          variant="warning"
+          onClick={() => {
+            onOk?.();
+            onHide();
+          }}
+        >
+          {okBtnLabel}
+        </Button>
+        <Button
+          variant="outline-secondary"
+          onClick={() => {
+            onCancel?.();
+            onHide();
+          }}
+        >
+          {cancelBtnLabel}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
 }
 
-ConfirmActionDialog.defaultProps = {
-  show: false,
-  title: '',
-  message: '',
-  okButtonText: 'Ok',
-  cancelButtonText: 'Cancel',
-  onOk: false,
-  onCancel: false,
-};
+export default ConfirmActionDialog;

--- a/ui/src/components/Main.jsx
+++ b/ui/src/components/Main.jsx
@@ -25,6 +25,7 @@ import './rachat.css';
 import { getInitialState } from '../actions/login';
 import MXNavbar from './MXNavbar/MXNavbar';
 import ChatWidget from './ChatWidget';
+import ClearQueueDialog from './SampleGrid/ClearQueueDialog';
 
 function Main() {
   const dispatch = useDispatch();
@@ -54,6 +55,7 @@ function Main() {
       )}
 
       <SelectProposalContainer />
+      <ClearQueueDialog />
       <TaskContainer />
       <PleaseWaitDialog />
       <ErrorNotificationPanel />

--- a/ui/src/components/SampleGrid/ClearQueueDialog.jsx
+++ b/ui/src/components/SampleGrid/ClearQueueDialog.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import ConfirmActionDialog from '../GenericDialog/ConfirmActionDialog';
+import { useDispatch, useSelector } from 'react-redux';
+import { clearQueue } from '../../actions/queue';
+import { showConfirmClearQueueDialog } from '../../actions/general';
+
+function ClearQueueDialog() {
+  const dispatch = useDispatch();
+  const show = useSelector(
+    (state) => state.general.showConfirmClearQueueDialog,
+  );
+
+  return (
+    <ConfirmActionDialog
+      title="Clear sample list?"
+      okBtnLabel="Clear"
+      show={show}
+      onOk={() => dispatch(clearQueue())}
+      onHide={() => dispatch(showConfirmClearQueueDialog(false))}
+    >
+      This will also <strong>clear the queue</strong>.
+    </ConfirmActionDialog>
+  );
+}
+
+export default ClearQueueDialog;

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -38,7 +38,6 @@ import {
 } from '../actions/sampleGrid';
 
 import {
-  clearQueue,
   deleteSamplesFromQueue,
   setEnabledSample,
   addSamplesToQueue,
@@ -54,7 +53,6 @@ import { showTaskForm } from '../actions/taskForm';
 
 import SampleGridTableContainer from './SampleGridTableContainer';
 
-import ConfirmActionDialog from '../components/GenericDialog/ConfirmActionDialog';
 import QueueSettings from './QueueSettings.jsx';
 
 import '../components/SampleGrid/SampleGridTable.css';
@@ -789,14 +787,6 @@ class SampleListViewContainer extends React.Component {
         id="sampleGridContainer"
         className="samples-grid-table-container mt-4"
       >
-        <ConfirmActionDialog
-          title="Clear sample grid ?"
-          message="This will remove all samples (and collections) from the grid,
-                    are you sure you would like to continue ?"
-          onOk={this.props.clearQueue}
-          show={this.props.general.showConfirmClearQueueDialog}
-          hide={this.props.confirmClearQueueHide}
-        />
         {this.props.loading ? (
           <div
             className="center-in-box"
@@ -863,7 +853,7 @@ class SampleListViewContainer extends React.Component {
                   <Button
                     className="nowrap-style"
                     variant="outline-secondary"
-                    onClick={this.props.confirmClearQueueShow}
+                    onClick={this.props.showConfirmClearQueueDialog}
                     disabled={this.props.queue.queueStatus === QUEUE_RUNNING}
                   >
                     <i
@@ -1016,15 +1006,10 @@ function mapDispatchToProps(dispatch) {
       dispatch(setEnabledSample(qidList, value)),
     deleteTask: (qid, taskIndex) => dispatch(deleteTask(qid, taskIndex)),
     deleteTaskList: (sampleIDList) => dispatch(deleteTaskList(sampleIDList)),
-    clearQueue: () => dispatch(clearQueue()),
     addSamplesToQueue: (sampleData) => dispatch(addSamplesToQueue(sampleData)),
     stopQueue: () => dispatch(stopQueue()),
-    confirmClearQueueShow: bindActionCreators(
+    showConfirmClearQueueDialog: bindActionCreators(
       showConfirmClearQueueDialog,
-      dispatch,
-    ),
-    confirmClearQueueHide: bindActionCreators(
-      showConfirmClearQueueDialog.bind(null, false),
       dispatch,
     ),
     showConfirmCollectDialog: bindActionCreators(


### PR DESCRIPTION
Still continuing to convert class components. Here I'm mainly focusing on the dialog that appears when clicking on the "Clear sample list" button to confirm the action. I'm creating a dedicated component for this dialog so it is self-contained and can be extracted from the `SampleListViewContainer` component.

I'm also tweaking the UX of the dialog slightly:

- Narrower dialog
- Dialog can be dismissed by clicking outside
- Title changed to match trigger button wording
- "Ok" button renamed "Clear"
- "Clear" button now uses the `warning` theme variant
- "Clear" button now comes before "Cancel" button (more common pattern, and means it's focusable first)
- I've reworded the text to highlight the fact that the action also clears the queue ~and unmounts the current sample, if any~.

The last point makes me wonder whether the naming of the "Clear sample list" button is right... The main action is in fact the clearing of the queue... I'll open an issue to discuss this.

![image](https://github.com/user-attachments/assets/16d3acaa-ef11-49ac-8034-976daa06973c)

![image](https://github.com/user-attachments/assets/74cfa65b-77d2-415a-9463-296db32ec671)
