### PR TITLE
Fix Ruff rule violations from the C4 group

### DIFF
--- a/mxcubeweb/app.py
+++ b/mxcubeweb/app.py
@@ -139,7 +139,7 @@ class MXCUBECore:
 
     @staticmethod
     def adapt_hardware_objects(app):
-        hwobject_list = [item for item in MXCUBECore.hwr.hardware_objects]
+        hwobject_list = list(MXCUBECore.hwr.hardware_objects)
 
         for ho_name in hwobject_list:
             # Go through all hardware objects exposed by mxcubecore
@@ -215,7 +215,7 @@ class MXCUBEApplication:
     VIDEO_FORMAT = "MPEG1"
 
     # Contains the complete client side ui state, managed up state_storage.py
-    UI_STATE = dict()
+    UI_STATE = {}
     TEMP_DISABLED = []
 
     # Below variables used for application wide settings

--- a/mxcubeweb/core/components/beamline.py
+++ b/mxcubeweb/core/components/beamline.py
@@ -137,7 +137,7 @@ class Beamline(ComponentBase):
     def beamline_get_all_attributes(self):
         ho = BeamlineAdapter(HWR.beamline)
         data = ho.dict()
-        actions = list()
+        actions = []
 
         try:
             cmds = HWR.beamline.beamline_actions.get_commands()

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -842,7 +842,7 @@ class Queue(ComponentBase):
         :param list sample_order: List of sample ids
         """
         current_queue = self.queue_to_dict()
-        sid_list = list([sid for sid in order if current_queue.get(sid, False)])
+        sid_list = [sid for sid in order if current_queue.get(sid, False)]
 
         if sid_list:
             queue_id_list = [current_queue[sid]["queueID"] for sid in sid_list]

--- a/mxcubeweb/core/util/convertutils.py
+++ b/mxcubeweb/core/util/convertutils.py
@@ -16,15 +16,10 @@ def convert_to_dict(ispyb_object):
                     (convert_to_dict(x) if not isinstance(x, dict) else x) for x in val
                 ]
             elif isinstance(val, dict):
-                val = dict(
-                    [
-                        (
-                            k,
-                            (convert_to_dict(x) if not isinstance(x, dict) else x),
-                        )
-                        for k, x in val.items()
-                    ]
-                )
+                val = {
+                    k: (convert_to_dict(x) if not isinstance(x, dict) else x)
+                    for k, x in val.items()
+                }
 
             d[key] = val
 

--- a/mxcubeweb/state_storage.py
+++ b/mxcubeweb/state_storage.py
@@ -7,7 +7,7 @@ from mxcubeweb.server import Server as server
 
 
 def flush():
-    mxcube.UI_STATE = dict()
+    mxcube.UI_STATE = {}
 
 
 def init():

--- a/ruff.toml
+++ b/ruff.toml
@@ -38,8 +38,6 @@ select = [
 ]
 "mxcubeweb/app.py" = [
     "BLE001",
-    "C408",
-    "C416",
     "E501",
     "EM101",
     "G002",
@@ -142,7 +140,6 @@ select = [
 ]
 "mxcubeweb/core/components/beamline.py" = [
     "BLE001",
-    "C408",
     "N806",
     "N814",
     "SIM118",
@@ -183,7 +180,6 @@ select = [
     "ARG002",
     "B010",
     "BLE001",
-    "C411",
     "C901",
     "E501",
     "EM101",
@@ -310,7 +306,6 @@ select = [
     "SLF001",
 ]
 "mxcubeweb/core/util/convertutils.py" = [
-    "C404",
     "FBT002",
     "PLW2901",
 ]
@@ -473,7 +468,6 @@ select = [
 ]
 "mxcubeweb/state_storage.py" = [
     "ARG001",
-    "C408",
     "N813",
     "SIM118",
 ]


### PR DESCRIPTION
Fix Ruff rule violations from the "`C4` flake8-comprehensions" group:

* `C404`
    * "Unnecessary list comprehension (rewrite as a dict comprehension)"
    * <https://docs.astral.sh/ruff/rules/unnecessary-list-comprehension-dict/>
* `C408`
    * "Unnecessary `{kind}()` call (rewrite as a literal)"
    * <https://docs.astral.sh/ruff/rules/unnecessary-collection-call/>
* `C411`
    * "Unnecessary `list()` call (remove the outer call to `list()`)"
    * <https://docs.astral.sh/ruff/rules/unnecessary-list-call/>
* `C416`
    * "Unnecessary `{kind}` comprehension (rewrite using `{kind}()`)"
    * <https://docs.astral.sh/ruff/rules/unnecessary-comprehension/>

All fixes were done automatically by Ruff itself.