### PR TITLE
ensure shape key is the upper-cased id

### DIFF
--- a/mxcubeweb/core/components/sampleview.py
+++ b/mxcubeweb/core/components/sampleview.py
@@ -266,8 +266,10 @@ class SampleView(ComponentBase):
         for shape in HWR.beamline.sample_view.get_shapes():
             s = shape.as_dict()
             shape_dict.update({shape.id: s})
-
-        return {"shapes": to_camel(shape_dict)}
+            # shape key comes case lowered from the to_camel (2dp1), this breaks ui
+            # lest ensure it upper case by only came casing the dict data
+            _shape = {shape.id: to_camel(shape_dict[shape.id])}
+        return {"shapes": _shape}
 
     def get_shape_width_sid(self, sid):
         shape = HWR.beamline.sample_view.get_shape(sid)


### PR DESCRIPTION
fixing an issue when the shape id reported by the server is lower cased (p1), but the UI expects upper cased (P1)

how to reproduce:
1 - Create a new point in the ui, check the state and you will see the ui state as  "P1"
2 - (you can run data collections on this)
3 - Refresh the page, check the state and you will see the ui state as  "p1"
4 - Now you cannot run tasks as the addTask method will try to access the shape with "P1" key

If you enable and the. disable the 3click centring, you would end up with both keys ("p1" and "P1") in the state (???)

I tried to hack my way into the `to_camel`method for achieving this but I got no luck.