### PR TITLE
Move all usage of  react-copy-to-clipboard to a single component

### DIFF
--- a/ui/src/components/CopyToClipboard/CopyToClipboard.jsx
+++ b/ui/src/components/CopyToClipboard/CopyToClipboard.jsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import { Button } from 'react-bootstrap';
+import { CopyToClipboard as TriggerCopyToClipboard } from 'react-copy-to-clipboard';
+import { MdContentCopy } from 'react-icons/md';
+
+import TooltipTrigger from '../TooltipTrigger';
+import styles from './CopyToClipboard.module.css';
+
+export default function CopyToClipboard(props) {
+  const { id, tittle, text, iconColor = 'black' } = props;
+
+  const [copied, setCopied] = useState(false);
+
+  function onCopy() {
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1100);
+  }
+
+  return (
+    <Button className={styles.btnContent} variant="unknown">
+      <TooltipTrigger
+        placement={copied ? 'auto' : 'right'}
+        rootClose={false}
+        id={id}
+        tooltipContent={
+          copied ? `${tittle} Copied` : `Copy ${tittle} to Clipboard`
+        }
+      >
+        <TriggerCopyToClipboard
+          onCopy={onCopy}
+          className={styles.link}
+          text={text}
+        >
+          <MdContentCopy color={iconColor} size="1em" />
+        </TriggerCopyToClipboard>
+      </TooltipTrigger>
+    </Button>
+  );
+}

--- a/ui/src/components/CopyToClipboard/CopyToClipboard.module.css
+++ b/ui/src/components/CopyToClipboard/CopyToClipboard.module.css
@@ -1,0 +1,11 @@
+.btnContent {
+  border: 0 !important;
+}
+
+.link {
+  opacity: 25%;
+}
+
+.link:hover {
+  opacity: 100%;
+}

--- a/ui/src/components/Equipment/Harvester.jsx
+++ b/ui/src/components/Equipment/Harvester.jsx
@@ -1,11 +1,9 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Card, Button, Badge } from 'react-bootstrap';
 import { contextMenu, Menu, Item, Separator } from 'react-contexify';
-
-import { CopyToClipboard } from 'react-copy-to-clipboard';
-import { MdContentCopy } from 'react-icons/md';
 import { FcRefresh, FcUpload, FcCollect } from 'react-icons/fc';
 
+import CopyToClipboard from '../../components/CopyToClipboard/CopyToClipboard.jsx';
 import ImageViewer from '../ImageViewer/ImageViewer.jsx';
 
 import styles from './equipment.module.css';
