### PR TITLE
Refactor `MotorControls` and `TwoAxisTranslationControl`

### DIFF
--- a/ui/src/components/SampleView/MotorControls.jsx
+++ b/ui/src/components/SampleView/MotorControls.jsx
@@ -1,113 +1,69 @@
-import React from 'react';
-import { Button, Row, Col } from 'react-bootstrap';
-import MotorInputContainer from '../../containers/MotorInputContainer';
+import React, { useState } from 'react';
+import { Button } from 'react-bootstrap';
+import { useSelector } from 'react-redux';
 
+import MotorInputContainer from '../../containers/MotorInputContainer';
 import TwoAxisTranslationControl from '../MotorInput/TwoAxisTranslationControl';
-import { find } from 'lodash';
+import styles from './MotorControls.module.css';
 
 import '../MotorInput/motor.css';
 
-export default class MotorControls extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { showAll: false };
+function MotorControls() {
+  const [showAll, setShowAll] = useState(false);
+
+  const motorsProps = useSelector((state) =>
+    state.uiproperties.sample_view.components.filter(
+      ({ value_type }) => value_type === 'MOTOR',
+    ),
+  );
+
+  const verticalMotorProps = motorsProps.find(
+    (c) => c.role === 'sample_vertical',
+  );
+  const horizontalMotorProps = motorsProps.find(
+    (c) => c.role === 'sample_horizontal',
+  );
+
+  if (!verticalMotorProps || !horizontalMotorProps) {
+    return motorsProps.map(({ attribute: k, role }) => (
+      <MotorInputContainer key={k} component="sample_view" role={role} />
+    ));
   }
 
-  renderMotorInputs(from, to) {
-    return this.props.uiproperties
-      .slice(from, to)
-      .map(({ attribute, role }) => (
-        <Col key={attribute} sm={12}>
-          <MotorInputContainer component="sample_view" role={role} />
-        </Col>
-      ));
-  }
+  return (
+    <>
+      {motorsProps.slice(0, 3).map(({ attribute: k, role }) => (
+        <MotorInputContainer key={k} component="sample_view" role={role} />
+      ))}
 
-  render() {
-    const sample_vertical_uiprop = find(this.props.uiproperties, {
-      role: 'sample_vertical',
-    });
+      <TwoAxisTranslationControl
+        verticalMotorProps={verticalMotorProps}
+        horizontalMotorProps={horizontalMotorProps}
+      />
 
-    const sample_horizontal_uiprop = find(this.props.uiproperties, {
-      role: 'sample_horizontal',
-    });
+      <Button
+        className={styles.showAllBtn}
+        size="sm"
+        variant="outline-secondary"
+        onClick={() => setShowAll(!showAll)}
+      >
+        <i className="fas fa-cogs me-2" />
+        <span className="flex-fill">
+          {showAll ? 'Hide motors' : 'Show motors'}
+        </span>
+        <i
+          className={`fas ${showAll ? 'fa-caret-up' : 'fa-caret-down'} ms-2`}
+        />
+      </Button>
 
-    const sample_vertical = find(this.props.hardwareObjects, {
-      name: sample_vertical_uiprop.attribute,
-    });
-
-    const sample_horizontal = find(this.props.hardwareObjects, {
-      name: sample_horizontal_uiprop.attribute,
-    });
-
-    const numel = this.props.uiproperties.length;
-
-    if (!sample_vertical || !sample_horizontal) {
-      return <Row className="row">{this.renderMotorInputs(0, numel)}</Row>;
-    }
-
-    const { save } = this.props;
-    const { saveStep } = this.props;
-    const _stop = this.props.stop;
-
-    const motors = {
-      sample_vertical: Object.assign(sample_vertical_uiprop, sample_vertical),
-      sample_horizontal: Object.assign(
-        sample_horizontal_uiprop,
-        sample_horizontal,
-      ),
-    };
-
-    return (
-      <Row className="row">
-        {this.renderMotorInputs(0, 3)}
-        <div>
-          <div>
-            <TwoAxisTranslationControl
-              save={save}
-              saveStep={saveStep}
-              motors={motors}
-              motorsDisabled={this.props.motorsDisabled}
-              steps={this.props.steps}
-              stop={_stop}
-            />
-          </div>
-          <div>
-            <Button
-              variant="outline-secondary"
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                marginTop: '1rem',
-                minWidth: '155px',
-                whiteSpace: 'nowrap',
-                textAlign: 'left',
-              }}
-              size="sm"
-              onClick={() => {
-                this.setState({ showAll: !this.state.showAll });
-              }}
-            >
-              <i className="fas fa-cogs" style={{ marginRight: '0.5rem' }} />
-              <span style={{ flex: '1 0 auto' }}>
-                {this.state.showAll ? 'Hide motors' : 'Show motors'}
-              </span>
-              <i
-                style={{ marginLeft: '0.5rem' }}
-                className={`fas ${
-                  this.state.showAll ? 'fa-caret-up' : 'fa-caret-down'
-                }`}
-              />
-            </Button>
-
-            {this.state.showAll && (
-              <div style={{ marginTop: '0.5rem' }}>
-                {this.renderMotorInputs(3, numel)}
-              </div>
-            )}
-          </div>
-        </div>
-      </Row>
-    );
-  }
+      {showAll &&
+        motorsProps
+          .slice(3)
+          .map(({ attribute: k, role }) => (
+            <MotorInputContainer key={k} component="sample_view" role={role} />
+          ))}
+    </>
+  );
 }
