### PR TITLE
(#1500) Makes default value for REMEMBER_PARAMETERS_BETWEEN_SAMPLES and queue_manager.centringMethod configurable

### DIFF
--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -12,6 +12,7 @@ from mxcubecore import queue_entry as qe
 from mxcubecore.HardwareObjects.Gphl import GphlQueueEntry
 from mxcubecore.model import queue_model_enumerables as qme
 from mxcubecore.model import queue_model_objects as qmo
+from mxcubecore.model.queue_model_enumerables import CENTRING_METHOD
 from mxcubecore.queue_entry.base_queue_entry import QUEUE_ENTRY_STATUS
 
 from mxcubeweb.core.components.component_base import ComponentBase
@@ -280,6 +281,7 @@ class Queue(ComponentBase):
             "numSnapshots": HWR.beamline.collect.get_property(
                 "num_snapshots", self.app.DEFAULT_NUM_SNAPSHOTS
             ),
+            "centringMethod": HWR.beamline.queue_manager.centring_method,
         }
 
         res.update(settings)
@@ -2076,6 +2078,21 @@ class Queue(ComponentBase):
         )
         self.app.AUTO_ADD_DIFFPLAN = HWR.beamline.collect.get_property(
             "auto_add_diff_plan", False
+        )
+        # Change value of the parameter, without changing the hardware object property.
+        # This allows to properly reset the value on logout when invoking init_queue_settings.
+        self.app.REMEMBER_PARAMETERS_BETWEEN_SAMPLES = (
+            HWR.beamline.queue_manager.get_property(
+                "remember_parameters_between_samples", False
+            )
+        )
+
+        centring_method_as_string = HWR.beamline.queue_manager.get_property(
+            "default_centring_method", "NONE"
+        )
+        HWR.beamline.queue_manager.centring_method = getattr(
+            CENTRING_METHOD,
+            centring_method_as_string,
         )
 
     def queue_start(self, sid):

--- a/mxcubeweb/core/models/generic.py
+++ b/mxcubeweb/core/models/generic.py
@@ -10,7 +10,8 @@ from mxcubeweb.core.models.configmodels import ModeEnum
 
 class SimpleNameValue(BaseModel):
     name: str
-    value: Union[str, bool, int]
+    # It's important to have str before bool, to avoid issue with bool being casted to string
+    value: Union[bool, str, int]
 
 
 class AppSettingsModel(BaseModel):


### PR DESCRIPTION
This PR makes settings mentioned in the title configurable. Also makes them behave in an expected manner, that is:
- they persist between refreshes (`centringMethod` was reset on the frontend after refresh)
- are reset properly when user logs out

The default values are set with `default_centring_method` and `default_remember_parameters_between_samples`. 


It also fixes the problem with `remember parameters between samples` checkbox. When It was changed in the settings, although boolean value was sent by client, it registered a bool-casted-to-string value, that is `"False"` or `"True"`.

Closes #1500 