### PR TITLE
Test main navigation and motor inputs

### DIFF
--- a/ui/cypress.config.js
+++ b/ui/cypress.config.js
@@ -10,6 +10,6 @@ export default defineConfig({
       installLogsPrinter(on);
     },
   },
-  viewportWidth: 1200,
-  viewportHeight: 800,
+  viewportWidth: 2048,
+  viewportHeight: 1024,
 });

--- a/ui/cypress/e2e/app.cy.js
+++ b/ui/cypress/e2e/app.cy.js
@@ -5,7 +5,27 @@ describe('app', () => {
     cy.loginWithControl();
   });
 
-  it('displays collection page', () => {
+  it('can access all pages', () => {
+    // Data collection
     cy.findByRole('button', { name: /Beamline Actions/u }).should('be.visible');
+    cy.findByText('Energy:').should('be.visible');
+    cy.findByText('Sample Changer').should('be.visible');
+    cy.findByText('Omega').should('be.visible');
+
+    // Samples list
+    cy.findByRole('link', { name: 'Samples' }).click();
+    cy.findByRole('button', { name: 'Get Samples' }).should('be.visible');
+
+    // Equipment
+    cy.findByRole('link', { name: 'Equipment' }).click();
+    cy.findByText('Power').should('be.visible');
+
+    // Help
+    cy.findByRole('link', { name: 'Help' }).click();
+    cy.findByText('Local Contact').should('be.visible');
+
+    // Remote control
+    cy.findByRole('link', { name: /Remote/u }).click();
+    cy.findByText('Users').should('be.visible');
   });
 });

--- a/ui/cypress/e2e/motors.cy.js
+++ b/ui/cypress/e2e/motors.cy.js
@@ -1,0 +1,73 @@
+/* global cy, it, describe, beforeEach */
+
+describe('Motors', () => {
+  beforeEach(() => {
+    cy.loginWithControl();
+  });
+
+  it('can control motors', () => {
+    cy.findByLabelText('Phase Control').select('Transfer');
+    cy.findByLabelText('Phase Control').should('have.value', 'Transfer');
+
+    cy.findByLabelText('Beam size').select('A20');
+    cy.findByLabelText('Beam size').should('have.value', 'A20');
+
+    cy.findByLabelText('Omega').type('{selectAll}200{enter}');
+    cy.findByLabelText('Omega').should('have.value', '200.00');
+
+    cy.findByRole('button', { name: 'Show motors' }).click();
+
+    cy.findByLabelText('Focus').type('{selectAll}1.1116{enter}');
+    cy.findByLabelText('Focus').should('have.value', '1.112');
+
+    // Move sample with two-axis control
+    cy.findByLabelText('Sample Vertical')
+      .invoke('val')
+      .then((initialValue) => {
+        cy.findByRole('button', { name: 'Move down' }).click();
+        cy.findByLabelText('Sample Vertical').should(
+          'have.value',
+          (Number.parseFloat(initialValue) - 0.1).toFixed(3),
+        );
+      });
+
+    // Change step of "Sample vertical" motor (in "Sample alignment motors" tooltip)
+    cy.findByRole('button', { name: 'Show sample alignment motors' }).click();
+    cy.findByTestId('TwoAxisTranslationControl_sample_vertical_step').type(
+      '{selectall}1{esc}',
+    );
+
+    // Move sample with two-axis control again to check that new step is used
+    cy.findByLabelText('Sample Vertical')
+      .invoke('val')
+      .then((initialValue) => {
+        cy.findByRole('button', { name: 'Move up' }).click();
+        cy.findByLabelText('Sample Vertical').should(
+          'have.value',
+          (Number.parseFloat(initialValue) + 1).toFixed(3),
+        );
+      });
+
+    // Move "X" motor with keyboard (up arrow)
+    cy.findByLabelText('X')
+      .invoke('val')
+      .then((initialValue) => {
+        cy.findByLabelText('X').type('{upArrow}');
+        cy.findByLabelText('X').should(
+          'have.value',
+          (Number.parseFloat(initialValue) + 0.1).toFixed(3),
+        );
+      });
+
+    // Move "Y" motor with down arrow button
+    cy.findByLabelText('Y')
+      .invoke('val')
+      .then((initialValue) => {
+        cy.findByTestId('MotorInput_phiy_down').click();
+        cy.findByLabelText('Y').should(
+          'have.value',
+          (Number.parseFloat(initialValue) - 0.1).toFixed(3),
+        );
+      });
+  });
+});

