### PR TITLE
Simplify UI for changing step of motor input

### DIFF
--- a/ui/src/components/MotorInput/MotorInput.jsx
+++ b/ui/src/components/MotorInput/MotorInput.jsx
@@ -3,8 +3,8 @@
 import React from 'react';
 import cx from 'classnames';
 import { Button } from 'react-bootstrap';
-import PopInput from '../PopInput/PopInput';
 import { MOTOR_STATE } from '../../constants';
+import styles from './MotorInput.module.css';
 import './motor.css';
 import '../input.css';
 
@@ -96,114 +96,76 @@ export default class MotorInput extends React.Component {
     return (
       <div className="motor-input-container">
         <p className="motor-name">{this.props.label}</p>
-        <div className="d-flex">
-          <form className="d-flex" onSubmit={this.handleKey} noValidate>
-            <div style={{ display: 'flex', width: '160px' }}>
-              <div
-                className="rw-widget rw-numberpicker rw-widget-no-right-border"
-                style={{ width: '90px', display: 'inline-block' }}
+        <form className="d-flex" onSubmit={this.handleKey} noValidate>
+          <div
+            className="rw-widget rw-numberpicker rw-widget-no-right-border"
+            style={{ width: '90px', display: 'inline-block' }}
+          >
+            <span className="rw-select">
+              <button
+                type="button"
+                className="rw-btn"
+                disabled={
+                  this.props.state !== MOTOR_STATE.READY || this.props.disabled
+                }
+                onClick={this.stepIncrement}
               >
-                <span className="rw-select">
-                  <button
-                    type="button"
-                    className="rw-btn"
-                    disabled={
-                      this.props.state !== MOTOR_STATE.READY ||
-                      this.props.disabled
-                    }
-                    onClick={this.stepIncrement}
-                  >
-                    <i aria-hidden="true" className="rw-i fas fa-caret-up" />
-                  </button>
-                  <button
-                    type="button"
-                    className="rw-btn"
-                    disabled={
-                      this.props.state !== MOTOR_STATE.READY ||
-                      this.props.disabled
-                    }
-                    onClick={this.stepDecrement}
-                  >
-                    <i aria-hidden="true" className="rw-i fas fa-caret-down" />
-                  </button>
-                </span>
+                <i aria-hidden="true" className="rw-i fas fa-caret-up" />
+              </button>
+              <button
+                type="button"
+                className="rw-btn"
+                disabled={
+                  this.props.state !== MOTOR_STATE.READY || this.props.disabled
+                }
+                onClick={this.stepDecrement}
+              >
+                <i aria-hidden="true" className="rw-i fas fa-caret-down" />
+              </button>
+            </span>
+            <input
+              ref={(ref) => {
+                this.motorValue = ref;
+              }}
+              className={inputCSS}
+              onKeyUp={this.handleKey}
+              type="number"
+              step={step}
+              defaultValue={valueCropped}
+              name={motorName}
+              disabled={
+                this.props.state !== MOTOR_STATE.READY || this.props.disabled
+              }
+            />
+          </div>
+          {this.props.saveStep &&
+            (this.props.state === MOTOR_STATE.READY ? (
+              <>
                 <input
-                  ref={(ref) => {
-                    this.motorValue = ref;
-                  }}
-                  className={inputCSS}
-                  onKeyUp={this.handleKey}
+                  className={styles.stepInput}
                   type="number"
-                  step={step}
-                  defaultValue={valueCropped}
-                  name={motorName}
-                  disabled={
-                    this.props.state !== MOTOR_STATE.READY ||
-                    this.props.disabled
+                  size={3}
+                  defaultValue={step}
+                  disabled={this.props.disabled}
+                  onChange={(evt) =>
+                    this.props.saveStep(
+                      motorName.toLowerCase(),
+                      Number(evt.target.value),
+                    )
                   }
                 />
-              </div>
-              {this.props.saveStep &&
-                (this.props.state === MOTOR_STATE.READY ? (
-                  <div
-                    className="rw-widget-right-border"
-                    style={{
-                      width: 'auto',
-                      display: 'inline-flex',
-                      alignItems: 'center',
-                      textAlign: 'center',
-                      fontSize: '12px',
-                      cursor: 'pointer',
-                      backgroundColor: '#EAEAEA',
-                    }}
-                  >
-                    {this.props.inplace ? (
-                      <span className="ms-2 me-2">
-                        {this.props.step} {suffix}
-                      </span>
-                    ) : (
-                      <PopInput
-                        pkey={motorName.toLowerCase()}
-                        value={step}
-                        suffix={suffix}
-                        inputSize="5"
-                        immediate
-                        precision={this.props.decimalPoints}
-                        onSave={this.props.saveStep}
-                        style={{
-                          display: 'inline-block',
-                          marginLeft: 'auto',
-                          marginRight: '0.5em',
-                          paddingLeft: '0.5em',
-                        }}
-                      />
-                    )}
-                  </div>
-                ) : (
-                  <Button
-                    className="btn-xs motor-abort rw-widget-no-left-border"
-                    variant="danger"
-                    onClick={this.stopMotor}
-                  >
-                    <i className="fas fa-times" />
-                  </Button>
-                ))}
-            </div>
-          </form>
-          {this.props.inplace && (
-            <PopInput
-              pkey={motorName.toLowerCase()}
-              value={step}
-              suffix={suffix}
-              inputSize="5"
-              inplace
-              immediate
-              precision={this.props.decimalPoints}
-              onSave={this.props.saveStep}
-              style={{ display: 'flex', alignItems: 'center' }}
-            />
-          )}
-        </div>
+                <span className={styles.unit}>{suffix}</span>
+              </>
+            ) : (
+              <Button
+                className="btn-xs motor-abort rw-widget-no-left-border"
+                variant="danger"
+                onClick={this.stopMotor}
+              >
+                <i className="fas fa-times" />
+              </Button>
+            ))}
+        </form>
       </div>
     );
   }

--- a/ui/src/components/MotorInput/MotorInput.module.css
+++ b/ui/src/components/MotorInput/MotorInput.module.css
@@ -1,0 +1,17 @@
+.stepInput {
+  background-color: #f5f5f5;
+  border: 1px solid #ccc;
+  font-size: 12px;
+  text-align: center;
+}
+
+.unit {
+  display: flex;
+  align-items: center;
+  padding: 0 0.5em;
+  background-color: #eaeaea;
+  border: 1px solid #ccc;
+  border-left: 0;
+  border-radius: 0 4px 4px 0;
+  font-size: 12px;
+}

--- a/ui/src/components/MotorInput/motor.css
+++ b/ui/src/components/MotorInput/motor.css
@@ -42,10 +42,6 @@
   font-size: 0.7em;
 }
 
