### PR TITLE
Fix Ruff violations from the `UP` group

### DIFF
--- a/mxcubeweb/__init__.py
+++ b/mxcubeweb/__init__.py
@@ -9,8 +9,8 @@ import os  # noqa: E402
 import sys  # noqa: E402
 import traceback  # noqa: E402
 from pathlib import Path  # noqa: E402
+from unittest import mock  # noqa: E402
 
-import mock  # noqa: E402
 from mxcubecore import HardwareRepository as HWR  # noqa: E402
 
 from mxcubeweb.app import MXCUBEApplication as mxcube  # noqa: E402

--- a/mxcubeweb/core/adapter/actuator_adapter.py
+++ b/mxcubeweb/core/adapter/actuator_adapter.py
@@ -18,7 +18,7 @@ class ActuatorAdapter(ActuatorAdapterBase):
         Args:
             (object): Hardware object.
         """
-        super(ActuatorAdapter, self).__init__(ho, *args)
+        super().__init__(ho, *args)
         self._event_rate = 4
 
         @RateLimited(self._event_rate)

--- a/mxcubeweb/core/adapter/adapter_base.py
+++ b/mxcubeweb/core/adapter/adapter_base.py
@@ -345,7 +345,7 @@ class ActuatorAdapterBase(AdapterBase):
             (object): Hardware object to mediate for.
             (str): The name of the object.
         """
-        super(ActuatorAdapterBase, self).__init__(ho, *args)
+        super().__init__(ho, *args)
 
         self._unique = False
 
@@ -425,7 +425,7 @@ class ActuatorAdapterBase(AdapterBase):
         Returns:
             (dict): The dictionary.
         """
-        data = super(ActuatorAdapterBase, self)._dict_repr()
+        data = super()._dict_repr()
 
         try:
             data.update({"value": self.get_value(), "limits": self.limits()})

--- a/mxcubeweb/core/adapter/beam_adapter.py
+++ b/mxcubeweb/core/adapter/beam_adapter.py
@@ -8,7 +8,7 @@ from mxcubeweb.core.util.adapterutils import export
 
 class BeamAdapter(ActuatorAdapterBase):
     def __init__(self, ho, *args):
-        super(BeamAdapter, self).__init__(ho, *args)
+        super().__init__(ho, *args)
 
     def limits(self):
         return -1, -1

--- a/mxcubeweb/core/adapter/beamline_adapter.py
+++ b/mxcubeweb/core/adapter/beamline_adapter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import logging
 
 import pydantic

--- a/mxcubeweb/core/adapter/data_publisher_adapter.py
+++ b/mxcubeweb/core/adapter/data_publisher_adapter.py
@@ -13,7 +13,7 @@ class DataPublisherAdapter(AdapterBase):
         Args:
             (object): Hardware object.
         """
-        super(DataPublisherAdapter, self).__init__(ho, *args)
+        super().__init__(ho, *args)
         self._all_data_list = []
         self._current_data_list = []
         self._current_info = {}

--- a/mxcubeweb/core/adapter/detector_adapter.py
+++ b/mxcubeweb/core/adapter/detector_adapter.py
@@ -7,7 +7,7 @@ class DetectorAdapter(AdapterBase):
         Args:
             (object): Hardware object.
         """
-        super(DetectorAdapter, self).__init__(ho, *args)
+        super().__init__(ho, *args)
         ho.connect("stateChanged", self._state_change)
 
     def _state_change(self, *args, **kwargs):

--- a/mxcubeweb/core/adapter/diffractometer_adapter.py
+++ b/mxcubeweb/core/adapter/diffractometer_adapter.py
@@ -10,7 +10,7 @@ class DiffractometerAdapter(AdapterBase):
         Args:
             (object): Hardware object.
         """
-        super(DiffractometerAdapter, self).__init__(ho, *args)
+        super().__init__(ho, *args)
         ho.connect("stateChanged", self._state_change)
         ho.connect("valueChanged", self._state_change)
         ho.connect("phaseChanged", self._diffractometer_phase_changed)

