### PR TITLE
Replace python-ldap with openldap in conda env

### DIFF
--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -1,24 +1,30 @@
+%YAML 1.2
+
 ---
+
 name: mxcubeweb
 
 channels:
   - conda-forge
 
 dependencies:
-  # ====================
+
   # Runtime dependencies
   # ====================
 
   - ffmpeg  # Not directly used by mxcube, but necessary for the video-streamer
   - python >=3.8,<3.12  # Make sure it matches `pyproject.toml`
 
-  # We install `python-ldap` from conda because it is "hard" to install.
-  # On PyPI it is not available as *wheel*, only as *sdist* which requires to be built
-  # with compilation steps that require a compiler and some header files.
-  # Installing with conda is much "easier".
-  - python-ldap ==3.4.3  # Make sure it matches `poetry.lock`
+  # `openldap` is necessary for `python-ldap` but can not be installed by pip or Poetry.
+  # Note also that on PyPI `python-ldap` is only available as *sdist*, not as *wheel*,
+  # and that installing it requires a compilation step.
+  # The `openldap` Conda package should provide enough for this compilation step
+  # (header files and things like this), but the C compiler itself.
+  # Make sure that a C compiler is available on the system,
+  # as it is NOT provided as a dependency in this Conda environment file.
+  - openldap
 
-  # ========================
+
   # Development dependencies
   # ========================
 


### PR DESCRIPTION
On PyPI, `python-ldap` is distributed as an *sdist* only, not *wheel*. But it still requires a compilation step before installation.

Some dependencies installed with conda are rightfully ignored by Poetry. Even when `python-ldap` is pre-installed by conda, Poetry would still need to reinstall it which implies compilation. Indeed there is an issue in how conda packages are created and how they are installed:
* <https://github.com/python-poetry/poetry/issues/6408#issuecomment-1237278487>
* <https://github.com/conda-forge/python-ldap-feedstock/issues/28>

So it does not make much sense to let conda install `python-ldap`. Instead we can instruct conda to install `openldap` only, and pip and Poetry should be able to compile `python-ldap`.

GitHub: https://github.com/mxcube/mxcubeweb/issues/1510
GitHub: https://github.com/mxcube/mxcubecore/pull/849#issuecomment-1956126473
GitHub: https://github.com/conda-forge/python-ldap-feedstock/issues/28
GitHub: https://github.com/mxcube/mxcubecore/pull/851