### PR TITLE
Refactor `MotorInputContainer` and `MotorInput`

### DIFF
--- a/docs/source/dev/tests.md
+++ b/docs/source/dev/tests.md
@@ -58,6 +58,8 @@ pnpm --prefix ui build
 CYPRESS_BASE_URL="http://127.0.0.1:8081" pnpm --prefix ui e2e
 ```
 
+> Currently, WebSockets don't work when running Cypress in the CI. In order to replicate the CI environement more accurately, WebSockets can be disabled locally via environment variable `VITE_DISABLE_WEBSOCKETS`. For instance, you can start the development server with sockets disabled with: `VITE_DISABLE_WEBSOCKETS=true pnpm --prefix ui start`.
+
 ### Best Practices
 
 The best use for development would be to test the components you changed first individually by using the cypress app. This allows for better error tracking and time efficiency as it prevents you from running tests on components that are not effected by your changes multiple times during development.

--- a/ui/cypress/e2e/sampleControls.cy.js
+++ b/ui/cypress/e2e/sampleControls.cy.js
@@ -24,7 +24,7 @@ describe('3-click centring', () => {
     cy.findByRole('button', { name: '3-click centring' }).click();
     cy.findByText(/Clicks left: 3/u, { hidden: true }).should('exist');
 
-    cy.get('.form-control[name="diffractometer.phi"]')
+    cy.findByTestId('MotorInput_value_diffractometer.phi')
       .invoke('val')
       .then((initialValue) => {
         cy.get('.canvas-container').click();
@@ -35,7 +35,7 @@ describe('3-click centring', () => {
         // Reload to see new omega value (since WebSockets don't work on CI)
         cy.reload();
 
-        cy.get('.form-control[name="diffractometer.phi"]')
+        cy.findByTestId('MotorInput_value_diffractometer.phi')
           .invoke('val')
           .should('equal', (Number.parseFloat(initialValue) + 90).toFixed(2));
       });

--- a/ui/cypress/support.js
+++ b/ui/cypress/support.js
@@ -22,6 +22,14 @@ Cypress.Commands.add('takeControl', () => {
       cy.findByRole('button', { name: 'Continue' }).click();
       cy.findByRole('link', { name: /Remote/u, hidden: true }).click();
       cy.findByRole('button', { name: 'Take control' }).click();
+
+      // Confirmation dialog appears only if sockets are enabled
+      // eslint-disable-next-line promise/no-nesting
+      cy.get('body').then(($body) => {
+        if ($body.text().includes('Hide')) {
+          cy.findByRole('button', { name: 'Hide' }).click();
+        }
+      });
     }
   });
 });

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,7 +16,7 @@
     "prettier": "prettier . --cache --check",
     "eslint": "eslint \"**/*.{js,jsx}\"",
     "e2e": "cypress run --e2e --browser firefox",
-    "cypress": "VITE_DISABLE_WEBSOCKETS=true cypress open --e2e --browser firefox"
+    "cypress": "cypress open --e2e --browser firefox"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",

--- a/ui/src/components/MotorInput/MotorInput.module.css
+++ b/ui/src/components/MotorInput/MotorInput.module.css
@@ -1,4 +1,4 @@
-.form {
+.wrapper {
   display: flex;
 }
 
@@ -20,7 +20,7 @@
   background-color: var(--hw-fault--bg) !important;
 }
 
-.valueInput[data-edited] {
+.valueInput[data-dirty] {
   background-color: var(--field-dirty--bg) !important;
 }
 

--- a/ui/src/components/SampleView/SampleControls.module.css
+++ b/ui/src/components/SampleView/SampleControls.module.css
@@ -108,7 +108,6 @@
   margin-top: 0.5rem;
   padding: 0.625rem 0.75rem;
   background-color: rgba(0, 0, 0, 0.6);
-  color: rgb(255, 255, 255);
   border-radius: 4px;
 }
 


### PR DESCRIPTION
I'll probably refactor them further, but since the conversion of `MotorInput` to a functional component wasn't trivial, I think it's best that I split things up.

Note that I also fix the styling of "dirty"/"edited", which I broke in #1438.

All the interactions still work:

- edit value manually then press <kbd>Enter</kbd>
- focus field then press <kbd>ArrowUp/Down</kbd>
- click on up/down arrow buttons
- change step
- abort/retry

![Peek 2024-10-10 11-50](https://github.com/user-attachments/assets/450c568a-44ab-49ed-ab2b-c3d5a17d35c2)
