### PR TITLE
Fix project metadata URLs in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ maintainers = [
     {name = "The MXCuBE collaboration", email = "mxcube@esrf.fr"},
 ]
 readme = "README.md"
-url.homepage = "https://github.com/mxcube/mxcubeweb"
-url.repository = "https://github.com/mxcube/mxcubeweb"
-url.documentation = "https://mxcubeweb.readthedocs.io/"
+urls.homepage = "https://github.com/mxcube/mxcubeweb"
+urls.repository = "https://github.com/mxcube/mxcubeweb"
+urls.documentation = "https://mxcubeweb.readthedocs.io/"
 keywords = ["mxcube", "mxcube3", "mxcubeweb"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/requirements.txt
+++ b/requirements.txt
@@ -334,7 +334,7 @@ dnspython==2.6.1 ; python_version >= "3.10" and python_version < "3.12" \
 email-validator==2.2.0 ; python_version >= "3.10" and python_version < "3.12" \
     --hash=sha256:561977c2d73ce3611850a06fa56b414621e0c8faa9d66f2611407d87465da631 \
     --hash=sha256:cb690f344c617a714f22e66ae771445a1ceb46821152df8e165c5f9a364582b7
-exceptiongroup==1.2.2 ; python_version >= "3.10" and python_version < "3.11" \
+exceptiongroup==1.2.2 ; python_version == "3.10" \
     --hash=sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b \
     --hash=sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc
 f90nml==1.4.3 ; python_version >= "3.10" and python_version < "3.12" \


### PR DESCRIPTION
This error was introduced in the following commit: 8bf09ef539ae282a6054aa7949c9f6d48c25f8d5

GitHub: related to https://github.com/mxcube/mxcubeweb/pull/1550