### PR TITLE
Remove unnecessary usage of dict as kwargs

### DIFF
--- a/mxcubeweb/core/adapter/actuator_adapter.py
+++ b/mxcubeweb/core/adapter/actuator_adapter.py
@@ -60,7 +60,7 @@ class ActuatorAdapter(ActuatorAdapterBase):
             ValueError: When value for any reason can't be retrieved.
         """
         try:
-            return FloatValueModel(**{"value": self._ho.get_value()})
+            return FloatValueModel(value=self._ho.get_value())
         except (AttributeError, TypeError):
             raise ValueError("Could not get value")
 

--- a/mxcubeweb/core/adapter/beam_adapter.py
+++ b/mxcubeweb/core/adapter/beam_adapter.py
@@ -57,7 +57,7 @@ class BeamAdapter(ActuatorAdapterBase):
             }
         )
 
-        return HOBeamValueModel(**{"value": beam_info_dict})
+        return HOBeamValueModel(value=beam_info_dict)
 
     @export
     def get_size(self) -> HOBeamModel:

--- a/mxcubeweb/core/adapter/beamline_action_adapter.py
+++ b/mxcubeweb/core/adapter/beamline_action_adapter.py
@@ -43,7 +43,7 @@ class BeamlineActionAdapter(ActuatorAdapterBase):
         self._ho.set_value(self._ho.VALUES[value.value])
 
     def _get_value(self) -> StrValueModel:
-        return StrValueModel(**{"value": self._ho.get_value().name})
+        return StrValueModel(value=self._ho.get_value().name)
 
     def msg(self):
         try:

--- a/mxcubeweb/core/adapter/machine_info_adapter.py
+++ b/mxcubeweb/core/adapter/machine_info_adapter.py
@@ -25,7 +25,7 @@ class MachineInfoAdapter(ActuatorAdapterBase):
         self.value_change(self.get_value(), **kwargs)
 
     def _get_value(self) -> HOMachineInfoModel:
-        return HOMachineInfoModel(**{"value": self.get_attributes()})
+        return HOMachineInfoModel(value=self.get_attributes())
 
     def get_attributes(self):
         """Read the information from the HO. Format the output."""

--- a/mxcubeweb/core/adapter/motor_adapter.py
+++ b/mxcubeweb/core/adapter/motor_adapter.py
@@ -48,7 +48,7 @@ class MotorAdapter(ActuatorAdapterBase):
         except (TypeError, AttributeError):
             value = 0.0
 
-        return FloatValueModel(**{"value": value})
+        return FloatValueModel(value=value)
 
     def state(self):
         """

--- a/mxcubeweb/core/adapter/nstate_adapter.py
+++ b/mxcubeweb/core/adapter/nstate_adapter.py
@@ -49,7 +49,7 @@ class NStateAdapter(ActuatorAdapterBase):
         self._ho.set_value(self._ho.VALUES[value.value])
 
     def _get_value(self) -> StrValueModel:
-        return StrValueModel(**{"value": self._ho.get_value().name})
+        return StrValueModel(value=self._ho.get_value().name)
 
     def msg(self):
         try:

--- a/mxcubeweb/core/adapter/wavelength_adapter.py
+++ b/mxcubeweb/core/adapter/wavelength_adapter.py
@@ -57,7 +57,7 @@ class WavelengthAdapter(ActuatorAdapterBase):
             ValueError: When value for any reason can't be retrieved.
         """
         try:
-            return FloatValueModel(**{"value": self._ho.get_wavelength()})
+            return FloatValueModel(value=self._ho.get_wavelength())
         except (AttributeError, TypeError) as ex:
             raise ValueError("Could not get value") from ex
 

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -1409,13 +1409,11 @@ class Queue(ComponentBase):
         queue_entry_name = task_name.title().replace("_", "") + "QueueEntry"
         entry_cls = getattr(qe, queue_entry_name)
         data = entry_cls.DATA_MODEL(
-            **{
-                "path_parameters": task["parameters"],
-                "common_parameters": task["parameters"],
-                "user_collection_parameters": task["parameters"],
-                "collection_parameters": task["parameters"],
-                "legacy_parameters": task["parameters"],
-            }
+            path_parameters=task["parameters"],
+            common_parameters=task["parameters"],
+            user_collection_parameters=task["parameters"],
+            collection_parameters=task["parameters"],
+            legacy_parameters=task["parameters"],
         )
 
         entry = entry_cls(Mock(), entry_cls.QMO(task_data=data))

--- a/ruff.toml
+++ b/ruff.toml
@@ -74,7 +74,6 @@ select = [
     "B904",
     "BLE001",
     "EM101",
-    "PIE804",
     "S110",
     "TRY003",
 ]
@@ -92,12 +91,8 @@ select = [
     "TRY003",
     "TRY400",
 ]
-"mxcubeweb/core/adapter/beam_adapter.py" = [
-    "PIE804",
-]
 "mxcubeweb/core/adapter/beamline_action_adapter.py" = [
     "BLE001",
-    "PIE804",
     "RET504",
     "SIM108",
     "TRY400",
@@ -127,17 +122,14 @@ select = [
 ]
 "mxcubeweb/core/adapter/machine_info_adapter.py" = [
     "ARG002",
-    "PIE804",
 ]
 "mxcubeweb/core/adapter/motor_adapter.py" = [
     "B904",
     "EM101",
-    "PIE804",
     "TRY003",
 ]
 "mxcubeweb/core/adapter/nstate_adapter.py" = [
     "BLE001",
-    "PIE804",
     "SIM108",
     "TRY400",
 ]
@@ -145,7 +137,6 @@ select = [
     "ARG002",
     "BLE001",
     "EM101",
-    "PIE804",
     "S110",
     "TRY003",
     "TRY203",
@@ -208,7 +199,6 @@ select = [
     "G004",
     "N806",
     "N814",
-    "PIE804",
     "PERF401",
     "PLR0912",
     "PLR0915",


### PR DESCRIPTION
This is enforced and fixed by Ruff's rule `PIE804`: <https://docs.astral.sh/ruff/rules/unnecessary-dict-kwargs/>