### PR TITLE
Don't manually reconnect logging websocket

### DIFF
--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -438,13 +438,6 @@ class ServerIO {
 
     this.loggingSocket.on('disconnect', (reason) => {
       console.log('loggingSocket disconnected!'); // eslint-disable-line no-console
-
-      if (reason === 'io server disconnect') {
-        const socket = this.loggingSocket;
-        setTimeout(() => {
-          socket.connect();
-        }, 500);
-      }
     });
 
     this.loggingSocket.on('log_record', (record) => {


### PR DESCRIPTION
I forgot about the logging socket when I removed the manual reconnection of the HWR socket in https://github.com/mxcube/mxcubeweb/pull/1487/files#diff-e612f081728e8f03615f1629c341ca0bc439c53d5e8d0c2139594c60a2394430L109

The reasoning is the same: socket IO already provides an automatic reconnection mechanism (and it's much better, obviously). Also, our custom reconnection mechanism would spam the server in some cases, like when restarting the server. @elmjag can you please check if this is sufficient to address the issue from #1509? If not, please do share a repro so I can investigate further.