### PR TITLE
add visual cues for development environment

### DIFF
--- a/docs/source/dev/front-end.md
+++ b/docs/source/dev/front-end.md
@@ -17,9 +17,9 @@ The front-end package manager is [pnpm](https://pnpm.io/):
 
 [Vite](https://vitejs.dev/) is used to build the project for production:
 
-- `pnpm start` - start the development server at http://localhost:5173
+- `pnpm start` - start the development server at <http://localhost:5173>
 - `pnpm build` - build the front-end for production into the `ui/build` folder
-- `pnpm preview` - serve the production build at http://localhost:5173
+- `pnpm preview` - serve the production build at <http://localhost:5173>
 
 The codebase is formatted with Prettier, linted with ESLint and tested with Cypress:
 
@@ -74,3 +74,4 @@ Environment variables are defined in file `ui/.env`. To override them, create yo
 The following environment variables are available:
 
 - `VITE_REDUX_LOGGER_ENABLED`: whether to log Redux actions to the browser console (disabled by default); useful if you're unable to install the [Redux devtools](https://github.com/reduxjs/redux-devtools/tree/main/extension#installation) browser extension.
+- `VITE_BG_COLOR`: background color for the `body` tag. Useful for making a distinction between various deployment environments.

--- a/ui/.env
+++ b/ui/.env
@@ -6,3 +6,5 @@
 
 # Redux logger ('true' to enable)
 VITE_REDUX_LOGGER_ENABLED=
+# Background color for the <body> element.
+VITE_BG_COLOR="transparent"

--- a/ui/index.html
+++ b/ui/index.html
@@ -15,7 +15,7 @@
     <link rel="apple-touch-icon" href="/mxcube_logo20.png" />
     <link rel="manifest" href="/manifest.json" />
   </head>
-  <body>
+  <body style="background-color: %VITE_BG_COLOR%">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <script type="module" src="/src/index.jsx"></script>


### PR DESCRIPTION
Add MAXIV we want to easily distinguish between development, testing and production environments.
This PR does so, by changing background color of `body` depending on the selected environment. It is opt-in behaviour, which can be enabled by setting `VITE_DEV_MODE_VISUAL_CUES_ENABLED="true"` in `.env` file. 

As a small note about the environments in vite:
- `development` is set when running with `vite`
- `production` is set when application is built with `vite build`
- `staging` is set when application is built with `vite build --mode staging`
 
 