### PR TITLE
fix type mismatch ms instead of s

### DIFF
--- a/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
+++ b/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
@@ -407,7 +407,7 @@ export default class TaskItem extends Component {
                         <tr>
                           <th>Start &deg; </th>
                           <th>Osc. &deg; </th>
-                          <th>t (ms)</th>
+                          <th>t (s)</th>
                           <th># Img</th>
                           <th>T (%)</th>
                           <th>Res. (&Aring;)</th>

--- a/ui/src/components/Tasks/Interleaved.jsx
+++ b/ui/src/components/Tasks/Interleaved.jsx
@@ -231,7 +231,7 @@ class Interleaved extends React.Component {
                     <th>Start &deg; </th>
                     <th>Osc. &deg; </th>
                     <th># Img</th>
-                    <th>t (ms)</th>
+                    <th>t (s)</th>
                     <th>T (%)</th>
                     <th>Res. (&Aring;)</th>
                     <th>E (keV)</th>


### PR DESCRIPTION
The exposure time in the queue Task Items result section was indicated to be in ms for `Characterisation` and `interleaved` tasks, when it should be in seconds.
![wrong-type-characterisation](https://github.com/user-attachments/assets/cf5c0832-bdee-44eb-a473-0ea89a2dda8c)
