### PR TITLE
Refactor `OneAxisTranslationControl`

### DIFF
--- a/ui/src/components/MotorInput/BaseMotorInput.jsx
+++ b/ui/src/components/MotorInput/BaseMotorInput.jsx
@@ -1,0 +1,91 @@
+/* eslint-disable jsx-a11y/control-has-associated-label */
+import React, { useEffect, useState } from 'react';
+import { Form } from 'react-bootstrap';
+import { HW_STATE } from '../../constants';
+
+function BaseMotorInput(props) {
+  const {
+    className,
+    style,
+    value,
+    state,
+    precision,
+    step,
+    min,
+    max,
+    disabled,
+    testId,
+    onChange,
+  } = props;
+
+  const [inputValue, setInputValue] = useState(value.toFixed(precision));
+  const [isEdited, setEdited] = useState(false);
+
+  useEffect(() => {
+    setInputValue(value.toFixed(precision));
+    setEdited(false);
+  }, [value, precision]);
+
+  function handleKey(evt) {
+    switch (evt.key) {
+      case 'ArrowUp': {
+        evt.preventDefault();
+        onChange(value + step);
+        break;
+      }
+      case 'ArrowDown': {
+        evt.preventDefault();
+        onChange(value - step);
+        break;
+      }
+      default:
+    }
+  }
+
+  function handleSubmit(evt) {
+    evt.preventDefault();
+
+    const newValue = Number.parseFloat(inputValue);
+
+    if (!Number.isNaN(newValue)) {
+      onChange(newValue);
+      setEdited(false);
+    }
+  }
+
+  const isReady = state === HW_STATE.READY;
+  const isBusy = state === HW_STATE.BUSY;
+  const isWarning = state === HW_STATE.WARNING;
+  const isFault =
+    state === HW_STATE.UNKNOWN ||
+    state === HW_STATE.FAULT ||
+    state === HW_STATE.OFF;
+
+  return (
+    <form noValidate onSubmit={handleSubmit}>
+      <Form.Control
+        className={className}
+        style={style}
+        type="number"
+        value={inputValue}
+        step={step}
+        max={max}
+        min={min}
+        disabled={disabled || !isReady}
+        data-testId={testId}
+        data-dirty={isEdited || undefined}
+        data-busy={isBusy || undefined}
+        data-warning={isWarning || undefined}
+        data-fault={isFault || undefined}
+        onKeyDown={handleKey}
+        onChange={(evt) => {
+          setInputValue(evt.target.value);
+          setEdited(true);
+        }}
+      />
+      <input type="submit" hidden /> {/* allow submit on Enter */}
+    </form>
+  );
+}
+
+export default BaseMotorInput;

--- a/ui/src/components/MotorInput/MotorInput.jsx
+++ b/ui/src/components/MotorInput/MotorInput.jsx
@@ -1,10 +1,11 @@
 /* eslint-disable jsx-a11y/control-has-associated-label */
 
-import React, { useEffect, useState } from 'react';
-import { Button, Form } from 'react-bootstrap';
+import React from 'react';
+import { Button } from 'react-bootstrap';
 import { HW_STATE } from '../../constants';
 import styles from './MotorInput.module.css';
 import './motor.css';
