### PR TITLE
Refactor visibility and positioning logic of context menu in sample view

### DIFF
--- a/ui/src/actions/sampleview.js
+++ b/ui/src/actions/sampleview.js
@@ -44,9 +44,23 @@ export function setMotorStep(role, value) {
   return { type: 'SET_MOTOR_STEP', role, value };
 }
 
-// eslint-disable-next-line unicorn/no-object-as-default-parameter
-export function showContextMenu(show, shape = { type: 'NONE' }, x = 0, y = 0) {
-  return { type: 'SHOW_CONTEXT_MENU', show, shape, x, y };
+export function showContextMenu(
+  show,
+  shape = { type: 'NONE' }, // eslint-disable-line unicorn/no-object-as-default-parameter
+  pageX = 0,
+  pageY = 0,
+  imageX = 0,
+  imageY = 0,
+) {
+  return {
+    type: 'SHOW_CONTEXT_MENU',
+    show,
+    shape,
+    pageX,
+    pageY,
+    imageX,
+    imageY,
+  };
 }
 
 export function setPixelsPerMm(pixelsPerMm) {

--- a/ui/src/components/SampleView/ContextMenu.jsx
+++ b/ui/src/components/SampleView/ContextMenu.jsx
@@ -1,48 +1,32 @@
 /* eslint-disable react/jsx-handler-names */
 import React from 'react';
+import { createPortal } from 'react-dom';
 import { Dropdown } from 'react-bootstrap';
 import { getLastUsedParameters } from '../Tasks/fields';
 
-// eslint-disable-next-line react/no-unsafe
+const BESPOKE_TASK_NAMES = new Set([
+  'datacollection',
+  'characterisation',
+  'xrf_spectrum',
+  'energy_scan',
+  'mesh',
+  'helical',
+  'workflow',
+  'interleaved',
+]);
+
 export default class ContextMenu extends React.Component {
   constructor(props) {
     super(props);
     this.toggleDrawGrid = this.toggleDrawGrid.bind(this);
     this.menuOptions = this.menuOptions.bind(this);
-    this.hideContextMenu = this.hideContextMenu.bind(this);
-  }
-
-  componentDidMount() {
-    document.addEventListener('click', this.hideContextMenu);
-  }
-
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    if (nextProps.show) {
-      this.showContextMenu(nextProps.x, nextProps.y);
-    } else {
-      this.hideContextMenu();
-    }
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('click', this.hideContextMenu);
   }
 
   // eslint-disable-next-line sonarjs/cognitive-complexity
   menuOptions() {
-    const bespokeTaskNames = new Set([
-      'datacollection',
-      'characterisation',
-      'xrf_spectrum',
-      'energy_scan',
-      'mesh',
-      'helical',
-      'workflow',
-      'interleaved',
-    ]);
     const generalTaskNames = Object.keys(
       this.props.taskForm.defaultParameters,
-    ).filter((tname) => !bespokeTaskNames.has(tname));
+    ).filter((tname) => !BESPOKE_TASK_NAMES.has(tname));
 
     const genericTasks = {
       point: [],
@@ -381,23 +365,11 @@ export default class ContextMenu extends React.Component {
         'There is no sample mounted, cannot collect data.',
       );
     }
-    this.hideContextMenu();
-    this.props.sampleViewActions.showContextMenu(false);
   }
 
   createCollectionOnCell() {
     const { cellCenter } = this.props.shape;
     this.createPoint(cellCenter[0], cellCenter[1]);
-    this.props.sampleViewActions.showContextMenu(false);
-  }
-
-  showContextMenu(x, y) {
-    const contextMenu = document.querySelector('#contextMenu');
-    if (contextMenu) {
-      contextMenu.style.top = `${y + 140}px`;
-      contextMenu.style.left = `${x + 170}px`;
-      contextMenu.style.display = 'block';
-    }
   }
 
   createPoint(x, y, cb = null) {
@@ -430,19 +402,18 @@ export default class ContextMenu extends React.Component {
         }
       });
     }
