### PR TITLE
Fix number inputs on Chrome

### DIFF
--- a/ui/src/components/MotorInput/MotorInput.module.css
+++ b/ui/src/components/MotorInput/MotorInput.module.css
@@ -13,6 +13,7 @@
 }
 
 .valueInput {
+  composes: numInputClean from '../../utils.module.css';
   width: 5em;
   height: 2.375em;
   padding: 0 0.25rem 0 0.5rem;
@@ -20,7 +21,6 @@
   border: 1px solid #ccc;
   border-radius: 0.375rem 0 0 0.375rem;
   transition: background-color 100ms ease-in;
-  appearance: textfield; /* hide default up/down arrows */
 }
 
 .valueInput[data-busy] {
@@ -68,12 +68,12 @@
 }
 
 .stepInput {
+  composes: numInputClean from '../../utils.module.css';
   width: 3em;
   background-color: #f5f5f5;
   border: 1px solid #ccc;
   font-size: 12px;
   text-align: center;
-  appearance: textfield; /* hide default up/down arrows */
 }
 
 .unit {

--- a/ui/src/components/MotorInput/OneAxisTranslationControl.module.css
+++ b/ui/src/components/MotorInput/OneAxisTranslationControl.module.css
@@ -15,6 +15,7 @@
 }
 
 .input {
+  composes: numInputClean from '../../utils.module.css';
   width: 5em;
   padding: 0 0.25rem;
   margin: 0 0.125rem;
@@ -23,7 +24,6 @@
   border-radius: 0.375rem;
   text-align: center;
   transition: background-color 100ms ease-in;
-  appearance: textfield; /* hide default up/down arrows */
 }
 
 .input[data-busy] {

--- a/ui/src/utils.module.css
+++ b/ui/src/utils.module.css
@@ -23,3 +23,12 @@
   opacity: 0.5;
   pointer-events: none;
 }
+
+.numInputClean {
+  appearance: textfield;
+}
+
+.numInputClean::-webkit-inner-spin-button,
+.numInputClean::-webkit-outer-spin-button {
+  appearance: none;
+}


### PR DESCRIPTION
Marcus noticed that in Chrome, the native up/down arrows of number inputs would appear on hover. I removed some code I shouldn't have, so I'm just putting it back but in a more reusable way.