### PR TITLE
fix mesh grid drawn in wrong positions sometimes

### DIFF
--- a/ui/src/components/SampleView/DrawGridPlugin.jsx
+++ b/ui/src/components/SampleView/DrawGridPlugin.jsx
@@ -766,7 +766,7 @@ export default class DrawGridPlugin {
    * Save a grid, reset any scaling to original scale
    */
   saveGrid(_gd) {
-    const gd = { ..._gd };
+    const gd = structuredClone(_gd);
 
     gd.screenCoord[0] /= this.scale;
     gd.screenCoord[1] /= this.scale;


### PR DESCRIPTION
## Mesh grid being drawn in wrong place
This PR fixes the following bug:
1. Open draw grid control
2. Draw some mesh grid
3. Move mouse outside of the unsaved grid
4. drag mouse somewhere (in other direction that bottom-left)
5. right click on previously drawn grid
6. Press 'Save Grid'
The grid would be drawn in some other place on the canvas

This bug was caused, because the top-left coordinates of the grid were set on `SampleImage`'s `onMouseDown` handler. So if we first drew the grid, and then dragged the mouse the following would happen:
- if the direction of the drag is towards bottom-left corner of the screen, then new grid would be drawn - this is ok
- otherwise, no new grid would appear, but the old grid's top-left corner coordinates would be changed - not ok.

I fixed it by only allowing the position of drawn grid's top-left corner to be changed if a grid should be really be redrawn.

Also there are 2 other minor changes:
### Typedef for `GridData`
I decided to add JSDoc [@typedef](https://jsdoc.app/tags-typedef) annotation to provide some kind of type hinting and better autocomplete in code editors. Regarding the type hint, I am not 100% sure if the `result` property is typed properly, and if it used at all? I haven't noticed a way to make it take another value than `''` or `null`, so I guess it could be removed in some other PR?
### small refactor
Removed 2 functions that were unused.