### PR TITLE
Adding documentation and dependency for missing video stream

### DIFF
--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -9,6 +9,7 @@ dependencies:
   # Runtime dependencies
   # ====================
 
+  - ffmpeg  # Not directly used by mxcube, but necessary for the video-streamer
   - python >=3.8,<3.12  # Make sure it matches `pyproject.toml`
 
   # We install `python-ldap` from conda because it is "hard" to install.

--- a/docs/source/dev/environment.md
+++ b/docs/source/dev/environment.md
@@ -167,6 +167,14 @@ pnpm --prefix ui start
 
 The above will automatically open a browser with the URL: <http://localhost:5173>
 
+> **Note**: In case that you decided to install MXCuBE-Web without using the `conda-environment.yml` file, the stream in the `Data Collection` tab of the UI might be missing. To resolve this:
+>
+> 1. Ensure that `ffmpeg` is properly installed on your side, to install run `sudo apt install ffmpeg`
+>    Then restart the server.
+> 1. Alternatively, you can manually install the dependencies of [MXCuBE's video-streamer](https://github.com/mxcube/video-streamer/) and restart the server afterwards.
+>
+> If the issue persists, please make sure to use the [issues](https://github.com/mxcube/mxcubeweb/issues) page and reach out for help.
+
 #### 9.3. Running the end to end (e2e) tests
 
 Keep both the backend and front-end servers running then run the following command in a third terminal, from the root directory of the project:


### PR DESCRIPTION
Following the discussion on #1495. I added `ffmpeg` as a dependency in `conda-environment.yml` and added a note in the documentation for quickly solving any missing dependencies from the [video-streamer](https://github.com/mxcube/video-streamer). 

Closes #1495 