### PR TITLE
[SampleGrid] - Fixes issue with tasks getting duplicated when sample mounted from sample list

### DIFF
--- a/ui/src/containers/SampleGridTableContainer.jsx
+++ b/ui/src/containers/SampleGridTableContainer.jsx
@@ -37,9 +37,9 @@ import {
   showGenericContextMenu,
 } from '../actions/sampleGrid';
 
-import { deleteTask, addSampleAndMount } from '../actions/queue';
+import { deleteTask } from '../actions/queue';
 
-import { unmountSample } from '../actions/sampleChanger';
+import { unmountSample, mountSample } from '../actions/sampleChanger';
 
 import { showTaskForm } from '../actions/taskForm';
 
@@ -1126,7 +1126,7 @@ class SampleGridTableContainer extends React.Component {
     });
 
     if (sampleData) {
-      this.props.addSampleAndMount(sampleData);
+      this.props.mountSample(sampleData);
       this.props.navigate('/datacollection', { replace: true });
     }
   }
@@ -1348,7 +1348,7 @@ function mapDispatchToProps(dispatch) {
       dispatch(showGenericContextMenu(show, id, x, y)),
     selectSamples: (keys, selected) =>
       dispatch(selectSamplesAction(keys, selected)),
-    addSampleAndMount: bindActionCreators(addSampleAndMount, dispatch),
+    mountSample: bindActionCreators(mountSample, dispatch),
     showDialog: bindActionCreators(showDialog, dispatch),
   };
 }


### PR DESCRIPTION
The method `addSampleAndMount` was, incorrectly, called from `Mount` in the sample list context menu. 

The consequence was that any contents of the sample  was added again, multiplying the number of tasks by two every-time a sample was mounted via the sample list.

The method `addSampleAndMount` was replaced by `mountSample` instead.