### PR TITLE
Remove "REST API" section of the docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
           - --strict
 
   - repo: https://github.com/python-poetry/poetry
-    rev: 1.8.3
+    rev: 1.8.5
     hooks:
 
       # Equivalent to running `poetry check --lock`.

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,7 +20,7 @@ build:
     # See "Caveats" at <https://pypi.org/project/sphinx-last-updated-by-git/>
     - "git fetch --unshallow || true"
     - "mamba env create --file conda-environment.yml --force"
-    - "mamba run --name mxcubeweb poetry install --only=docs,main"
+    - "mamba run --name mxcubeweb poetry -vvv install --only=docs,main"
     # yamllint disable-line rule:line-length
     - "mamba run --name mxcubeweb python -m sphinx -T -E -b html -d _build/doctrees -c docs docs/source ${READTHEDOCS_OUTPUT}/html"
 

--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -12,7 +12,7 @@ dependencies:
   # Runtime dependencies
   # ====================
 
-  - ffmpeg  # Not directly used by mxcube, but necessary for the video-streamer
+  # TODO - ffmpeg  # Not directly used by mxcube, but necessary for the video-streamer
   - python >=3.8,<3.12  # Make sure it matches `pyproject.toml`
 
   # `openldap` is necessary for `python-ldap` but can not be installed by pip or Poetry.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,12 +115,6 @@ extensions.append("sphinx.ext.napoleon")
 extensions.append("sphinx.ext.viewcode")
 
 
-# -- sphinxcontrib.autohttp.flask
-# https://sphinxcontrib-httpdomain.readthedocs.io
-
-extensions.append("sphinxcontrib.autohttp.flask")
-
-
 # -- Options for sphinx_last_updated_by_git
 # https://pypi.org/project/sphinx-last-updated-by-git/
 

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -11,5 +11,4 @@ Contents:
     index.md
     config/index
     dev/index
-    rest-api/index
     *

--- a/docs/source/rest-api/beamline.rst
+++ b/docs/source/rest-api/beamline.rst
@@ -1,6 +1,0 @@
-*****************
-Beamline REST API
-*****************
-
-.. autoflask:: mxcubeweb:server.flask
-    :blueprints: beamline

--- a/docs/source/rest-api/detector.rst
+++ b/docs/source/rest-api/detector.rst
@@ -1,6 +1,0 @@
-*****************
-Detector REST API
-*****************
-
-.. autoflask:: mxcubeweb:server.flask
-    :blueprints: detector

--- a/docs/source/rest-api/diffractometer.rst
+++ b/docs/source/rest-api/diffractometer.rst
@@ -1,6 +1,0 @@
-***********************
-Diffractometer REST API
-***********************
-
-.. autoflask:: mxcubeweb:server.flask
-    :blueprints: diffractometer

--- a/docs/source/rest-api/index.rst
+++ b/docs/source/rest-api/index.rst
@@ -1,9 +1,0 @@
-########
-REST API
-########
-
-.. toctree::
-    :glob:
-    :titlesonly:
-
-    *

--- a/docs/source/rest-api/lims.rst
+++ b/docs/source/rest-api/lims.rst
@@ -1,6 +1,0 @@
-*************
-LIMS REST API
-*************
-
-.. autoflask:: mxcubeweb:server.flask
-    :blueprints: lims

--- a/docs/source/rest-api/login.rst
+++ b/docs/source/rest-api/login.rst
@@ -1,6 +1,0 @@
-**************
-Login REST API
-**************
-
-.. autoflask:: mxcubeweb:server.flask
-    :blueprints: login

--- a/docs/source/rest-api/queue.rst
+++ b/docs/source/rest-api/queue.rst
@@ -1,6 +1,0 @@
-**************
-Queue REST API
-**************
-
-.. autoflask:: mxcubeweb:server.flask
-    :blueprints: queue

--- a/docs/source/rest-api/remote-access.rst
+++ b/docs/source/rest-api/remote-access.rst
@@ -1,6 +1,0 @@
-**********************
-Remote access REST API
-**********************
-
-.. autoflask:: mxcubeweb:server.flask
-    :blueprints: remote_access

--- a/docs/source/rest-api/sample-view.rst
+++ b/docs/source/rest-api/sample-view.rst
@@ -1,6 +1,0 @@
-********************
-Sample view REST API
-********************
-
-.. autoflask:: mxcubeweb:server.flask
-    :blueprints: sampleview

--- a/poetry.lock
+++ b/poetry.lock
@@ -3333,21 +3333,6 @@ lint = ["docutils-stubs", "flake8", "mypy"]
 test = ["html5lib", "pytest"]
 
 [[package]]
-name = "sphinxcontrib-httpdomain"
-version = "1.8.1"
-description = "Sphinx domain for documenting HTTP APIs"
-optional = false
-python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
-files = [
-    {file = "sphinxcontrib-httpdomain-1.8.1.tar.gz", hash = "sha256:6c2dfe6ca282d75f66df333869bb0ce7331c01b475db6809ff9d107b7cdfe04b"},
-    {file = "sphinxcontrib_httpdomain-1.8.1-py2.py3-none-any.whl", hash = "sha256:21eefe1270e4d9de8d717cc89ee92cc4871b8736774393bafc5e38a6bb77b1d5"},
-]
-
-[package.dependencies]
-six = "*"
-Sphinx = ">=1.6"
-
-[[package]]
 name = "sphinxcontrib-jsmath"
 version = "1.0.1"
 description = "A sphinx extension which renders display math in HTML via JavaScript"
@@ -3857,4 +3842,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "6db4b366f0622da3780d42993ddaaff256fca31f2e93954e5867ac27f05b1043"
+content-hash = "7773711ab8a99269be2d1d09aecf3c409a9ead96cfc2e956ffdb75c7cc83ddf7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ furo = "^2023.9.10"
 myst-parser = "^2.0.0"
 sphinx = "<7.2"
 sphinx-last-updated-by-git = "^0.3.7"
-sphinxcontrib-httpdomain = "^1.8.1"
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
Likely this section of the documentation is never looked up. On the other hand it is resource intensive to generate these pages.

GitHub: https://github.com/mxcube/mxcubeweb/issues/1519