### PR TITLE
Log user out from UI on 401

### DIFF
--- a/ui/src/actions/beamline.js
+++ b/ui/src/actions/beamline.js
@@ -4,12 +4,6 @@ import {
   sendPrepareBeamlineForNewSample,
 } from '../api/beamline';
 import { sendLogFrontEndTraceBack } from '../api/log';
-// The different states a beamline attribute can assume.
-export const STATE = {
-  IDLE: 'READY',
-  BUSY: 'BUSY',
-  ABORT: 'UNUSABLE',
-};
 
 // Action types
 export const BL_UPDATE_HARDWARE_OBJECT = 'BL_UPDATE_HARDWARE_OBJECT';

--- a/ui/src/actions/login.js
+++ b/ui/src/actions/login.js
@@ -7,7 +7,8 @@ import { fetchAvailableWorkflows } from '../api/workflow';
 import { fetchAvailableTasks, fetchQueueState } from '../api/queue';
 
 import { showErrorPanel, applicationFetched } from './general';
-import { fetchLoginInfo, sendLogIn, sendSignOut } from '../api/login';
+import { sendSignOut } from '../api/login';
+import { fetchLoginInfo, sendLogIn } from '../api/loginBase';
 import { fetchDetectorInfo } from '../api/detector';
 import { fetchSampleChangerInitialState } from '../api/sampleChanger';
 import { fetchHarvesterInitialState } from '../api/harvester';
@@ -20,21 +21,6 @@ export function setLoginInfo(loginInfo) {
     type: 'SET_LOGIN_INFO',
     loginInfo,
   };