--- a/mxcubeweb/core/adapter/energy_adapter.py
+++ b/mxcubeweb/core/adapter/energy_adapter.py
@@ -15,7 +15,7 @@ class EnergyAdapter(ActuatorAdapter):
         Args:
             (object): Hardware object.
         """
-        super(EnergyAdapter, self).__init__(*args)
+        super().__init__(*args)
         self._add_adapter("wavelength", self._ho, WavelengthAdapter)
         self._type = "ENERGY"
 

--- a/mxcubeweb/core/adapter/flux_adapter.py
+++ b/mxcubeweb/core/adapter/flux_adapter.py
@@ -12,7 +12,7 @@ class FluxAdapter(ActuatorAdapterBase):
         Args:
             (object): Hardware object.
         """
-        super(FluxAdapter, self).__init__(ho, *args, **kwargs)
+        super().__init__(ho, *args, **kwargs)
 
         self._read_only = ho.read_only
 

--- a/mxcubeweb/core/adapter/motor_adapter.py
+++ b/mxcubeweb/core/adapter/motor_adapter.py
@@ -12,7 +12,7 @@ class MotorAdapter(ActuatorAdapterBase):
         Args:
             (object): Hardware object.
         """
-        super(MotorAdapter, self).__init__(ho, *args)
+        super().__init__(ho, *args)
         ho.connect("valueChanged", self._value_change)
         ho.connect("stateChanged", self.state_change)
 

--- a/mxcubeweb/core/adapter/nstate_adapter.py
+++ b/mxcubeweb/core/adapter/nstate_adapter.py
@@ -15,7 +15,7 @@ class NStateAdapter(ActuatorAdapterBase):
         Args:
             (object): Hardware object.
         """
-        super(NStateAdapter, self).__init__(ho, *args)
+        super().__init__(ho, *args)
         self._value_change_model = HOActuatorValueChangeModel
 
         ho.connect("valueChanged", self._value_change)

