### PR TITLE
Refactoring usermanager.py

### DIFF
--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -21,20 +21,21 @@ from mxcubeweb.core.util.networkutils import is_local_host
 
 class BaseUserManager(ComponentBase):
     """Base class for managing user-related operations
-     
-    Operation it manages are: authentication, session management, and Single Sign-On 
-    (SSO) integration. It provides methods to handle user login, logout, session 
+
+    Operation it manages are: authentication, session management, and Single Sign-On
+    (SSO) integration. It provides methods to handle user login, logout, session
     updates, and role assignments. The class also includes functionality to manage
     active users, set operators, and validate SSO tokens. It is designed to be extended
     by more specific user manager implementations.
 
     Attributes:
-        app: The application instance used to access various components and 
+        app: The application instance used to access various components and
             configurations such as the Flask server instance and the configuration
             settings.
-        config: The configuration settings for the user manager, contains information 
+        config: The configuration settings for the user manager, contains information
             such as SSO client ID, client secret, and metadata URI..
     """
+
     def __init__(self, app, config):
         super().__init__(app, config)
         HWR.beamline.lims.connect("sessionsChanged", self.handle_sessions_changed)
@@ -507,14 +508,15 @@ class BaseUserManager(ComponentBase):
 
 
 class UserManager(BaseUserManager):
-    """Class to provide specific implementations for user login and signout operations. 
-    
+    """Class to provide specific implementations for user login and signout operations.
+
     It includes methods to handle login conditions such as checking if the user is
     active, anonymous, in-house, or accessing locally/remotely. The class also ensures