-
-    this.props.sampleViewActions.showContextMenu(false);
   }
 
   goToPoint() {
-    this.props.sampleViewActions.showContextMenu(false);
     this.props.sampleViewActions.moveToPoint(this.props.shape.id);
   }
 
   goToBeam() {
-    const { x, y, imageRatio } = this.props;
-    this.props.sampleViewActions.showContextMenu(false);
-    this.props.sampleViewActions.moveToBeam(x / imageRatio, y / imageRatio);
+    const { imageX, imageY, imageRatio } = this.props;
+    this.props.sampleViewActions.moveToBeam(
+      imageX / imageRatio,
+      imageY / imageRatio,
+    );
   }
 
   removeShape() {
@@ -450,37 +421,26 @@ export default class ContextMenu extends React.Component {
       this.props.sampleViewActions.abortCentring();
     }
 
-    // eslint-disable-next-line promise/catch-or-return
-    this.props.sampleViewActions
-      .deleteShape(this.props.shape.id)
-      // eslint-disable-next-line promise/prefer-await-to-then
-      .then(() => {
-        this.props.sampleViewActions.showContextMenu(false);
-      });
+    this.props.sampleViewActions.deleteShape(this.props.shape.id);
   }
 
   measureDistance() {
-    this.props.sampleViewActions.showContextMenu(false);
     this.props.sampleViewActions.measureDistance(true);
   }
 
   toggleDrawGrid() {
-    this.props.sampleViewActions.showContextMenu(false);
     this.props.sampleViewActions.toggleDrawGrid();
   }
 
   saveGrid() {
-    this.props.sampleViewActions.showContextMenu(false);
-
     const gd = { ...this.props.shape.gridData };
     this.props.sampleViewActions.addShape({ t: 'G', ...gd });
     this.props.sampleViewActions.toggleDrawGrid();
   }
 
   createPointAndShowModal(name, extraParams = {}) {
-    const { x, y, imageRatio } = this.props;
-    this.props.sampleViewActions.showContextMenu(false);
-    this.createPoint(x / imageRatio, y / imageRatio, (shape) =>
+    const { imageX, imageY, imageRatio } = this.props;
+    this.createPoint(imageX / imageRatio, imageY / imageRatio, (shape) =>
       this.showModal(name, {}, shape, extraParams),
     );
   }
@@ -497,18 +457,9 @@ export default class ContextMenu extends React.Component {
       lines.map((x) => sid.splice(sid.indexOf(x), 1));
     }
 
-    this.props.sampleViewActions.showContextMenu(false);
     this.props.sampleViewActions.addShape({ t: 'L', refs: shape.id }, (s) => {
       this.showModal(modal, wf, s);
     });
-  }
-
-  hideContextMenu() {
-    const ctxMenu = document.querySelector('#contextMenu');
-    if (ctxMenu && this.props.show) {
-      ctxMenu.style.display = 'none';
-      this.props.sampleViewActions.showContextMenu(false);
-    }
   }
 
   listOptions(type) {
@@ -530,6 +481,8 @@ export default class ContextMenu extends React.Component {
   }
 
   render() {
+    const { pageX, pageY, show } = this.props;
+
     const menuOptions = this.menuOptions();
     let optionList = [];
 
@@ -538,10 +491,28 @@ export default class ContextMenu extends React.Component {
     } else {
       optionList = menuOptions.NONE.map(this.listOptions);
     }
-    return (
-      <Dropdown.Menu show id="contextMenu" role="menu">
-        {optionList}
-      </Dropdown.Menu>
+
+    return createPortal(
+      <Dropdown
+        className="position-absolute"
+        style={{ top: `${pageY}px`, left: `${pageX}px` }}
+        role="menu"
+        show={show}
+        autoClose
+        onToggle={(nextShow) => {
+          if (!nextShow) {
+            // Hide menu when clicking outside or selecting option
+            this.props.sampleViewActions.showContextMenu(false);
+          }
+        }}
+      >
+        <Dropdown.Menu
+          rootCloseEvent="mousedown" // faster than `click`
+        >
+          {optionList}
+        </Dropdown.Menu>
+      </Dropdown>,
+      document.body,
     );
   }
 }

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -500,7 +500,7 @@ export default class SampleImage extends React.Component {
       this.canvas.discardActiveObject();
     }
 
-    showContextMenu(true, ctxMenuObj, e.offsetX, e.offsetY);
+    showContextMenu(true, ctxMenuObj, e.pageX, e.pageY, e.offsetX, e.offsetY);
   }
 
   // eslint-disable-next-line sonarjs/cognitive-complexity
