### PR TITLE
Fix violations "flake8-return `RET`" Ruff rules

### DIFF
--- a/mxcubeweb/__init__.py
+++ b/mxcubeweb/__init__.py
@@ -143,8 +143,7 @@ def main():
     if server and cfg:
         server.run(cfg)
         return 0
-    else:
-        return 1
+    return 1
 
 
 if __name__ == "__main__":

--- a/mxcubeweb/app.py
+++ b/mxcubeweb/app.py
@@ -112,6 +112,7 @@ class MXCUBECore:
     def _get_object_from_id(_id):
         if _id in MXCUBECore.adapter_dict:
             return MXCUBECore.adapter_dict[_id]["adapter"]
+        return None
 
     @staticmethod
     def _get_adapter_id(ho):

--- a/mxcubeweb/config.py
+++ b/mxcubeweb/config.py
@@ -51,6 +51,4 @@ class Config:
 
     def load_config(self, component_name, schema):
         fpath = os.path.join(Config.CONFIG_ROOT_PATH, f"{component_name}.yaml")
-        config = ConfigLoader().load(path=fpath, schema=schema)
-
-        return config
+        return ConfigLoader().load(path=fpath, schema=schema)

--- a/mxcubeweb/core/adapter/adapter_base.py
+++ b/mxcubeweb/core/adapter/adapter_base.py
@@ -81,8 +81,7 @@ class AdapterBase:
         try:
             if _cmd:
                 return _cmd(**args)
-            else:
-                return self._ho.execute_exported_command(cmd_name, args)
+            return self._ho.execute_exported_command(cmd_name, args)
         except Exception as ex:
             self._command_exception(cmd_name, ex)
             logging.getLogger("MX3.HWR").exception("")
@@ -198,8 +197,7 @@ class AdapterBase:
     def _pydantic_model_for_command(self, cmd_name):
         if cmd_name in self.METHODS:
             return self._model_from_typehint(getattr(self, cmd_name, None))["args"]
-        else:
-            return self._ho.pydantic_model[cmd_name]
+        return self._ho.pydantic_model[cmd_name]
 
     def _exported_methods(self):
         exported_methods = {}

--- a/mxcubeweb/core/adapter/beamline_action_adapter.py
+++ b/mxcubeweb/core/adapter/beamline_action_adapter.py
@@ -30,14 +30,12 @@ class BeamlineActionAdapter(ActuatorAdapterBase):
         self.value_change(v)
 
     def commands(self):
