### PR TITLE
brings back v/h-space controls (#1443)

### DIFF
--- a/demo/mxcube-web/ui.yaml
+++ b/demo/mxcube-web/ui.yaml
@@ -78,6 +78,9 @@ sample_view:
 
 sample_view_video_controls:
   id: sample_view_video_controls
+  grid_settings:
+    show_mesh_grid_vspace: false
+    show_mesh_grid_hspace: false
   components:
     - id: snapshot
       show: true

--- a/demo/mxcube-web/ui.yaml
+++ b/demo/mxcube-web/ui.yaml
@@ -78,14 +78,13 @@ sample_view:
 
 sample_view_video_controls:
   id: sample_view_video_controls
-  grid_settings:
-    show_mesh_grid_vspace: false
-    show_mesh_grid_hspace: false
   components:
     - id: snapshot
       show: true
     - id: draw_grid
       show: true
+      show_vspace: false
+      show_hspace: true
     - id: 3_click_centring
       show: true
     - id: focus

--- a/docs/source/config/ui.rst
+++ b/docs/source/config/ui.rst
@@ -102,6 +102,9 @@ The section has the following syntax:
 
     sample_view_video_controls:
       id: sample_view_video_controls
+      grid_settings:
+        show_mesh_grid_vspace: false
+        show_mesh_grid_hspace: false
       components:
         - id: snapshot
           show: <show>
@@ -120,8 +123,12 @@ The section has the following syntax:
         - id: video_size
           show: <show>
 
-It is a list of all supported sample video widgets.
-``<show>`` flag is a boolean, when it's *true* the widget is included, when *false* it is omitted.
+It consists of two keys:
+- `grid_settings` - settings related to the mesh grid controls in the `draw_grid` component.
+- `components` - a list of all supported sample video widgets, in the format:
+  - id: widget id
+  - show: <show> - boolean flag, when it's *true* the widget is included, when *false* it is omitted.
+
 
 .. image:: video_controls.png
 

--- a/docs/source/config/ui.rst
+++ b/docs/source/config/ui.rst
@@ -102,14 +102,13 @@ The section has the following syntax:
 
     sample_view_video_controls:
       id: sample_view_video_controls
-      grid_settings:
-        show_mesh_grid_vspace: false
-        show_mesh_grid_hspace: false
       components:
         - id: snapshot
           show: <show>
         - id: draw_grid
           show: <show>
+          show_hspace: <show_hspace>
+          show_vspace: <show_vspace>
         - id: 3_click_centring
           show: <show>
         - id: focus
@@ -123,12 +122,9 @@ The section has the following syntax:
         - id: video_size
           show: <show>
 
-It consists of two keys:
-- `grid_settings` - settings related to the mesh grid controls in the `draw_grid` component.
-- `components` - a list of all supported sample video widgets, in the format:
-  - id: widget id
-  - show: <show> - boolean flag, when it's *true* the widget is included, when *false* it is omitted.
-
+It is a list of all supported sample video widgets.
+``<show>`` flag is a boolean, when it's *true* the widget is included, when *false* it is omitted.
+The `draw_grid` component also allows to enable setting horizontal and vertical spacing.
 
 .. image:: video_controls.png
 

--- a/mxcubeweb/core/models/configmodels.py
+++ b/mxcubeweb/core/models/configmodels.py
@@ -55,6 +55,11 @@ class _UISampleViewVideoControlsModel(BaseModel):
     show: bool
 
 
+class _UISampleViewVideoGridSettingsModel(BaseModel):
+    show_mesh_grid_vspace: bool = False
+    show_mesh_grid_hspace: bool = False
+
+
 class UIPropertiesModel(BaseModel):
     id: str
     components: List[UIComponentModel]
@@ -65,6 +70,9 @@ class UICameraConfigModel(UIPropertiesModel):
 
 
 class UISampleViewVideoControlsModel(UIPropertiesModel):
+    grid_settings: _UISampleViewVideoGridSettingsModel = Field(
+        default_factory=_UISampleViewVideoGridSettingsModel
+    )
     components: List[_UISampleViewVideoControlsModel]
 
 

--- a/mxcubeweb/core/models/configmodels.py
+++ b/mxcubeweb/core/models/configmodels.py
@@ -1,6 +1,7 @@
 from enum import Enum
+from pydantic import model_validator
 from pydantic.v1 import BaseModel, Field
-from typing import List, Dict, Optional
+from typing import List, Dict, Literal, Optional, Union
 import datetime
 
 
@@ -56,8 +57,10 @@ class _UISampleViewVideoControlsModel(BaseModel):
 
 
 class _UISampleViewVideoGridSettingsModel(BaseModel):
-    show_mesh_grid_vspace: bool = False
-    show_mesh_grid_hspace: bool = False
+    id: Literal["draw_grid"]
+    show: bool
+    show_vspace: bool = False
+    show_hspace: bool = False
 
 
 class UIPropertiesModel(BaseModel):
@@ -70,10 +73,10 @@ class UICameraConfigModel(UIPropertiesModel):
 
 
 class UISampleViewVideoControlsModel(UIPropertiesModel):
-    grid_settings: _UISampleViewVideoGridSettingsModel = Field(
-        default_factory=_UISampleViewVideoGridSettingsModel
-    )
-    components: List[_UISampleViewVideoControlsModel]
+    # It is important to keep the Union elements in that order; from the more specific to the more general.
+    components: List[
+        Union[_UISampleViewVideoGridSettingsModel, _UISampleViewVideoControlsModel]
+    ]
 
 
 class UIPropertiesListModel(BaseModel):

--- a/ui/src/components/SampleView/GridForm.jsx
+++ b/ui/src/components/SampleView/GridForm.jsx
@@ -28,13 +28,14 @@ export default function GridForm(props) {
 
   const draggableRef = useRef(null);
   const [position, setPosition] = useState({ x: 20, y: 64 });
-  const { show_mesh_grid_hspace, show_mesh_grid_vspace } = useSelector(
-    (state) => state.uiproperties.sample_view_video_controls.grid_settings,
+  const { show_vspace, show_hspace } = useSelector((state) =>
+    state.uiproperties.sample_view_video_controls.components.find(
+      (component) => component.id === 'draw_grid',
+    ),
   );
 
   // we want these buttons to have the same size. Additionally we want to assign them more space when there are additional controls shown.
-  const addOrRemoveButtonSize =
-    show_mesh_grid_hspace || show_mesh_grid_vspace ? '100%' : '75%';
+  const addOrRemoveButtonSize = show_hspace || show_vspace ? '100%' : '75%';
 
   // we use the useEffect function with a ref here, since React's synthetic event
   // system (onContextMenu) could not stop the propagation
@@ -69,8 +70,8 @@ export default function GridForm(props) {
           <td>
             <span style={{ lineHeight: '24px' }}>{grid.name}</span>
           </td>
-          {show_mesh_grid_hspace ? <td>{grid.cellHSpace.toFixed(2)}</td> : null}
-          {show_mesh_grid_vspace ? <td>{grid.cellVSpace.toFixed(2)}</td> : null}
+          {show_hspace ? <td>{grid.cellHSpace.toFixed(2)}</td> : null}
+          {show_vspace ? <td>{grid.cellVSpace.toFixed(2)}</td> : null}
           <td>
             {vdim} x {hdim}
           </td>
@@ -125,7 +126,7 @@ export default function GridForm(props) {
         <td>
           <span style={{ lineHeight: '24px' }}>*</span>
         </td>
-        {show_mesh_grid_hspace && (
+        {show_hspace && (
           <td>
             {/* prevents refresh when pressing enter */}
             <Form onSubmit={(event) => event.preventDefault()}>
@@ -138,7 +139,7 @@ export default function GridForm(props) {
             </Form>
           </td>
         )}
-        {show_mesh_grid_vspace && (
+        {show_vspace && (
           <td>
             <Form onSubmit={(event) => event.preventDefault()}>
               <Form.Control
@@ -188,8 +189,8 @@ export default function GridForm(props) {
             <thead>
               <tr>
                 <th>Name</th>
-                {show_mesh_grid_hspace && <th>H-Space (µm)</th>}
-                {show_mesh_grid_vspace && <th>V-Space (µm)</th>}
+                {show_hspace && <th>H-Space (µm)</th>}
+                {show_vspace && <th>V-Space (µm)</th>}
                 <th>Dim (µm)</th>
                 <th>#Cells</th>
                 <th>R x C</th>

--- a/ui/src/components/SampleView/GridForm.jsx
+++ b/ui/src/components/SampleView/GridForm.jsx
@@ -4,6 +4,7 @@ import { Row, Col, Form, Button, Table } from 'react-bootstrap';
 import Draggable from 'react-draggable';
 
 import './SampleView.css';
+import { useSelector } from 'react-redux';
 
 function handleContextMenu(e) {
   e.stopPropagation();
@@ -17,6 +18,8 @@ export default function GridForm(props) {
     rotateTo,
     saveGrid,
     selectedGrids,
+    setHCellSpacing,
+    setVCellSpacing,
     selectGrid,
     setGridOverlayOpacity,
     show,
@@ -25,6 +28,13 @@ export default function GridForm(props) {
 
   const draggableRef = useRef(null);
   const [position, setPosition] = useState({ x: 20, y: 64 });
+  const { show_mesh_grid_hspace, show_mesh_grid_vspace } = useSelector(
+    (state) => state.uiproperties.sample_view_video_controls.grid_settings,
+  );
+
+  // we want these buttons to have the same size. Additionally we want to assign them more space when there are additional controls shown.
+  const addOrRemoveButtonSize =
+    show_mesh_grid_hspace || show_mesh_grid_vspace ? '100%' : '75%';
 
   // we use the useEffect function with a ref here, since React's synthetic event
   // system (onContextMenu) could not stop the propagation
@@ -59,6 +69,8 @@ export default function GridForm(props) {
           <td>
             <span style={{ lineHeight: '24px' }}>{grid.name}</span>
           </td>
+          {show_mesh_grid_hspace ? <td>{grid.cellHSpace.toFixed(2)}</td> : null}
+          {show_mesh_grid_vspace ? <td>{grid.cellVSpace.toFixed(2)}</td> : null}
           <td>
             {vdim} x {hdim}
           </td>
@@ -93,8 +105,8 @@ export default function GridForm(props) {
           </td>
           <td>
             <Button
-              size="sm"
-              style={{ width: '75%' }}
+              // we want these buttons to have the same size. Additionally we want to assign them more space when there are additional controls shown.
+              style={{ width: addOrRemoveButtonSize }}
               variant="outline-secondary"
               onClick={(e) => {
                 e.stopPropagation();
@@ -113,6 +125,31 @@ export default function GridForm(props) {
         <td>
           <span style={{ lineHeight: '24px' }}>*</span>
         </td>
+        {show_mesh_grid_hspace && (
+          <td>
+            {/* prevents refresh when pressing enter */}
+            <Form onSubmit={(event) => event.preventDefault()}>
+              <Form.Control
+                style={{ width: '50px' }}
+                type="text"
+                defaultValue={0}
+                onChange={setHCellSpacing}
+              />
+            </Form>
+          </td>
+        )}
+        {show_mesh_grid_vspace && (
+          <td>
+            <Form onSubmit={(event) => event.preventDefault()}>
+              <Form.Control
+                style={{ width: '50px' }}
+                type="text"
+                defaultValue={0}
+                onChange={setVCellSpacing}
+              />
+            </Form>
+          </td>
+        )}
         <td />
         <td />
         <td />
@@ -121,8 +158,8 @@ export default function GridForm(props) {
         <td />
         <td>
           <Button
-            size="sm"
-            style={{ width: '75%' }}
+            // we want these buttons to have the same size. Additionally we want to assign them more space when there are additional controls shown.
+            style={{ width: addOrRemoveButtonSize }}
             variant="outline-secondary"
             onClick={() => saveGrid()}
           >
@@ -151,6 +188,8 @@ export default function GridForm(props) {
             <thead>
               <tr>
                 <th>Name</th>
+                {show_mesh_grid_hspace && <th>H-Space (µm)</th>}
+                {show_mesh_grid_vspace && <th>V-Space (µm)</th>}
                 <th>Dim (µm)</th>
                 <th>#Cells</th>
                 <th>R x C</th>

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -34,6 +34,8 @@ export default class SampleImage extends React.Component {
     this.keyUp = this.keyUp.bind(this);
     this.wheel = this.wheel.bind(this);
     this.goToBeam = this.goToBeam.bind(this);
+    this.setHCellSpacing = this.setHCellSpacing.bind(this);
+    this.setVCellSpacing = this.setVCellSpacing.bind(this);
     this.setGridOverlayOpacity = this.setGridOverlayOpacity.bind(this);
     this.getGridOverlayOpacity = this.getGridOverlayOpacity.bind(this);
     this.saveGrid = this.saveGrid.bind(this);
@@ -201,6 +203,58 @@ export default class SampleImage extends React.Component {
     if (this.props.autoScale) {
       const { clientWidth } = document.querySelector('#outsideWrapper');
       this.props.sampleViewActions.setImageRatio(clientWidth);
+    }
+  }
+
+  setVCellSpacing(e) {
+    let value = Number.parseFloat(e.target.value);
+    if (Number.isNaN(value)) {
+      value = '';
+    }
+
+    const gridData = this.selectedGrid();
+
+    if (gridData) {
+      const gd = this.drawGridPlugin.setCellSpace(
+        gridData,
+        true,
+        gridData.cellHSpace,
+        value,
+      );
+      this.props.sampleViewActions.updateShapes([gd]);
+    } else if (this.props.drawGrid) {
+      this.drawGridPlugin.setCurrentCellSpace(
+        null,
+        value,
+        this.props.imageRatio,
+      );
+      this.drawGridPlugin.repaint(this.canvas);
+    }
+  }
+
+  setHCellSpacing(e) {
+    let value = Number.parseFloat(e.target.value);
+    if (Number.isNaN(value)) {
+      value = '';
+    }
+
+    const gridData = this.selectedGrid();
+
+    if (gridData) {
+      const gd = this.drawGridPlugin.setCellSpace(
+        gridData,
+        true,
+        value,
+        gridData.cellVSpace,
+      );
+      this.props.sampleViewActions.updateShapes([gd]);
+    } else if (this.props.drawGrid) {
+      this.drawGridPlugin.setCurrentCellSpace(
+        value,
+        null,
+        this.props.imageRatio,
+      );
+      this.drawGridPlugin.repaint(this.canvas);
     }
   }
 
@@ -881,6 +935,8 @@ export default class SampleImage extends React.Component {
               getGridOverlayOpacity={this.getGridOverlayOpacity}
               setGridOverlayOpacity={this.setGridOverlayOpacity}
               cellSpacing={this.props.cellSpacing}
+              setHCellSpacing={this.setHCellSpacing}
+              setVCellSpacing={this.setVCellSpacing}
               gridList={this.props.grids}
               currentGrid={this.drawGridPlugin.currentGridData()}
               removeGrid={this.props.sampleViewActions.deleteShape}

--- a/ui/src/containers/SampleViewContainer.jsx
+++ b/ui/src/containers/SampleViewContainer.jsx
@@ -32,7 +32,6 @@ import {
   logFrontEndTraceBack,
   setAttribute,
 } from '../actions/beamline';
-import { find } from 'lodash';
 
 import '../components/SampleView/SampleView.css';
 import styles from './SampleViewContainer.module.css';
@@ -45,13 +44,10 @@ class SampleViewContainer extends Component {
   }
 
   getControlAvailability(name) {
-    const available = find(
-      this.props.uiproperties.sample_view_video_controls.components,
-      {
-        id: name,
-        show: true,
-      },
-    );
+    const available =
+      this.props.uiproperties.sample_view_video_controls.components.find(
+        (component) => component.id === name && component.show === true,
+      );
 
     return available?.show || false;
   }


### PR DESCRIPTION
This PR brings back controls removed in this PR https://github.com/mxcube/mxcubeweb/pull/1397 
As this feature is rarely used, it can be optionally enabled via `ui.yaml` config file.
Here's part of configuration which enables these:
```yaml
sample_view_video_controls:
  id: sample_view_video_controls
  grid_settings:
    show_mesh_grid_vspace: true
    show_mesh_grid_hspace: true
```
The `grid_settings` key can be omitted and these new keys will have default value of `false` (added at the time of `pydantic` validation.
Additionally changed the way add / remove grid buttons' sizes are being calculated, as adding these h-space/v-space controls may cause them to become awkwardly small ( at least it did so on my 1920x1080 screen :))
