### PR TITLE
 Resetting queue and sample list when session changes

### DIFF
--- a/mxcubeweb/core/components/lims.py
+++ b/mxcubeweb/core/components/lims.py
@@ -219,12 +219,9 @@ class Lims(ComponentBase):
             # Re-initialize the samplelist
             self.app.lims.init_sample_list()
 
-            # If a sample is mounted (and not already marked as such),
-            # get sample changer contents and add mounted sample to the queue
-            address = self.app.sample_changer.get_loaded_sample()
-            if not self.app.sample_changer.get_current_sample() and address:
-                self.app.sample_changer.get_sample_list()
-                self.app.server.emit("update_queue", {}, namespace="/hwr")
+            # Get sample list and send update to client
+            self.app.sample_changer.get_sample_list()
+            self.app.server.emit("update_queue", {}, namespace="/hwr")
 
             HWR.beamline.session.proposal_code = session.code
             HWR.beamline.session.proposal_number = session.number

--- a/mxcubeweb/core/components/lims.py
+++ b/mxcubeweb/core/components/lims.py
@@ -206,6 +206,7 @@ class Lims(ComponentBase):
                 )
 
         if HWR.beamline.session.session_id != HWR.beamline.lims.get_session_id():
+            # ruff: noqa: G004
             logging.getLogger("MX3.HWR").info(
                 f"[LIMS] New session, clearing queue and sample list for {session.code}{session.number}"
             )

--- a/mxcubeweb/core/components/lims.py
+++ b/mxcubeweb/core/components/lims.py
@@ -210,7 +210,7 @@ class Lims(ComponentBase):
                 f"[LIMS] New session, clearing queue and sample list for {session.code}{session.number}"
             )
 
-            # Clear data collection queue
+            # Clear data collection queue (HardwareObject)
             self.app.queue.clear_queue()
 
             # Remove any items on the sample view (shapes)

--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -234,16 +234,16 @@ class BaseUserManager(ComponentBase):
 
         # If operator logs out clear queue and sample list
         if self.is_operator():
-            self.app.queue.clear_queue()
-            HWR.beamline.sample_view.clear_all()
-            self.app.lims.init_sample_list()
+            # self.app.queue.clear_queue()
+            # HWR.beamline.sample_view.clear_all()
+            # self.app.lims.init_sample_list()
 
-            self.app.queue.init_queue_settings()
+            # self.app.queue.init_queue_settings()
 
             if hasattr(HWR.beamline.session, "clear_session"):
                 HWR.beamline.session.clear_session()
 
-            self.app.CURRENTLY_MOUNTED_SAMPLE = ""
+            # self.app.CURRENTLY_MOUNTED_SAMPLE = ""
 
             self.db_set_in_control(current_user, False)
 

--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -211,14 +211,6 @@ class BaseUserManager(ComponentBase):
 
             # Important to make flask_security user tracking work
             self.app.server.security.datastore.commit()
-
-            address = self.app.sample_changer.get_loaded_sample()
-
-            # If A sample is mounted (and not already marked as such),
-            # get sample changer contents and add mounted sample to the queue
-            if not self.app.sample_changer.get_current_sample() and address:
-                self.app.sample_changer.get_sample_list()
-
             self.update_operator(new_login=True)
 
             msg = "User %s signed in" % user.username
@@ -234,16 +226,8 @@ class BaseUserManager(ComponentBase):
 
         # If operator logs out clear queue and sample list
         if self.is_operator():
-            # self.app.queue.clear_queue()
-            # HWR.beamline.sample_view.clear_all()
-            # self.app.lims.init_sample_list()
-
-            # self.app.queue.init_queue_settings()
-
             if hasattr(HWR.beamline.session, "clear_session"):
                 HWR.beamline.session.clear_session()
-
-            # self.app.CURRENTLY_MOUNTED_SAMPLE = ""
 
             self.db_set_in_control(current_user, False)
 

--- a/ui/cypress/e2e/queue.cy.js
+++ b/ui/cypress/e2e/queue.cy.js
@@ -12,17 +12,13 @@ describe('queue', () => {
     );
   });
 
-  it('unmount sample and clear queue on log out', () => {
+  it('queue is not cleard and sample not un-mounted on logout', () => {
     cy.mountSample('foo', 'bar');
     cy.findByRole('button', { name: 'Sample: bar - foo' }).should('be.visible');
 
     cy.findByRole('button', { name: /Sign out/u, hidden: true }).click();
     cy.login();
 
-    cy.findByRole('button', { name: 'Sample: bar - foo' }).should('not.exist');
-    cy.findByRole('button', { name: 'Current' }).should('be.visible');
-    cy.findByRole('button', { name: 'Queued Samples (0)' }).should(
-      'be.visible',
-    );
+    cy.findByRole('button', { name: 'Sample: bar - foo' }).should('be.visible');
   });
 });

--- a/ui/src/actions/sampleChanger.js
+++ b/ui/src/actions/sampleChanger.js
@@ -27,10 +27,6 @@ export function setSCGlobalState(data) {
   return { type: 'SET_SC_GLOBAL_STATE', data };
 }
 
-export function updateSCContents(data) {
-  return { type: 'UPDATE_SC_CONTENTS', data };
-}
-
 export function setCurrentPlate(plate_index) {
   return { type: 'SET_SC_CURRENT_PLATE', plate_index };
 }

--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -53,7 +53,6 @@ import {
   setSCState,
   setLoadedSample,
   setSCGlobalState,
-  updateSCContents,
 } from './actions/sampleChanger';
 
 import {
@@ -414,8 +413,8 @@ class ServerIO {
       dispatch(setSCGlobalState(data));
     });
 
-    this.hwrSocket.on('sc_contents_update', () => {
-      dispatch(updateSCContents());
+    this.hwrSocket.on('update_queue', () => {
+      dispatch(getQueue());
     });
 
     this.hwrSocket.on('diff_phase_changed', (data) => {


### PR DESCRIPTION
Resetting queue and sample list when session changes. The recent changes triggered some logic that cleared the queue when the user in-control logs out. This scenario happened very rarely in the past as control was passed automatically and the beamline instance always was running, and this logic was simply not executed.

Control is no longer passed automatically and we don't any longer have any requirement on having a MXCuBE web client open to run the core of the application.