### PR TITLE
fix warnings on datacollection task

### DIFF
--- a/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
+++ b/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
@@ -283,7 +283,7 @@ export default class TaskItem extends Component {
           style={{ marginBottom: 0, height: '18px' }}
           min={0}
           max={1}
-          active={this.props.progress < 1}
+          animated={this.props.progress < 1}
           label={`${(this.props.progress * 100).toPrecision(3)} %`}
           now={this.props.progress}
         />

--- a/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
+++ b/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
@@ -217,7 +217,7 @@ export default class EnergyScanTaskItem extends Component {
                       style={{ marginBottom: 0, height: '18px' }}
                       min={0}
                       max={1}
-                      active={this.props.progress < 1}
+                      animated={this.props.progress < 1}
                       label={`${(this.props.progress * 100).toPrecision(3)} %`}
                       now={this.props.progress}
                     />

--- a/ui/src/components/SampleQueue/TaskItem.jsx
+++ b/ui/src/components/SampleQueue/TaskItem.jsx
@@ -238,7 +238,7 @@ export default class TaskItem extends Component {
           style={{ marginBottom: 0, height: '18px' }}
           min={0}
           max={1}
-          active={this.props.progress < 1}
+          animated={this.props.progress < 1}
           label={`${(this.props.progress * 100).toPrecision(3)} %`}
           now={this.props.progress}
         />

--- a/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
+++ b/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
@@ -156,7 +156,7 @@ export default class WorkflowTaskItem extends Component {
           style={{ marginBottom: 0, height: '18px' }}
           min={0}
           max={1}
-          active={this.props.progress < 1}
+          animated={this.props.progress < 1}
           label={`${(this.props.progress * 100).toPrecision(3)} %`}
           now={this.props.progress}
         />

--- a/ui/src/components/SampleQueue/XRFTaskItem.jsx
+++ b/ui/src/components/SampleQueue/XRFTaskItem.jsx
@@ -285,7 +285,7 @@ export default class XRFTaskItem extends Component {
                       style={{ marginBottom: 0, height: '18px' }}
                       min={0}
                       max={1}
-                      active={this.props.progress < 1}
+                      animated={this.props.progress < 1}
                       label={`${(this.props.progress * 100).toPrecision(3)} %`}
                       now={this.props.progress}
                     />

--- a/ui/src/components/Tasks/fields.jsx
+++ b/ui/src/components/Tasks/fields.jsx
@@ -218,7 +218,8 @@ function ReduxInputField(prop) {
 }
 
 export function InputField(prop) {
-  return <Field name={prop.propName} component={ReduxInputField} {...prop} />;
+  const { propName, ...otherProps } = prop;
+  return <Field name={propName} component={ReduxInputField} {...otherProps} />;
 }
 
 export function DisplayField({ label, value }) {


### PR DESCRIPTION
While running datacollections in the mock environment, a few warnings popped up in the console. This PR will fix them.
It includes the following changes:
- destructuring props of `InputField` to prevent `propName` to be passed to a native DOM element.
- `ProgressBar` does not have an attribute `active`, hence I replaced it with `animated` on a few occasions.