--- a/ui/cypress/e2e/sampleControls.cy.js
+++ b/ui/cypress/e2e/sampleControls.cy.js
@@ -1,41 +1,42 @@
 /* global cy, it, describe, beforeEach */
 
-describe('3-click centring', () => {
+describe('Sample controls', () => {
   beforeEach(() => {
     cy.loginWithControl();
   });
 
-  it('displays error when no sample is mounted', () => {
+  it('3-click centring', () => {
     cy.clearSamples(); // another test may have mounted a sample
     cy.findByRole('link', { name: /Data collection/u, hidden: true }).click();
 
+    // Start 3-click centring
     cy.findByRole('button', { name: '3-click centring' }).click();
-    cy.findByRole('alert', 'Error: There is no sample mounted').should(
-      'be.visible',
-    );
-  });
 
-  it('rotates sample by 90 degrees on click', () => {
+    // Error because no sample is mounted
+    cy.findByRole('alert').should('contain', 'There is no sample mounted');
+    cy.findByRole('button', { name: 'Close alert' }).click();
+
+    // Mount sample
     cy.mountSample();
     cy.findByRole('button', { name: 'Sample: test - test' }).should(
       'be.visible',
     );
 
+    // Start 3-click centring again
     cy.findByRole('button', { name: '3-click centring' }).click();
     cy.findByText(/Clicks left: 3/u, { hidden: true }).should('exist');
 
-    cy.findByTestId('MotorInput_value_diffractometer.phi')
+    // Click on sample view to rotate sample once
+    cy.findByLabelText('Omega')
       .invoke('val')
       .then((initialValue) => {
         cy.get('.canvas-container').click();
         cy.findByText(/Clicks left: 2/u, { hidden: true }).should('exist');
 
-        // Wait for omega motor to finish moving
-        cy.wait(1000);
-
-        cy.findByTestId('MotorInput_value_diffractometer.phi')
-          .invoke('val')
-          .should('equal', (Number.parseFloat(initialValue) + 90).toFixed(2));
+        cy.findByLabelText('Omega').should(
+          'have.value',
+          (Number.parseFloat(initialValue) + 90).toFixed(2),
+        );
       });
   });
 });

--- a/ui/src/components/MotorInput/BaseMotorInput.jsx
+++ b/ui/src/components/MotorInput/BaseMotorInput.jsx
@@ -4,6 +4,7 @@ import { HW_STATE } from '../../constants';
 
 function BaseMotorInput(props) {
   const {
+    id,
     className,
     value,
     state,
@@ -12,7 +13,6 @@ function BaseMotorInput(props) {
     min,
     max,
     disabled,
-    testId,
     onChange,
   } = props;
 
@@ -62,6 +62,7 @@ function BaseMotorInput(props) {
   return (
     <form className="d-flex" noValidate onSubmit={handleSubmit}>
       <input
+        id={id}
         className={className}
         type="number"
         value={inputValue}
@@ -69,7 +70,6 @@ function BaseMotorInput(props) {
         max={max}
         min={min}
         disabled={disabled || !isReady}
-        data-testid={testId}
         data-dirty={isEdited || undefined}
         data-busy={isBusy || undefined}
         data-warning={isWarning || undefined}

--- a/ui/src/components/MotorInput/BaseMotorInput.jsx
+++ b/ui/src/components/MotorInput/BaseMotorInput.jsx
@@ -22,7 +22,7 @@ function BaseMotorInput(props) {
   useEffect(() => {
     setInputValue(value.toFixed(precision));
     setEdited(false);
-  }, [value, precision]);
+  }, [value, precision, state]); // `state` to re-apply `precision` in case `value` doesn't change
 
   function handleKey(evt) {
     switch (evt.key) {

--- a/ui/src/components/MotorInput/MotorInput.jsx
+++ b/ui/src/components/MotorInput/MotorInput.jsx
@@ -11,7 +11,7 @@ import { HW_STATE, QUEUE_RUNNING } from '../../constants';
 import styles from './MotorInput.module.css';
 
 function MotorInput(props) {
-  const { role } = props;
+  const { role, idPrefix = 'MotorInput' } = props;
   const dispatch = useDispatch();
 
   const { attribute, label, precision, step, suffix } = useSelector((state) =>
@@ -30,6 +30,7 @@ function MotorInput(props) {
 
   const { state, value } = motor;
   const isReady = state === HW_STATE.READY;
+  const id = `${idPrefix}_${role}`;
 
   if (Number.isNaN(motor.value)) {
     return null;
@@ -37,15 +38,18 @@ function MotorInput(props) {
 
   return (
     <div className={styles.container}>
-      <p className={styles.label}>{label}</p>
+      <label className={styles.label} htmlFor={id}>
+        {label}
+      </label>
+
       <div className={styles.wrapper}>
         <BaseMotorInput
+          id={id}
           className={styles.valueInput}
           value={value}
           state={state}
           precision={precision}
           step={step}
-          testId={`MotorInput_value_${attribute}`}
           disabled={disabled}
           onChange={(val) => dispatch(setAttribute(attribute, val))}
         />
@@ -54,6 +58,7 @@ function MotorInput(props) {
           <button
             type="button"
             className={styles.arrowBtn}
+            data-testid={`${id}_up`}
             disabled={!isReady || disabled}
             onClick={() => dispatch(setAttribute(attribute, value + step))}
           >
@@ -62,6 +67,7 @@ function MotorInput(props) {
           <button
             type="button"
             className={styles.arrowBtn}
+            data-testid={`${id}_down`}
             disabled={!isReady || disabled}
             onClick={() => dispatch(setAttribute(attribute, value - step))}
           >
@@ -73,6 +79,7 @@ function MotorInput(props) {
           <>
             <input
               className={styles.stepInput}
+              data-testid={`${id}_step`}
               type="number"
               defaultValue={step}
               disabled={disabled}

--- a/ui/src/components/MotorInput/MotorInput.module.css
+++ b/ui/src/components/MotorInput/MotorInput.module.css
@@ -3,6 +3,7 @@
 }
 
 .label {
+  display: block;
   margin-bottom: 0.125rem;
   font-weight: bold;
 }

--- a/ui/src/components/MotorInput/OneAxisTranslationControl.jsx
+++ b/ui/src/components/MotorInput/OneAxisTranslationControl.jsx
@@ -51,7 +51,6 @@ function OneAxisTranslationControl(props) {
         step={step}
         min={limits[0]}
         max={limits[1]}
-        testId={`MotorInput_value_${attribute}`}
         disabled={disabled}
         onChange={(val) => dispatch(setAttribute(attribute, val))}
       />

--- a/ui/src/components/MotorInput/TwoAxisTranslationControl.jsx
+++ b/ui/src/components/MotorInput/TwoAxisTranslationControl.jsx
@@ -28,6 +28,7 @@ function TwoAxisTranslationControl(props) {
     <div className={styles.root}>
       <Button
         className={styles.btn}
+        aria-label="Move up"
         variant="outline-secondary"
         onClick={() =>
           dispatch(
@@ -43,6 +44,7 @@ function TwoAxisTranslationControl(props) {
       </Button>
       <Button
         className={styles.btn}
+        aria-label="Move left"
         variant="outline-secondary"
         disabled={motorsDisabled || horizontalMotor.state !== HW_STATE.READY}
         onClick={() =>
@@ -65,19 +67,30 @@ function TwoAxisTranslationControl(props) {
           <Popover>
             <Popover.Header as="h3">Sample alignment motors</Popover.Header>
             <Popover.Body>
-              <MotorInput role="sample_vertical" />
-              <MotorInput role="sample_horizontal" />
+              <MotorInput
+                role="sample_vertical"
+                idPrefix="TwoAxisTranslationControl"
+              />
+              <MotorInput
+                role="sample_horizontal"
+                idPrefix="TwoAxisTranslationControl"
+              />
             </Popover.Body>
           </Popover>
         }
       >
-        <Button className={styles.btn} variant="outline-secondary">
+        <Button
+          className={styles.btn}
+          aria-label="Show sample alignment motors"
+          variant="outline-secondary"
+        >
           <i className={`${styles.btnIcon} fas fa-cog`} />
         </Button>
       </OverlayTrigger>
 
       <Button
         className={styles.btn}
+        aria-label="Move right"
         variant="outline-secondary"
         disabled={motorsDisabled || horizontalMotor.state !== HW_STATE.READY}
         onClick={() =>
@@ -93,6 +106,7 @@ function TwoAxisTranslationControl(props) {
       </Button>
       <Button
         className={styles.btn}
+        aria-label="Move down"
         variant="outline-secondary"
         disabled={motorsDisabled || verticalMotor.state !== HW_STATE.READY}
         onClick={() =>

--- a/ui/src/components/SampleView/ApertureInput.jsx
+++ b/ui/src/components/SampleView/ApertureInput.jsx
@@ -16,6 +16,7 @@ function ApertureInput() {
 
   return (
     <Form.Select
+      id="ApertureInput"
       className={styles.select}
       value={value}
       data-busy={state === 'BUSY' || undefined}

--- a/ui/src/components/SampleView/PhaseInput.jsx
+++ b/ui/src/components/SampleView/PhaseInput.jsx
@@ -16,6 +16,7 @@ function PhaseInput() {
 
   return (
     <Form.Select
+      id="PhaseInput"
       className={styles.select}
       value={value}
       data-busy={state === 'BUSY' || undefined}

--- a/ui/src/containers/SampleViewContainer.jsx
+++ b/ui/src/containers/SampleViewContainer.jsx
@@ -120,12 +120,19 @@ class SampleViewContainer extends Component {
           <Col sm={2} xxl={1} className={styles.controllers}>
             <DefaultErrorBoundary>
               <div className={motorInputStyles.container}>
-                <p className={motorInputStyles.label}>Phase Control</p>
+                <label className={motorInputStyles.label} htmlFor="PhaseInput">
+                  Phase Control
+                </label>
                 <PhaseInput />
               </div>
 
               <div className={motorInputStyles.container}>
-                <p className={motorInputStyles.label}>Beam size</p>
+                <label
+                  className={motorInputStyles.label}
+                  htmlFor="ApertureInput"
+                >
+                  Beam size
+                </label>
                 <ApertureInput />
               </div>
 


### PR DESCRIPTION
I've made separate commits but basically, I:

- increase the viewport when testing so it's a bit nicer to work with;
- merge the two 3-click centring tests to save time;
- add a smoke test for the main navigation to make sure that all pages render as expected (expect "System logs" since it is likely to be removed);
- test motor inputs in the sidebar (I think I cover most possible user interactions)
- label motor inputs for accessibility (and testing);
- add `data-testid` attributes on some elements that are a bit difficult to label properly for now (so I can find them in the tests);
- fix a subtle bug when reapplying the same value in a motor input (e.g. if the value is `0.1` and the precision is `1`, typing `0.09` and <kbd>Enter</kbd> would keep `0.09` in the field instead of re-applying `0.1`)

![Peek 2024-10-17 11-19](https://github.com/user-attachments/assets/1771ae4d-c243-40c8-a375-4822a62fbca8)