-    that only one user can be logged in at a time and restricts in-house logins 
-    to local hosts. Additionally, it handles Single Sign-On (SSO) logout by making 
+    that only one user can be logged in at a time and restricts in-house logins
+    to local hosts. Additionally, it handles Single Sign-On (SSO) logout by making
     a request to the configured SSO logout URI.
     """
+
     def __init__(self, app, config):
         super().__init__(app, config)
 
@@ -561,7 +563,8 @@ class UserManager(BaseUserManager):
 
         # Only allow in-house log-in from local host
         if self.is_inhouse_user(login_id) and not is_local_host():
-            raise Exception("In-house only allowed from localhost")
+            msg = "In-house only allowed from localhost"
+            raise Exception(msg)
 
         # Only allow local login when remote is disabled
         if not self.app.ALLOW_REMOTE and not is_local_host():

--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -20,6 +20,21 @@ from mxcubeweb.core.util.networkutils import is_local_host
 
 
 class BaseUserManager(ComponentBase):
+    """Base class for managing user-related operations
+     
+    Operation it manages are: authentication, session management, and Single Sign-On 
+    (SSO) integration. It provides methods to handle user login, logout, session 
+    updates, and role assignments. The class also includes functionality to manage
+    active users, set operators, and validate SSO tokens. It is designed to be extended
+    by more specific user manager implementations.
+
+    Attributes:
+        app: The application instance used to access various components and 
+            configurations such as the Flask server instance and the configuration
+            settings.
+        config: The configuration settings for the user manager, contains information 
+            such as SSO client ID, client secret, and metadata URI..
+    """
     def __init__(self, app, config):
         super().__init__(app, config)
         HWR.beamline.lims.connect("sessionsChanged", self.handle_sessions_changed)
@@ -492,6 +507,14 @@ class BaseUserManager(ComponentBase):
 
 
 class UserManager(BaseUserManager):
+    """Class to provide specific implementations for user login and signout operations. 
+    
+    It includes methods to handle login conditions such as checking if the user is
+    active, anonymous, in-house, or accessing locally/remotely. The class also ensures
+    that only one user can be logged in at a time and restricts in-house logins 
+    to local hosts. Additionally, it handles Single Sign-On (SSO) logout by making 
+    a request to the configured SSO logout URI.
+    """
     def __init__(self, app, config):
         super().__init__(app, config)
 

--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -107,10 +107,10 @@ class BaseUserManager(ComponentBase):
         return user
 
     def update_active_users(self) -> None:
-        """
-        Check if any user have been inactive for a period longer than the
-        session lifetime. If so, deactivate the user in datastore and emit
-        the relvant signals `userChanged` and `observersChanged` to the client.
+        """Check if any user have been inactive for longer than session lifetime.
+
+        If so, deactivate the user in datastore and emit the relvant signals 
+        ``userChanged`` and ``observersChanged`` to the client.
         """
         for _u in User.query.all():
             if (
@@ -178,10 +178,13 @@ class BaseUserManager(ComponentBase):
                         self.app.lims.select_session(_u.selected_proposal)
 
     def is_inhouse_user(self, user_id: str) -> bool:
-        """Retrun True if the user_id is in the in-house user list.
+        """Check if the ``user_id`` is in the in-house user list.
 
         Attributes:
             user_id: user id composed from code and number.
+
+        Returns:
+            ``True`` if ``user_id`` is in the in-house user list, ``False`` otherwise.
         """
         user_id_list = [
             "%s%s" % (code, number)
@@ -223,14 +226,15 @@ class BaseUserManager(ComponentBase):
             self.signout()
 
     def login(self, login_id: str, password: str, sso_data: dict = {}) -> None:
-        """
+        """Login the user.
+
         Create new session for the user if it does not exist. Activate user in
         data store. If a sample is loaded in sample changer but not mounted,
         mount it and update the smaple list. Try update the operator.
 
         Attributes:
-            login_id: username.
-            password: password.
+            login_id: The username.
+            password: The password.
         """
         try:
             self._login(login_id, password)
@@ -288,7 +292,11 @@ class BaseUserManager(ComponentBase):
         self.app.server.emit("observersChanged", namespace="/hwr")
 
     def is_authenticated(self) -> bool:
-        """Return True whether the current user is authenticated."""
+        """Check if the current user is authenticated.
+        
+        Returns:
+            ``True`` if the current user is authenticated.
+        """
         return current_user.is_authenticated()
 
     def force_signout_user(self, username: str) -> None:
@@ -307,12 +315,17 @@ class BaseUserManager(ComponentBase):
             self.app.server.emit("forceSignout", room=socketio_sid, namespace="/hwr")
 
     def login_info(self) -> dict:
-        """
-        Login information to be displayed in the application such as: synchrotron and
-        beamline names, user infromation, proposals list, selected proposal etc.
+        """Get the login information to be displayed in the application.
+
+        Login information to be displayed in the application such as: 
+        * synchrotron and beamline names
+        * user infromation
+        * proposals list
+        * selected proposal
+        * and so on
 
         Returns:
-            dictionary with login information.
+            Dictionary with login information.
         """
         # update_operator will update the login status of current_user, and make
         # sure that the is_anonymous has the correct value.

--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -256,6 +256,7 @@ class BaseUserManager(ComponentBase):
         Args:
             login_id: The username.
             password: The password.
+            sso_data: Dictionary containing information from the SSO service used.
         """
         try:
             self._login(login_id, password)
@@ -438,7 +439,7 @@ class BaseUserManager(ComponentBase):
             user: representation of username (eventually part of it).
                 Also a nickname for new users.
             password: password (unused).
-            sso_data: dictionary with the lims data to be updated.
+            sso_data: dictionary containing information from the SSO service used.
 
         Returns:
             User model instance existing in or added to datastore.

--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -109,7 +109,7 @@ class BaseUserManager(ComponentBase):
     def update_active_users(self) -> None:
         """Check if any user have been inactive for longer than session lifetime.
 
-        If so, deactivate the user in datastore and emit the relvant signals 
+        If so, deactivate the user in datastore and emit the relvant signals
         ``userChanged`` and ``observersChanged`` to the client.
         """
         for _u in User.query.all():
@@ -132,10 +132,10 @@ class BaseUserManager(ComponentBase):
         self.app.server.emit("observersChanged", namespace="/hwr")
 
     def update_operator(self, new_login: bool = False) -> None:
-        """
-        Set the operator based on the logged in users. If no user is currently
-        in control, the first logged in user is set. Additionally, proposal
-        is set based on the operator selected_proposal field.
+        """Sets the operator based on the logged in users.
+
+        If no user is currently in control, the first logged in user is set.
+        Additionally, proposal is set based on the operator selected_proposal field.
 
         Attributes:
             new_login: True if method was invoked with new user login.
@@ -293,7 +293,7 @@ class BaseUserManager(ComponentBase):
 
     def is_authenticated(self) -> bool:
         """Check if the current user is authenticated.
-        
+
         Returns:
             ``True`` if the current user is authenticated.
         """
@@ -317,7 +317,7 @@ class BaseUserManager(ComponentBase):
     def login_info(self) -> dict:
         """Get the login information to be displayed in the application.
 
-        Login information to be displayed in the application such as: 
+        Login information to be displayed in the application such as:
         * synchrotron and beamline names
         * user infromation
         * proposals list

--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -29,11 +29,12 @@ class BaseUserManager(ComponentBase):
     by more specific user manager implementations.
 
     Attributes:
-        app: The application instance used to access various components and
-            configurations such as the Flask server instance and the configuration
-            settings.
-        config: The configuration settings for the user manager, contains information
-            such as SSO client ID, client secret, and metadata URI..
+        app: The application instance.
+            It is used to access various components and configurations such as
+            the Flask server instance and the configuration settings.
+        config: The configuration settings for the user manager.
+            It contains information such as SSO client ID, client secret and
+            metadata URI.
     """
 
     def __init__(self, app, config):
@@ -79,13 +80,17 @@ class BaseUserManager(ComponentBase):
         return user
 
     def is_operator(self) -> bool:
-        """Return True if the current_user is an operator."""
+        """Check if current user is an operator.
+
+        Returns:
+            ``True`` if the current_user is an operator.
+        """
         return getattr(current_user, "in_control", False)
 
     def active_logged_in_users(self, exclude_inhouse: bool = False) -> list[User]:
         """List of active and logged in users.
 
-        Attributes:
+        Args:
             exclude_inhouse (bool): exclude inhouse users from the list
         """
         self.update_active_users()
@@ -153,7 +158,7 @@ class BaseUserManager(ComponentBase):
         If no user is currently in control, the first logged in user is set.
         Additionally, proposal is set based on the operator selected_proposal field.
 
-        Attributes:
+        Args:
             new_login: True if method was invoked with new user login.
         """
         if not current_user.is_anonymous:
@@ -196,7 +201,7 @@ class BaseUserManager(ComponentBase):
     def is_inhouse_user(self, user_id: str) -> bool:
         """Check if the ``user_id`` is in the in-house user list.
 
-        Attributes:
+        Args:
             user_id: user id composed from code and number.
 
         Returns:
@@ -248,7 +253,7 @@ class BaseUserManager(ComponentBase):
         data store. If a sample is loaded in sample changer but not mounted,
         mount it and update the smaple list. Try update the operator.
 
-        Attributes:
+        Args:
             login_id: The username.
             password: The password.
         """
@@ -318,7 +323,7 @@ class BaseUserManager(ComponentBase):
     def force_signout_user(self, username: str) -> None:
         """Force signout of the annonymous or non operating user.
 
-        Attributes:
+        Args:
             username: username of the user to be signed out.
         """
         user = self.get_user(username)
@@ -394,7 +399,7 @@ class BaseUserManager(ComponentBase):
     def update_user(self, user: User) -> None:
         """Update user information in datastore.
 
-        Attributes:
+        Args:
             user: User model instance.
         """
         self.app.server.user_datastore.put(user)
@@ -405,7 +410,7 @@ class BaseUserManager(ComponentBase):
 
         Inhouse user has always assigned staff role additionaly.
 
-        Attributes:
+        Args:
             user: username.
         """
         roles = set()
@@ -429,10 +434,10 @@ class BaseUserManager(ComponentBase):
         Assign roles to the user, prevoiusly making sure the roles of 'staff' and
         'incontrol' existis in data store. If not create them also.
 
-        Attributes:
-            user: representation of username (eventually part of it). Also a nickname
-                for new users.
-            password (unused): password.
+        Args:
+            user: representation of username (eventually part of it).
+                Also a nickname for new users.
+            password: password (unused).
             sso_data: dictionary with the lims data to be updated.
 
         Returns:
@@ -481,13 +486,13 @@ class BaseUserManager(ComponentBase):
     def db_set_in_control(self, user: User, control: bool) -> None:
         """Update users (their in_control field) in the datastore.
 
-        If the passed user becomes an operator (control=True), the remaining users'
-        in_control fields are set to False. If passed user stops being an operator,
-        only its in_control field is set to False.
+        If the passed user becomes an operator (``control=True``), the remaining users'
+        in_control fields are set to ``False``. If passed user stops being an operator,
+        only its in_control field is set to ``False``.
 
-        Attributes:
+        Args:
             user: User model instance.
-            control: the user becomes an operator (Ture) or not (False).
+            control: the user becomes an operator (``True``) or not (``False``).
         """
         user_datastore = self.app.server.user_datastore
 
@@ -526,7 +531,7 @@ class UserManager(BaseUserManager):
     def _login(self, login_id: str, password: str) -> LimsSessionManager:
         """Check loging conditions such as: active, anonymous, inhouse, local/remote.
 
-        Attributes:
+        Args:
             login_id: username
             password: password
 


### PR DESCRIPTION
This is a continuation of PR: https://github.com/mxcube/mxcubeweb/pull/1461

These changes are an effect of working on the deprecated bug: showing wrong proposal name, the one chosen by the previous user, when another one was logging in. The aim was to add some type hints and docstrings into UserBanager and BaseUserManager classes to have better understanding of what's going on. I think, it is good to not lose those changes that may be useful for future development.