### PR TITLE
Remove unused variable assignments and parameters

### DIFF
--- a/mxcubeweb/routes/queue.py
+++ b/mxcubeweb/routes/queue.py
@@ -160,7 +160,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.require_control
     @server.restrict
     def set_queue():
-        app.queue.set_queue(request.get_json(), session)
+        app.queue.set_queue(request.get_json())
         return Response(status=200)
 
     @bp.route("/", methods=["POST"])


### PR DESCRIPTION
This PR cleans up the `queue` component a little bit.
In general there are two steps for the clean-up: 

- Replacing some variable that were assigned during unpacking of function calls but never used by the underscore (`_`) placeholder
- Remove unused function parameters in the function definitions and everywhere the functions were called (luckily there was only one function that was called outside this file and everyone of them was only called once or twice)