### PR TITLE
synch requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -578,9 +578,9 @@ importlib-resources==6.4.5 ; python_version >= "3.8" and python_version < "3.12"
 itsdangerous==2.2.0 ; python_version >= "3.8" and python_version < "3.12" \
     --hash=sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef \
     --hash=sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173
-jinja2==3.1.4 ; python_version >= "3.8" and python_version < "3.12" \
-    --hash=sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369 \
-    --hash=sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d
+jinja2==3.1.5 ; python_version >= "3.8" and python_version < "3.12" \
+    --hash=sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb \
+    --hash=sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb
 jsonpickle==2.2.0 ; python_version >= "3.8" and python_version < "3.12" \
     --hash=sha256:7b272918b0554182e53dc340ddd62d9b7f902fec7e7b05620c04f3ccef479a0e \
     --hash=sha256:de7f2613818aa4f234138ca11243d6359ff83ae528b2185efdd474f62bcf9ae1


### PR DESCRIPTION
This PR should synchronize the `requirements.txt` file with `pyproject.toml` again to prevent checks from not passing like for #1522 due to #1521 