### PR TITLE
[BEAM SIZE] - Label is a string

### DIFF
--- a/mxcubeweb/routes/signals.py
+++ b/mxcubeweb/routes/signals.py
@@ -613,7 +613,7 @@ def beam_changed(*args, **kwargs):
         "shape": "",
         "size_x": 0,
         "size_y": 0,
-        "label": 0,
+        "label": "",
     }
     _beam = beam_info.get_value()
     beam_info_dict.update(


### PR DESCRIPTION
The label of the beam size is a string defaulting it to 0 (int) causes a validation error