### PR TITLE
remove fixed column size for samples nav

### DIFF
--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -845,8 +845,8 @@ class SampleListViewContainer extends React.Component {
         ) : null}
         <Card className="samples-grid-table-card">
           <Card.Header className="samples-grid-table-card-header">
-            <Row className="samples-grid-table-row-header">
-              <Col sm={5} className="d-flex">
+            <Row className="gap-2">
+              <Col className="d-flex">
                 {this.getSynchronizationDropDownList()}
                 <span style={{ marginLeft: '1.5em' }} />
                 <Button
@@ -895,7 +895,7 @@ class SampleListViewContainer extends React.Component {
                   </Dropdown.Menu>
                 </Dropdown>
               </Col>
-              <Col sm={5} className="d-flex me-auto">
+              <Col className="d-flex me-auto">
                 <Form onSubmit={(evt) => evt.preventDefault()}>
                   <Form.Group as={Row} className="d-flex">
                     <Form.Label
@@ -942,7 +942,7 @@ class SampleListViewContainer extends React.Component {
                   Add Task to Samples <LuSettings2 />
                 </Button>
               </Col>
-              <Col className="d-flex justify-content-end" sm={2}>
+              <Col className="d-flex justify-content-end">
                 <span style={{ marginLeft: '1em' }} />
                 <QueueSettings />
                 <span style={{ marginLeft: '1em' }} />


### PR DESCRIPTION
In the `Samples` page, the column sizes of the top row including the filter and some buttons are fixed, which causes the different elements to overlap and sometimes hide features on smaller screens. 

This PR removes the fixed sizes, you can see the differences below for different screen sizes
Before:
![Screenshot from 2025-01-23 15-05-48](https://github.com/user-attachments/assets/f3b39f03-1d5f-4b59-8736-88987dead786)

![Screenshot from 2025-01-23 15-06-10](https://github.com/user-attachments/assets/84b69379-1c28-45bd-a22c-5722551e5f38)

![Screenshot from 2025-01-23 15-07-06](https://github.com/user-attachments/assets/4b698b1d-1da5-404c-a64c-528f22db9a41)

Now:

![Screenshot from 2025-01-23 15-02-46](https://github.com/user-attachments/assets/a05bdc24-2546-429e-b8c6-d1304a75544b)

![Screenshot from 2025-01-23 15-06-33](https://github.com/user-attachments/assets/d53b0daf-af91-479d-a57f-cf6e49103b50)

![Screenshot from 2025-01-23 15-06-49](https://github.com/user-attachments/assets/dc0cf3f5-5f37-41db-a5b0-87a0b7441a94)
