### PR TITLE
Fix violations of `flake8-simplify SIM` Ruff rules

### DIFF
--- a/mxcubeweb/app.py
+++ b/mxcubeweb/app.py
@@ -396,10 +396,7 @@ class MXCUBEApplication:
             )
             uilog_file_handler.setFormatter(file_formatter)
 
-        if not log_level:
-            log_level = "INFO"
-        else:
-            log_level = log_level.upper()
+        log_level = "INFO" if not log_level else log_level.upper()
 
         custom_log_handler = MX3LoggingHandler(MXCUBEApplication.server)
         custom_log_handler.setLevel(log_level)

--- a/mxcubeweb/core/adapter/adapter_base.py
+++ b/mxcubeweb/core/adapter/adapter_base.py
@@ -1,3 +1,4 @@
+import contextlib
 import inspect
 import logging
 import traceback
@@ -40,7 +41,7 @@ class AdapterBase:
         self._msg = ""
 
     def get_adapter_id(self, ho=None):
-        ho = self._ho if not ho else ho
+        ho = ho if ho else self._ho
         return self.app.mxcubecore._get_adapter_id(ho)
 
     def _add_adapter(self, attr_name, ho, adapter_cls=None):
@@ -347,10 +348,8 @@ class ActuatorAdapterBase(AdapterBase):
 
         self._unique = False
 
-        try:
+        with contextlib.suppress(AttributeError):
             self._read_only = ho.read_only
-        except AttributeError:
-            pass
 
     # Don't limit rate this method with utils.LimitRate, all subclasses
     # will share this method thus all methods will be effected if limit rated.

--- a/mxcubeweb/core/adapter/beamline_action_adapter.py
+++ b/mxcubeweb/core/adapter/beamline_action_adapter.py
@@ -22,10 +22,7 @@ class BeamlineActionAdapter(ActuatorAdapterBase):
         ho.connect("stateChanged", self.state_change)
 
     def _value_change(self, value):
-        if isinstance(value, Enum):
-            v = value.name
-        else:
-            v = value
+        v = value.name if isinstance(value, Enum) else value
 
         self.value_change(v)
 

--- a/mxcubeweb/core/adapter/flux_adapter.py
+++ b/mxcubeweb/core/adapter/flux_adapter.py
@@ -1,3 +1,4 @@
+import contextlib
 from decimal import Decimal
 
 from mxcubecore.BaseHardwareObjects import HardwareObjectState
@@ -16,10 +17,8 @@ class FluxAdapter(ActuatorAdapterBase):
 
         self._read_only = ho.read_only
 
-        try:
+        with contextlib.suppress(Exception):
             ho.connect("valueChanged", self._value_change)
-        except Exception:
-            pass
 
     @RateLimited(6)
     def _value_change(self, value, **kwargs):

--- a/mxcubeweb/core/adapter/nstate_adapter.py
+++ b/mxcubeweb/core/adapter/nstate_adapter.py
@@ -22,10 +22,7 @@ class NStateAdapter(ActuatorAdapterBase):
         ho.connect("stateChanged", self.state_change)
 
     def _value_change(self, value):
-        if isinstance(value, Enum):
-            v = value.name
-        else:
-            v = value
+        v = value.name if isinstance(value, Enum) else value
 
         self.value_change(v)
 

--- a/mxcubeweb/core/components/beamline.py
+++ b/mxcubeweb/core/components/beamline.py
@@ -189,7 +189,7 @@ class Beamline(ComponentBase):
         beamline_actions = HWR.beamline.beamline_actions
 
         if getattr(beamline_actions, "pydantic_model", None):
