### PR TITLE
Store sampleview coords in context menu state

### DIFF
--- a/ui/src/actions/sampleview.js
+++ b/ui/src/actions/sampleview.js
@@ -49,8 +49,8 @@ export function showContextMenu(
   shape = { type: 'NONE' }, // eslint-disable-line unicorn/no-object-as-default-parameter
   pageX = 0,
   pageY = 0,
-  imageX = 0,
-  imageY = 0,
+  sampleViewX = 0,
+  sampleViewY = 0,
 ) {
   return {
     type: 'SHOW_CONTEXT_MENU',
@@ -58,8 +58,8 @@ export function showContextMenu(
     shape,
     pageX,
     pageY,
-    imageX,
-    imageY,
+    sampleViewX,
+    sampleViewY,
   };
 }
 
@@ -216,6 +216,14 @@ export function acceptCentring() {
 
 export function moveToBeam(x, y) {
   return () => sendMoveToBeam(x, y);
+}
+
+export function add2DPoint(x, y, state, successCb) {
+  return (dispatch) => {
+    return dispatch(
+      addShape({ t: '2DP', screenCoord: [x, y], state }, successCb),
+    );
+  };
 }
 
 export function addShape(shapeData = {}, successCb = null) {

--- a/ui/src/actions/sampleview.js
+++ b/ui/src/actions/sampleview.js
@@ -46,11 +46,11 @@ export function setMotorStep(role, value) {
 
 export function showContextMenu(
   show,
-  shape = { type: 'NONE' }, // eslint-disable-line unicorn/no-object-as-default-parameter
-  pageX = 0,
-  pageY = 0,
-  sampleViewX = 0,
-  sampleViewY = 0,
+  shape,
+  pageX,
+  pageY,
+  sampleViewX,
+  sampleViewY,
 ) {
   return {
     type: 'SHOW_CONTEXT_MENU',

--- a/ui/src/components/SampleView/ContextMenu.jsx
+++ b/ui/src/components/SampleView/ContextMenu.jsx
@@ -299,7 +299,21 @@ export default class ContextMenu extends React.Component {
   showModal(modalName, extraParams = {}, _shape = null) {
     const { sampleID, shape, sampleData, defaultParameters } = this.props;
 
-    const sid = _shape ? _shape.id : shape.id;
+    if (this.props.clickCentring) {
+      this.props.sampleViewActions.stopClickCentring();
+      this.props.sampleViewActions.acceptCentring();
+    }
+
+    if (!sampleData) {
+      this.props.showErrorPanel(
+        true,
+        'There is no sample mounted, cannot collect data.',
+      );
+
+      return;
+    }
+
+    const sid = _shape ? _shape.id : shape?.id;
     if (Array.isArray(sid)) {
       // we remove any line
       // in case we have selected (by drawing a box) two points
@@ -316,11 +330,6 @@ export default class ContextMenu extends React.Component {
       }
     }
 
-    if (this.props.clickCentring) {
-      this.props.sampleViewActions.stopClickCentring();
-      this.props.sampleViewActions.acceptCentring();
-    }
-
     const type =
       modalName === 'Generic' ? extraParams.type : modalName.toLowerCase();
     const name =
@@ -332,39 +341,32 @@ export default class ContextMenu extends React.Component {
 
     params = getLastUsedParameters(type, params);
 
-    if (sampleData) {
-      const [cell_count, numRows, numCols] = shape.gridData
-        ? [
-            shape.gridData.numCols * shape.gridData.numRows,
-            shape.gridData.numRows,
-            shape.gridData.numCols,
-          ]
-        : ['none', 0, 0];
+    const [cell_count, numRows, numCols] = shape?.gridData
+      ? [
+          shape.gridData.numCols * shape.gridData.numRows,
+          shape.gridData.numRows,
+          shape.gridData.numCols,
+        ]
+      : ['none', 0, 0];
 
-      this.props.showForm(
-        modalName,
-        [sampleID],
-        {
-          parameters: {
-            ...params,
-            ...extraParams,
-            prefix: sampleData.defaultPrefix,
-            name,
-            subdir: `${this.props.groupFolder}${sampleData.defaultSubDir}`,
-            cell_count,
-            numRows,
-            numCols,
-          },
-          type,
+    this.props.showForm(
+      modalName,
+      [sampleID],
+      {
+        parameters: {
+          ...params,
+          ...extraParams,
+          prefix: sampleData.defaultPrefix,
+          name,
+          subdir: `${this.props.groupFolder}${sampleData.defaultSubDir}`,
+          cell_count,
+          numRows,
+          numCols,
         },
-        sid,
-      );
-    } else {
-      this.props.showErrorPanel(
-        true,
-        'There is no sample mounted, cannot collect data.',
-      );
-    }
+        type,
+      },
+      sid,
+    );
   }
 
   createCollectionOnCell() {
@@ -484,7 +486,7 @@ export default class ContextMenu extends React.Component {
     const menuOptions = this.menuOptions();
     let optionList = [];
 
-    if (this.props.sampleID !== undefined) {
+    if (this.props.shape && this.props.sampleID) {
       optionList = menuOptions[this.props.shape.type].map(this.listOptions);
     } else {
       optionList = menuOptions.NONE.map(this.listOptions);

--- a/ui/src/components/SampleView/ContextMenu.jsx
+++ b/ui/src/components/SampleView/ContextMenu.jsx
@@ -369,13 +369,10 @@ export default class ContextMenu extends React.Component {
 
   createCollectionOnCell() {
     const { cellCenter } = this.props.shape;
-    this.createPoint(cellCenter[0], cellCenter[1]);
-  }
-
-  createPoint(x, y, cb = null) {
-    this.props.sampleViewActions.addShape(
-      { screenCoord: [x, y], t: '2DP', state: 'SAVED' },
-      cb,
+    this.props.sampleViewActions.add2DPoint(
+      cellCenter[0],
+      cellCenter[1],
+      'SAVED',
     );
   }
 
@@ -409,11 +406,8 @@ export default class ContextMenu extends React.Component {
   }
 
   goToBeam() {
-    const { imageX, imageY, imageRatio } = this.props;
-    this.props.sampleViewActions.moveToBeam(
-      imageX / imageRatio,
-      imageY / imageRatio,
-    );
+    const { sampleViewX, sampleViewY } = this.props;
+    this.props.sampleViewActions.moveToBeam(sampleViewX, sampleViewY);
   }
 
   removeShape() {
@@ -439,9 +433,13 @@ export default class ContextMenu extends React.Component {
   }
 
   createPointAndShowModal(name, extraParams = {}) {
-    const { imageX, imageY, imageRatio } = this.props;
-    this.createPoint(imageX / imageRatio, imageY / imageRatio, (shape) =>
-      this.showModal(name, {}, shape, extraParams),
+    const { sampleViewX, sampleViewY } = this.props;
+
+    this.props.sampleViewActions.add2DPoint(
+      sampleViewX,
+      sampleViewY,
+      'SAVED',
+      (shape) => this.showModal(name, {}, shape, extraParams),
     );
   }
 

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -370,7 +370,7 @@ export default class SampleImage extends React.Component {
 
     const group = this.canvas.getActiveObject();
     const clickPoint = new fabric.Point(e.offsetX, e.offsetY);
-    let ctxMenuObj = { type: 'NONE' };
+    let ctxMenuObj;
     let objectFound = false;
     // Existing selection clicked
     if (

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -500,7 +500,15 @@ export default class SampleImage extends React.Component {
       this.canvas.discardActiveObject();
     }
 
-    showContextMenu(true, ctxMenuObj, e.pageX, e.pageY, e.offsetX, e.offsetY);
+    const { imageRatio } = this.props;
+    showContextMenu(
+      true,
+      ctxMenuObj,
+      e.pageX,
+      e.pageY,
+      e.offsetX / imageRatio,
+      e.offsetY / imageRatio,
+    );
   }
 
   // eslint-disable-next-line sonarjs/cognitive-complexity

--- a/ui/src/containers/SampleViewContainer.jsx
+++ b/ui/src/containers/SampleViewContainer.jsx
@@ -188,7 +188,6 @@ class SampleViewContainer extends Component {
                 sampleID={currentSampleID}
                 sampleData={this.props.sampleList[currentSampleID]}
                 defaultParameters={this.props.defaultParameters}
-                imageRatio={imageRatio * sourceScale}
                 workflows={this.props.workflows}
                 savedPointId={this.props.sampleViewState.savedPointId}
                 groupFolder={this.props.groupFolder}

--- a/ui/src/reducers/contextMenu.js
+++ b/ui/src/reducers/contextMenu.js
@@ -3,8 +3,8 @@ const INITIAL_STATE = {
   shape: { type: 'NONE' },
   pageX: 0,
   pageY: 0,
-  imageX: 0,
-  imageY: 0,
+  sampleViewX: 0,
+  sampleViewY: 0,
   genericContextMenu: {
     id: '',
     show: false,
@@ -22,8 +22,8 @@ function contextMenuReducer(state = INITIAL_STATE, action = {}) {
         shape: action.shape,
         pageX: action.pageX,
         pageY: action.pageY,
-        imageX: action.imageX,
-        imageY: action.imageY,
+        sampleViewX: action.sampleViewX,
+        sampleViewY: action.sampleViewY,
       };
     }
     case 'SHOW_GENERIC_CONTEXT_MENU': {


### PR DESCRIPTION
I now store `e.offset<X|Y> / imageRatio` instead of just `e.offset<X|Y>` in the state, which saves `ContextMenu` from having to do this calculation in a couple of places.

I've made a couple of additional commits to move some logic around, inline some methods, etc., and to let the right-clicked shape be `undefined` in the state (instead of storing a fake shape object `{ type: 'NONE' }`).