### PR TITLE
Adds a way to preserve user-preferred mesh grid state

### DIFF
--- a/mxcubeweb/core/components/sampleview.py
+++ b/mxcubeweb/core/components/sampleview.py
@@ -274,7 +274,6 @@ class SampleView(ComponentBase):
 
     def update_shapes(self, shapes):
         updated_shapes = []
-
         for s in shapes:
             shape_data = from_camel(s)
             pos = []
@@ -285,6 +284,7 @@ class SampleView(ComponentBase):
             # If shape does not exist add it
             if not shape:
                 refs, t = shape_data.pop("refs", []), shape_data.pop("t", "")
+                user_state = shape_data.pop("user_state", "SAVED")
 
                 # Store pixels per mm for third party software, to facilitate
                 # certain calculations
@@ -329,13 +329,15 @@ class SampleView(ComponentBase):
                             pos.append(center_positions)
 
                         shape = HWR.beamline.sample_view.add_shape_from_mpos(
-                            pos, (x, y), t
+                            pos, (x, y), t, user_state
                         )
                     except Exception:
                         logging.getLogger("HWR.MX3").info(shape_data)
 
                 else:
-                    shape = HWR.beamline.sample_view.add_shape_from_refs(refs, t)
+                    shape = HWR.beamline.sample_view.add_shape_from_refs(
+                        refs, t, user_state
+                    )
 
             # shape will be none if creation failed, so we check if shape exists
             # before setting additional parameters

--- a/mxcubeweb/core/components/sampleview.py
+++ b/mxcubeweb/core/components/sampleview.py
@@ -284,6 +284,7 @@ class SampleView(ComponentBase):
             # If shape does not exist add it
             if not shape:
                 refs, t = shape_data.pop("refs", []), shape_data.pop("t", "")
+                state = shape_data.pop("state", "SAVED")
                 user_state = shape_data.pop("user_state", "SAVED")
 
                 # Store pixels per mm for third party software, to facilitate
@@ -329,14 +330,14 @@ class SampleView(ComponentBase):
                             pos.append(center_positions)
 
                         shape = HWR.beamline.sample_view.add_shape_from_mpos(
-                            pos, (x, y), t, user_state
+                            pos, (x, y), t, state, user_state
                         )
                     except Exception:
                         logging.getLogger("HWR.MX3").info(shape_data)
 
                 else:
                     shape = HWR.beamline.sample_view.add_shape_from_refs(
-                        refs, t, user_state
+                        refs, t, state, user_state
                     )
 
             # shape will be none if creation failed, so we check if shape exists

--- a/poetry.lock
+++ b/poetry.lock
@@ -1856,13 +1856,13 @@ websockets = ">=12.0,<13.0"
 
 [[package]]
 name = "mxcubecore"
-version = "1.183.0"
+version = "1.188.0"
 description = "Core libraries for the MXCuBE application"
 optional = false
 python-versions = "<3.12,>=3.8"
 files = [
-    {file = "mxcubecore-1.183.0-py3-none-any.whl", hash = "sha256:a82383fc4b3059313c1e58b46f282c0b7ab134e2ebc433d99cdff0157f9beaa0"},
-    {file = "mxcubecore-1.183.0.tar.gz", hash = "sha256:c2ad371d361608e4273b7c9060541dd5608b94030789f066eab3266c50ed63d3"},
+    {file = "mxcubecore-1.188.0-py3-none-any.whl", hash = "sha256:5cb10c808719e0817ba7c1bcd04c2f07343cd30bbe7d411c2bdfbad7fb95c74a"},
+    {file = "mxcubecore-1.188.0.tar.gz", hash = "sha256:3898180aeb55a70e65e4f5be6524e2a884f3aadc8a4eb955b656af15f7194eec"},
 ]
 
 [package.dependencies]
