### PR TITLE
Extract `FocusControl` and `ZoomControl` from `SampleControls`

### DIFF
--- a/ui/src/components/SampleControls/FocusControl.jsx
+++ b/ui/src/components/SampleControls/FocusControl.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Button, OverlayTrigger } from 'react-bootstrap';
+
+import OneAxisTranslationControl from '../MotorInput/OneAxisTranslationControl';
+import styles from './SampleControls.module.css';
+import { useSelector } from 'react-redux';
+
+function FocusControl() {
+  const focusMotorProps = useSelector((state) =>
+    state.uiproperties.sample_view.components.find((c) => c.role === 'focus'),
+  );
+
+  return (
+    <OverlayTrigger
+      trigger="click"
+      rootClose
+      placement="bottom"
+      overlay={
+        <div className={styles.overlay}>
+          <OneAxisTranslationControl motorProps={focusMotorProps} />
+        </div>
+      }
+    >
+      <Button
+        className={styles.controlBtn}
+        name="focus"
+        title="Focus"
+        data-toggle="tooltip"
+      >
+        <i className={`${styles.controlIcon} fas fa-adjust`} />
+        <span className={styles.controlLabel}>Focus</span>
+      </Button>
+    </OverlayTrigger>
+  );
+}
+
+export default FocusControl;

--- a/ui/src/components/SampleControls/SampleControls.jsx
+++ b/ui/src/components/SampleControls/SampleControls.jsx
@@ -4,13 +4,14 @@
 import React from 'react';
 import { OverlayTrigger, Button, Dropdown } from 'react-bootstrap';
 
-import OneAxisTranslationControl from '../MotorInput/OneAxisTranslationControl';
 import SnapshotControl from './SnapshotControl';
 import { HW_STATE } from '../../constants';
 
 import styles from './SampleControls.module.css';
 import GridControl from './GridControl';
 import CentringControl from './CentringControl';