-            for cmd_name in beamline_actions.exported_attributes.keys():
+            for cmd_name in beamline_actions.exported_attributes:
                 cmd_object = beamline_actions.get_annotated_command(cmd_name)
 
                 actions.append(

--- a/mxcubeweb/core/components/lims.py
+++ b/mxcubeweb/core/components/lims.py
@@ -197,12 +197,13 @@ class Lims(ComponentBase):
             self.app.usermanager.signout()
             return False
 
-        if HWR.beamline.lims.is_user_login_type() and "Commissioning" in session.title:
-            if hasattr(HWR.beamline.session, "set_in_commissioning"):
-                HWR.beamline.session.set_in_commissioning(self.get_proposal_info())
-                logging.getLogger("MX3.HWR").info(
-                    "[LIMS] Commissioning proposal flag set."
-                )
+        if (
+            HWR.beamline.lims.is_user_login_type()
+            and "Commissioning" in session.title
+            and hasattr(HWR.beamline.session, "set_in_commissioning")
+        ):
+            HWR.beamline.session.set_in_commissioning(self.get_proposal_info())
+            logging.getLogger("MX3.HWR").info("[LIMS] Commissioning proposal flag set.")
 
         if HWR.beamline.session.session_id != HWR.beamline.lims.get_session_id():
             # ruff: noqa: G004

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -1,3 +1,4 @@
+import contextlib
 import itertools
 import json
 import logging
@@ -111,10 +112,8 @@ class Queue(ComponentBase):
                 else:
                     tlist.extend(group.get_children())
 
-            try:
+            with contextlib.suppress(Exception):
                 index = tlist.index(node)
-            except Exception:
-                pass
 
         return {
             "sample": sample,
@@ -648,10 +647,7 @@ class Queue(ComponentBase):
         """
         result = []
 
-        if isinstance(node, list):
-            node_list = node
-        else:
-            node_list = node.get_children()
+        node_list = node if isinstance(node, list) else node.get_children()
 
         for node in node_list:
             # NB under GPhL workflow, nodes do not have predictable distance
@@ -1639,7 +1635,7 @@ class Queue(ComponentBase):
         HWR.beamline.queue_model.add_child(parent_model, group_model)
         HWR.beamline.queue_model.add_child(group_model, wf_model)
 
-        if not task["parameters"]["wfpath"] == "Gphl":
+        if task["parameters"]["wfpath"] != "Gphl":
             self.set_wf_params(wf_model, dc_entry, task, sample_model)
 
         group_entry = qe.TaskGroupQueueEntry(Mock(), group_model)

--- a/mxcubeweb/core/components/samplechanger.py
+++ b/mxcubeweb/core/components/samplechanger.py
@@ -53,10 +53,7 @@ class SampleChanger(ComponentBase):
         for s in samples_list:
             if not s.is_present():
                 continue
-            if s.has_been_loaded():
-                state = COLLECTED
-            else:
-                state = UNCOLLECTED
+            state = COLLECTED if s.has_been_loaded() else UNCOLLECTED
             sample_dm = s.get_id() or ""
             coords = s.get_coords()
             sample_data = {
@@ -207,9 +204,10 @@ class SampleChanger(ComponentBase):
                 )
                 logging.getLogger("user_level_log").info(msg)
 
-                if not sc.get_loaded_sample():
-                    res = sc.load(sample["sampleID"], wait=True)
-                elif sc.get_loaded_sample().get_address() != sample["location"]:
+                if (
+                    not sc.get_loaded_sample()
+                    or sc.get_loaded_sample().get_address() != sample["location"]
+                ):
                     res = sc.load(sample["sampleID"], wait=True)
 
                 if (
@@ -264,7 +262,7 @@ class SampleChanger(ComponentBase):
         try:
             signals.sc_unload(sample["location"])
 
-            if not sample["location"] == "Manual":
+            if sample["location"] != "Manual":
                 HWR.beamline.sample_changer.unload(sample["location"], wait=False)
             else:
                 self.set_current_sample(None)

--- a/mxcubeweb/core/components/sampleview.py
+++ b/mxcubeweb/core/components/sampleview.py
@@ -51,9 +51,7 @@ class HttpStreamer:
             )
 
     def _new_frame_received(self, img, width, height, *args, **kwargs):
-        if isinstance(img, str):
-            img = img
-        elif isinstance(img, bytes):
+        if isinstance(img, str | bytes):
             img = img
         else:
             rawdata = img.bits().asstring(img.numBytes())

--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -1,3 +1,4 @@
+import contextlib
 import datetime
 import json
 import logging
@@ -186,9 +187,8 @@ class BaseUserManager(ComponentBase):
         return "access_token" not in res
 
     def handle_sso_logout(self):
-        if current_user.is_anonymous:
-            if self.sso_token_expired():
-                self.signout()
+        if current_user.is_anonymous and self.sso_token_expired():
+            self.signout()
 
     def login(self, login_id: str, password: str, sso_data: dict = {}):
         try:
@@ -258,10 +258,8 @@ class BaseUserManager(ComponentBase):
         # sure that the is_anonymous has the correct value.
         # Update operator calls lims.select_session that raises an exception if
         # there are no valid LIMS sessions.
-        try:
+        with contextlib.suppress(Exception):
             self.update_operator()
-        except Exception:
-            pass
 
         login_type = "User" if HWR.beamline.lims.is_user_login_type() else "Proposal"
 

--- a/mxcubeweb/core/util/adapterutils.py
+++ b/mxcubeweb/core/util/adapterutils.py
@@ -36,13 +36,9 @@ def get_adapter_cls_from_hardware_object(ho):
     from mxcubeweb.core.adapter.motor_adapter import MotorAdapter
     from mxcubeweb.core.adapter.nstate_adapter import NStateAdapter
 
-    if isinstance(ho, AbstractNState.AbstractNState) or isinstance(
-        ho, AbstractShutter.AbstractShutter
-    ):
+    if isinstance(ho, AbstractNState.AbstractNState | AbstractShutter.AbstractShutter):
         return NStateAdapter
-    if isinstance(ho, MiniDiff.MiniDiff) or isinstance(
-        ho, GenericDiffractometer.GenericDiffractometer
-    ):
+    if isinstance(ho, MiniDiff.MiniDiff | GenericDiffractometer.GenericDiffractometer):
         return DiffractometerAdapter
     if isinstance(ho, AbstractEnergy.AbstractEnergy):
         return EnergyAdapter

--- a/mxcubeweb/core/util/fsutils.py
+++ b/mxcubeweb/core/util/fsutils.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 
 from scandir import scandir
@@ -6,10 +7,8 @@ from scandir import scandir
 def scantree(path, include):
     res = []
 
-    try:
+    with contextlib.suppress(OSError):
         res = _scantree_rec(path, include, [])
-    except OSError:
-        pass
 
     return res
 
@@ -18,8 +17,7 @@ def _scantree_rec(path, include=[], files=[]):
     for entry in scandir(path):
         if entry.is_dir(follow_symlinks=False):
             _scantree_rec(entry.path, include, files)
-        elif entry.is_file():
-            if os.path.splitext(entry.path)[1][1:] in include:
-                files.append(entry.path)
+        elif entry.is_file() and os.path.splitext(entry.path)[1][1:] in include:
+            files.append(entry.path)
 
     return files

--- a/mxcubeweb/core/util/networkutils.py
+++ b/mxcubeweb/core/util/networkutils.py
@@ -25,10 +25,7 @@ def RateLimited(maxPerSecond):
 
     def decorate(func):
         def rateLimitedFunction(*args, **kargs):
-            if type(args[0]) is dict:
-                key = args[0].get("Signal")
-            else:
-                key = args[0]
+            key = args[0].get("Signal") if type(args[0]) is dict else args[0]
             elapsed = time.time() - lastTimeCalled.get(key, 0)
             leftToWait = minInterval - elapsed
             if leftToWait > 0:

--- a/mxcubeweb/routes/beamline.py
+++ b/mxcubeweb/routes/beamline.py
@@ -123,7 +123,7 @@ def add_adapter_routes(app, server, bp):
 
         exported_methods = adapter._exported_methods()
 
-        for cmd_name in exported_methods.keys():
+        for cmd_name in exported_methods:
             create_route(app, server, bp, adapter, _id, cmd_name)
 
 

--- a/mxcubeweb/routes/harvester.py
+++ b/mxcubeweb/routes/harvester.py
@@ -108,7 +108,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
     def send_ha_command(cmdparts, args=None):
         try:
             if cmdparts == "set_room_temperature_mode":
-                value = True if args in ["true", "True", "TRUE", "1"] else False
+                value = args in ["true", "True", "TRUE", "1"]
                 HWR.beamline.harvester_maintenance.send_command(cmdparts, value)
                 # Temporary set MD and SC Temperature mode at the same time
                 HWR.beamline.sample_changer.set_room_temperature_mode(value)

--- a/mxcubeweb/routes/lims.py
+++ b/mxcubeweb/routes/lims.py
@@ -92,9 +92,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
                 elif result_file_test("data-collection-results.html"):
                     r = apply_template("data-collection-results.html", data)
 
-            elif isinstance(model, qmo.Characterisation) or isinstance(
-                model, qmo.Workflow
-            ):
+            elif isinstance(model, qmo.Characterisation | qmo.Workflow):
                 if result_file_test("characterisation-results.js"):
                     try:
                         url_list = data["limsResultData"]["workflow_result_url_list"]
@@ -122,11 +120,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
                 elif result_file_test("characterisation-results.html"):
                     r = apply_template("characterisation-results.html", data)
 
-            elif isinstance(model, qmo.Workflow):
-                pass
-            elif isinstance(model, qmo.XRFSpectrum):
-                pass
-            elif isinstance(model, qmo.EnergyScan):
+            elif isinstance(model, qmo.Workflow | qmo.XRFSpectrum | qmo.EnergyScan):
                 pass
             else:
                 pass

--- a/mxcubeweb/routes/queue.py
+++ b/mxcubeweb/routes/queue.py
@@ -388,11 +388,6 @@ def init_route(app, server, url_prefix):  # noqa: C901
     def set_setting():
         result = app.queue.set_setting(SimpleNameValue(**request.json))
 
-        if result:
-            resp = jsonify({result[0]: result[1]})
-        else:
-            resp = Response(status=409)
-
-        return resp
+        return jsonify({result[0]: result[1]}) if result else Response(status=409)
 
     return bp

--- a/mxcubeweb/routes/ra.py
+++ b/mxcubeweb/routes/ra.py
@@ -25,13 +25,12 @@ def init_route(app, server, url_prefix):  # noqa: C901
         def handle_timeout_gives_control(sid, timeout=30):
             gevent.sleep(timeout)
 
-            if app.TIMEOUT_GIVES_CONTROL:
+            if app.TIMEOUT_GIVES_CONTROL and current_user.requests_control:
                 # Pass control to user if still waiting
-                if current_user.requests_control:
-                    toggle_operator(
-                        current_user.username,
-                        "Timeout expired, you have control",
-                    )
+                toggle_operator(
+                    current_user.username,
+                    "Timeout expired, you have control",
+                )
 
         # Is someone already asking for control
         for observer in app.usermanager.get_observers():

--- a/mxcubeweb/routes/signals.py
+++ b/mxcubeweb/routes/signals.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import logging
 
@@ -175,10 +176,7 @@ def loaded_sample_changed(sample):
         else:
             sample = HWR.beamline.sample_changer.get_loaded_sample()
 
-            if sample:
-                address = sample.get_address()
-            else:
-                address = None
+            address = sample.get_address() if sample else None
 
             mxcube.sample_changer.set_current_sample(address)
 
@@ -405,10 +403,8 @@ def collect_oscillation_failed(
     mxcube.NODE_ID_TO_LIMS_ID[node["queue_id"]] = lims_id
 
     if not mxcube.queue.is_interleaved(node["node"]):
-        try:
+        with contextlib.suppress(Exception):
             HWR.beamline.get_dc(lims_id)
-        except Exception:
-            pass
 
         msg = {
             "Signal": "collectOscillationFailed",

--- a/mxcubeweb/server.py
+++ b/mxcubeweb/server.py
@@ -119,9 +119,8 @@ class Server:
         Server.flask.register_blueprint(bp)
 
         for key, function in Server.flask.view_functions.items():
-            if key.startswith(bp.name):
-                if not hasattr(function, "tags"):
-                    function.tags = [bp.name.title().replace("_", " ")]
+            if key.startswith(bp.name) and not hasattr(function, "tags"):
+                function.tags = [bp.name.title().replace("_", " ")]
 
     @staticmethod
     def register_routes(mxcube):

--- a/mxcubeweb/state_storage.py
+++ b/mxcubeweb/state_storage.py
@@ -47,4 +47,4 @@ def init():
 
     @server.flask_socketio.on("ui_state_getkeys", namespace="/ui_state")
     def ui_state_getkeys(*args):
-        return ["reduxPersist:" + k for k in mxcube.UI_STATE.keys()]
+        return ["reduxPersist:" + k for k in mxcube.UI_STATE]

--- a/ruff.toml
+++ b/ruff.toml
@@ -51,7 +51,6 @@ select = [
     "PTH123",
     "RUF012",
     "S103",
-    "SIM108",
     "SIM115",
     "T201",
     "UP031",
@@ -74,8 +73,6 @@ select = [
     "G003",
     "G004",
     "RUF012",
-    "SIM105",
-    "SIM212",
     "SLF001",
     "TRY003",
     "TRY400",
@@ -83,7 +80,6 @@ select = [
 ]
 "mxcubeweb/core/adapter/beamline_action_adapter.py" = [
     "BLE001",
-    "SIM108",
     "TRY400",
 ]
 "mxcubeweb/core/adapter/beamline_adapter.py" = [
@@ -105,7 +101,6 @@ select = [
     "BLE001",
     "ERA001",
     "S110",
-    "SIM105",
     "UP032",
 ]
 "mxcubeweb/core/adapter/machine_info_adapter.py" = [
@@ -117,7 +112,6 @@ select = [
 ]
 "mxcubeweb/core/adapter/nstate_adapter.py" = [
     "BLE001",
-    "SIM108",
     "TRY400",
 ]
 "mxcubeweb/core/adapter/wavelength_adapter.py" = [
@@ -131,7 +125,6 @@ select = [
     "BLE001",
     "N806",
     "N814",
-    "SIM118",
     "TRY002",
     "UP031",
 ]
@@ -159,7 +152,6 @@ select = [
     "FURB188",
     "G002",
     "N814",
-    "SIM102",
     "TRY301",
     "UP031",
 ]
@@ -190,9 +182,6 @@ select = [
     "PTH113",
     "PTH118",
     "S110",
-    "SIM105",
-    "SIM108",
-    "SIM201",
     "SLF001",
     "TD002",
     "TD003",
@@ -209,9 +198,6 @@ select = [
     "N806",
     "N814",
     "PLR5501",
-    "SIM108",
-    "SIM114",
-    "SIM201",
     "TRY300",
     "UP031",
 ]
@@ -222,7 +208,6 @@ select = [
     "N814",
     "PLR5501",
     "PLW0127",
-    "SIM114",
     "TRY003",
     "TRY203",
     "UP031",
@@ -244,8 +229,6 @@ select = [
     "PLR5501",
     "S110",
     "S113",
-    "SIM102",
-    "SIM105",
     "TRY002",
     "TRY003",
     "TRY201",
@@ -278,7 +261,6 @@ select = [
 ]
 "mxcubeweb/core/util/adapterutils.py" = [
     "PLR0911",
-    "SIM101",
     "SLF001",
 ]
 "mxcubeweb/core/util/convertutils.py" = [
@@ -288,8 +270,6 @@ select = [
 "mxcubeweb/core/util/fsutils.py" = [
     "B006",
     "PTH122",
-    "SIM102",
-    "SIM105",
 ]
 "mxcubeweb/core/util/networkutils.py" = [
     "BLE001",
@@ -298,7 +278,6 @@ select = [
     "N803",
     "N806",
     "N814",
-    "SIM108",
     "TRY400",
     "UP031",
 ]
@@ -313,7 +292,6 @@ select = [
     "G002",
     "N814",
     "PLR0913",
-    "SIM118",
     "SLF001",
     "TRY300",
     "TRY400",
@@ -324,7 +302,6 @@ select = [
 ]
 "mxcubeweb/routes/harvester.py" = [
     "N814",
-    "SIM210",
 ]
 "mxcubeweb/routes/lims.py" = [
     "BLE001",
@@ -339,8 +316,6 @@ select = [
     "RUF100",
     "S603",
     "S607",
-    "SIM101",
-    "SIM114",
     "UP030",
     "UP032",
 ]
@@ -370,13 +345,11 @@ select = [
     "BLE001",
     "N814",
     "PLR0915",
-    "SIM108",
     "TRY300",
 ]
 "mxcubeweb/routes/ra.py" = [
     "ARG001",
     "PLR0915",
-    "SIM102",
 ]
 "mxcubeweb/routes/samplecentring.py" = [
     "ARG001",
@@ -408,8 +381,6 @@ select = [
     "N816",
     "PLR0913",
     "S110",
-    "SIM105",
-    "SIM108",
     "SLF001",
     "TD002",
     "TD003",
@@ -428,13 +399,11 @@ select = [
     "PTH123",
     "S104",
     "S108",
-    "SIM102",
     "UP031",
 ]
 "mxcubeweb/state_storage.py" = [
     "ARG001",
     "N813",
-    "SIM118",
 ]
 "test/*.py" = [
     "INP001",
@@ -449,7 +418,6 @@ select = [
     "PTH120",
     "S101",  # "Use of `assert` detected": ignored because tests do rely on `assert`
     "S108",
-    "SIM105",
 ]
 "test/test_*.py" = [
     "E712",
@@ -461,7 +429,6 @@ select = [
     "PLR2044",
     "PTH107",
     "S108",
-    "SIM105",
 ]
 "test/test_diffractometer_routes.py" = [
     "N814",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -24,6 +24,8 @@ sys.path.append(MXCUBE_ROOT)
 sys.path.append("./")
 
 
+import contextlib
+
 from mxcubecore import HardwareRepository
 
 from mxcubeweb import build_server_and_config
@@ -33,10 +35,8 @@ _SIO_TEST_CLIENT = None
 
 @pytest.fixture
 def client():
-    try:
+    with contextlib.suppress(FileNotFoundError):
         os.remove("/tmp/mxcube-test-user.db")
-    except FileNotFoundError:
-        pass
 
     global _SIO_TEST_CLIENT
 
@@ -91,10 +91,8 @@ def client():
 
     client.get("/mxcube/api/v0.1/login/signout/")
 
-    try:
+    with contextlib.suppress(FileNotFoundError):
         os.remove("/tmp/mxcube-test-user.db")
-    except FileNotFoundError:
-        pass
 
 
 @pytest.fixture

--- a/test/test_authn.py
+++ b/test/test_authn.py
@@ -3,6 +3,7 @@
 
 """Authentication tests."""
 
+import contextlib
 import os
 import time
 
@@ -34,10 +35,8 @@ def login_type(request):
 
 @pytest.fixture
 def server(request, login_type):
-    try:
+    with contextlib.suppress(FileNotFoundError):
         os.remove(USER_DB_PATH)
-    except FileNotFoundError:
-        pass
 
     mxcubecore.HardwareRepository.uninit_hardware_repository()
 
@@ -54,10 +53,8 @@ def server(request, login_type):
 
     yield server_
 
-    try:
+    with contextlib.suppress(FileNotFoundError):
         os.remove(USER_DB_PATH)
-    except FileNotFoundError:
-        pass
 
 
 @pytest.fixture


### PR DESCRIPTION
Fix violations of Ruff rules in the `flake8-simplify SIM` group:

* `SIM101`
    * Multiple `isinstance` calls, merge into a single call
    * <https://docs.astral.sh/ruff/rules/duplicate-isinstance-call/>
* `SIM102`
    * Use a single if statement instead of nested if statements
    * <https://docs.astral.sh/ruff/rules/collapsible-if/>
* `SIM105`
    * Use `contextlib.suppress` instead of `try`-`except`-`pass`
    * <https://docs.astral.sh/ruff/rules/suppressible-exception/>
* `SIM108`
    * Use ternary operator instead of `if`-`else`-`block`
    * <https://docs.astral.sh/ruff/rules/if-else-block-instead-of-if-exp/>
* `SIM114`
    * Combine `if` branches using logical `or` operator
    * <https://docs.astral.sh/ruff/rules/if-with-same-arms/>
* `SIM118`
    * Use `key {operator} dict` instead of `key {operator} dict.keys()`
    * <https://docs.astral.sh/ruff/rules/in-dict-keys/>
* `SIM201`
    * Use `{left} != {right}` instead of `not {left} == {right}`
    * <https://docs.astral.sh/ruff/rules/negate-equal-op/>
* `SIM210`
    * Remove unnecessary `True if ... else False`
    * <https://docs.astral.sh/ruff/rules/if-expr-with-true-false/>
* `SIM212`
    * Use `{expr_else} if {expr_else} else {expr_body}` instead of `{expr_body} if not {expr_else} else {expr_else}`
    * <https://docs.astral.sh/ruff/rules/if-expr-with-twisted-arms/>

Most fixes were done by Ruff itself automatically. For some fixes some light manual editing was done beforehand.

Violations that have no automatic fix and are left untouched:

* `SIM115`
    * Use a context manager for opening files
    * <https://docs.astral.sh/ruff/rules/open-file-with-context-handler/>