+import BaseMotorInput from './BaseMotorInput';
 
 function MotorInput(props) {
   const {
@@ -14,105 +15,51 @@ function MotorInput(props) {
     step,
     state,
     suffix,
-    decimalPoints,
+    precision,
     disabled,
     save,
     stop,
     saveStep,
   } = props;
 
-  const [inputValue, setInputValue] = useState(value.toFixed(decimalPoints));
-  const [isEdited, setEdited] = useState(false);
-
-  useEffect(() => {
-    setInputValue(value.toFixed(decimalPoints));
-    setEdited(false);
-  }, [value, decimalPoints]);
-
-  function handleKey(evt) {
-    switch (evt.key) {
-      case 'ArrowUp': {
-        evt.preventDefault();
-        save(motorName, value + step);
-        break;
-      }
-      case 'ArrowDown': {
-        evt.preventDefault();
-        save(motorName, value - step);
-        break;
-      }
-      default:
-    }
-  }
-
-  function handleSubmit(evt) {
-    evt.preventDefault();
-
-    const newValue = Number.parseFloat(inputValue);
-
-    if (!Number.isNaN(newValue)) {
-      save(motorName, newValue);
-      setEdited(false);
-    }
-  }
-
   return (
     <div className="motor-input-container">
       <p className="motor-name">{label}</p>
       <div className={styles.wrapper}>
-        <form noValidate onSubmit={handleSubmit}>
-          <div
-            className="rw-widget rw-numberpicker rw-widget-no-right-border"
-            style={{ width: '90px', display: 'inline-block' }}
-          >
-            <span className="rw-select">
-              <button
-                type="button"
-                className="rw-btn"
-                disabled={state !== HW_STATE.READY || disabled}
-                onClick={() => {
-                  save(motorName, value + step);
-                }}
-              >
-                <i aria-hidden="true" className="rw-i fas fa-caret-up" />
-              </button>
-              <button
-                type="button"
-                className="rw-btn"
-                disabled={state !== HW_STATE.READY || disabled}
-                onClick={() => {
-                  save(motorName, value - step);
-                }}
-              >
-                <i aria-hidden="true" className="rw-i fas fa-caret-down" />
-              </button>
-            </span>
-            <Form.Control
-              className={`${styles.valueInput} rw-input`}
-              name="value"
-              type="number"
-              step={step}
+        <div
+          className="rw-widget rw-numberpicker rw-widget-no-right-border"
+          style={{ width: '90px', display: 'inline-block' }}
+        >
+          <span className="rw-select">
+            <button
+              type="button"
+              className="rw-btn"
               disabled={state !== HW_STATE.READY || disabled}
-              data-dirty={isEdited || undefined}
-              data-busy={state === HW_STATE.BUSY || undefined}
-              data-warning={state === HW_STATE.WARNING || undefined}
-              data-fault={
-                state === HW_STATE.UNKNOWN ||
-                state === HW_STATE.FAULT ||
-                state === HW_STATE.OFF ||
-                undefined
-              }
-              value={inputValue}
-              onChange={(evt) => {
-                setInputValue(evt.target.value);
-                setEdited(true);
-              }}
-              onKeyDown={handleKey}
-              data-testId={`MotorInput_value_${motorName}`}
-            />
-            <input type="submit" hidden /> {/* allow submit on Enter */}
-          </div>
-        </form>
+              onClick={() => save(motorName, value + step)}
+            >
+              <i aria-hidden="true" className="rw-i fas fa-caret-up" />
+            </button>
+            <button
+              type="button"
+              className="rw-btn"
+              disabled={state !== HW_STATE.READY || disabled}
+              onClick={() => save(motorName, value - step)}
+            >
+              <i aria-hidden="true" className="rw-i fas fa-caret-down" />
+            </button>
+          </span>
+
+          <BaseMotorInput
+            className={`${styles.valueInput} rw-input`}
+            value={value}
+            state={state}
+            precision={precision}
+            step={step}
+            testId={`MotorInput_value_${motorName}`}
+            disabled={disabled}
+            onChange={(val) => save(motorName, val)}
+          />
+        </div>
         {saveStep &&
           (state === HW_STATE.READY ? (
             <>
@@ -131,9 +78,7 @@ function MotorInput(props) {
             <Button
               className="btn-xs motor-abort rw-widget-no-left-border"
               variant="danger"
-              onClick={() => {
-                stop(motorName);
-              }}
+              onClick={() => stop(motorName)}
             >
               <i className="fas fa-times" />
             </Button>

--- a/ui/src/components/MotorInput/OneAxisTranslationControl.jsx
+++ b/ui/src/components/MotorInput/OneAxisTranslationControl.jsx
@@ -1,169 +1,74 @@
 import React from 'react';
-import { Button, Form, Popover } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
+
+import BaseMotorInput from './BaseMotorInput';
 import { HW_STATE } from '../../constants';
-import MotorInput from './MotorInput';
 import './motor.css';
 import styles from './OneAxisTranslationControl.module.css';
 
-// eslint-disable-next-line react/no-unsafe
-export default class OneAxisTranslationControl extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { edited: false };
-    this.handleKey = this.handleKey.bind(this);
-    this.stepChange = this.stepChange.bind(this);
-  }
+function OneAxisTranslationControl(props) {
+  const { motorName, value, state, step, disabled, precision, min, max, save } =
+    props;
 
-  /* eslint-enable react/no-set-state */
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    if (nextProps.value && nextProps.value !== this.props.value) {
-      this.motorValue.value = nextProps.value.toFixed(this.props.decimalPoints);
-      this.motorValue.defaultValue = nextProps.value.toFixed(
-        this.props.decimalPoints,
-      );
-      this.setState({ edited: false });
-    }
-  }
+  return (
+    <div className={`${styles.root} arrow-control`}>
+      <Button
+        variant="outline-secondary"
+        style={{ marginRight: '2px' }}
+        className="arrow-small arrow-left"
+        disabled={state !== HW_STATE.READY || disabled}
+        onClick={() => save(motorName, value - 10 * step)}
+      >
+        <i className="fas fa-angle-double-left" />
+      </Button>
+      <Button
+        variant="outline-secondary"
+        className="arrow-small arrow-left"
+        disabled={state !== HW_STATE.READY || disabled}
+        onClick={() => save(motorName, value - step)}
+      >
+        <i className="fas fa-angle-left" />
+      </Button>
 
-  handleKey(e) {
-    e.preventDefault();
-    e.stopPropagation();
+      <BaseMotorInput
+        className={`${styles.input} rw-input`}
+        style={{
+          width: `${Number.parseFloat(precision) + 2}em`,
+          height: '2.1em',
+          display: 'inline-block',
+          marginLeft: '5px',
+          marginRight: '5px',
+        }}
+        value={value}
+        state={state}
+        precision={precision}
+        step={step}
+        max={max}
+        min={min}
+        testId={`MotorInput_value_${motorName}`}
+        disabled={disabled}
+        onChange={(val) => save(motorName, val)}
+      />
 
-    this.setState({ edited: true });
-    if (this.props.value) {
-      if (
-        [13, 38, 40].includes(e.keyCode) &&
-        this.props.state === HW_STATE.READY
-      ) {
-        this.setState({ edited: false });
-        this.props.save(e.target.name, e.target.valueAsNumber);
-        this.motorValue.value = this.props.value.toFixed(
-          this.props.decimalPoints,
-        );
-      } else if (this.props.state === HW_STATE.BUSY) {
-        this.setState({ edited: false });
-        this.motorValue.value = this.props.value.toFixed(
-          this.props.decimalPoints,
-        );
-      }
-    }
-  }
-  /* eslint-enable react/no-set-state */
-
-  stepChange(name, step, operator) {
-    const { value } = this.props;
-    const newValue = value + step * operator;
-    this.props.save(name, newValue);
-  }
-
-  renderMotorSettings() {
-    return (
-      <Popover title={<b>Sample alignment motors</b>}>
-        <div>
-          <MotorInput
-            save={this.props.save}
-            value={this.props.motors.sample_vertical.position}
-            saveStep={this.props.saveStep}
-            step={this.props.steps.sample_verticalStep}
-            motorName="sample_vertical"
-            label="Vertical"
-            suffix="mm"
-            decimalPoints="3"
-            state={this.props.motors.sample_vertical.state}
-            stop={this.props.stop}
-            disabled={this.props.motorsDisabled}
-            inplace
-          />
-          <MotorInput
-            save={this.props.save}
-            value={this.props.motors.sample_horizontal.position}
-            saveStep={this.props.saveStep}
-            step={this.props.steps.sample_horizontalStep}
-            motorName="sample_horizontal"
-            label="Horizontal"
-            suffix="mm"
-            decimalPoints="3"
-            state={this.props.motors.sample_horizontal.state}
-            stop={this.props.stop}
-            disabled={this.props.motorsDisabled}
-            inplace
-          />
-        </div>
-      </Popover>
-    );
-  }
-
-  render() {
-    const { value, motorName, step, decimalPoints } = this.props;
-    const valueCropped = value ? value.toFixed(decimalPoints) : '';
-
-    return (
-      <div className="arrow-control">
-        <Button
-          variant="outline-secondary"
-          style={{ marginRight: '2px' }}
-          className="arrow-small arrow-left"
-          disabled={this.props.state !== HW_STATE.READY || this.props.disabled}
-          onClick={() => this.stepChange(motorName, 10 * step, -1)}
-        >
-          <i className="fas fa-angle-double-left" />
-        </Button>
-        <Button
-          variant="outline-secondary"
-          className="arrow-small arrow-left"
-          disabled={this.props.state !== HW_STATE.READY || this.props.disabled}
-          onClick={() => this.stepChange(motorName, step, -1)}
-        >
-          <i className="fas fa-angle-left" />
-        </Button>
-        <Form.Control
-          style={{
-            width: `${Number.parseFloat(decimalPoints) + 2}em`,
-            height: '2.1em',
-            display: 'inline-block',
-            marginLeft: '5px',
-            marginRight: '5px',
-          }}
-          ref={(ref) => {
-            this.motorValue = ref;
-          }}
-          className={`${styles.input} rw-input`}
-          onKeyUp={this.handleKey}
-          type="number"
-          max={this.props.max}
-          min={this.props.min}
-          step={step}
-          defaultValue={valueCropped}
-          name={motorName}
-          disabled={this.props.state !== HW_STATE.READY || this.props.disabled}
-          data-dirty={this.state.edited || undefined}
-          data-busy={this.props.state === HW_STATE.BUSY || undefined}
-          data-warning={this.props.state === HW_STATE.WARNING || undefined}
-          data-fault={
-            this.props.state === HW_STATE.UNKNOWN ||
-            this.props.state === HW_STATE.FAULT ||
-            this.props.state === HW_STATE.OFF ||
-            undefined
-          }
-        />
-        <Button
-          variant="outline-secondary"
-          className="arrow-small arrow-right"
-          disabled={this.props.state !== HW_STATE.READY || this.props.disabled}
-          onClick={() => this.stepChange(motorName, step, 1)}
-        >
-          <i className="fas fa-angle-right" />
-        </Button>
-        <Button
-          variant="outline-secondary"
-          style={{ marginLeft: '2px' }}
-          className="arrow-small arrow-right"
-          disabled={this.props.state !== HW_STATE.READY || this.props.disabled}
-          onClick={() => this.stepChange(motorName, 10 * step, 1)}
-        >
-          <i className="fas fa-angle-double-right" />
-        </Button>
-      </div>
-    );
-  }
+      <Button
+        variant="outline-secondary"
+        className="arrow-small arrow-right"
+        disabled={state !== HW_STATE.READY || disabled}
+        onClick={() => save(motorName, value + step)}
+      >
+        <i className="fas fa-angle-right" />
+      </Button>
+      <Button
+        variant="outline-secondary"
+        style={{ marginLeft: '2px' }}
+        className="arrow-small arrow-right"
+        disabled={state !== HW_STATE.READY || disabled}
+        onClick={() => save(motorName, value + 10 * step)}
+      >
+        <i className="fas fa-angle-double-right" />
+      </Button>
+    </div>
+  );
 }
+
+export default OneAxisTranslationControl;

--- a/ui/src/components/MotorInput/OneAxisTranslationControl.module.css
+++ b/ui/src/components/MotorInput/OneAxisTranslationControl.module.css
@@ -1,3 +1,7 @@
+.root {
+  display: flex;
+}
+
 .input {
   background-color: var(--hw-ready--bg) !important;
   transition: background-color 100ms ease-in;

--- a/ui/src/components/MotorInput/TwoAxisTranslationControl.jsx
+++ b/ui/src/components/MotorInput/TwoAxisTranslationControl.jsx
@@ -82,11 +82,10 @@ function TwoAxisTranslationControl(props) {
                 motorName={verticalMotorProps.attribute}
                 label={verticalMotorProps.label}
                 suffix={verticalMotorProps.suffix}
-                decimalPoints={verticalMotorProps.precision}
+                precision={verticalMotorProps.precision}
                 state={verticalMotor.state}
                 stop={(cmdName) => dispatch(stopBeamlineAction(cmdName))}
                 disabled={motorsDisabled}
-                inplace
               />
               <MotorInput
                 save={(name, val) => dispatch(setAttribute(name, val))}
@@ -96,11 +95,10 @@ function TwoAxisTranslationControl(props) {
                 motorName={horizontalMotorProps.attribute}
                 label={horizontalMotorProps.label}
                 suffix={horizontalMotorProps.suffix}
-                decimalPoints={horizontalMotorProps.precision}
+                precision={horizontalMotorProps.precision}
                 state={horizontalMotor.state}
                 stop={(cmdName) => dispatch(stopBeamlineAction(cmdName))}
                 disabled={motorsDisabled}
-                inplace
               />
             </Popover.Body>
           </Popover>

--- a/ui/src/components/SampleView/SampleControls.jsx
+++ b/ui/src/components/SampleView/SampleControls.jsx
@@ -222,7 +222,7 @@ export default class SampleControls extends React.Component {
                   step={this.props.steps.focusStep}
                   motorName={foucs_motor_uiprop.attribute}
                   suffix={foucs_motor_uiprop.suffix}
-                  decimalPoints={foucs_motor_uiprop.precision}
+                  precision={foucs_motor_uiprop.precision}
                   state={focus_motor.state}
                   disabled={this.props.motorsDisabled}
                 />

--- a/ui/src/containers/BeamlineSetupContainer.jsx
+++ b/ui/src/containers/BeamlineSetupContainer.jsx
@@ -54,7 +54,7 @@ function BeamlineSetupContainer(props) {
             step={step}
             motorName={motor.name}
             suffix="mm"
-            decimalPoints="3"
+            precision="3"
             state={motor.state}
             disabled={beamline.motorInputDisable}
           />

--- a/ui/src/containers/MotorInputContainer.jsx
+++ b/ui/src/containers/MotorInputContainer.jsx
@@ -38,7 +38,7 @@ function MotorInputContainer(props) {
       motorName={motorProps.attribute}
       label={`${motorProps.label}:`}
       suffix={motorProps.suffix}
-      decimalPoints={motorProps.precision}
+      precision={motorProps.precision}
       state={motor.state}
       stop={(cmdName) => dispatch(stopBeamlineAction(cmdName))}
       disabled={motorDisabled}


### PR DESCRIPTION
`OneAxisTranslationControl` has an input field that behaves the same way as the input field in `MotorInput`: you can type a number and press enter, or use up/down arrow to increment decrement, and it updates the value and shows the state of the underlying motor.

So in this PR, I extract this shared input from `MotorInput` into a `BaseMotorInput` component, and use it in `OneAxisTranslationControl`. This resolves a few minor inconsistencies between the two components and removes a bunch of duplicated code.

![Peek 2024-10-14 09-30](https://github.com/user-attachments/assets/836b460b-bf93-4056-bea4-cedb68973f47)

Still more refactoring to go — notably, I'd like to reduce the number of props that are passed down to some of the components.