--- a/mxcubeweb/core/adapter/wavelength_adapter.py
+++ b/mxcubeweb/core/adapter/wavelength_adapter.py
@@ -17,7 +17,7 @@ class WavelengthAdapter(ActuatorAdapterBase):
         Args:
             (object): Hardware object.
         """
-        super(WavelengthAdapter, self).__init__(ho, *args)
+        super().__init__(ho, *args)
         self._type = "MOTOR"
 
         try:

--- a/mxcubeweb/core/components/beamline.py
+++ b/mxcubeweb/core/components/beamline.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import logging
 
 from mxcubecore import HardwareRepository as HWR

--- a/mxcubeweb/core/components/component_base.py
+++ b/mxcubeweb/core/components/component_base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import importlib
 import logging
 

--- a/mxcubeweb/core/components/harvester.py
+++ b/mxcubeweb/core/components/harvester.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from __future__ import annotations
 
 import logging

--- a/mxcubeweb/core/components/lims.py
+++ b/mxcubeweb/core/components/lims.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import logging
 import math
 import re

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -1,12 +1,11 @@
-# -*- coding: utf-8 -*-
 import itertools
 import json
 import logging
 import os
 import re
 from functools import reduce
+from unittest.mock import Mock
 
-from mock import Mock
 from mxcubecore import HardwareRepository as HWR
 from mxcubecore import queue_entry as qe
 from mxcubecore.HardwareObjects.Gphl import GphlQueueEntry

--- a/mxcubeweb/core/components/samplechanger.py
+++ b/mxcubeweb/core/components/samplechanger.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import logging
 
 import gevent

--- a/mxcubeweb/core/components/sampleview.py
+++ b/mxcubeweb/core/components/sampleview.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import logging
 from io import StringIO
 

--- a/mxcubeweb/core/components/user/database.py
+++ b/mxcubeweb/core/components/user/database.py
@@ -1,5 +1,4 @@
 import datetime
-import typing
 
 from flask_security import SQLAlchemySessionUserDatastore
 from sqlalchemy import create_engine
@@ -38,12 +37,12 @@ class UserDatastore(SQLAlchemySessionUserDatastore):
     def __init__(
         self,
         *args,
-        message_model=typing.Type["Message"],  # noqa: F821
+        message_model=type["Message"],  # noqa: F821
         **kwargs,
     ):
         SQLAlchemySessionUserDatastore.__init__(self, *args, **kwargs)
         self._message_model = message_model
-        self._messages_users_model = typing.Type["MessagesUsers"]  # noqa: F821
+        self._messages_users_model = type["MessagesUsers"]  # noqa: F821
 
     def create_message(self, message, from_username, from_nickname, from_host):
         return self.put(

--- a/mxcubeweb/core/components/workflow.py
+++ b/mxcubeweb/core/components/workflow.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import base64
 
 from mxcubecore import HardwareRepository as HWR

--- a/mxcubeweb/core/models/adaptermodels.py
+++ b/mxcubeweb/core/models/adaptermodels.py
@@ -1,10 +1,3 @@
-# -*- coding: utf-8 -*-
-from typing import (
-    List,
-    Tuple,
-    Union,
-)
-
 from pydantic.v1 import (
     BaseModel,
     Field,
@@ -22,7 +15,7 @@ class HOModel(BaseModel):
         description="True if the object can only be read (not manipluated)",
     )
     attributes: dict = Field({}, description="Data attributes")
-    commands: Union[dict, list] = Field({}, description="Available methods")
+    commands: dict | list = Field({}, description="Available methods")
 
     # pyflakes are a bit picky with F821 (Undefined name),
     # not even sure "forbid" should ba considered as an undefined name
@@ -32,7 +25,7 @@ class HOModel(BaseModel):
 
 class HOActuatorModel(HOModel):
     value: float = Field(0, description="Value of actuator (position)")
-    limits: Tuple[float, float] = Field((-1, -1), description="Limits (min max)")
+    limits: tuple[float, float] = Field((-1, -1), description="Limits (min max)")
 
 
 class NStateModel(HOActuatorModel):
@@ -49,9 +42,9 @@ class HOActuatorValueChangeModel(BaseModel):
 
 
 class HOBeamRawValueModel(BaseModel):
-    apertureList: List[str] = Field([0], description="List of available apertures")
+    apertureList: list[str] = Field([0], description="List of available apertures")
     currentAperture: str = Field(0, description="Current aperture label")
-    position: Tuple[float, float] = Field((0, 0), description="Beam position on OAV")
+    position: tuple[float, float] = Field((0, 0), description="Beam position on OAV")
     shape: str = Field("ellipse", descrption="Beam shape")
     size_x: float = Field(
         0.01,

--- a/mxcubeweb/core/models/configmodels.py
+++ b/mxcubeweb/core/models/configmodels.py
@@ -1,11 +1,7 @@
 import datetime
 from enum import Enum
 from typing import (
-    Dict,
-    List,
     Literal,
-    Optional,
-    Union,
 )
 
 from pydantic.v1 import (
@@ -20,7 +16,7 @@ class FlaskConfigModel(BaseModel):
         description="Flask secret key",
     )
     DEBUG: bool = Field(False, description="")
-    ALLOWED_CORS_ORIGINS: List[str] = Field(["*"], description="")
+    ALLOWED_CORS_ORIGINS: list[str] = Field(["*"], description="")
     SECURITY_PASSWORD_SALT: str = Field("ASALT", description="")
     SECURITY_TRACKABLE: bool = Field(True, description="")
     USER_DB_PATH: str = Field("/tmp/mxcube-user.db", description="")
@@ -57,24 +53,24 @@ class SSOConfigModel(BaseModel):
 class UIComponentModel(BaseModel):
     label: str
     attribute: str
-    role: Optional[str]
-    step: Optional[float]
-    precision: Optional[int]
-    suffix: Optional[str]
-    description: Optional[str]
+    role: str | None
+    step: float | None
+    precision: int | None
+    suffix: str | None
+    description: str | None
     # Set internally not to be set through configuration
-    value_type: Optional[str]
-    object_type: Optional[str]
-    format: Optional[str]
+    value_type: str | None
+    object_type: str | None
+    format: str | None
 
 
 class _UICameraConfigModel(BaseModel):
     label: str
     url: str
-    format: Optional[str]
-    description: Optional[str]
-    width: Optional[int]
-    height: Optional[int]
+    format: str | None
+    description: str | None
+    width: int | None
+    height: int | None
 
 
 class _UISampleViewVideoControlsModel(BaseModel):
@@ -91,25 +87,25 @@ class _UISampleViewVideoGridSettingsModel(BaseModel):
 
 class UIPropertiesModel(BaseModel):
     id: str
-    components: List[UIComponentModel]
+    components: list[UIComponentModel]
 
 
 class UICameraConfigModel(UIPropertiesModel):
-    components: List[_UICameraConfigModel]
+    components: list[_UICameraConfigModel]
 
 
 class UISampleViewVideoControlsModel(UIPropertiesModel):
     # It is important to keep the Union elements in that order; from the more specific to the more general.
-    components: List[
-        Union[_UISampleViewVideoGridSettingsModel, _UISampleViewVideoControlsModel]
+    components: list[
+        _UISampleViewVideoGridSettingsModel | _UISampleViewVideoControlsModel
     ]
 
 
 class UIPropertiesListModel(BaseModel):
     sample_view: UIPropertiesModel
     beamline_setup: UIPropertiesModel
-    camera_setup: Optional[UICameraConfigModel]
-    sample_view_video_controls: Optional[UISampleViewVideoControlsModel]
+    camera_setup: UICameraConfigModel | None
+    sample_view_video_controls: UISampleViewVideoControlsModel | None
 
 
 class UserManagerUserConfigModel(BaseModel):
@@ -125,7 +121,7 @@ class UserManagerConfigModel(BaseModel):
         True,
         description="Treat users defined as inhouse in session.xml as staff",
     )
-    users: List[UserManagerUserConfigModel]
+    users: list[UserManagerUserConfigModel]
 
 
 class ModeEnum(str, Enum):
@@ -157,10 +153,10 @@ class MXCUBEAppConfigModel(BaseModel):
         ModeEnum.OSC, description="MXCuBE mode OSC, SSX-CHIP or SSX-INJECTOR"
     )
     usermanager: UserManagerConfigModel
-    ui_properties: Dict[str, UIPropertiesModel] = {}
+    ui_properties: dict[str, UIPropertiesModel] = {}
 
 
 class AppConfigModel(BaseModel):
     server: FlaskConfigModel
     mxcube: MXCUBEAppConfigModel
-    sso: Optional[SSOConfigModel]
+    sso: SSOConfigModel | None

--- a/mxcubeweb/core/models/generic.py
+++ b/mxcubeweb/core/models/generic.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 from pydantic.v1 import (
     BaseModel,
     Field,
@@ -11,7 +9,7 @@ from mxcubeweb.core.models.configmodels import ModeEnum
 class SimpleNameValue(BaseModel):
     name: str
     # It's important to have str before bool, to avoid issue with bool being casted to string
-    value: Union[bool, str, int]
+    value: bool | str | int
 
 
 class AppSettingsModel(BaseModel):

--- a/mxcubeweb/routes/lims.py
+++ b/mxcubeweb/routes/lims.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import logging
 from os.path import (
     isfile,

--- a/mxcubeweb/routes/ra.py
+++ b/mxcubeweb/routes/ra.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import gevent
 from flask import (
     Blueprint,

--- a/mxcubeweb/routes/workflow.py
+++ b/mxcubeweb/routes/workflow.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import io
 
 from flask import (

--- a/mxcubeweb/server.py
+++ b/mxcubeweb/server.py
@@ -53,7 +53,7 @@ class Server:
         # of non-zero exit code, so we don't kill the processes
         # when running the tests
         if not Server.flask.testing:
-            with open("/tmp/mxcube.pid", "r") as f:
+            with open("/tmp/mxcube.pid") as f:
                 pid_list = f.read().strip()
                 pid_list = pid_list.split(" ")
                 pid_list.reverse()

--- a/ruff.toml
+++ b/ruff.toml
@@ -31,7 +31,6 @@ select = [
     "PTH109",
     "RET505",
     "S108",
-    "UP026",
 ]
 "mxcubeweb/__version__.py" = [
     "I001",
@@ -75,7 +74,6 @@ select = [
     "EM101",
     "S110",
     "TRY003",
-    "UP008",
 ]
 "mxcubeweb/core/adapter/adapter_base.py" = [
     "ARG002",
@@ -90,11 +88,7 @@ select = [
     "SLF001",
     "TRY003",
     "TRY400",
-    "UP008",
     "UP031",
-]
-"mxcubeweb/core/adapter/beam_adapter.py" = [
-    "UP008",
 ]
 "mxcubeweb/core/adapter/beamline_action_adapter.py" = [
     "BLE001",
@@ -107,30 +101,22 @@ select = [
     "N802",
     "PLW0603",
     "TRY400",
-    "UP009",
 ]
 "mxcubeweb/core/adapter/data_publisher_adapter.py" = [
     "RUF012",
-    "UP008",
-]
-"mxcubeweb/core/adapter/detector_adapter.py" = [
-    "UP008",
 ]
 "mxcubeweb/core/adapter/diffractometer_adapter.py" = [
     "RET504",
     "RUF012",
-    "UP008",
 ]
 "mxcubeweb/core/adapter/energy_adapter.py" = [
     "N814",
-    "UP008",
 ]
 "mxcubeweb/core/adapter/flux_adapter.py" = [
     "BLE001",
     "ERA001",
     "S110",
     "SIM105",
-    "UP008",
     "UP032",
 ]
 "mxcubeweb/core/adapter/machine_info_adapter.py" = [
@@ -140,13 +126,11 @@ select = [
     "B904",
     "EM101",
     "TRY003",
-    "UP008",
 ]
 "mxcubeweb/core/adapter/nstate_adapter.py" = [
     "BLE001",
     "SIM108",
     "TRY400",
-    "UP008",
 ]
 "mxcubeweb/core/adapter/wavelength_adapter.py" = [
     "ARG002",
@@ -155,7 +139,6 @@ select = [
     "S110",
     "TRY003",
     "TRY203",
-    "UP008",
 ]
 "mxcubeweb/core/components/beamline.py" = [
     "BLE001",
@@ -164,7 +147,6 @@ select = [
     "N814",
     "SIM118",
     "TRY002",
-    "UP009",
     "UP031",
 ]
 "mxcubeweb/core/components/chat.py" = [
@@ -175,7 +157,6 @@ select = [
 "mxcubeweb/core/components/component_base.py" = [
     "FLY002",
     "G004",
-    "UP009",
 ]
 "mxcubeweb/core/components/harvester.py" = [
     "BLE001",
@@ -184,7 +165,6 @@ select = [
     "N814",
     "RET504",
     "TRY300",
-    "UP009",
 ]
 "mxcubeweb/core/components/lims.py" = [
     "B016",
@@ -196,7 +176,6 @@ select = [
     "N814",
     "SIM102",
     "TRY301",
-    "UP009",
     "UP031",
 ]
 "mxcubeweb/core/components/queue.py" = [
@@ -238,8 +217,6 @@ select = [
     "TD003",
     "TRY002",
     "TRY003",
-    "UP009",
-    "UP026",
     "UP030",
     "UP031",
     "UP032",
@@ -256,7 +233,6 @@ select = [
     "SIM114",
     "SIM201",
     "TRY300",
-    "UP009",
     "UP031",
 ]
 "mxcubeweb/core/components/sampleview.py" = [
@@ -270,12 +246,10 @@ select = [
     "SIM114",
     "TRY003",
     "TRY203",
-    "UP009",
     "UP031",
 ]
 "mxcubeweb/core/components/user/database.py" = [
     "DTZ005",
-    "UP006",
 ]
 "mxcubeweb/core/components/user/dummyusermanager.py" = [
     "RET504",
@@ -311,29 +285,20 @@ select = [
     "N814",
     "RET504",
     "S110",
-    "UP009",
 ]
 "mxcubeweb/core/models/adaptermodels.py" = [
     "FBT003",
     "N815",
-    "UP006",
-    "UP007",
-    "UP009",
-    "UP035",
 ]
 "mxcubeweb/core/models/configmodels.py" = [
     "E501",
     "FBT003",
     "RUF012",
     "S108",
-    "UP006",
-    "UP007",
-    "UP035",
 ]
 "mxcubeweb/core/models/generic.py" = [
     "E501",
     "FBT003",
-    "UP007",
 ]
 "mxcubeweb/core/models/usermodels.py" = [
     "FBT003",
@@ -410,7 +375,6 @@ select = [
     "S607",
     "SIM101",
     "SIM114",
-    "UP009",
     "UP030",
     "UP032",
 ]
@@ -448,7 +412,6 @@ select = [
     "ARG001",
     "PLR0915",
     "SIM102",
-    "UP009",
 ]
 "mxcubeweb/routes/samplecentring.py" = [
     "ARG001",
@@ -495,7 +458,6 @@ select = [
 "mxcubeweb/routes/workflow.py" = [
     "ARG001",
     "RET504",
-    "UP009",
 ]
 "mxcubeweb/server.py" = [
     "ARG004",
@@ -507,7 +469,6 @@ select = [
     "S104",
     "S108",
     "SIM102",
-    "UP015",
     "UP031",
 ]
 "mxcubeweb/state_storage.py" = [
@@ -532,7 +493,6 @@ select = [
     "S101",  # "Use of `assert` detected": ignored because tests do rely on `assert`
     "S108",
     "SIM105",
-    "UP009",
 ]
 "test/test_*.py" = [
     "E712",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Helper functions for pytest"""
 
 from gevent import monkey


