### PR TITLE
Prevents: x not in list error in nstate_adapter.py

### DIFF
--- a/mxcubeweb/core/adapter/nstate_adapter.py
+++ b/mxcubeweb/core/adapter/nstate_adapter.py
@@ -31,7 +31,8 @@ class NStateAdapter(ActuatorAdapterBase):
 
     def _get_valid_states(self):
         state_names = [v.name for v in self._ho.VALUES]
-        state_names.remove("UNKNOWN")
+        if "UNKNOWN" in state_names:
+            state_names.remove("UNKNOWN")
 
         return state_names
 


### PR DESCRIPTION
I noticed this small problem in the nstate_adapter.py file. It throws an error sometimes when trying to remove "UNKNOWN" from a list that doesn't contain it.
I added a conditional to fix this.  I think it was there in a previous version but was removed.  