### PR TITLE
fix queue_mount_sample() signature

### DIFF
--- a/mxcubeweb/core/components/samplechanger.py
+++ b/mxcubeweb/core/components/samplechanger.py
@@ -416,7 +416,7 @@ class SampleChanger(ComponentBase):
 
 
 # Disabling C901 function is too complex (19)
-def queue_mount_sample(view, data_model, centring_done_cb, async_result):  # noqa: C901
+def queue_mount_sample(data_model, centring_done_cb, async_result):  # noqa: C901
     from mxcubeweb.app import MXCUBEApplication as mxcube
     from mxcubeweb.routes import signals
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1856,13 +1856,13 @@ websockets = ">=12.0,<13.0"
 
 [[package]]
 name = "mxcubecore"
-version = "1.169.0"
+version = "1.177.0"
 description = "Core libraries for the MXCuBE application"
 optional = false
 python-versions = "<3.12,>=3.8"
 files = [
-    {file = "mxcubecore-1.169.0-py3-none-any.whl", hash = "sha256:49939b2b6704de1a164ce2331d312fd77025b1af68b1b1627f521aaa73149d85"},
-    {file = "mxcubecore-1.169.0.tar.gz", hash = "sha256:f606f07f60e00841593c7a20cdb87939db196041bb2e813a23e51004ae99def1"},
+    {file = "mxcubecore-1.177.0-py3-none-any.whl", hash = "sha256:3ab3cf1cda9aea33e662a7c54188d7c4eb276a5546e9399fa0bca2ec9d84d555"},
+    {file = "mxcubecore-1.177.0.tar.gz", hash = "sha256:464bc8f6add5cfc0edb9e8babecaeebdc727602fe1bbb93fe02c93d7f79a37ad"},
 ]
 
 [package.dependencies]
@@ -3754,4 +3754,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "483c2b8d74de8c84cd33806bd3bd88d7648468dbcf4fdadbf7a02af8cf7f334f"
+content-hash = "c6f6cd4026ab03bd8ebc579e8f0cf4097b728b25fe1ded9cf9ae439277d3c6d1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ pydantic = ">=2.8.2,<2.9.0"
 PyDispatcher = "^2.0.6"
 pytz = "^2022.6"
 tzlocal = "^4.2"
-mxcubecore = ">=1.169.0"
+mxcubecore = ">=1.177.0"
 mxcube-video-streamer = ">=1.5.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -857,9 +857,9 @@ mock==4.0.3 ; python_version >= "3.8" and python_version < "3.12" \
 mxcube-video-streamer==1.5.0 ; python_version >= "3.8" and python_version < "3.12" \
     --hash=sha256:998a8a909e9b69a55bb3776e56ae7725479ec3b196990bf15f6849c3fb824f37 \
     --hash=sha256:fd9d337aad522f60b69182050f9ddfe81d3d2490c2bc8e86ccc669f3e5855718
-mxcubecore==1.169.0 ; python_version >= "3.8" and python_version < "3.12" \
-    --hash=sha256:49939b2b6704de1a164ce2331d312fd77025b1af68b1b1627f521aaa73149d85 \
-    --hash=sha256:f606f07f60e00841593c7a20cdb87939db196041bb2e813a23e51004ae99def1
+mxcubecore==1.177.0 ; python_version >= "3.8" and python_version < "3.12" \
+    --hash=sha256:3ab3cf1cda9aea33e662a7c54188d7c4eb276a5546e9399fa0bca2ec9d84d555 \
+    --hash=sha256:464bc8f6add5cfc0edb9e8babecaeebdc727602fe1bbb93fe02c93d7f79a37ad
 numpy==1.24.4 ; python_version >= "3.8" and python_version < "3.12" \
     --hash=sha256:04640dab83f7c6c85abf9cd729c5b65f1ebd0ccf9de90b270cd61935eef0197f \
     --hash=sha256:1452241c290f3e2a312c137a9999cdbf63f78864d63c79039bda65ee86943f61 \


### PR DESCRIPTION
The queue_mount_sample() is now called with 3 arguments, `view` argument is no longer provided.

The invocation of queue_mount_sample() have been changed in this commit: https://github.com/mxcube/mxcubecore/commit/cb742731c8669149bc5741681f006bf1d0d58823

This change makes mxcubeweb incompatible with older versions of mxcubecore, thus we need to bump mxcubecore version.

This change fixed the pytest tests, when running against latest mxcubecore.