### PR TITLE
Pin micromamba version in GitHub Actions workflows

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,12 +41,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      # Pin micromamba version because of following issue:
+      # https://github.com/mamba-org/setup-micromamba/issues/225
       - name: Set up Conda environment
         uses: mamba-org/setup-micromamba@v1
         with:
           create-args: >-
             python=${{ matrix.python-version }}
-          micromamba-version: "latest"
+          micromamba-version: 1.5.10-0
           environment-file: conda-environment.yml
           cache-environment: true
           post-cleanup: "all"

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -40,10 +40,13 @@ jobs:
           fetch-depth: 0
 
       # Use micromamba instead of conda for better performance
+      # Pin micromamba version because of following issue:
+      # https://github.com/mamba-org/setup-micromamba/issues/225
       - name: "Setup conda environment with micromamba"
         uses: "mamba-org/setup-micromamba@v1"  # tested with v1.4.4
         with:
           environment-file: "conda-environment.yml"
+          micromamba-version: 1.5.10-0
 
       - name: "Install dependencies with Poetry"
         run: "${MAMBA_EXE} run --name mxcubeweb poetry install --only=docs,main"

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -1,6 +1,10 @@
 ---
 # yamllint disable rule:line-length
 
+
+# Pin micromamba version to `1.5.10-0` because of following issue:
+# https://github.com/mamba-org/setup-micromamba/issues/225
+
 name: UI
 
 "on":
@@ -22,7 +26,7 @@ jobs:
       - name: Set up Conda environment
         uses: mamba-org/setup-micromamba@v1
         with:
-          micromamba-version: "latest"
+          micromamba-version: 1.5.10-0
           environment-file: conda-environment.yml
           cache-environment: true
           post-cleanup: "all"
@@ -56,7 +60,7 @@ jobs:
       - name: Set up Conda environment
         uses: mamba-org/setup-micromamba@v1
         with:
-          micromamba-version: "latest"
+          micromamba-version: 1.5.10-0
           environment-file: conda-environment.yml
           cache-environment: true
           post-cleanup: "all"
@@ -107,7 +111,7 @@ jobs:
       - name: Set up Conda environment
         uses: mamba-org/setup-micromamba@v1
         with:
-          micromamba-version: "latest"
+          micromamba-version: 1.5.10-0
           environment-file: conda-environment.yml
           cache-environment: true
           post-cleanup: "all"


### PR DESCRIPTION
Pin version of micromamba to `1.5.10-0` in GitHub Actions workflows because of following issue:
https://github.com/mamba-org/setup-micromamba/issues/225

GitHub: fix https://github.com/mxcube/mxcubeweb/issues/1424