### PR TITLE
Tabs are renamed

### DIFF
--- a/ui/src/components/LoginForm/SelectProposal.jsx
+++ b/ui/src/components/LoginForm/SelectProposal.jsx
@@ -78,10 +78,7 @@ function SelectProposal() {
         />
 
         <Tabs id="scheduled-tab" defaultActiveKey="scheduled">
-          <Tab
-            eventKey="scheduled"
-            title={`Scheduled (${scheduledSessions.length})`}
-          >
+          <Tab eventKey="active" title={`Active (${scheduledSessions.length})`}>
             <div className={styles.table}>
               <SessionTable
                 sessions={scheduledSessions}
@@ -91,8 +88,8 @@ function SelectProposal() {
             </div>
           </Tab>
           <Tab
-            eventKey="unscheduled"
-            title={`Unscheduled (${unscheduledSessions.length})`}
+            eventKey="scheduled"
+            title={`Scheduled (${unscheduledSessions.length})`}
           >
             <div className={styles.table}>
               <SessionTable


### PR DESCRIPTION
This closes #1562 
The tabs of the "select session" window are renamed for clarity"
![image](https://github.com/user-attachments/assets/786409f6-9d7c-4c50-8d77-54fe490f2d3d)
