### PR TITLE
makes app read collect HWO config when started

### DIFF
--- a/mxcubeweb/app.py
+++ b/mxcubeweb/app.py
@@ -238,7 +238,7 @@ class MXCUBEApplication:
     AUTO_ADD_DIFFPLAN = False
 
     # Number of sample snapshots taken before collect
-    NUM_SNAPSHOTS = 4
+    DEFAULT_NUM_SNAPSHOTS = 4
 
     # Remember collection paramters between samples
     # or reset (defualt) between samples.
@@ -520,7 +520,9 @@ class MXCUBEApplication:
             "VIDEO_FORMAT": MXCUBEApplication.VIDEO_FORMAT,
             "AUTO_MOUNT_SAMPLE": MXCUBEApplication.AUTO_MOUNT_SAMPLE,
             "AUTO_ADD_DIFFPLAN": MXCUBEApplication.AUTO_ADD_DIFFPLAN,
-            "NUM_SNAPSHOTS": MXCUBEApplication.NUM_SNAPSHOTS,
+            "NUM_SNAPSHOTS": HWR.beamline.collect.get_property(
+                "num_snapshots", MXCUBEApplication.DEFAULT_NUM_SNAPSHOTS
+            ),
             "UI_STATE": MXCUBEApplication.UI_STATE,
         }
 

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -41,6 +41,7 @@ ORIGIN_MX3 = "MX3"
 class Queue(ComponentBase):
     def __init__(self, app, config):
         super().__init__(app, config)
+        self.init_queue_settings()
 
     def build_prefix_path_dict(self, path_list):
         prefix_path_dict = {}

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -265,7 +265,6 @@ class Queue(ComponentBase):
         settings = {}
 
         for setting_name in [
-            "NUM_SNAPSHOTS",
             "REMEMBER_PARAMETERS_BETWEEN_SAMPLES",
             "CENTRING_METHOD",
             "AUTO_ADD_DIFFPLAN",
@@ -279,6 +278,9 @@ class Queue(ComponentBase):
             "queue": sample_order,
             "sampleList": self.app.lims.sample_list_get(current_queue=queue),
             "queueStatus": self.queue_exec_state(),
+            "numSnapshots": HWR.beamline.collect.get_property(
+                "num_snapshots", self.app.DEFAULT_NUM_SNAPSHOTS
+            ),
         }
 
         res.update(settings)
@@ -1433,7 +1435,10 @@ class Queue(ComponentBase):
         dc_model = qmo.DataCollection()
         dc_model.set_origin(ORIGIN_MX3)
         dc_model.center_before_collect = True
-        dc_model.take_snapshots = self.app.NUM_SNAPSHOTS
+        dc_model.take_snapshots = HWR.beamline.collect.get_property(
+            "num_snapshots", self.app.DEFAULT_NUM_SNAPSHOTS
+        )
+
         dc_entry = qe.DataCollectionQueueEntry(Mock(), dc_model)
 
         return dc_model, dc_entry
@@ -2114,8 +2119,6 @@ class Queue(ComponentBase):
         )
 
     def init_queue_settings(self):
-        self.app.NUM_SNAPSHOTS = HWR.beamline.collect.get_property("num_snapshots", 4)
-        HWR.beamline.collect.number_of_snapshots = self.app.NUM_SNAPSHOTS
         self.app.AUTO_MOUNT_SAMPLE = HWR.beamline.collect.get_property(
             "auto_mount_sample", False
         )
@@ -2376,7 +2379,9 @@ class Queue(ComponentBase):
                 "inverse_beam": False,
                 "take_dark_current": True,
                 "skip_existing_images": False,
-                "take_snapshots": self.app.NUM_SNAPSHOTS,
+                "take_snapshots": HWR.beamline.collect.get_property(
+                    "num_snapshots", self.app.DEFAULT_NUM_SNAPSHOTS
+                ),
                 "helical": False,
                 "mesh": False,
                 "prefixTemplate": "{PREFIX}_{POSITION}",
@@ -2482,3 +2487,10 @@ class Queue(ComponentBase):
             result = ()
 
         return result
+
+    def set_num_snapshots(self, num_snapshots: int):
+        """Sets the number of snapshots to take during data collection
+        Args:
+            num_snapshots (int): number of snapshots to be taken
+        """
+        HWR.beamline.collect.number_of_snapshots = num_snapshots

--- a/mxcubeweb/routes/queue.py
+++ b/mxcubeweb/routes/queue.py
@@ -342,9 +342,10 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.restrict
     def set_num_snapshots():
         data = request.get_json()
-        app.NUM_SNAPSHOTS = data.get("numSnapshots", 4)
-        HWR.beamline.collect.number_of_snapshots = app.NUM_SNAPSHOTS
-        resp = jsonify({"numSnapshots": data.get("numSnapshots", 4)})
+        app.queue.set_num_snapshots(data.get("numSnapshots", app.DEFAULT_NUM_SNAPSHOTS))
+        resp = jsonify(
+            {"numSnapshots": data.get("numSnapshots", app.DEFAULT_NUM_SNAPSHOTS)}
+        )
         resp.status_code = 200
 
         return resp


### PR DESCRIPTION
This PR intends to fix the bug in which when some values in the app config change, even though they shouldn't.

For example
- the app is started
- `NUM_SNAPSHOTS` is set to 4 here: https://github.com/mxcube/mxcubeweb/blob/c6c520b220f5140317a71713991fc2fb5b08f8c8/mxcubeweb/app.py#L241
- users logs out 
- `NUM_SNAPSHOTS` is set to value from `HWR.beamline.collect` here https://github.com/mxcube/mxcubeweb/blob/c6c520b220f5140317a71713991fc2fb5b08f8c8/mxcubeweb/core/components/queue.py#L2125-L2133

The expected outcome should be that these settings should be loaded when the app starts instead of when user logs out. It also messes up with default setting for `NUM_SNAPSHOTS` we want at MicroMAX, as we want to set it 0. 
