### PR TITLE
remove duplicate LIMS call when setting active session

### DIFF
--- a/mxcubeweb/core/components/lims.py
+++ b/mxcubeweb/core/components/lims.py
@@ -188,7 +188,6 @@ class Lims(ComponentBase):
 
         # Selecting the active session in the LIMS object
         try:
-            HWR.beamline.lims.set_active_session_by_id(session_id)
             session = HWR.beamline.lims.set_active_session_by_id(session_id)
             if session is None:
                 raise "No session selected on LIMS"


### PR DESCRIPTION
No need to call set_active_session_by_id() twice on a LIMS object.