### PR TITLE
Updates to UserManager related to LIMS session handling

### DIFF
--- a/mxcubeweb/core/components/lims.py
+++ b/mxcubeweb/core/components/lims.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import json
 import logging
 import math
 import re
@@ -167,7 +166,7 @@ class Lims(ComponentBase):
         return prefix
 
     def get_session_manager(self) -> LimsSessionManager:
-        return LimsSessionManager.parse_obj(json.loads(current_user.limsdata))
+        return HWR.beamline.lims.session_manager
 
     def is_rescheduled_session(self, session):
         """

--- a/mxcubeweb/core/components/lims.py
+++ b/mxcubeweb/core/components/lims.py
@@ -267,9 +267,7 @@ class Lims(ComponentBase):
 
     def synch_with_lims(self, lims_name):
         self.app.queue.queue_clear()
-
-        # session_id is not used, so we can pass None as second argument to
-        # 'db_connection.get_samples'
+        self.app.sample_changer.get_sample_list()
 
         samples_info_list = HWR.beamline.lims.get_samples(lims_name)
         for sample_info in samples_info_list:

--- a/mxcubeweb/core/components/lims.py
+++ b/mxcubeweb/core/components/lims.py
@@ -267,6 +267,8 @@ class Lims(ComponentBase):
         return HWR.beamline.session.get_default_subdir(sample_data)
 
     def synch_with_lims(self, lims_name):
+        self.app.queue.queue_clear()
+
         # session_id is not used, so we can pass None as second argument to
         # 'db_connection.get_samples'
 

--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -41,6 +41,7 @@ class BaseUserManager(ComponentBase):
 
     def handle_sessions_changed(self, sessions):
         self.app.server.emit("sessionsChanged", namespace="/hwr")
+
     def get_observers(self):
         return [
             user
@@ -105,7 +106,9 @@ class BaseUserManager(ComponentBase):
                 logging.getLogger("HWR.MX3").info(
                     f"Logged out inactive user {_u.username}"
                 )
-                self.app.server.user_datastore.deactivate_user(_u)
+                self.app.server.user_datastore.delete_user(_u)
+                self.app.server.user_datastore.commit()
+
                 self.app.server.emit(
                     "userChanged", room=_u.socketio_session_id, namespace="/hwr"
                 )
@@ -251,7 +254,8 @@ class BaseUserManager(ComponentBase):
             msg = "User %s signed out" % user.username
             logging.getLogger("MX3.HWR").info(msg)
 
-        self.app.server.user_datastore.deactivate_user(user)
+        self.app.server.user_datastore.delete_user(user)
+        self.app.server.user_datastore.commit()
         flask_security.logout_user()
 
         self.app.server.emit("observersChanged", namespace="/hwr")

--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -419,6 +419,7 @@ class UserManager(BaseUserManager):
             "_login. proposal_tuple retrieved. Sessions=%s "
             % str(len(session_manager.sessions))
         )
+
         inhouse = self.is_inhouse_user(login_id)
 
         active_users = self.active_logged_in_users()
@@ -466,6 +467,7 @@ class UserManager(BaseUserManager):
     def _signout(self, sso_data={}):
         if self.app.CONFIG.sso.LOGOUT_URI:
             if not current_user.is_anonymous:
+                HWR.beamline.lims.remove_user(current_user.username)
                 refresh_token = current_user.refresh_token
             else:
                 refresh_token = sso_data.get("refresh_token", None)

--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -450,23 +450,6 @@ class UserManager(BaseUserManager):
         if inhouse and not (inhouse and is_local_host()):
             raise Exception("In-house only allowed from localhost")
 
-        # # Only allow other users to log-in if they are from the same proposal
-        # if (
-        #     active_users
-        #     and (login_id not in [p.split("-")[0] for p in active_users])
-        #     and not HWR.beamline.lims.is_user_login_type()
-        # ):
-        #     raise Exception("Another user is already logged in")
-
-        # # Only allow if no one else is logged in
-        # if not current_user.is_anonymous:
-        #     if (
-        #         active_users
-        #         and current_user.username != login_id
-        #         and HWR.beamline.lims.is_user_login_type()
-        #     ):
-        #         raise Exception("Another user is already logged in")
-
         # Only allow local login when remote is disabled
         if not self.app.ALLOW_REMOTE and not is_local_host():
             raise Exception("Remote access disabled")

--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -456,7 +456,9 @@ class UserManager(BaseUserManager):
 
         return session_manager
 
-    def _signout(self, sso_data={}):
+    def _signout(self, sso_data=None):
+        sso_data = sso_data or {}
+
         if self.app.CONFIG.sso.LOGOUT_URI:
             if not current_user.is_anonymous:
                 HWR.beamline.lims.remove_user(current_user.username)

--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -285,6 +285,15 @@ class BaseUserManager(ComponentBase):
 
         if not current_user.is_anonymous:
             session_manager: LimsSessionManager = self.app.lims.get_session_manager()
+
+            # If no previous session selected and a single session available
+            # then it selects automatically the session
+            if (
+                current_user.selected_proposal is None
+                and session_manager.active_session is not None
+            ):
+                self.app.lims.select_session(session_manager.active_session.session_id)
+
             login_type = (
                 "User" if HWR.beamline.lims.is_user_login_type() else "Proposal"
             )

--- a/mxcubeweb/routes/lims.py
+++ b/mxcubeweb/routes/lims.py
@@ -52,6 +52,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
         # proposal_number is the session identifier
         session_id = request.get_json().get("proposal_number", None)
         app.lims.select_session(session_id)
+        app.usermanager.update_active_users()
 
         return Response(status=200)
 

--- a/ui/src/components/LoginForm/SelectProposal.jsx
+++ b/ui/src/components/LoginForm/SelectProposal.jsx
@@ -41,9 +41,11 @@ function SelectProposal() {
     (s) => s.is_scheduled_beamline && s.is_scheduled_time,
   );
   const unscheduledSessions = filteredSessions.filter(
-    (s) => !s.is_scheduled_beamline || !s.is_scheduled_time,
+    (s) => s.is_scheduled_beamline && !s.is_scheduled_time,
   );
-
+  const otherBeamlineSessions = filteredSessions.filter(
+    (s) => !s.is_scheduled_beamline && s.is_scheduled_time,
+  );
   function handleHide() {
     if (selectedProposalID === null) {
       dispatch(signOut());
@@ -96,6 +98,19 @@ function SelectProposal() {
               <SessionTable
                 showBeamline
                 sessions={unscheduledSessions}
+                selectedSessionId={selectedSessionId}
+                onSessionSelected={setSelectedSession}
+              />
+            </div>
+          </Tab>
+          <Tab
+            eventKey="other-unscheduled"
+            title={`Other beamlines (${otherBeamlineSessions.length})`}
+          >
+            <div className={styles.table}>
+              <SessionTable
+                showBeamline
+                sessions={otherBeamlineSessions}
                 selectedSessionId={selectedSessionId}
                 onSessionSelected={setSelectedSession}
               />

--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -370,6 +370,10 @@ class ServerIO {
       dispatch(signOut());
     });
 
+    this.hwrSocket.on('sessionsChanged', () => {
+      dispatch(getLoginInfo());
+    });
+
     this.hwrSocket.on('workflowParametersDialog', (data) => {
       if (data) {
         dispatch(showWorkflowParametersDialog(data, true));


### PR DESCRIPTION
Updates to UserManager related to LIMS session handling:

  -  Not storing LIMS data in the user database
  -  Consistent handling of "force signout" and "signout" using `delete_user` in both cases
  -  Session handling; updating session list on change, automatically selecting session if there is only one available
  -  Added separate tab for sessions from other beamlines