@@ -3754,4 +3754,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "03f0437fca23614034c39ca7726296c664cdf58db97ce790a016f2561416637b"
+content-hash = "7193d71cd93bf65a53e52017c12a177eb0ae92152156947b385ad13d60dcef73"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ pydantic = ">=2.8.2,<2.9.0"
 PyDispatcher = "^2.0.6"
 pytz = "^2022.6"
 tzlocal = "^4.2"
-mxcubecore = ">=1.183.0"
+mxcubecore = ">=1.188.0"
 mxcube-video-streamer = ">=1.5.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -857,9 +857,9 @@ mock==4.0.3 ; python_version >= "3.8" and python_version < "3.12" \
 mxcube-video-streamer==1.5.0 ; python_version >= "3.8" and python_version < "3.12" \
     --hash=sha256:998a8a909e9b69a55bb3776e56ae7725479ec3b196990bf15f6849c3fb824f37 \
     --hash=sha256:fd9d337aad522f60b69182050f9ddfe81d3d2490c2bc8e86ccc669f3e5855718
-mxcubecore==1.183.0 ; python_version >= "3.8" and python_version < "3.12" \
-    --hash=sha256:a82383fc4b3059313c1e58b46f282c0b7ab134e2ebc433d99cdff0157f9beaa0 \
-    --hash=sha256:c2ad371d361608e4273b7c9060541dd5608b94030789f066eab3266c50ed63d3
+mxcubecore==1.188.0 ; python_version >= "3.8" and python_version < "3.12" \
+    --hash=sha256:3898180aeb55a70e65e4f5be6524e2a884f3aadc8a4eb955b656af15f7194eec \
+    --hash=sha256:5cb10c808719e0817ba7c1bcd04c2f07343cd30bbe7d411c2bdfbad7fb95c74a
 numpy==1.24.4 ; python_version >= "3.8" and python_version < "3.12" \
     --hash=sha256:04640dab83f7c6c85abf9cd729c5b65f1ebd0ccf9de90b270cd61935eef0197f \
     --hash=sha256:1452241c290f3e2a312c137a9999cdbf63f78864d63c79039bda65ee86943f61 \