### PR DESCRIPTION
Fix some violations from the "pyupgrade `UP`" Ruff linter rules group:

* `UP006`
    * "Use `{to}` instead of `{from}` for type annotation"
    * <https://docs.astral.sh/ruff/rules/non-pep585-annotation/>
* `UP007`
    * "Use `X | Y` for type annotations"
    * <https://docs.astral.sh/ruff/rules/non-pep604-annotation-union/>
* `UP008`
    * "Use `super()` instead of `super(__class__, self)`"
    * <https://docs.astral.sh/ruff/rules/super-call-with-parameters/>
* `UP009`
    * "UTF-8 encoding declaration is unnecessary"
    * <https://docs.astral.sh/ruff/rules/utf8-encoding-declaration/>
* `UP015`
    * "Unnecessary mode argument"
    * <https://docs.astral.sh/ruff/rules/redundant-open-modes/>
* `UP026`
    * "`mock` is deprecated, use `unittest.mock`"
    * <https://docs.astral.sh/ruff/rules/deprecated-mock-import/>
* `UP035`
    * "Import from `{target}` instead: `{names}`"
    * <https://docs.astral.sh/ruff/rules/deprecated-import/>

These were all fixed automatically by Ruff itself.

The remaining violations in the "pyupgrade `UP`" rules group are all related to "string interpolation".