@@ -514,13 +514,8 @@ export default class SampleImage extends React.Component {
       clickCentring,
       measureDistance,
       imageRatio,
-      contextMenuVisible,
       drawGrid,
     } = this.props;
-
-    if (contextMenuVisible) {
-      sampleViewActions.showContextMenu(false);
-    }
 
     if (clickCentring) {
       this.canvas.selection = false; // Disable group selection

--- a/ui/src/components/SampleView/SampleView.css
+++ b/ui/src/components/SampleView/SampleView.css
@@ -22,13 +22,6 @@
   left: 0;
 }
 
-#contextMenu {
-  position: absolute;
-  top: 0;
-  left: 0;
-  display: none;
-}
-
 #video-message-overlay {
   width: 40%;
   background-color: rgb(34, 34, 34);

--- a/ui/src/reducers/contextMenu.js
+++ b/ui/src/reducers/contextMenu.js
@@ -1,8 +1,10 @@
 const INITIAL_STATE = {
   show: false,
   shape: { type: 'NONE' },
-  x: 0,
-  y: 0,
+  pageX: 0,
+  pageY: 0,
+  imageX: 0,
+  imageY: 0,
   genericContextMenu: {
     id: '',
     show: false,
@@ -18,8 +20,10 @@ function contextMenuReducer(state = INITIAL_STATE, action = {}) {
         ...state,
         show: action.show,
         shape: action.shape,
-        x: action.x,
-        y: action.y,
+        pageX: action.pageX,
+        pageY: action.pageY,
+        imageX: action.imageX,
+        imageY: action.imageY,
       };
     }
     case 'SHOW_GENERIC_CONTEXT_MENU': {


### PR DESCRIPTION
I'm starting to refactor `SampleView/ContextMenu.jsx`, which is the component that renders the context menu of the sample view. It's a bit class component with a lot of logic for all the various actions that the context menu allows, and therefore a lot of props. The logic for rendering the menu options is difficult to follow, and the component uses `UNSAFE_componentWillReceiveProps`, which is obviously not great. I'd like to extract a lot of the action-related logic to reduce the reliance on global state, render the options more declaratively in JSX if possible, and then of course convert the component to a function and replace all the props with `useSelector`.

But first, I do a bit of a clean-up of the visibility and positioning logic of the context menu:

- I make better use of Bootstrap's `Dropdown` component and all its features, which avoids having to manually hide the menu ourselves after every action or when clicking outside of it (`autoClose` + `onToggle`).
- I show/hide the menu declaratively rather than imperatively with the `show` prop, which removes the need for `UNSAFE_componentWillReceiveProps`.
- I render the menu as a direct child of `document.body` via a React Portal, which simplifies the positioning logic: I can now save the position of the right-click event relative to the page (`pageX` and `pageY`) and use that directly as the menu's `left` and `top` positions.

Note that the top left-hand corner of the context menu is now exactly under the cursor, which matches the behaviour of the native context menu:

[Screencast from 2024-10-29 09-33-11.webm](https://github.com/user-attachments/assets/47c8e9b7-eeed-44bb-b493-80a605001e1c)