-        method_list = [
+        return [
             attribute
             for attribute in dir(self._ho.__class__)
             if callable(getattr(self._ho.__class__, attribute))
             and attribute.startswith("_") is False
         ]
-
-        return method_list
 
     def _set_value(self, value: HOActuatorValueChangeModel):
         self._ho.set_value(self._ho.VALUES[value.value])

--- a/mxcubeweb/core/adapter/diffractometer_adapter.py
+++ b/mxcubeweb/core/adapter/diffractometer_adapter.py
@@ -33,9 +33,7 @@ class DiffractometerAdapter(AdapterBase):
 
     def head_configuration(self) -> dict:
         data = self._ho.get_head_configuration()
-        data = data.dict() if data else {}
-
-        return data
+        return data.dict() if data else {}
 
     def set_chip_layout(
         self,

--- a/mxcubeweb/core/components/harvester.py
+++ b/mxcubeweb/core/components/harvester.py
@@ -50,7 +50,7 @@ class Harvester(ComponentBase):
         except Exception:
             state = "OFFLINE"
 
-        initial_state = {
+        return {
             "state": state,
             "contents": contents,
             "global_state": {"global_state": global_state, "commands_state": cmdstate},
@@ -58,8 +58,6 @@ class Harvester(ComponentBase):
             "msg": msg,
             "plate_mode": HWR.beamline.diffractometer.in_plate_mode(),
         }
-
-        return initial_state
 
     def mount_from_harvester(self):
         sc = HWR.beamline.sample_changer

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -166,13 +166,11 @@ class Queue(ComponentBase):
         if not node:
             node = HWR.beamline.queue_model.get_model_root()
 
-        res = reduce(
+        return reduce(
             lambda x, y: x.update(y) or x,
             self.queue_to_dict_rec(node, include_lims_data),
             {},
         )
-
-        return res
 
     def queue_to_json(self, node=None, include_lims_data=False):
         """
@@ -358,7 +356,7 @@ class Queue(ComponentBase):
             else dtype_label
         )
 
-        res = {
+        return {
             "label": dtype_label + " (" + parameters["fileName"] + ")",
             "type": "DataCollection",
             "parameters": parameters,
@@ -369,8 +367,6 @@ class Queue(ComponentBase):
             "checked": node.is_enabled(),
             "state": state,
         }
-
-        return res
 
     def _handle_gphl_wf(self, sample_node, node, include_lims_data=False):
         pt = node.path_template
@@ -400,7 +396,7 @@ class Queue(ComponentBase):
             parameters["directory"], parameters["fileName"]
         )
 
-        res = {
+        return {
             "label": parameters["label"],
             "strategy_name": parameters["strategy_name"],
             "type": "GphlWorkflow",
@@ -412,8 +408,6 @@ class Queue(ComponentBase):
             "checked": node.is_enabled(),
             "state": state,
         }
-
-        return res
 
     def _handle_wf(self, sample_node, node, include_lims_data):
         queueID = node._node_id
@@ -437,7 +431,7 @@ class Queue(ComponentBase):
             parameters["path"], parameters["fileName"]
         )
 
-        res = {
+        return {
             "label": parameters["label"],
             "type": "Workflow",
             "name": node._type,
@@ -448,8 +442,6 @@ class Queue(ComponentBase):
             "checked": node.is_enabled(),
             "state": state,
         }
-
-        return res
 
     def _handle_xrf(self, sample_node, node):
         queueID = node._node_id
@@ -475,7 +467,7 @@ class Queue(ComponentBase):
             parameters["path"], parameters["fileName"]
         )
 
-        res = {
+        return {
             "label": "XRF Scan",
             "type": "xrf_spectrum",
             "parameters": parameters,
@@ -486,8 +478,6 @@ class Queue(ComponentBase):
             "checked": node.is_enabled(),
             "state": state,
         }
-
-        return res
 
     def _handle_energy_scan(self, sample_node, node):
         queueID = node._node_id
@@ -515,7 +505,7 @@ class Queue(ComponentBase):
             parameters["path"], parameters["fileName"]
         )
 
-        res = {
+        return {
             "label": "Energy Scan",
             "type": "energy_scan",
             "parameters": parameters,
@@ -526,8 +516,6 @@ class Queue(ComponentBase):
             "checked": node.is_enabled(),
             "state": state,
         }
-
-        return res
 
     def _handle_char(self, parent_node, node, include_lims_data=False):
         sample_node = parent_node.get_sample_node()
@@ -544,7 +532,7 @@ class Queue(ComponentBase):
 
         originID, task = self._handle_diffraction_plan(node, sample_node)
 
-        res = {
+        return {
             "label": "CHARACTERISATION",
             "type": "Characterisation",
             "parameters": parameters,
@@ -557,8 +545,6 @@ class Queue(ComponentBase):
             "diffractionPlan": task,
             "diffractionPlanID": originID,
         }
-
-        return res
 
     def _handle_diffraction_plan(self, node, sample_node):
         model, _ = self.get_entry(node._node_id)
@@ -590,7 +576,7 @@ class Queue(ComponentBase):
         queueID = node._node_id
         _, state = self.get_node_state(queueID)
 
-        res = {
+        return {
             "label": "Interleaved",
             "type": "Interleaved",
             "parameters": {
@@ -604,8 +590,6 @@ class Queue(ComponentBase):
             "queueID": node._node_id,
             "state": state,
         }
-
-        return res
 
     def _handle_sample(self, node, include_lims_data=False):
         location = "Manual" if node.free_pin_mode else node.loc_str
@@ -909,9 +893,7 @@ class Queue(ComponentBase):
                 for ti in reversed(tindex_list):
                     self.delete_entry_at([[sid, int(ti)]])
 
-        res = self.queue_to_dict()
-
-        return res
+        return self.queue_to_dict()
 
     def _queue_add_item_rec(self, item_list, sample_node_id=None):
         """
@@ -2407,11 +2389,10 @@ class Queue(ComponentBase):
             msg = "[QUEUE] sample info could not be retrieved"
             logging.getLogger("MX3.HWR").error(msg)
             raise Exception(msg)
-        else:
-            # Find task with queue id method_id
-            for task in sample.tasks:
-                if task["queueID"] == int(method_id):
-                    return task
+        # Find task with queue id method_id
+        for task in sample.tasks:
+            if task["queueID"] == int(method_id):
+                return task
 
         msg = "[QUEUE] method info could not be retrieved, it does not exits for"
         msg += " the given sample"

--- a/mxcubeweb/core/components/samplechanger.py
+++ b/mxcubeweb/core/components/samplechanger.py
@@ -315,11 +315,10 @@ class SampleChanger(ComponentBase):
         num_samples = 0
         for basket in baskets:
             num_samples += basket.get_number_of_samples()
-        res = {
+        return {
             "num_baskets": len(baskets),
             "num_samples": num_samples,
         }
-        return res
 
     def get_maintenance_cmds(self):
         if HWR.beamline.sample_changer_maintenance is not None:
@@ -357,7 +356,7 @@ class SampleChanger(ComponentBase):
         except Exception:
             state = "OFFLINE"
 
-        initial_state = {
+        return {
             "state": state,
             "loaded_sample": loaded_sample,
             "contents": contents,
@@ -369,8 +368,6 @@ class SampleChanger(ComponentBase):
             "msg": msg,
             "plate_mode": HWR.beamline.diffractometer.in_plate_mode(),
         }
-
-        return initial_state
 
     def sync_with_crims(self):
         """
@@ -394,8 +391,7 @@ class SampleChanger(ComponentBase):
                     "sample": x.sample,
                 }
                 xtal_list.append(response)
-            res = {"xtal_list": xtal_list}
-            return res
+            return {"xtal_list": xtal_list}
         except Exception:
             logging.getLogger("MX3.HWR").exception("Could not get crystal List")
             return {"xtal_list": xtal_list}

--- a/mxcubeweb/core/components/user/dummyusermanager.py
+++ b/mxcubeweb/core/components/user/dummyusermanager.py
@@ -7,8 +7,7 @@ class DummyUserManager(BaseUserManager):
 
     def _login(self, login_id, password):
         # Assuming that ISPyB is used
-        login_res = self.app.lims.lims_login(login_id, password, create_session=False)
-        return login_res
+        return self.app.lims.lims_login(login_id, password, create_session=False)
 
     def _signout(self):
         pass

--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -418,13 +418,12 @@ class UserManager(BaseUserManager):
                 if current_user.username == login_id:
                     msg = "You are already logged in"
                     raise Exception(msg)
-                else:
-                    msg = (
-                        "Login rejected, you are already logged in"
-                        " somewhere else\nand Another user is already"
-                        " logged in"
-                    )
-                    raise Exception(msg)
+                msg = (
+                    "Login rejected, you are already logged in"
+                    " somewhere else\nand Another user is already"
+                    " logged in"
+                )
+                raise Exception(msg)
 
         # Only allow in-house log-in from local host
         if inhouse and not (inhouse and is_local_host()):

--- a/mxcubeweb/core/components/workflow.py
+++ b/mxcubeweb/core/components/workflow.py
@@ -40,11 +40,10 @@ class Workflow(ComponentBase):
         base64data = HWR.beamline.sample_view.get_grid_data(gid)
         base64data = base64data if base64data else ""
 
-        data = base64.b64decode(base64data)
-        return data
+        return base64.b64decode(base64data)
 
     def test_workflow_dialog(self, wf):
-        dialog = {
+        return {
             "properties": {
                 "name": {
                     "title": "Task name",
@@ -66,5 +65,3 @@ class Workflow(ComponentBase):
             "required": ["name"],
             "dialogName": "Trouble shooting !",
         }
-
-        return dialog

--- a/mxcubeweb/core/util/adapterutils.py
+++ b/mxcubeweb/core/util/adapterutils.py
@@ -40,23 +40,22 @@ def get_adapter_cls_from_hardware_object(ho):
         ho, AbstractShutter.AbstractShutter
     ):
         return NStateAdapter
-    elif isinstance(ho, MiniDiff.MiniDiff) or isinstance(
+    if isinstance(ho, MiniDiff.MiniDiff) or isinstance(
         ho, GenericDiffractometer.GenericDiffractometer
     ):
         return DiffractometerAdapter
-    elif isinstance(ho, AbstractEnergy.AbstractEnergy):
+    if isinstance(ho, AbstractEnergy.AbstractEnergy):
         return EnergyAdapter
-    elif isinstance(ho, AbstractDetector.AbstractDetector):
+    if isinstance(ho, AbstractDetector.AbstractDetector):
         return DetectorAdapter
-    elif isinstance(ho, AbstractMachineInfo.AbstractMachineInfo):
+    if isinstance(ho, AbstractMachineInfo.AbstractMachineInfo):
         return MachineInfoAdapter
-    elif isinstance(ho, AbstractBeam.AbstractBeam):
+    if isinstance(ho, AbstractBeam.AbstractBeam):
         return BeamAdapter
-    elif isinstance(ho, DataPublisher.DataPublisher):
+    if isinstance(ho, DataPublisher.DataPublisher):
         return DataPublisherAdapter
-    elif isinstance(ho, AbstractMotor.AbstractMotor):
+    if isinstance(ho, AbstractMotor.AbstractMotor):
         return MotorAdapter
-    elif isinstance(ho, AbstractActuator.AbstractActuator):
+    if isinstance(ho, AbstractActuator.AbstractActuator):
         return ActuatorAdapter
-    else:
-        return None
+    return None

--- a/mxcubeweb/core/util/networkutils.py
+++ b/mxcubeweb/core/util/networkutils.py
@@ -33,7 +33,7 @@ def RateLimited(maxPerSecond):
             leftToWait = minInterval - elapsed
             if leftToWait > 0:
                 # ignore update
-                return
+                return None
             ret = func(*args, **kargs)
             lastTimeCalled.update({key: time.time()})
             return ret
@@ -80,8 +80,7 @@ def valid_login_only(f):
     def wrapped(*args, **kwargs):
         if not current_user.is_authenticated:
             return flask.Response(status=404)
-        else:
-            return f(*args, **kwargs)
+        return f(*args, **kwargs)
 
     return wrapped
 
@@ -91,8 +90,7 @@ def require_control(f):
     def wrapped(*args, **kwargs):
         if current_user.is_authenticated and not current_user.in_control:
             return flask.Response(status=401)
-        else:
-            return f(*args, **kwargs)
+        return f(*args, **kwargs)
 
     return wrapped
 
@@ -102,8 +100,8 @@ def ws_valid_login_only(f):
     def wrapped(*args, **kwargs):
         if not current_user.is_authenticated:
             flask_socketio.disconnect()
-        else:
-            return f(*args, **kwargs)
+            return None
+        return f(*args, **kwargs)
 
     return wrapped
 

--- a/mxcubeweb/routes/harvester.py
+++ b/mxcubeweb/routes/harvester.py
@@ -44,12 +44,11 @@ def init_route(app, server, url_prefix):  # noqa: C901
             HWR.beamline.harvester.harvest_crystal(crystal_uuid)
         except Exception:
             logging.getLogger("MX3.HWR").exception("Cannot Harvest Crystal")
-            resp = (
+            return (
                 "Cannot Harvest Crystal",
                 409,
                 {"Content-Type": "application/json"},
             )
-            return resp
 
         return jsonify(app.harvester.get_harvester_contents())
 
@@ -65,12 +64,11 @@ def init_route(app, server, url_prefix):  # noqa: C901
             )
         except Exception:
             logging.getLogger("MX3.HWR").exception("Cannot Harvest or mount Crystal")
-            resp = (
+            return (
                 "Cannot Harvest or Mount Sample",
                 409,
                 {"Content-Type": "application/json"},
             )
-            return resp
         app.harvester.init_signals()
         return jsonify(app.harvester.get_harvester_contents())
 
@@ -81,6 +79,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
         ret = HWR.beamline.harvester_maintenance.calibrate_pin()
         if ret:
             return jsonify(app.harvester.get_harvester_contents())
+        return None
 
     @bp.route("/send_data_collection_info_to_crims", methods=["GET"])
     @server.require_control
@@ -89,6 +88,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
         ret = app.harvester.send_data_collection_info_to_crims()
         if ret:
             return jsonify(app.harvester.get_harvester_contents())
+        return None
 
     @bp.route("/validate_calibration", methods=["POST"])
     @server.restrict

--- a/mxcubeweb/routes/login.py
+++ b/mxcubeweb/routes/login.py
@@ -63,10 +63,7 @@ def init_route(app, server, url_prefix):
     @bp.route("/ssologin", methods=["GET"])
     def ssosignin():
         redirect_uri = url_for("login.auth", _external=True)
-        response = app.usermanager.oauth_client.keycloak.authorize_redirect(
-            redirect_uri
-        )
-        return response
+        return app.usermanager.oauth_client.keycloak.authorize_redirect(redirect_uri)
 
     @bp.route("/auth", methods=["GET"])
     def auth():

--- a/mxcubeweb/routes/samplecentring.py
+++ b/mxcubeweb/routes/samplecentring.py
@@ -123,8 +123,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
 
         if point:
             return Response(status=200)
-        else:
-            return Response(status=409)
+        return Response(status=409)
 
     @bp.route("/shapes", methods=["GET"])
     @server.restrict
@@ -156,8 +155,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
             resp = jsonify(shape)
             resp.status_code = 200
             return resp
-        else:
-            return Response(status=409)
+        return Response(status=409)
 
     @bp.route("/shapes/<sid>", methods=["POST"])
     def shape_add_result(sid):

--- a/mxcubeweb/routes/signals.py
+++ b/mxcubeweb/routes/signals.py
@@ -242,7 +242,7 @@ def get_task_state(entry):
     _, state = mxcube.queue.get_node_state(node_id)
     node_index = mxcube.queue.node_index(entry.get_data_model())
 
-    msg = {
+    return {
         "Signal": "",
         "Message": "",
         "taskIndex": node_index["idx"],
@@ -251,8 +251,6 @@ def get_task_state(entry):
         "state": state,
         "progress": 1 if state == COLLECTED else 0,
     }
-
-    return msg
 
 
 def update_task_result(entry):

--- a/mxcubeweb/routes/workflow.py
+++ b/mxcubeweb/routes/workflow.py
@@ -34,12 +34,10 @@ def init_route(app, server, url_prefix):
     @bp.route("/mesh_result/<gid>/<t>", methods=["GET"])
     # @server.restrict
     def get_grid_data(gid, t, rand):
-        res = send_file(
+        return send_file(
             io.BytesIO(app.workflow.get_mesh_result(gid, t)),
             mimetype="image/png",
         )
-
-        return res
 
     # This route is only for testing
     @bp.route("/dialog/<wf>", methods=["GET"])

--- a/ruff.toml
+++ b/ruff.toml
@@ -29,7 +29,6 @@ select = [
     "N813",
     "N814",
     "PTH109",
-    "RET505",
     "S108",
 ]
 "mxcubeweb/__version__.py" = [
@@ -50,7 +49,6 @@ select = [
     "PTH118",
     "PTH120",
     "PTH123",
-    "RET503",
     "RUF012",
     "S103",
     "SIM108",
@@ -62,7 +60,6 @@ select = [
     "G004",
     "PTH118",
     "PTH123",
-    "RET504",
     "TRY400",
 ]
 "mxcubeweb/core/adapter/actuator_adapter.py" = [
@@ -76,7 +73,6 @@ select = [
     "B904",
     "G003",
     "G004",
-    "RET505",
     "RUF012",
     "SIM105",
     "SIM212",
@@ -87,7 +83,6 @@ select = [
 ]
 "mxcubeweb/core/adapter/beamline_action_adapter.py" = [
     "BLE001",
-    "RET504",
     "SIM108",
     "TRY400",
 ]
@@ -101,7 +96,6 @@ select = [
     "RUF012",
 ]
 "mxcubeweb/core/adapter/diffractometer_adapter.py" = [
-    "RET504",
     "RUF012",
 ]
 "mxcubeweb/core/adapter/energy_adapter.py" = [
@@ -155,7 +149,6 @@ select = [
     "N803",
     "N806",
     "N814",
-    "RET504",
     "TRY300",
 ]
 "mxcubeweb/core/components/lims.py" = [
@@ -196,8 +189,6 @@ select = [
     "PLW2901",
     "PTH113",
     "PTH118",
-    "RET504",
-    "RET506",
     "S110",
     "SIM105",
     "SIM108",
@@ -218,7 +209,6 @@ select = [
     "N806",
     "N814",
     "PLR5501",
-    "RET504",
     "SIM108",
     "SIM114",
     "SIM201",
@@ -240,9 +230,6 @@ select = [
 "mxcubeweb/core/components/user/database.py" = [
     "DTZ005",
 ]
-"mxcubeweb/core/components/user/dummyusermanager.py" = [
-    "RET504",
-]
 "mxcubeweb/core/components/user/usermanager.py" = [
     "ARG002",
     "B006",
@@ -255,7 +242,6 @@ select = [
     "FBT003",
     "N814",
     "PLR5501",
-    "RET506",
     "S110",
     "S113",
     "SIM102",
@@ -271,7 +257,6 @@ select = [
     "ARG002",
     "BLE001",
     "N814",
-    "RET504",
     "S110",
 ]
 "mxcubeweb/core/models/adaptermodels.py" = [
@@ -293,7 +278,6 @@ select = [
 ]
 "mxcubeweb/core/util/adapterutils.py" = [
     "PLR0911",
-    "RET505",
     "SIM101",
     "SLF001",
 ]
@@ -314,9 +298,6 @@ select = [
     "N803",
     "N806",
     "N814",
-    "RET502",
-    "RET503",
-    "RET505",
     "SIM108",
     "TRY400",
     "UP031",
@@ -343,8 +324,6 @@ select = [
 ]
 "mxcubeweb/routes/harvester.py" = [
     "N814",
-    "RET503",
-    "RET504",
     "SIM210",
 ]
 "mxcubeweb/routes/lims.py" = [
@@ -373,7 +352,6 @@ select = [
 "mxcubeweb/routes/login.py" = [
     "BLE001",
     "C901",
-    "RET504",
     "UP031",
 ]
 "mxcubeweb/routes/main.py" = [
@@ -406,7 +384,6 @@ select = [
     "E501",
     "N814",
     "PLR0915",
-    "RET505",
     "TRY002",
     "TRY003",
     "TRY301",
@@ -430,7 +407,6 @@ select = [
     "N814",
     "N816",
     "PLR0913",
-    "RET504",
     "S110",
     "SIM105",
     "SIM108",
@@ -443,7 +419,6 @@ select = [
 ]
 "mxcubeweb/routes/workflow.py" = [
     "ARG001",
-    "RET504",
 ]
 "mxcubeweb/server.py" = [
     "ARG004",


### PR DESCRIPTION
Fix violations of Ruff rules in the "flake8-return `RET`" group:

* `RET502`
    * "Do not implicitly return None in function able to return non-`None` value"
    * <https://docs.astral.sh/ruff/rules/implicit-return-value/>
* `RET503`
    * "Missing explicit `return` at the end of function able to return non-`None` value"
    * <https://docs.astral.sh/ruff/rules/implicit-return/>
* `RET504`
    * "Unnecessary assignment before `return` statement"
    * <https://docs.astral.sh/ruff/rules/unnecessary-assign/>
* `RET505`
    * "Unnecessary branch after return statement"
    * <https://docs.astral.sh/ruff/rules/superfluous-else-return/>
* `RET506`
    * "Unnecessary branch after raise statement"
    * <https://docs.astral.sh/ruff/rules/superfluous-else-raise/>

All fixes done automatically by Ruff itself.