+
+export default MotorControls;

--- a/ui/src/components/SampleView/MotorControls.module.css
+++ b/ui/src/components/SampleView/MotorControls.module.css
@@ -1,0 +1,8 @@
+.showAllBtn {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.5rem;
+  min-width: 155px;
+  white-space: nowrap;
+  text-align: left;
+}

--- a/ui/src/containers/SampleViewContainer.jsx
+++ b/ui/src/containers/SampleViewContainer.jsx
@@ -33,7 +33,6 @@ import {
   logFrontEndTraceBack,
   setAttribute,
 } from '../actions/beamline';
-import { stopBeamlineAction } from '../actions/beamlineActions';
 import { find } from 'lodash';
 
 import styles from './SampleViewContainer.module.css';
@@ -57,22 +56,13 @@ class SampleViewContainer extends Component {
   }
 
   render() {
-    const { uiproperties, hardwareObjects } = this.props;
+    const { uiproperties } = this.props;
 
     if (!('sample_view' in uiproperties)) {
       return null;
     }
 
-    const motorUiProperties = uiproperties.sample_view.components.filter(
-      ({ value_type }) => value_type === 'MOTOR',
-    );
-
-    const motorhardwareObjects = Object.values(hardwareObjects).filter(
-      ({ type }) => type === 'MOTOR',
-    );
-
     const { sourceScale, imageRatio, motorSteps } = this.props.sampleViewState;
-    const { setStepSize } = this.props.sampleViewActions;
     const { currentSampleID } = this.props;
     const [points, lines, grids, twoDPoints] = [{}, {}, {}, {}];
     const selectedGrids = [];
@@ -178,20 +168,8 @@ class SampleViewContainer extends Component {
                   inPopover
                 />
               )}
-              <MotorControls
-                save={this.props.setAttribute}
-                saveStep={setStepSize}
-                uiproperties={motorUiProperties}
-                hardwareObjects={motorhardwareObjects}
-                motorsDisabled={
-                  this.props.motorInputDisable ||
-                  this.props.queueState === QUEUE_RUNNING
-                }
-                steps={motorSteps}
-                stop={this.props.stopBeamlineAction}
-                sampleViewActions={this.props.sampleViewActions}
-                sampleViewState={this.props.sampleViewState}
-              />
+
+              <MotorControls />
             </DefaultErrorBoundary>
           </Col>
           <Col sm={6}>
@@ -269,7 +247,6 @@ function mapStateToProps(state) {
     queueState: state.queue.queueStatus,
     sampleViewState: state.sampleview,
     contextMenu: state.contextMenu,
-    motorInputDisable: state.beamline.motorInputDisable,
     hardwareObjects: state.beamline.hardwareObjects,
     availableMethods: state.beamline.availableMethods,
     defaultParameters: state.taskForm.defaultParameters,
@@ -306,7 +283,6 @@ function mapDispatchToProps(dispatch) {
     showForm: bindActionCreators(showTaskForm, dispatch),
     showErrorPanel: bindActionCreators(showErrorPanel, dispatch),
     setAttribute: bindActionCreators(setAttribute, dispatch),
-    stopBeamlineAction: bindActionCreators(stopBeamlineAction, dispatch),
     setBeamlineAttribute: bindActionCreators(setBeamlineAttribute, dispatch),
     displayImage: bindActionCreators(displayImage, dispatch),
     sendExecuteCommand: bindActionCreators(executeCommand, dispatch),


### PR DESCRIPTION
As usual, converting to function components and introducing `useSelector`.

One change worth mentioning is that the decision to show the `TwoAxisTranslationControl` (the buttons in a cross in the sidebar) is now based only on the existence of the `uiproperties` objects (with roles `sample_vertical` and `sample_horizontal`) instead of the corresponding hardware objects. This simplifies the logic significantly.