-}
-
-export function resetLoginInfo() {
-  return setLoginInfo({
-    beamlineName: '',
-    synchrotronName: '',
-    loginType: '',
-    user: '',
-    proposalList: [],
-    selectedProposal: '',
-    selectedProposalID: '',
-    loggedIn: false,
-    rootPath: '',
-    useSSO: false,
-  });
 }
 
 export function showProposalsForm() {
@@ -88,7 +74,7 @@ export function logIn(proposal, password) {
 
 export function signOut() {
   return async (dispatch) => {
-    dispatch(resetLoginInfo()); // disconnect sockets before actually logging out (cf. `App.jsx`)
+    dispatch(setLoginInfo({ loggedIn: false })); // disconnect sockets before actually logging out (cf. `App.jsx`)
     dispatch(applicationFetched(false));
 
     try {

--- a/ui/src/api/api.js
+++ b/ui/src/api/api.js
@@ -1,0 +1,16 @@
+/* eslint-disable promise/prefer-await-to-callbacks */
+import baseApi from './apiBase';
+import { fetchLoginInfo } from './loginBase';
+import { store } from '../store';
+
+const api = baseApi
+  .options({ credendials: 'include' })
+  .catcher(401, async (error) => {
+    // User got logged out somehow: refetch login info to update local state and redirect to login page.
+    // Don't use `getLoginInfo` action to avoid import cycle.
+    const loginInfo = await fetchLoginInfo();
+    store.dispatch({ type: 'SET_LOGIN_INFO', loginInfo });
+    throw error;
+  });
+
+export default api;

--- a/ui/src/api/apiBase.js
+++ b/ui/src/api/apiBase.js
@@ -1,9 +1,8 @@
 import wretch from 'wretch';
 import safeJsonAddon from './addons/safeJson';
 
-const api = wretch('/mxcube/api/v0.1')
+const baseApi = wretch('/mxcube/api/v0.1')
   .addon(safeJsonAddon())
-  .options({ credendials: 'include' })
   .headers({ Accept: 'application/json' });
 
-export default api;
+export default baseApi;

--- a/ui/src/api/beamline.js
+++ b/ui/src/api/beamline.js
@@ -1,4 +1,4 @@
-import api from '.';
+import api from './api';
 
 const endpoint = api.url('/beamline');
 

--- a/ui/src/api/detector.js
+++ b/ui/src/api/detector.js
@@ -1,4 +1,4 @@
-import api from '.';
+import api from './api';
 
 const endpoint = api.url('/detector');
 

--- a/ui/src/api/diffractometer.js
+++ b/ui/src/api/diffractometer.js
@@ -1,4 +1,4 @@
-import api from '.';
+import api from './api';
 
 const endpoint = api.url('/diffractometer');
 

--- a/ui/src/api/harvester.js
+++ b/ui/src/api/harvester.js
@@ -1,4 +1,4 @@
-import api from '.';
+import api from './api';
 
 const endpoint = api.url('/harvester');
 

--- a/ui/src/api/lims.js
+++ b/ui/src/api/lims.js
@@ -1,4 +1,4 @@
-import api from '.';
+import api from './api';
 
 const endpoint = api.url('/lims');
 

--- a/ui/src/api/log.js
+++ b/ui/src/api/log.js
@@ -1,4 +1,4 @@
-import api from '.';
+import api from './api';
 
 const endpoint = api.url('/log');
 

--- a/ui/src/api/login.js
+++ b/ui/src/api/login.js
@@ -1,17 +1,9 @@
-import api from '.';
+import api from './api';
 
 const endpoint = api.url('/login');
 
-export function sendLogIn(proposal, password, previousUser) {
-  return endpoint.post({ proposal, password, previousUser }, '/').safeJson();
-}
-
 export function sendSignOut() {
   return endpoint.headers({ Accept: '*/*' }).get('/signout').res();
-}
-
-export function fetchLoginInfo() {
-  return endpoint.get('/login_info').safeJson();
 }
 
 export function sendFeedback(sender, content) {

--- a/ui/src/api/loginBase.js
+++ b/ui/src/api/loginBase.js
@@ -1,0 +1,15 @@
+/**
+ * Unauthenticated `/login/*` endpoints.
+ * Separate from authenticated endpoints to avoid import cycle with `api.js`.
+ */
+import baseApi from './apiBase';
+
+const endpoint = baseApi.url('/login');
+
+export function sendLogIn(proposal, password, previousUser) {
+  return endpoint.post({ proposal, password, previousUser }, '/').safeJson();
+}
+
+export function fetchLoginInfo() {
+  return endpoint.get('/login_info').safeJson();
+}

--- a/ui/src/api/main.js
+++ b/ui/src/api/main.js
@@ -1,4 +1,4 @@
-import api from '.';
+import api from './api';
 
 export function fetchUIProperties() {
   return api.get('/uiproperties').safeJson();

--- a/ui/src/api/queue.js
+++ b/ui/src/api/queue.js
@@ -1,4 +1,4 @@
-import api from '.';
+import api from './api';
 
 const endpoint = api.url('/queue');
 

--- a/ui/src/api/remoteAccess.js
+++ b/ui/src/api/remoteAccess.js
@@ -1,4 +1,4 @@
-import api from '.';
+import api from './api';
 
 const endpoint = api.url('/ra');
 

--- a/ui/src/api/sampleChanger.js
+++ b/ui/src/api/sampleChanger.js
@@ -1,4 +1,4 @@
-import api from '.';
+import api from './api';
 
 const endpoint = api.url('/sample_changer');
 

--- a/ui/src/api/sampleview.js
+++ b/ui/src/api/sampleview.js
@@ -1,4 +1,4 @@
-import api from '.';
+import api from './api';
 
 const endpoint = api.url('/sampleview');
 

--- a/ui/src/api/workflow.js
+++ b/ui/src/api/workflow.js
@@ -1,4 +1,4 @@
-import api from '.';
+import api from './api';
 
 const endpoint = api.url('/workflow');
 

--- a/ui/src/reducers/beamline.js
+++ b/ui/src/reducers/beamline.js
@@ -1,6 +1,12 @@
 /* eslint-disable sonarjs/no-duplicate-string */
-import { STATE } from '../actions/beamline';
 import { RUNNING, HW_STATE } from '../constants';
+
+// The different states a beamline attribute can assume.
+export const STATE = {
+  IDLE: 'READY',
+  BUSY: 'BUSY',
+  ABORT: 'UNUSABLE',
+};
 
 /**
  *  Initial redux state for beamline hardwareObjects, object containing each beamline


### PR DESCRIPTION
Following https://github.com/mxcube/mxcubeweb/pull/1509#issuecomment-2548421307, I'm adding a global fetch error catcher to log the user out from the UI whenever they encounter a 401 response.

The challenge was dealing with import cycles... The global catcher is set on the wretch API object, which is used by all the endpoint functions, which are used by the Redux actions... I had to:

- register the 401 catcher on a separate wretch API object (in a dedicated file) specifically for authenticated endpoints;
- make sure that unauthenticated endpoint functions, including `/login_info`, made use of the base wretch API object (the one without the 401 catcher);
- make sure not to use the `getLoginInfo` action creator in the 401 catcher (otherwise, I would have had to move it into a separate file as well...)

Anyway, it was a bit of a mess, but I got there I think.

To test the behaviour, I recommend:

1. Commenting out the `forceSignout` socket event handler in `serverIO.js`
2. Logging in twice into the UI (e.g. normal and private window)
3. Logging the other user out and waiting for the `/refresh_session` or `/ra` endpoint to be called for that user

[Screencast from 2024-12-19 14-14-17.webm](https://github.com/user-attachments/assets/9fdc89ed-8cd1-4f35-a6e4-cb813e95b583)
