### PR TITLE
Show error boundary when development server is down

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -41,6 +41,7 @@
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^17.0.2",
     "react-draggable": "^4.4.4",
+    "react-error-boundary": "4.1.2",
     "react-hook-form": "7.45.0",
     "react-icons": "^4.3.1",
     "react-lazyload": "^3.2.0",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       react-draggable:
         specifier: ^4.4.4
         version: 4.4.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      react-error-boundary:
+        specifier: 4.1.2
+        version: 4.1.2(react@17.0.2)
       react-hook-form:
         specifier: 7.45.0
         version: 7.45.0(react@17.0.2)
@@ -3455,6 +3458,11 @@ packages:
       react: '>= 16.3.0'
       react-dom: '>= 16.3.0'
 
+  react-error-boundary@4.1.2:
+    resolution: {integrity: sha512-GQDxZ5Jd+Aq/qUxbCm1UtzmL/s++V7zKgE8yMktJiCQXCCFZnMZh9ng+6/Ne6PjNSXH0L9CjeOEREfRnq6Duag==}
+    peerDependencies:
+      react: '>=16.13.1'
+
   react-hook-form@7.45.0:
     resolution: {integrity: sha512-AbHeZ4ad+0dEIknSW9dBgIwcvRDfZ1O97sgj75WaMdOX0eg8TBiUf9wxzVkIjZbk76BBIE9lmFOzyD4PN80ZQg==}
     engines: {node: '>=12.22.0'}
@@ -6289,9 +6297,9 @@ snapshots:
       eslint-config-prettier: 8.8.0(eslint@8.42.0)
       eslint-import-resolver-jsconfig: 1.1.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5)(eslint@8.42.0)
+      eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0))(eslint@8.42.0)
       eslint-plugin-etc: 2.0.2(eslint@8.42.0)(typescript@5.0.3)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-typescript@3.5.4)(eslint@8.42.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0))(eslint@8.42.0))(eslint@8.42.0)
       eslint-plugin-jest: 27.2.1(@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0)(typescript@5.0.3)
       eslint-plugin-jest-dom: 4.0.3(eslint@8.42.0)
       eslint-plugin-jest-formatting: 3.1.0(eslint@8.42.0)
@@ -6342,12 +6350,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5)(eslint@8.42.0):
+  eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0))(eslint@8.42.0):
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       enhanced-resolve: 5.17.1
       eslint: 8.42.0
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-typescript@3.5.4)(eslint@8.42.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0))(eslint@8.42.0))(eslint@8.42.0)
       get-tsconfig: 4.7.6
       globby: 13.2.2
       is-core-module: 2.15.0
@@ -6356,14 +6364,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.4)(eslint@8.42.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0))(eslint@8.42.0))(eslint@8.42.0):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
       '@typescript-eslint/parser': 5.56.0(eslint@8.42.0)(typescript@5.0.3)
       eslint: 8.42.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5)(eslint@8.42.0)
+      eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0))(eslint@8.42.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6380,7 +6388,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-typescript@3.5.4)(eslint@8.42.0):
+  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0))(eslint@8.42.0))(eslint@8.42.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.flat: 1.3.2
@@ -6389,7 +6397,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.42.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.4)(eslint@8.42.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.42.0)(typescript@5.0.3))(eslint@8.42.0))(eslint@8.42.0))(eslint@8.42.0)
       has: 1.0.3
       is-core-module: 2.15.0
       is-glob: 4.0.3
@@ -8145,6 +8153,11 @@ snapshots:
       prop-types: 15.8.1
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+
+  react-error-boundary@4.1.2(react@17.0.2):
+    dependencies:
+      '@babel/runtime': 7.25.0
+      react: 17.0.2
 
   react-hook-form@7.45.0(react@17.0.2):
     dependencies:

--- a/ui/src/components/App.jsx
+++ b/ui/src/components/App.jsx
@@ -19,6 +19,7 @@ import { serverIO } from '../serverIO';
 import { getLoginInfo } from '../actions/login';
 import PrivateOutlet from './PrivateOutlet';
 import { sendRefreshSession } from '../api/login';
+import { useErrorBoundary } from 'react-error-boundary';
 
 const REFRESH_INTERVAL = 9000;
 