@@ -31,8 +29,6 @@ const sampleStateBackground = (key) => {
 };
 
 export default function Harvester(props) {
-  const [copied, setCopied] = useState(false);
-
   function showContextMenu(event, id) {
     let position = {
       x: event.clientX,
@@ -58,11 +54,6 @@ export default function Harvester(props) {
 
   const harvestAndLoadCrystal = (UUID) => {
     props.harvestAndLoadCrystal(UUID);
-  };
-
-  const onCopy = () => {
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1000);
   };
 
   const renderCrystalMenu = (key) => (
@@ -129,30 +120,13 @@ export default function Harvester(props) {
                             {item.state ? item.state.replaceAll('_', ' ') : ''}
                           </Badge>
                         </div>
-                        <div className={styles.crystal_uuid_caption}>
+                        <div>
                           <span className="me-1">{item.crystal_uuid}</span>
                           <CopyToClipboard
-                            className="copy-link copy-link-ha"
                             text={item.crystal_uuid}
-                            onCopy={onCopy}
-                          >
-                            <Button variant="content" className="btn-copy-link">
-                              <MdContentCopy
-                                style={{ float: 'right' }}
-                                size=""
-                              />
-                              <span
-                                className={`tooltiptext ${
-                                  copied ? 'copy-link-glow' : ''
-                                }`}
-                                id="myTooltip"
-                              >
-                                {copied
-                                  ? 'crystal uuid Copied'
-                                  : 'Copy crystal uuid to Clipboard'}
-                              </span>
-                            </Button>
-                          </CopyToClipboard>
+                            tittle="crystal uuid"
+                            id={item.crystal_uuid}
+                          />
                         </div>
                       </div>
                     </div>

--- a/ui/src/components/Equipment/Harvester.jsx
+++ b/ui/src/components/Equipment/Harvester.jsx
@@ -125,7 +125,7 @@ export default function Harvester(props) {
                           <CopyToClipboard
                             text={item.crystal_uuid}
                             tittle="crystal uuid"
-                            id={item.crystal_uuid}
+                            id={`copy_${item.crystal_uuid}`}
                           />
                         </div>
                       </div>

--- a/ui/src/components/Equipment/equipment.module.css
+++ b/ui/src/components/Equipment/equipment.module.css
@@ -121,8 +121,6 @@
   border-radius: 6px;
   position: absolute;
   font-size: 12px;
-
-  z-index: 9999;
   bottom: 75%;
   left: 50%;
   opacity: 0;
@@ -167,8 +165,6 @@
 }
 
 .crystal_uuid_caption {
-  /* text-transform: capitalize; */
   color: gray;
   margin-bottom: 10px;
-  /* white-space: nowrap; */
 }

--- a/ui/src/components/SampleGrid/SampleGridTable.css
+++ b/ui/src/components/SampleGrid/SampleGridTable.css
@@ -152,7 +152,6 @@
 }
 
 .samples-grid-table-item-tasks {
-  /* width: fit-content; */
   height: 26px;
   padding-left: 19px;
   display: grid;
@@ -178,10 +177,6 @@
   left: 1px;
 }
 
-.samples-grid-table-item-tasks > .slick-next {
-  /* right: -25px */
-}
-
 .new-sample-grid-task-item {
   margin: 0 !important;
 }
@@ -194,10 +189,6 @@
   border: 3px dashed #585555 !important;
 }
 
-.div-samples-grid-table-item-top {
-  /* width: 180px; */
-}
-
 .samples-grid-table-item-name-pt {
   white-space: nowrap;
   overflow: hidden;
@@ -207,13 +198,10 @@
   font-size: small;
   font-weight: bold;
   pointer-events: auto;
-  max-width: 62%;
+  max-width: 160px;
   background: #5cb85c;
-  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  position: absolute;
-  top: 8px;
 }
 
 .dm {
@@ -293,75 +281,10 @@
   font-weight: bolder;
 }
 
-.copy-link {
-  width: 20px;
-  height: 20px;
-  padding: 0%;
-  margin-bottom: -25px;
-  position: relative;
-  top: -5px;
-  opacity: 25%;
-}
-
-.copy-link-ha {
-  margin-top: -14px;
-}
-.copy-link:hover {
-  opacity: 100%;
-}
-
-.copy-link > .copy-icon {
-  color: #e7eff1;
-}
-
-.copy-link > .tooltiptext::after {
-  content: '';
-  position: absolute;
-  bottom: 100%;
-  left: 20%;
-  margin-left: -5px;
-  border-width: 5px;
-  border-style: solid;
-  border-color: transparent transparent #0122388e transparent;
-}
-
-.copy-link > .tooltiptext {
-  z-index: 20000;
-  visibility: hidden;
-  white-space: nowrap;
-  background-color: #015f9d;
-  color: #ffffff;
-  text-align: center;
-  border-radius: 6px;
-  padding: 2px;
-  position: relative;
-  z-index: 1;
-  top: 8px;
-  right: 40px;
-  opacity: 0;
-  transition: opacity 0.3s;
-}
-
-.copy-link:focus {
-  cursor: pointer;
-  outline: none;
-}
-
-.copy-link-glow {
-  margin-left: 20px;
-  transition: all 0.1s ease-in-out;
-}
-
-.copy-link:hover .tooltiptext {
-  visibility: visible;
-  opacity: 1;
-}
-
 /* Graphical View / Flex grid css */
 
 .div-flex-pie-collapsible {
   width: 95%;
-  /* margin: auto auto 2em auto; */
 }
 
 .div-svg-flex {

--- a/ui/src/components/SampleGrid/SampleGridTableItem.jsx
+++ b/ui/src/components/SampleGrid/SampleGridTableItem.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-handler-names */
 import React from 'react';
 import {
   ListGroup,
@@ -9,12 +8,11 @@ import {
 } from 'react-bootstrap';
 import cx from 'classnames';
 
-import { CopyToClipboard } from 'react-copy-to-clipboard';
+import CopyToClipboard from '../../components/CopyToClipboard/CopyToClipboard';
 
 import { isCollected } from '../../constants';
 
 import { BsSquare, BsCheck2Square } from 'react-icons/bs';
-import { MdContentCopy } from 'react-icons/md';
 import './SampleGridTable.css';
 import TooltipTrigger from '../TooltipTrigger';
 
@@ -22,13 +20,8 @@ export class SampleGridTableItem extends React.Component {
   constructor(props) {
     super(props);
     this.pickButtonOnClick = this.pickButtonOnClick.bind(this);
-    this.sampleItemOnClick = this.sampleItemOnClick.bind(this);
-
+    this.handleItemClick = this.handleItemClick.bind(this);
     this.sampleInformation = this.sampleInformation.bind(this);
-    this.onCopy = this.onCopy.bind(this);
-    this.state = {
-      copied: false,
-    };
   }
 
   pickButtonOnClick(e) {
@@ -132,7 +125,7 @@ export class SampleGridTableItem extends React.Component {
     );
   }
 
-  sampleItemOnClick(e) {
+  handleItemClick(e) {
     if (this.props.onClick) {
       this.props.onClick(e, this.props.sampleData.sampleID);
     }
@@ -140,11 +133,6 @@ export class SampleGridTableItem extends React.Component {
 
   currentSampleText() {
     return this.props.current ? '(MOUNTED)' : '';
-  }
-
-  onCopy() {
-    this.setState({ copied: true });
-    setTimeout(() => this.setState({ copied: false }), 1000);
   }
 
   render() {
@@ -165,31 +153,12 @@ export class SampleGridTableItem extends React.Component {
         ref={(ref) => {
           this.sampleItem = ref;
         }}
-        onClick={this.sampleItemOnClick}
+        onClick={this.handleItemClick}
       >
         <ListGroup.Item className={classes}>
           <div className="samples-grid-table-item-top d-flex">
             {this.itemControls()}
-            <div className="div-samples-grid-table-item-top">
-              <CopyToClipboard
-                className="copy-link"
-                text={this.sampleDisplayName()}
-                onCopy={this.onCopy}
-              >
-                <Button variant="content" className="btn-copy-link">
-                  <MdContentCopy style={{ float: 'right' }} size="" />
-                  <span
-                    className={`tooltiptext ${
-                      this.state.copied ? 'copy-link-glow' : ''
-                    }`}
-                    id="myTooltip"
-                  >
-                    {this.state.copied
-                      ? 'Sample Name Copied'
-                      : 'Copy Sample Name to Clipboard'}
-                  </span>
-                </Button>
-              </CopyToClipboard>
+            <div>
               <OverlayTrigger
                 placement="right"
                 overlay={
@@ -213,7 +182,7 @@ export class SampleGridTableItem extends React.Component {
                   ref={(ref) => {
                     this.pacronym = ref;
                   }}
-                  className="samples-grid-table-item-name-protein-acronym ms-1"
+                  className="samples-grid-table-item-name-protein-acronym ms-1 mt-2"
                   data-type="text"
                   data-pk="1"
                   data-url="/post"
@@ -229,6 +198,11 @@ export class SampleGridTableItem extends React.Component {
                 {this.props.sampleData.location} {this.currentSampleText()}
               </div>
             </div>
+            <CopyToClipboard
+              text={this.sampleDisplayName()}
+              tittle="Sample Name"
+              id={this.sampleDisplayName()}
+            />
             {this.seqId()}
           </div>
           {this.props.children}

--- a/ui/src/components/SampleGrid/SampleGridTableItem.jsx
+++ b/ui/src/components/SampleGrid/SampleGridTableItem.jsx
@@ -201,7 +201,7 @@ export class SampleGridTableItem extends React.Component {
             <CopyToClipboard
               text={this.sampleDisplayName()}
               tittle="Sample Name"
-              id={this.sampleDisplayName()}
+              id={`copy_${this.sampleDisplayName()}`}
             />
             {this.seqId()}
           </div>

--- a/ui/src/components/TooltipTrigger.jsx
+++ b/ui/src/components/TooltipTrigger.jsx
@@ -2,11 +2,17 @@ import React from 'react';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 
 function TooltipTrigger(props) {
-  const { id, placement = 'bottom', tooltipContent, children } = props;
+  const {
+    id,
+    rootClose = true,
+    placement = 'bottom',
+    tooltipContent,
+    children,
+  } = props;
 
   return (
     <OverlayTrigger
-      rootClose // ensures focus is removed from child (and tooltip closed) when clicking anywhere else
+      rootClose={rootClose} // ensures whether focus is removed from child (and tooltip closed) when clicking anywhere else
       placement={placement}
       overlay={<Tooltip id={id}>{tooltipContent}</Tooltip>}
     >


### PR DESCRIPTION
- Create a generic component from react-copy-to-clipboard
- Move usage of copy-to-clipboard to this generic component
-  small related cleanup 

[Screencast from 2025-02-25 13-53-33.webm](https://github.com/user-attachments/assets/48524fca-a03c-4794-bef0-f80674b497c8)


[Screencast from 2025-02-25 13-55-12.webm](https://github.com/user-attachments/assets/6a0bb26d-ca6f-4733-bf77-5890a03bde78)