--- a/ui/src/components/SampleView/GridForm.jsx
+++ b/ui/src/components/SampleView/GridForm.jsx
@@ -58,12 +58,13 @@ export default function GridForm(props) {
 
     for (const grid of Object.values(gridList)) {
       const selectedStyle = selectedGrids.includes(grid.id) ? 'selected' : '';
+      const hiddenStyle = grid.userState === 'HIDDEN' ? 'hid-by-user' : '';
       const vdim = grid.numRows * (grid.cellHeight + grid.cellVSpace);
       const hdim = grid.numCols * (grid.cellWidth + grid.cellHSpace);
 
       gridControlList.push(
         <tr
-          className={selectedStyle}
+          className={`${selectedStyle} ${hiddenStyle}`}
           key={grid.name}
           onClick={(e) => selectGrid([grid], e.ctrlKey)}
         >

--- a/ui/src/components/SampleView/GridForm.jsx
+++ b/ui/src/components/SampleView/GridForm.jsx
@@ -5,9 +5,26 @@ import Draggable from 'react-draggable';
 
 import './SampleView.css';
 import { useSelector } from 'react-redux';
+import TooltipTrigger from '../TooltipTrigger';
 
 function handleContextMenu(e) {
   e.stopPropagation();
+}
+/**
+ * Returns the tooltip content for the hide button
+ *
+ * @param {boolean} userHidden - if the grid is hidden by the user
+ * @param {boolean} autoHidden - if the grid is hidden automatically (out of view)
+ * @returns {string} - the tooltip content
+ */
+function getHideButtonTooltip(userHidden, autoHidden) {
+  if (userHidden) {
+    return 'Grid is hidden by user';
+  }
+  if (autoHidden) {
+    return 'Grid is out of view';
+  }
+  return 'Hide grid';
 }
 
 export default function GridForm(props) {
@@ -57,14 +74,15 @@ export default function GridForm(props) {
     const gridControlList = [];
 
     for (const grid of Object.values(gridList)) {
-      const selectedStyle = selectedGrids.includes(grid.id) ? 'selected' : '';
-      const hiddenStyle = grid.userState === 'HIDDEN' ? 'hid-by-user' : '';
       const vdim = grid.numRows * (grid.cellHeight + grid.cellVSpace);
       const hdim = grid.numCols * (grid.cellWidth + grid.cellHSpace);
-
+      const selected = selectedGrids.includes(grid.id);
+      const userHidden = grid.userState === 'HIDDEN';
+      const autoHidden = grid.state === 'HIDDEN' && !userHidden;
       gridControlList.push(
         <tr
-          className={`${selectedStyle} ${hiddenStyle}`}
+          data-selected={selected}
+          data-user-hidden={userHidden}
           key={grid.name}
           onClick={(e) => selectGrid([grid], e.ctrlKey)}
         >
@@ -94,16 +112,21 @@ export default function GridForm(props) {
             </Button>
           </td>
           <td>
-            <Button
-              size="sm"
-              variant="outline-secondary"
-              onClick={(e) => {
-                e.stopPropagation();
-                toggleVisibility(grid.id);
-              }}
+            <TooltipTrigger
+              id={`grid-${grid.id}-visibility`}
+              tooltipContent={getHideButtonTooltip(userHidden, autoHidden)}
             >
-              {grid.state === 'HIDDEN' ? 'Show' : 'Hide '}
-            </Button>
+              <Button
+                size="sm"
+                variant="outline-secondary"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  toggleVisibility(grid.id);
+                }}
+              >
+                {grid.state === 'HIDDEN' ? 'Show' : 'Hide '}
+              </Button>
+            </TooltipTrigger>
           </td>
           <td>
             <Button

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -736,8 +736,10 @@ export default class SampleImage extends React.Component {
 
     if (grid.state === 'HIDDEN') {
       grid.state = 'SAVED';
+      grid.user_state = 'SAVED';
     } else {
       grid.state = 'HIDDEN';
+      grid.user_state = 'HIDDEN';
     }
 
     this.props.sampleViewActions.updateShapes([grid]);

--- a/ui/src/components/SampleView/SampleView.css
+++ b/ui/src/components/SampleView/SampleView.css
@@ -169,3 +169,7 @@
   color: #000;
   font-weight: bold;
 }
+
+.hid-by-user {
+  background-color: #aaa !important;
+}

--- a/ui/src/components/SampleView/SampleView.css
+++ b/ui/src/components/SampleView/SampleView.css
@@ -164,12 +164,13 @@
   border-radius: 4px;
 }
 
-.selected {
-  background-color: #dff0d8 !important;
+table.table-striped > tbody > tr[data-selected='true'] {
+  background-color: #dff0d8;
   color: #000;
   font-weight: bold;
 }
 
-.hid-by-user {
-  background-color: #aaa !important;
+table.table-striped > tbody > tr[data-user-hidden='true'] {
+  background-color: #a3ceff;
+  font-style: italic;
 }


### PR DESCRIPTION


Fixes a bug / bad UX in which caused mesh grid to became unhidden after certain operations like DataCollection or Phase change.

The steps to reproduce the bugs were as following:
- mount a sample
- open `draw_grid` control
- draw a few grids
- make some of them hidden
- right click on canvas, press `Data Collection` button
- run the task
After the task was done, each of the grids was shown again.
It's also worth adding that in the demo beamline many of the motors seem to not be mocked, so the behavior can't be observed. 


The reason for this behavior was further described in this Pull request https://github.com/mxcube/mxcubecore/pull/1044 for mxcubecore. This PR will be marked as draft until the mxcubecore one is merged.

The fix writes to state set by user to `Shape.user_state` attribute on the mxcubecore side.
When the data collection or phase change is finished, then the user-preferred state is restored by setting `Shape.state` to be equal to `Shape.user_state`.  