### PR TITLE
Fixes grid-scan heatmap issue

### DIFF
--- a/ui/src/components/SampleView/DrawGridPlugin.jsx
+++ b/ui/src/components/SampleView/DrawGridPlugin.jsx
@@ -430,7 +430,7 @@ export default class DrawGridPlugin {
           if (result[index] !== undefined) {
             fillingMatrix[nw][nh] = this.heatMapColorForValue(
               gd,
-              result[index],
+              result[index][0],
             );
           }
         }

--- a/ui/src/components/SampleView/DrawGridPlugin.jsx
+++ b/ui/src/components/SampleView/DrawGridPlugin.jsx
@@ -430,7 +430,7 @@ export default class DrawGridPlugin {
           if (result[index] !== undefined) {
             fillingMatrix[nw][nh] = this.heatMapColorForValue(
               gd,
-              result[index][0],
+              result[index][1],
             );
           }
         }


### PR DESCRIPTION
The current version of the code is displaying heatmaps incorrectly (see the figure below). This is probably due to a recent refactor that is passing the wrong argument to the `heatMapColorForValue` function.

To fix this, I only changed the following line:

`this.heatMapColorForValue(
              gd,
              result[index],
              result[index],)
`

to 

`this.heatMapColorForValue(
              gd,
              result[index],
              result[index][1],)
`

The value `result[index][1]` contains the correct RGBA input values for the `heatMapColorForValue` function (which is the value that was passed as of version `4.34.0`)


![heatmap_res](https://github.com/user-attachments/assets/ae1a0cef-bfd7-4a16-9452-fa58a14bb134)


