### PR TITLE
fix minor issues in get_shapes method

### DIFF
--- a/mxcubeweb/core/components/sampleview.py
+++ b/mxcubeweb/core/components/sampleview.py
@@ -265,11 +265,10 @@ class SampleView(ComponentBase):
 
         for shape in HWR.beamline.sample_view.get_shapes():
             s = shape.as_dict()
-            shape_dict.update({shape.id: s})
-            # shape key comes case lowered from the to_camel (2dp1), this breaks ui
-            # lest ensure it upper case by only came casing the dict data
-            _shape = {shape.id: to_camel(shape_dict[shape.id])}
-        return {"shapes": _shape}
+            # shape key comes case lowered from the to_camel (2dp1), this breaks UI
+            # let's ensure it's upper case by only camel casing the dict data
+            shape_dict.update({shape.id: to_camel(s)})
+        return {"shapes": shape_dict}
 
     def get_shape_width_sid(self, sid):
         shape = HWR.beamline.sample_view.get_shape(sid)


### PR DESCRIPTION
The changes introduced in #1442 fixed an issue related to the camel casing of the shape ids. However the introduction of a new `dict` object came with issues (see #1442 for a more in detail review) related to:
- no shapes: the new dict object was not correctly initialized
- more than one shape: the dict object would only contain a single object

The changes proposed in this PR should fix the issues and remove the necessity of an additional `dict` object