-.step-size {
-  display: inline;
-}
-
 .mx-btn {
   display: block;
   height: 1.143em;
@@ -90,12 +86,6 @@ input::-webkit-inner-spin-button {
   border-left: 0;
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
-}
-
-.rw-widget-right-border {
-  border: #ccc 1px solid;
-  border-top-right-radius: 4px;
-  border-bottom-right-radius: 4px;
 }
 
 .rw-widget > .rw-select {

--- a/ui/src/components/SampleView/SampleView.css
+++ b/ui/src/components/SampleView/SampleView.css
@@ -154,14 +154,6 @@
   display: inline;
 }
 
-.step-size .popinput-input-value {
-  min-width: 0;
-}
-
-.step-size span {
-  font-size: 11px;
-}
-
 .btn-link:hover,
 .btn-link:focus {
   text-decoration: initial !important;

--- a/ui/src/containers/MotorInputContainer.jsx
+++ b/ui/src/containers/MotorInputContainer.jsx
@@ -16,21 +16,19 @@ class MotorInputContainer extends Component {
 
     if (!Number.isNaN(motorhwo.value)) {
       result = (
-        <div>
-          <MotorInput
-            save={this.props.setAttribute}
-            saveStep={this.props.setStepSize}
-            step={uiprop.step}
-            value={motorhwo.value}
-            motorName={uiprop.attribute}
-            label={`${uiprop.label}:`}
-            suffix={uiprop.suffix}
-            decimalPoints={uiprop.precision}
-            state={motorhwo.state}
-            stop={this.props.stopBeamlineAction}
-            disabled={this.props.motorInputDisabled}
-          />
-        </div>
+        <MotorInput
+          save={this.props.setAttribute}
+          saveStep={this.props.setStepSize}
+          step={uiprop.step}
+          value={motorhwo.value}
+          motorName={uiprop.attribute}
+          label={`${uiprop.label}:`}
+          suffix={uiprop.suffix}
+          decimalPoints={uiprop.precision}
+          state={motorhwo.state}
+          stop={this.props.stopBeamlineAction}
+          disabled={this.props.motorInputDisabled}
+        />
       );
     }
 


### PR DESCRIPTION
Fix #1311 

I replace the cumbersome popover UI with a simple number input.

![Peek 2024-10-01 10-28](https://github.com/user-attachments/assets/4ca6c55a-f348-4d69-9a65-98a15b931bed)

Since the step is a front-end state, which is updated synchronously in the Redux store, we can simply update it on every `change` event of the step input. No need to require the user to press <kbd>Enter</kbd> as I initially proposed in #1311.

---

Now, slight problem (which was already present before this change): in the mock environment, I can't seem to get the step inputs of the following "motors" to work:

- Sample Vertical
- Sample Horizontal
- Focus

If I recall, those are actually abstract motors that control multiple physical motors, so perhaps it is a limitation of the mock environment?

![Peek 2024-10-01 10-29](https://github.com/user-attachments/assets/80a9ce42-a803-4a10-af5e-93a9e99a9508)

Interestingly, if you pay close attention, when I press the arrows, the motor input sometimes receives a value that does not make sense whatsoever for a split millisecond (starting with `3` when pressing the up arrow, or `-0.` when pressing the down arrow) — it seems to overshoot before going back to the initial value +/- 0.1.