### PR TITLE
Fix Ruff "flake8-errmsg `EM`" rule violations

### DIFF
--- a/mxcubeweb/app.py
+++ b/mxcubeweb/app.py
@@ -248,9 +248,8 @@ class MXCUBEApplication:
     server = None
 
     def __init__(self):
-        raise NotImplementedError(
-            "MXCUBEApplication is to be used as a pure static class, dont instanciate"
-        )
+        msg = "MXCUBEApplication is to be used as a pure static class, dont instanciate"
+        raise NotImplementedError(msg)
 
     @staticmethod
     def init(

--- a/mxcubeweb/core/adapter/actuator_adapter.py
+++ b/mxcubeweb/core/adapter/actuator_adapter.py
@@ -62,7 +62,8 @@ class ActuatorAdapter(ActuatorAdapterBase):
         try:
             return FloatValueModel(value=self._ho.get_value())
         except (AttributeError, TypeError):
-            raise ValueError("Could not get value")
+            msg = "Could not get value"
+            raise ValueError(msg)
 
     def stop(self):
         """

--- a/mxcubeweb/core/adapter/adapter_base.py
+++ b/mxcubeweb/core/adapter/adapter_base.py
@@ -418,7 +418,8 @@ class ActuatorAdapterBase(AdapterBase):
             # as we are returning floats
             return (0, 0) if None in self._ho.get_limits() else self._ho.get_limits()
         except (AttributeError, TypeError):
-            raise ValueError("Could not get limits")
+            msg = "Could not get limits"
+            raise ValueError(msg)
 
     def _dict_repr(self):
         """Dictionary representation of the hardware object.

--- a/mxcubeweb/core/adapter/motor_adapter.py
+++ b/mxcubeweb/core/adapter/motor_adapter.py
@@ -72,4 +72,5 @@ class MotorAdapter(ActuatorAdapterBase):
         try:
             return self._ho.get_limits()
         except (AttributeError, TypeError):
-            raise ValueError("Could not get limits")
+            msg = "Could not get limits"
+            raise ValueError(msg)

--- a/mxcubeweb/core/adapter/wavelength_adapter.py
+++ b/mxcubeweb/core/adapter/wavelength_adapter.py
@@ -59,7 +59,8 @@ class WavelengthAdapter(ActuatorAdapterBase):
         try:
             return FloatValueModel(value=self._ho.get_wavelength())
         except (AttributeError, TypeError) as ex:
-            raise ValueError("Could not get value") from ex
+            msg = "Could not get value"
+            raise ValueError(msg) from ex
 
     def state(self):
         """
@@ -87,7 +88,8 @@ class WavelengthAdapter(ActuatorAdapterBase):
         try:
             return self._ho.get_wavelength_limits()
         except (AttributeError, TypeError) as ex:
-            raise ValueError("Could not get limits") from ex
+            msg = "Could not get limits"
+            raise ValueError(msg) from ex
 
     def read_only(self):
         """

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -73,7 +73,8 @@ class Queue(ComponentBase):
             pt.run_number += 1
 
             if pt.run_number > 1000:
-                raise RuntimeError("Over a thousand runs of the same collection")
+                msg = "Over a thousand runs of the same collection"
+                raise RuntimeError(msg)
 
             start_fname, end_fname = pt.get_first_and_last_file()
 

--- a/mxcubeweb/core/components/sampleview.py
+++ b/mxcubeweb/core/components/sampleview.py
@@ -400,7 +400,8 @@ class SampleView(ComponentBase):
             logging.getLogger("user_level_log").warning(
                 "Diffracomter is busy, cannot start centering"
             )
-            raise RuntimeError("Diffracomter is busy, cannot start centering")
+            msg = "Diffracomter is busy, cannot start centering"
+            raise RuntimeError(msg)
 
         return {"clicksLeft": self.centring_clicks_left()}
 

--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -416,21 +416,25 @@ class UserManager(BaseUserManager):
                 self.force_signout_user(login_id)
             else:
                 if current_user.username == login_id:
-                    raise Exception("You are already logged in")
+                    msg = "You are already logged in"
+                    raise Exception(msg)
                 else:
-                    raise Exception(
+                    msg = (
                         "Login rejected, you are already logged in"
                         " somewhere else\nand Another user is already"
                         " logged in"
                     )
+                    raise Exception(msg)
 
         # Only allow in-house log-in from local host
         if inhouse and not (inhouse and is_local_host()):
-            raise Exception("In-house only allowed from localhost")
+            msg = "In-house only allowed from localhost"
+            raise Exception(msg)
 
         # Only allow local login when remote is disabled
         if not self.app.ALLOW_REMOTE and not is_local_host():
-            raise Exception("Remote access disabled")
+            msg = "Remote access disabled"
+            raise Exception(msg)
 
         return session_manager
 

--- a/mxcubeweb/routes/samplecentring.py
+++ b/mxcubeweb/routes/samplecentring.py
@@ -56,7 +56,8 @@ def init_route(app, server, url_prefix):  # noqa: C901
 
             # Check if send data is a jpeg image
             if "image/jpeg" not in mimetype:
-                raise Exception("Image type should be jpeg")
+                msg = "Image type should be jpeg"
+                raise Exception(msg)
 
             image = HWR.beamline.sample_view.take_snapshot(
                 overlay_data=overlay_data,

--- a/mxcubeweb/server.py
+++ b/mxcubeweb/server.py
@@ -37,9 +37,8 @@ class Server:
     flask_socketio = None
 
     def __init__(self):
-        raise NotImplementedError(
-            "Server is to be used as a pure static class, don't instantiate."
-        )
+        msg = "Server is to be used as a pure static class, don't instantiate."
+        raise NotImplementedError(msg)
 
     @staticmethod
     def exception_handler(e):

--- a/ruff.toml
+++ b/ruff.toml
@@ -39,7 +39,6 @@ select = [
 "mxcubeweb/app.py" = [
     "BLE001",
     "E501",
-    "EM101",
     "G002",
     "G004",
     "I001",
@@ -69,14 +68,12 @@ select = [
 "mxcubeweb/core/adapter/actuator_adapter.py" = [
     "B904",
     "BLE001",
-    "EM101",
     "S110",
     "TRY003",
 ]
 "mxcubeweb/core/adapter/adapter_base.py" = [
     "ARG002",
     "B904",
-    "EM101",
     "G003",
     "G004",
     "RET505",
@@ -122,7 +119,6 @@ select = [
 ]
 "mxcubeweb/core/adapter/motor_adapter.py" = [
     "B904",
-    "EM101",
     "TRY003",
 ]
 "mxcubeweb/core/adapter/nstate_adapter.py" = [
@@ -133,7 +129,6 @@ select = [
 "mxcubeweb/core/adapter/wavelength_adapter.py" = [
     "ARG002",
     "BLE001",
-    "EM101",
     "S110",
     "TRY003",
     "TRY203",
@@ -182,7 +177,6 @@ select = [
     "BLE001",
     "C901",
     "E501",
-    "EM101",
     "ERA001",
     "FBT002",
     "FBT003",
@@ -235,7 +229,6 @@ select = [
     "ARG002",
     "BLE001",
     "E501",
-    "EM101",
     "N814",
     "PLR5501",
     "PLW0127",
@@ -256,7 +249,6 @@ select = [
     "BLE001",
     "C901",
     "DTZ005",
-    "EM101",
     "ERA001",
     "FBT001",
     "FBT002",
@@ -412,7 +404,6 @@ select = [
     "ARG001",
     "BLE001",
     "E501",
-    "EM101",
     "N814",
     "PLR0915",
     "RET505",
@@ -456,7 +447,6 @@ select = [
 ]
 "mxcubeweb/server.py" = [
     "ARG004",
-    "EM101",
     "N805",
     "PTH118",
     "PTH120",


### PR DESCRIPTION
Fix Ruff rule violations from the "flake8-errmsg `EM`" group:

* `EM101`
    * "Exception must not use a string literal, assign to variable first"
    * <https://docs.astral.sh/ruff/rules/raw-string-in-exception/>

All fixes were made automatically by Ruff itself.