### PR TITLE
Now sends loginType to anonymous users in login_info

### DIFF
--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -279,10 +279,16 @@ class BaseUserManager(ComponentBase):
         except Exception:
             pass
 
+        login_type = "User" if HWR.beamline.lims.is_user_login_type() else "Proposal"
+
         if current_user.is_anonymous:
             self._signout()
             logging.getLogger("MX3.HWR").info("Logged out")
-            res = {"loggedIn": False, "useSSO": self.app.CONFIG.sso.USE_SSO}
+            return {
+                "loggedIn": False,
+                "useSSO": self.app.CONFIG.sso.USE_SSO,
+                "loginType": login_type,
+            }
 
         session_manager: LimsSessionManager = self.app.lims.get_session_manager()
 
@@ -293,8 +299,6 @@ class BaseUserManager(ComponentBase):
             and session_manager.active_session is not None
         ):
             self.app.lims.select_session(session_manager.active_session.session_id)
-
-        login_type = "User" if HWR.beamline.lims.is_user_login_type() else "Proposal"
 
         res = {
             "synchrotronName": HWR.beamline.session.synchrotron_name,

--- a/ui/src/components/LoginForm/LoginForm.jsx
+++ b/ui/src/components/LoginForm/LoginForm.jsx
@@ -11,6 +11,19 @@ import { logIn } from '../../actions/login';
 
 const SSO_PATH = '/mxcube/api/v0.1/login/ssologin';
 
+/**
+ * @param loginType {'User' | 'Proposal'} - login type; 'User' for User-type login, 'Proposal' otherwise.
+ * @param useSSO {boolean} - true if SSO is enabled
+ *
+ * @returns {string} - text used in the sign-in button
+ */
+function getSignInText(useSSO, loginType) {
+  if (useSSO) {
+    return 'Sign in with SSO';
+  }
+  return loginType === 'User' ? 'Sign in' : 'Sign in with proposal';
+}
+
 function LoginForm() {
   const dispatch = useDispatch();
 
@@ -26,6 +39,8 @@ function LoginForm() {
   } = useForm({ defaultValues: { username: '', password: '' } });
 
   const useSSO = useSelector((state) => state.login.useSSO);
+  const loginType = useSelector((state) => state.login.loginType);
+  const signInText = getSignInText(useSSO, loginType);
 
   async function handleSubmit(data) {
     if (useSSO) {
@@ -116,7 +131,7 @@ function LoginForm() {
           {loading && (
             <img className={styles.loader} src={loader} width="25" alt="" />
           )}
-          Sign in with {useSSO ? 'SSO' : 'proposal'}
+          {signInText}
         </Button>
 
         {!loading && showErrorPanel && (


### PR DESCRIPTION
At MAX IV we don't use proposal-based login nor SSO. This PR makes it so, that in the case of user log in appropriate text shows up ("Sign in").

Also did small cleanup to `UserManager.login_info` - now uses early return.