### PR TITLE
Extract `VideoSizeControl` from `SampleControls`

### DIFF
--- a/ui/src/actions/beamline.js
+++ b/ui/src/actions/beamline.js
@@ -45,10 +45,6 @@ export function updateBeamlineHardwareObjectStateAction(data) {
   return { type: BL_UPDATE_HARDWARE_OBJECT_STATE, data };
 }
 
-export function setBeamlineAttribute(name, value) {
-  return updateBeamlineHardwareObjectAction({ name, value });
-}
-
 export function setAttribute(name, value) {
   return (_, getState) => {
     const state = getState();

--- a/ui/src/components/SampleControls/CentringControl.jsx
+++ b/ui/src/components/SampleControls/CentringControl.jsx
@@ -12,6 +12,7 @@ function CentringControl() {
   return (
     <Button
       className={styles.controlBtn}
+      data-default-styles
       active={isActive}
       title={`${isActive ? 'Stop' : 'Start'} 3-click centring`}
       onClick={() => dispatch(toggleCentring())}

--- a/ui/src/components/SampleControls/FocusControl.jsx
+++ b/ui/src/components/SampleControls/FocusControl.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, OverlayTrigger } from 'react-bootstrap';
+import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 
 import OneAxisTranslationControl from '../MotorInput/OneAxisTranslationControl';
 import styles from './SampleControls.module.css';
@@ -16,16 +16,16 @@ function FocusControl() {
       rootClose
       placement="bottom"
       overlay={
-        <div className={styles.overlay}>
+        <Popover id="FocusControl_popover" className={styles.popover} body>
           <OneAxisTranslationControl motorProps={focusMotorProps} />
-        </div>
+        </Popover>
       }
     >
       <Button
-        className={styles.controlBtn}
+        className={styles.popoverBtn}
+        data-default-styles
         name="focus"
         title="Focus"
-        data-toggle="tooltip"
       >
         <i className={`${styles.controlIcon} fas fa-adjust`} />
         <span className={styles.controlLabel}>Focus</span>

--- a/ui/src/components/SampleControls/GridControl.jsx
+++ b/ui/src/components/SampleControls/GridControl.jsx
@@ -12,6 +12,7 @@ function GridControl() {
   return (
     <Button
       className={styles.controlBtn}
+      data-default-styles
       active={isActive}
       title="Draw grid"
       onClick={() => dispatch(toggleDrawGrid())}

--- a/ui/src/components/SampleControls/LightControl.jsx
+++ b/ui/src/components/SampleControls/LightControl.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/control-has-associated-label */
 import React from 'react';
-import { Button, OverlayTrigger } from 'react-bootstrap';
+import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { HW_STATE } from '../../constants';
@@ -33,7 +33,7 @@ function LightControl(props) {
         rootClose
         placement="bottom"
         overlay={
-          <div className={styles.overlay}>
+          <Popover id={`${hwoId}_popover`} className={styles.popover} body>
             <input
               className="bar"
               type="range"
@@ -46,14 +46,15 @@ function LightControl(props) {
                 dispatch(setAttribute(hwoId, evt.target.value))
               }
             />
-          </div>
+          </Popover>
         }
       >
         {({ ref, ...triggerHandlers }) => (
           <>
             <Button
               ref={ref}
-              className={styles.controlBtnWithOverlay}
+              className={styles.lightBtn}
+              data-default-styles
               active={lightSwitch.value === lightSwitch.commands[0]}
               title={`${label} on/off`}
               onClick={handleToggleClick}
@@ -61,7 +62,11 @@ function LightControl(props) {
               <i className={`${styles.controlIcon} fas fa-lightbulb`} />
               <span className={styles.controlLabel}>{label}</span>
             </Button>
-            <Button className={styles.overlayTrigger} {...triggerHandlers}>
+            <Button
+              className={styles.lightArrowBtn}
+              data-default-styles
+              {...triggerHandlers}
+            >
               <i className="fas fa-sort-down" />
             </Button>
           </>

--- a/ui/src/components/SampleControls/SampleControls.jsx
+++ b/ui/src/components/SampleControls/SampleControls.jsx
@@ -22,10 +22,10 @@ function SampleControls(props) {
       {useShowControl('focus') && <FocusControl />}
       {useShowControl('zoom') && <ZoomControl />}
       {useShowControl('backlight') && (
-        <LightControl label="Frontlight" hwoId="diffractometer.backlight" />
+        <LightControl label="Backlight" hwoId="diffractometer.backlight" />
       )}
       {useShowControl('frontlight') && (
-        <LightControl label="Backlight" hwoId="diffractometer.frontlight" />
+        <LightControl label="Frontlight" hwoId="diffractometer.frontlight" />
       )}
       {useShowControl('video_size') && <VideoSizeControl />}
     </div>

--- a/ui/src/components/SampleControls/SampleControls.jsx
+++ b/ui/src/components/SampleControls/SampleControls.jsx
@@ -8,31 +8,28 @@ import ZoomControl from './ZoomControl';
 import LightControl from './LightControl';
 import VideoSizeControl from './VideoSizeControl';
 
+import { useShowControl } from './utils';
 import styles from './SampleControls.module.css';
 
-class SampleControls extends React.Component {
-  render() {
-    const { getControlAvailability } = this.props;
+function SampleControls(props) {
+  const { canvas } = props;
 
-    return (
-      <div className={styles.controls}>
-        {getControlAvailability('snapshot') && (
-          <SnapshotControl canvas={this.props.canvas} />
-        )}
-        {getControlAvailability('draw_grid') && <GridControl />}
-        {getControlAvailability('3_click_centring') && <CentringControl />}
-        {getControlAvailability('focus') && <FocusControl />}
-        {getControlAvailability('zoom') && <ZoomControl />}
-        {getControlAvailability('backlight') && (
-          <LightControl label="Frontlight" hwoId="diffractometer.backlight" />
-        )}
-        {getControlAvailability('frontlight') && (
-          <LightControl label="Backlight" hwoId="diffractometer.frontlight" />
-        )}
-        {getControlAvailability('video_size') && <VideoSizeControl />}
-      </div>
-    );
-  }
+  return (
+    <div className={styles.controls}>
+      {useShowControl('snapshot') && <SnapshotControl canvas={canvas} />}
+      {useShowControl('draw_grid') && <GridControl />}
+      {useShowControl('3_click_centring') && <CentringControl />}
+      {useShowControl('focus') && <FocusControl />}
+      {useShowControl('zoom') && <ZoomControl />}
+      {useShowControl('backlight') && (
+        <LightControl label="Frontlight" hwoId="diffractometer.backlight" />
+      )}
+      {useShowControl('frontlight') && (
+        <LightControl label="Backlight" hwoId="diffractometer.frontlight" />
+      )}
+      {useShowControl('video_size') && <VideoSizeControl />}
+    </div>
+  );
 }
 
 export default SampleControls;

--- a/ui/src/components/SampleControls/SampleControls.jsx
+++ b/ui/src/components/SampleControls/SampleControls.jsx
@@ -1,59 +1,16 @@
 import React from 'react';
-import { Dropdown } from 'react-bootstrap';
 
 import SnapshotControl from './SnapshotControl';
-
-import styles from './SampleControls.module.css';
 import GridControl from './GridControl';
 import CentringControl from './CentringControl';
 import FocusControl from './FocusControl';
 import ZoomControl from './ZoomControl';
 import LightControl from './LightControl';
+import VideoSizeControl from './VideoSizeControl';
+
+import styles from './SampleControls.module.css';
 
 class SampleControls extends React.Component {
-  constructor(props) {
-    super(props);
-    this.availableVideoSizes = this.availableVideoSizes.bind(this);
-  }
-
-  availableVideoSizes() {
-    const items = this.props.videoSizes.map((size) => {
-      const sizeGClass =
-        this.props.width === String(size[0])
-          ? 'fas fa-circle'
-          : 'far fa-circle';
-
-      return (
-        <Dropdown.Item
-          key={`${size[0]} x ${size[1]}`}
-          eventKey="1"
-          onClick={() =>
-            this.props.sampleViewActions.setVideoSize(size[0], size[1])
-          }
-        >
-          <span className={sizeGClass} /> {`${size[0]} x ${size[1]}`}
-        </Dropdown.Item>
-      );
-    });
-
-    items.push(
-      <Dropdown.Item
-        eventKey="3"
-        key="reset"
-        onClick={() => {
-          this.props.sampleViewActions.setVideoSize(
-            this.props.width,
-            this.props.height,
-          );
-        }}
-      >
-        <span className="far fa-redo" /> Reset
-      </Dropdown.Item>,
-    );
-
-    return items;
-  }
-
   render() {
     const { getControlAvailability } = this.props;
 
@@ -72,21 +29,7 @@ class SampleControls extends React.Component {
         {getControlAvailability('frontlight') && (
           <LightControl label="Backlight" hwoId="diffractometer.frontlight" />
         )}
-        {getControlAvailability('video_size') && (
-          <Dropdown drop="down-centered">
-            <Dropdown.Toggle
-              className={styles.controlDropDown}
-              variant="content"
-            >
-              <i className={`${styles.controlIcon} fas fa-video`} />
-              <i className={`${styles.dropDownIcon} fas fa-sort-down`} />
-              <span className={styles.controlLabel}>Video size</span>
-            </Dropdown.Toggle>
-            <Dropdown.Menu className={styles.dropDownMenu}>
-              {this.availableVideoSizes()}
-            </Dropdown.Menu>
-          </Dropdown>
-        )}
+        {getControlAvailability('video_size') && <VideoSizeControl />}
       </div>
     );
   }

--- a/ui/src/components/SampleControls/SampleControls.module.css
+++ b/ui/src/components/SampleControls/SampleControls.module.css
@@ -9,17 +9,6 @@
   border-radius: 0 0 0.25rem 0.25rem;
 }
 
-.controls > .controlWrapper,
-.controls > .controlBtn {
-  min-width: 60px;
-}
-
-@media (max-width: 1400px) {
-  .controls > .controlWrapper {
-    max-width: 60px;
-  }
-}
-
 .controlWrapper {
   position: relative;
 }
@@ -34,72 +23,59 @@
   white-space: nowrap;
 }
 
-.controlDropDown,
-.controlBtnWithOverlay,
-.overlayTrigger {
-  composes: controlBtn;
+.controls > .controlWrapper,
+.controls > .controlBtn {
+  min-width: 60px;
 }
 
-.controlDropDown::after {
-  content: none;
+@media (max-width: 1400px) {
+  .controls > .controlWrapper {
+    max-width: 60px;
+  }
 }
 
-.dropDownIcon {
-  margin-top: 6px;
-  margin-left: 4px;
-  margin-right: -3px;
-  vertical-align: top;
-}
-
-.dropDownMenu {
-  top: 6px !important;
-}
-
-.dropDownItem:global(.active) {
-  background-color: transparent;
-  color: inherit;
-  font-weight: bold;
-}
-
-.dropDownItem:global(.active):hover {
-  background-color: var(--bs-dropdown-link-hover-bg);
-}
-
-.controlBtnWithOverlay .controlIcon {
-  transform: translateX(-35%);
-}
-
-.overlayTrigger {
-  position: absolute;
-  top: 2px;
-  left: 55%;
-  padding-left: 4px;
-}
-
-.controlBtn:active {
-  color: #33beff !important;
-}
-.controlBtn:focus {
-  color: #33beff;
-}
 .controlBtn:focus-visible,
 .controlBtn:hover {
   color: #97deff;
 }
 
 .controlBtn:global(.active),
-.controlBtn:global(.active) + .overlayTrigger {
+.controlBtn:global(.active) + .lightArrowBtn {
   color: orange;
 }
 
-.controlBtn:global(.active):active,
-.controlBtn:global(.active) + .overlayTrigger:active {
-  color: orange !important;
+.controlBtn:global(.active):hover,
+.controlBtn:global(.active) + .lightArrowBtn:hover {
+  color: #ffba39;
 }
 
-.controlBtn:global(.active):hover,
-.controlBtn:global(.active) + .overlayTrigger:hover {
-  color: #ffba39;
+.controlBtn:global(.active):active,
+.controlBtn:global(.active) + .lightArrowBtn:active {
+  color: orange;
+}
+
+.dropdownBtn,
+.popoverBtn,
+.lightBtn,
+.lightArrowBtn {
+  composes: controlBtn;
+}
+
+.dropdownBtn::after {
+  content: none;
+}
+
+.popoverBtn[aria-describedby],
+.dropdownBtn[aria-expanded='true'],
+.lightBtn[aria-describedby] + .lightArrowBtn {
+  color: var(--bs-btn-active-color) !important;
+}
+
+.lightArrowBtn {
+  position: absolute;
+  top: 2px;
+  left: 55%;
+  padding-left: 4px;
 }
 
 .controlLabel {
@@ -111,16 +87,36 @@
   font-size: 25px;
 }
 
-.overlay {
-  position: absolute;
-  z-index: 1001;
-  display: flex;
-  margin-top: 0.5rem;
-  padding: 0.625rem 0.75rem;
-  background-color: rgba(0, 0, 0, 0.6);
-  border-radius: 4px;
+.dropdownIcon {
+  margin-top: 6px;
+  margin-left: 4px;
+  margin-right: -3px;
+  vertical-align: top;
 }
 
-.zoomSlider {
-  margin: 0 0 0.25rem;
+.lightBtn .controlIcon {
+  transform: translateX(-35%);
+}
+
+.popover {
+  --bs-popover-bg: rgba(34, 34, 34, 0.8);
+}
+
+.dropdownMenu {
+  --bs-dropdown-bg: rgba(34, 34, 34, 0.8);
+  --bs-dropdown-color: white;
+  --bs-dropdown-link-color: white;
+  --bs-dropdown-link-active-bg: transparent;
+  --bs-dropdown-link-active-color: white;
+  --bs-dropdown-link-hover-bg: #212529;
+  --bs-dropdown-link-hover-color: white;
+  top: 6px !important;
+}
+
+.dropdownItem:global(.active) {
+  font-weight: bold;
+}
+
+.dropdownItem:global(.active):hover {
+  background-color: var(--bs-dropdown-link-hover-bg);
 }

--- a/ui/src/components/SampleControls/SampleControls.module.css
+++ b/ui/src/components/SampleControls/SampleControls.module.css
@@ -55,6 +55,16 @@
   top: 6px !important;
 }
 
+.dropDownItem:global(.active) {
+  background-color: transparent;
+  color: inherit;
+  font-weight: bold;
+}
+
+.dropDownItem:global(.active):hover {
+  background-color: var(--bs-dropdown-link-hover-bg);
+}
+
 .controlBtnWithOverlay .controlIcon {
   transform: translateX(-35%);
 }

--- a/ui/src/components/SampleControls/SnapshotControl.jsx
+++ b/ui/src/components/SampleControls/SnapshotControl.jsx
@@ -48,6 +48,7 @@ function SnapshotControl(props) {
   return (
     <Button
       className={styles.controlBtn}
+      data-default-styles
       title="Take snapshot"
       onClick={() => takeSnapshot()}
     >

--- a/ui/src/components/SampleControls/VideoSizeControl.jsx
+++ b/ui/src/components/SampleControls/VideoSizeControl.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Dropdown } from 'react-bootstrap';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { setVideoSize } from '../../actions/sampleview';
+import styles from './SampleControls.module.css';
+
+function VideoSizeControl() {
+  const dispatch = useDispatch();
+
+  const videoSizes = useSelector((state) => state.sampleview.videoSizes);
+  const width = useSelector((state) => state.sampleview.width);
+
+  return (
+    <Dropdown
+      drop="down-centered"
+      onSelect={(i) => dispatch(setVideoSize(...videoSizes[i]))}
+    >
+      <Dropdown.Toggle className={styles.controlDropDown}>
+        <i className={`${styles.controlIcon} fas fa-video`} />
+        <i className={`${styles.dropDownIcon} fas fa-sort-down`} />
+        <span className={styles.controlLabel}>Video size</span>
+      </Dropdown.Toggle>
+
+      <Dropdown.Menu className={styles.dropDownMenu}>
+        {videoSizes.map(([w, h], i) => {
+          const isActive = w.toString() === width;
+          return (
+            <Dropdown.Item
+              key={`${w}_${h}`}
+              className={styles.dropDownItem}
+              eventKey={i}
+              active={isActive}
+            >
+              <span className={`${isActive ? 'fas' : 'far'} fa-circle me-1`} />{' '}
+              {`${w} x ${h}`}
+            </Dropdown.Item>
+          );
+        })}
+      </Dropdown.Menu>
+    </Dropdown>
+  );
+}
+
+export default VideoSizeControl;

--- a/ui/src/components/SampleControls/VideoSizeControl.jsx
+++ b/ui/src/components/SampleControls/VideoSizeControl.jsx
@@ -16,19 +16,20 @@ function VideoSizeControl() {
       drop="down-centered"
       onSelect={(i) => dispatch(setVideoSize(...videoSizes[i]))}
     >
-      <Dropdown.Toggle className={styles.controlDropDown}>
+      <Dropdown.Toggle className={styles.dropdownBtn} data-default-styles>
         <i className={`${styles.controlIcon} fas fa-video`} />
-        <i className={`${styles.dropDownIcon} fas fa-sort-down`} />
+        <i className={`${styles.dropdownIcon} fas fa-sort-down`} />
         <span className={styles.controlLabel}>Video size</span>
       </Dropdown.Toggle>
 
-      <Dropdown.Menu className={styles.dropDownMenu}>
+      <Dropdown.Menu className={styles.dropdownMenu}>
         {videoSizes.map(([w, h], i) => {
           const isActive = w.toString() === width;
           return (
             <Dropdown.Item
               key={`${w}_${h}`}
-              className={styles.dropDownItem}
+              className={styles.dropdownItem}
+              data-default-styles
               eventKey={i}
               active={isActive}
             >

--- a/ui/src/components/SampleControls/ZoomControl.jsx
+++ b/ui/src/components/SampleControls/ZoomControl.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/control-has-associated-label */
 import React from 'react';
-import { Button, OverlayTrigger } from 'react-bootstrap';
+import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { HW_STATE } from '../../constants';
@@ -22,9 +22,8 @@ function ZoomControl() {
       rootClose
       placement="bottom"
       overlay={
-        <div className={styles.overlay}>
+        <Popover id="ZoomControl_popover" className={styles.popover} body>
           <input
-            className={styles.zoomSlider}
             type="range"
             list="ZoomControl_commands"
             min={0}
@@ -42,14 +41,14 @@ function ZoomControl() {
               <option key={cmd} value={index} />
             ))}
           </datalist>
-        </div>
+        </Popover>
       }
     >
       <Button
-        className={styles.controlBtn}
+        className={styles.popoverBtn}
+        data-default-styles
         name="zoomOut"
         title="Zoom in/out"
-        data-toggle="tooltip"
       >
         <i className={`${styles.controlIcon} fas fa-search`} />
         <span className={styles.controlLabel}>Zoom ({value}) </span>

--- a/ui/src/components/SampleControls/utils.js
+++ b/ui/src/components/SampleControls/utils.js
@@ -1,3 +1,13 @@
+import { useSelector } from 'react-redux';
+
+export function useShowControl(name) {
+  return useSelector((state) =>
+    state.uiproperties.sample_view_video_controls.components.some(
+      (c) => c.id === name && c.show,
+    ),
+  );
+}
+
 export function download(filename, url) {
   const anchor = document.createElement('a');
   anchor.download = filename;

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -118,7 +118,7 @@ export default class SampleImage extends React.Component {
       this.initJSMpeg();
     }
 
-    this.renderSampleView(this.props);
+    this.renderSampleView();
   }
 
   componentWillUnmount() {
@@ -214,7 +214,7 @@ export default class SampleImage extends React.Component {
     this.drawGridPlugin.setGridOverlay(value);
     this.props.sampleViewActions.setOverlay(value);
     this.drawGridPlugin.repaint(this.canvas);
-    this.renderSampleView(this.props);
+    this.renderSampleView();
   }
 
   getGridOverlayOpacity() {
@@ -764,7 +764,7 @@ export default class SampleImage extends React.Component {
     e.nativeEvent.stopImmediatePropagation();
   }
 
-  renderSampleView(nextProps) {
+  renderSampleView() {
     const {
       imageRatio,
       beamPosition,
@@ -778,7 +778,8 @@ export default class SampleImage extends React.Component {
       grids,
       pixelsPerMm,
       sourceScale,
-    } = nextProps;
+    } = this.props;
+
     this.drawCanvas(imageRatio, sourceScale);
     this.canvas.add(
       ...makeImageOverlay(
@@ -890,13 +891,10 @@ export default class SampleImage extends React.Component {
               selectedGrids={this.props.selectedGrids.map((grid) => grid.id)}
             />
             {this.createVideoPlayerContainer(this.props.videoFormat)}
-            <SampleControls
-              showErrorPanel={this.props.showErrorPanel}
-              {...this.props}
-              canvas={this.canvas}
-              imageRatio={this.props.imageRatio}
-            />
+
+            <SampleControls canvas={this.canvas} />
             <div>{this.centringMessage()}</div>
+
             <canvas id="canvas" className="coveringCanvas" />
           </div>
         </div>

--- a/ui/src/components/SampleView/SampleView.css
+++ b/ui/src/components/SampleView/SampleView.css
@@ -89,14 +89,6 @@
   position: relative;
 }
 
-.btn:focus {
-  outline: none !important;
-}
-
-.btn:active {
-  color: grey !important;
-}
-
 .task-title-head {
   width: 100%;
   height: 12px;

--- a/ui/src/containers/SampleViewContainer.jsx
+++ b/ui/src/containers/SampleViewContainer.jsx
@@ -28,7 +28,6 @@ import {
 } from '../actions/sampleChanger';
 
 import {
-  setBeamlineAttribute,
   executeCommand,
   logFrontEndTraceBack,
   setAttribute,
@@ -204,8 +203,6 @@ class SampleViewContainer extends Component {
                 showErrorPanel={this.props.showErrorPanel}
               />
               <SampleImage
-                getControlAvailability={this.getControlAvailability}
-                showErrorPanel={this.props.showErrorPanel}
                 sampleViewActions={this.props.sampleViewActions}
                 {...this.props.sampleViewState}
                 uiproperties={uiproperties}
@@ -220,12 +217,8 @@ class SampleViewContainer extends Component {
                 selectedGrids={selectedGrids}
                 cellCounting={this.props.cellCounting}
                 cellSpacing={this.props.cellSpacing}
-                currentSampleID={this.props.currentSampleID}
-                sampleList={this.props.sampleList}
-                proposal={this.props.proposal}
                 busy={this.props.queueState === QUEUE_RUNNING}
                 setAttribute={this.props.setAttribute}
-                setBeamlineAttribute={this.props.setBeamlineAttribute}
                 displayImage={this.props.displayImage}
                 meshResultFormat={this.props.meshResultFormat}
               />
@@ -262,7 +255,6 @@ function mapStateToProps(state) {
     workflows: state.workflow.workflows,
     cellCounting: state.taskForm.defaultParameters.mesh.cell_counting,
     cellSpacing: state.taskForm.defaultParameters.mesh.cell_spacing,
-    proposal: state.login.selectedProposal,
     remoteAccess: state.remoteAccess,
     uiproperties: state.uiproperties,
     taskForm: state.taskForm,
@@ -291,7 +283,6 @@ function mapDispatchToProps(dispatch) {
     showForm: bindActionCreators(showTaskForm, dispatch),
     showErrorPanel: bindActionCreators(showErrorPanel, dispatch),
     setAttribute: bindActionCreators(setAttribute, dispatch),
-    setBeamlineAttribute: bindActionCreators(setBeamlineAttribute, dispatch),
     displayImage: bindActionCreators(displayImage, dispatch),
     sendExecuteCommand: bindActionCreators(executeCommand, dispatch),
     logFrontEndTraceBack: bindActionCreators(logFrontEndTraceBack, dispatch),

--- a/ui/src/main.css
+++ b/ui/src/main.css
@@ -111,14 +111,14 @@ input[type='color']:focus,
   background: #dff0d8 !important;
 }
 
-.btn:focus,
-.btn:active {
+.btn:not([data-default-styles]):focus,
+.btn:not([data-default-styles]):active {
   outline: none !important;
   box-shadow: none !important;
 }
 
-.dropdown-item:focus,
-.dropdown-item:active {
+.dropdown-item:not([data-default-styles]):focus,
+.dropdown-item:not([data-default-styles]):active {
   outline: none !important;
   box-shadow: none !important;
   background: transparent;


### PR DESCRIPTION
Since it was the last component to be extracted, I also refactor `SampleControls` and clean-up the props that are passed down to it from `SampleViewContainer` through `SampleImage`.

Finally, I review all the sample controls to make sure they have a consistent design (notably when hovered/active/expanded) and are more accessible (`id`, outline on `:focus-visible`, etc.) This includes using Bootstrap's `Popover` component to have consistent overlay styles, using Bootstrap's CSS variables to remove a few custom styles, and using `:not(data-default-styles)` to remove some of our own global styles that make things less accessible (e.g. by removing focus outlines).

Here's a screen recording that demonstrates the result:

![Peek 2024-10-21 11-24](https://github.com/user-attachments/assets/d2405c3d-a134-469f-a936-9840bc9e3258)

... and another one to demonstrate the focus outlines when navigating with the keyboard:

![Peek 2024-10-21 11-28](https://github.com/user-attachments/assets/c5597941-9f55-4fef-baac-47462ff250a8)