+import FocusControl from './FocusControl';
+import ZoomControl from './ZoomControl';
 
 class SampleControls extends React.Component {
   constructor(props) {
@@ -76,16 +77,6 @@ class SampleControls extends React.Component {
   render() {
     const { hardwareObjects, getControlAvailability } = this.props;
 
-    const focusMotorProps = this.props.uiproperties.sample_view.components.find(
-      (c) => c.role === 'focus',
-    );
-
-    const zoomMotorProps = this.props.uiproperties.sample_view.components.find(
-      (c) => c.role === 'zoom',
-    );
-
-    const zoomMotor = this.props.hardwareObjects[zoomMotorProps.attribute];
-
     return (
       <div className={styles.controls}>
         {getControlAvailability('snapshot') && (
@@ -93,79 +84,8 @@ class SampleControls extends React.Component {
         )}
         {getControlAvailability('draw_grid') && <GridControl />}
         {getControlAvailability('3_click_centring') && <CentringControl />}
-        {getControlAvailability('focus') && (
-          <OverlayTrigger
-            trigger="click"
-            rootClose
-            placement="bottom"
-            overlay={
-              <div className={styles.overlay}>
-                <OneAxisTranslationControl motorProps={focusMotorProps} />
-              </div>
-            }
-          >
-            <Button
-              className={styles.controlBtn}
-              name="focus"
-              title="Focus"
-              data-toggle="tooltip"
-            >
-              <i className={`${styles.controlIcon} fas fa-adjust`} />
-              <span className={styles.controlLabel}>Focus</span>
-            </Button>
-          </OverlayTrigger>
-        )}
-        {getControlAvailability('zoom') && (
-          <OverlayTrigger
-            trigger="click"
-            rootClose
-            placement="bottom"
-            overlay={
-              <div className={styles.overlay}>
-                <input
-                  className={styles.zoomSlider}
-                  type="range"
-                  min={0}
-                  max={zoomMotor.commands.length - 1}
-                  value={zoomMotor.commands.indexOf(zoomMotor.value)}
-                  disabled={zoomMotor.state !== HW_STATE.READY}
-                  onMouseUp={(e) => {
-                    this.props.setAttribute(
-                      'diffractometer.zoom',
-                      zoomMotor.commands[Number.parseFloat(e.target.value)],
-                    );
-                  }}
-                  onChange={(e) => {
-                    this.props.setBeamlineAttribute(
-                      'diffractometer.zoom',
-                      zoomMotor.commands[Number.parseFloat(e.target.value)],
-                    );
-                  }}
-                  list="volsettings"
-                  name="zoomSlider"
-                />
-
-                <datalist id="volsettings">
-                  {zoomMotor.commands.map((cmd, index) => (
-                    <option key={cmd} value={index} />
-                  ))}
-                </datalist>
-              </div>
-            }
-          >
-            <Button
-              className={styles.controlBtn}
-              name="zoomOut"
-              title="Zoom in/out"
-              data-toggle="tooltip"
-            >
-              <i className={`${styles.controlIcon} fas fa-search`} />
-              <span className={styles.controlLabel}>
-                Zoom ({zoomMotor.value}){' '}
-              </span>
-            </Button>
-          </OverlayTrigger>
-        )}
+        {getControlAvailability('focus') && <FocusControl />}
+        {getControlAvailability('zoom') && <ZoomControl />}
         {getControlAvailability('backlight') && (
           <div className={styles.controlWrapper}>
             <OverlayTrigger

--- a/ui/src/components/SampleControls/ZoomControl.jsx
+++ b/ui/src/components/SampleControls/ZoomControl.jsx
@@ -1,0 +1,62 @@
+/* eslint-disable jsx-a11y/control-has-associated-label */
+import React from 'react';
+import { Button, OverlayTrigger } from 'react-bootstrap';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { HW_STATE } from '../../constants';
+import { setAttribute } from '../../actions/beamline';
+import styles from './SampleControls.module.css';
+
+const ZOOM_HWO_ID = 'diffractometer.zoom';
+
+function ZoomControl() {
+  const dispatch = useDispatch();
+
+  const { state, value, commands } = useSelector(
+    (state) => state.beamline.hardwareObjects[ZOOM_HWO_ID],
+  );
+
+  return (
+    <OverlayTrigger
+      trigger="click"
+      rootClose
+      placement="bottom"
+      overlay={
+        <div className={styles.overlay}>
+          <input
+            className={styles.zoomSlider}
+            name="zoomSlider"
+            type="range"
+            list="ZoomControl_commands"
+            min={0}
+            max={commands.length - 1}
+            value={commands.indexOf(value)}
+            disabled={state !== HW_STATE.READY}
+            onChange={(evt) => {
+              const cmdIndex = Number.parseFloat(evt.target.value);
+              dispatch(setAttribute(ZOOM_HWO_ID, commands[cmdIndex]));
+            }}
+          />
+
+          <datalist id="ZoomControl_commands">
+            {commands.map((cmd, index) => (
+              <option key={cmd} value={index} />
+            ))}
+          </datalist>
+        </div>
+      }
+    >
+      <Button
+        className={styles.controlBtn}
+        name="zoomOut"
+        title="Zoom in/out"
+        data-toggle="tooltip"
+      >
+        <i className={`${styles.controlIcon} fas fa-search`} />
+        <span className={styles.controlLabel}>Zoom ({value}) </span>
+      </Button>
+    </OverlayTrigger>
+  );
+}
+
+export default ZoomControl;


### PR DESCRIPTION
No difficulty, but note that I've removed the "optimistic" update when interacting with the zoom slider (more info in comment):

#### BEFORE

![Peek 2024-10-17 15-57](https://github.com/user-attachments/assets/61a5fee9-9399-4feb-a0b1-9bc99e42b502)

#### AFTER

![Peek 2024-10-17 15-56](https://github.com/user-attachments/assets/9071765c-bfac-4907-8a7f-03023df9e5d9)