@@ -68,10 +69,11 @@ const router = createBrowserRouter([
 
 function App() {
   const dispatch = useDispatch();
+  const { showBoundary } = useErrorBoundary();
   const loggedIn = useSelector((state) => state.login.loggedIn);
 
   useEffect(() => {
-    dispatch(getLoginInfo());
+    dispatch(getLoginInfo()).catch(showBoundary); // eslint-disable-line promise/prefer-await-to-then
 
     if (loggedIn) {
       serverIO.listen();
@@ -85,7 +87,7 @@ function App() {
 
     // no clean-up required, until we connect to serverIO
     return undefined;
-  }, [loggedIn, dispatch]);
+  }, [loggedIn, dispatch, showBoundary]);
 
   if (loggedIn === null) {
     // Fetching login info

--- a/ui/src/containers/DefaultErrorBoundary.jsx
+++ b/ui/src/containers/DefaultErrorBoundary.jsx
@@ -1,63 +1,37 @@
 import React from 'react';
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
-import { store } from '../store';
+import { ErrorBoundary } from 'react-error-boundary';
 
 import { logFrontEndTraceBack } from '../actions/beamline';
+import { Button } from 'react-bootstrap';
+import { useDispatch } from 'react-redux';
 
-class DefaultErrorBoundary extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { error: null, errorInfo: null, store: null };
-  }
+function DefaultErrorBoundary(props) {
+  const { children } = props;
+  const dispatch = useDispatch();
 
-  componentDidCatch(error, errorInfo) {
-    this.setState({
-      error,
-      errorInfo,
-      store: store.getState(),
-    });
-    this.props.logFrontEndTraceBack(errorInfo.componentStack);
-  }
-
-  render() {
-    if (this.state.errorInfo) {
-      return (
-        <div>
-          <h3>Something went wrong</h3>
-          <p>
-            We are terribly sorry but something went wrong, the error has been
-            logged. If it remains please contact suport.
+  return (
+    <ErrorBoundary
+      fallbackRender={({ error }) => (
+        <div className="p-4">
+          <h3 className="mb-3">Something went wrong</h3>
+          <p className="mb-2">
+            We are terribly sorry but an error occurred:{' '}
+            <code>{error?.toString()}</code>
           </p>
           <p>
-            Simply, <a href="/datacollection">reloading</a> the page might fix
-            the issue.
+            Reloading the page might fix the issue. If it remains, please
+            contact support.
           </p>
-          <details style={{ whiteSpace: 'pre-wrap' }}>
-            {this.state.error && this.state.error.toString()}
-            <br />
-            {this.state.errorInfo.componentStack}
-            <br />
-            {JSON.stringify(this.state.store)}
-          </details>
+          <Button onClick={() => window.location.reload()}>Reload</Button>
         </div>
-      );
-    }
-    return this.props.children;
-  }
+      )}
+      onError={(_, { componentStack }) => {
+        dispatch(logFrontEndTraceBack(componentStack));
+      }}
+    >
+      {children}
+    </ErrorBoundary>
+  );
 }
 
-function mapStateToProps(state) {
-  return {};
-}
-
-function mapDispatchToProps(dispatch) {
-  return {
-    logFrontEndTraceBack: bindActionCreators(logFrontEndTraceBack, dispatch),
-  };
-}
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(DefaultErrorBoundary);
+export default DefaultErrorBoundary;


### PR DESCRIPTION
When the development server is down, the app gets stuck on the loading screen:

![Screenshot from 2024-12-16 14-00-09](https://github.com/user-attachments/assets/3f97a51c-4db1-4a72-a52d-0aebb1301ade)

The `/login_info` request triggered by the `getLoginInfo` action (dispatched from inside the `useEffect`, in `App.jsx`) doesn't succeed since the server is down. Unfortunately, since the request is triggered from `useEffect`, the `DefaultErrorBoundary` doesn't see the error and therefore doesn't show the "Something went wrong" message below, as one would expect:

![Screenshot from 2024-12-16 13-30-38](https://github.com/user-attachments/assets/a07ed7ca-888c-468e-8e9a-622bd45bf6dd)

In this PR, I refactor `DefaultErrorBoundary` using an external library called [react-error-boundary](https://github.com/bvaughn/react-error-boundary), which provides more features than our basic implementation. One of these features is the `useErrorBoundary` hook, which gives us the ability to imperatively show the closest error boundary.

While I'm at it, I improve the design of the "Something went wrong" message a bit:

![Screenshot from 2024-12-16 13-59-36](https://github.com/user-attachments/assets/95536e00-f725-410d-a9d8-e9a0228a35eb)

Granted, the error message above when the development server is down is not very clear, but for some reason Vite's proxy server triggers a 500 error, so I don't want to risk hiding a real server-side 500 error...