### PR TITLE
Hanling user "logged in" state in a more robust way in login_info

### DIFF
--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -264,10 +264,17 @@ class BaseUserManager(ComponentBase):
             self.app.server.emit("forceSignout", room=socketio_sid, namespace="/hwr")
 
     def login_info(self):
+        # update_operator will update the login status of current_user, and make
+        # sure that the is_anonymous has the correct value.
+        # Update operator calls lims.select_session that raises an exception if
+        # there are no valid LIMS sessions.
+        try:
+            self.update_operator()
+        except Exception:
+            pass
+
         if not current_user.is_anonymous:
             session_manager: LimsSessionManager = self.app.lims.get_session_manager()
-            self.update_operator()
-
             login_type = (
                 "User" if HWR.beamline.lims.is_user_login_type() else "Proposal"
             )

--- a/mxcubeweb/routes/main.py
+++ b/mxcubeweb/routes/main.py
@@ -63,11 +63,6 @@ def init_route(app, server, url_prefix):
 
     @server.flask.before_request
     def before_request():
-        # logging.getLogger("MX3.HWR").debug('Remote Addr: %s', request.remote_addr)
-        # logging.getLogger("MX3.HWR").debug('Path: %s', request.full_path)
-        # logging.getLogger("MX3.HWR").debug('scheme: %s', request.scheme)
-        # logging.getLogger("MX3.HWR").debug('Headers: %s', request.headers)
-
         if not flask_login.current_user.is_anonymous:
             flask_login.current_user.last_request_timestamp = datetime.now()
             app.usermanager.update_user(flask_login.current_user)
@@ -77,7 +72,7 @@ def init_route(app, server, url_prefix):
         tb = traceback.format_exc()
         timestamp = time.strftime("[%Y-%b-%d %H:%M]")
         logging.getLogger("MX3.HWR").debug(
-            "%s %s %s %s %s 5xx INTERNAL SERVER ERROR\n%s",
+            "%s %s %s %s %s 501 INTERNAL SERVER ERROR\n%s",
             timestamp,
             request.remote_addr,
             request.method,
@@ -86,6 +81,6 @@ def init_route(app, server, url_prefix):
             tb,
         )
 
-        return tb
+        return jsonify({"error": "Server error"}), 501
 
     return bp


### PR DESCRIPTION
The request to `login_info` raised an exception and incorrectly returned a stack trace with the 200 status code.

The handling within `login_info` is perhaps still not ideal but this PR makes sure that the `is_anonymous` on `current_user` is updated correctly before the code that returns the user information is called. The "event" of "no valid sessions" should probably not be seen as an exception.

All requests raising an exceptions now returns a 501 without the traceback

Fixes https://github.com/mxcube/mxcubeweb/issues/1477


