### PR TITLE
Refactor BeamlineActionsContainer

### DIFF
--- a/ui/src/components/BeamlineActions/BeamlineActionControl.jsx
+++ b/ui/src/components/BeamlineActions/BeamlineActionControl.jsx
@@ -6,30 +6,43 @@ import {
   twoStateActuatorIsActive,
   TWO_STATE_ACTUATOR,
 } from '../../constants';
+import { showActionOutput } from '../../actions/beamlineActions';
+import { useDispatch } from 'react-redux';
 
 export default function BeamlineActionControl(props) {
-  let variant = props.state === RUNNING ? 'danger' : 'primary';
-  let label = props.state === RUNNING ? 'Stop' : 'Run';
-  const showOutput = props.type !== TWO_STATE_ACTUATOR;
+  const {
+    actionId,
+    actionArguments,
+    handleStartAction,
+    handleStopAction,
+    state,
+    disabled,
+    type,
+    data,
+  } = props;
+  let variant = state === RUNNING ? 'danger' : 'primary';
+  let label = state === RUNNING ? 'Stop' : 'Run';
+  const showOutput = type !== TWO_STATE_ACTUATOR;
+  const dispatch = useDispatch();
 
-  if (props.type === 'INOUT') {
-    label = String(props.data).toUpperCase();
-    variant = twoStateActuatorIsActive(props.data) ? 'success' : 'danger';
+  if (type === 'INOUT') {
+    label = String(data).toUpperCase();
+    variant = twoStateActuatorIsActive(data) ? 'success' : 'danger';
   }
 
   return (
     <ButtonToolbar>
       <ButtonGroup className="d-flex flex-row" aria-label="First group">
-        {props.actionArguments.length === 0 ? (
+        {actionArguments.length === 0 ? (
           <Button
             size="sm"
             className="me-1"
             variant={variant}
-            disabled={props.disabled}
+            disabled={disabled}
             onClick={
-              props.state !== RUNNING
-                ? () => props.handleStartAction(props.actionId, showOutput)
-                : () => props.handleStopAction(props.actionId)
+              state !== RUNNING
+                ? () => handleStartAction(actionId, showOutput)
+                : () => handleStopAction(actionId)
             }
           >
             {label}
@@ -40,9 +53,9 @@ export default function BeamlineActionControl(props) {
         {showOutput ? (
           <Button
             variant="outline-secondary"
-            disabled={props.disabled}
+            disabled={disabled}
             size="sm"
-            onClick={() => props.handleShowOutput(props.actionId)}
+            onClick={() => dispatch(showActionOutput(actionId))}
           >
             <BiLinkExternal />
           </Button>

--- a/ui/src/components/BeamlineActions/BeamlineActionDialog.jsx
+++ b/ui/src/components/BeamlineActions/BeamlineActionDialog.jsx
@@ -21,7 +21,6 @@ export default function BeamlineActionDialog(props) {
     handleStartAction,
     handleStartAnnotatedAction,
     handleOnPlotDisplay,
-    handleSetActionArgument,
     plotId,
   } = props;
 
@@ -43,7 +42,6 @@ export default function BeamlineActionDialog(props) {
             actionArguments={actionArguments}
             handleStopAction={handleStopAction}
             handleStartAction={handleStartAction}
-            handleSetActionArgument={handleSetActionArgument}
           />
         )}
         {actionType === 'JSONSchema' && (
@@ -65,7 +63,7 @@ export default function BeamlineActionDialog(props) {
             {actionMessages.length > 0 && (
               <Card>
                 {actionMessages.map((message) => (
-                  <p key={message}>{message.message}</p>
+                  <p key={`message- ${message.timestamp}`}>{message.message}</p>
                 ))}
               </Card>
             )}

--- a/ui/src/components/BeamlineActions/BeamlineActionForm.jsx
+++ b/ui/src/components/BeamlineActions/BeamlineActionForm.jsx
@@ -1,5 +1,7 @@
 import React, { Fragment } from 'react';
 import { Row, Col, Button, Form } from 'react-bootstrap';
+import { useDispatch } from 'react-redux';
+import { setArgumentValue } from '../../actions/beamlineActions';
 
 export default function BeamlineActionForm(props) {
   const {
@@ -8,8 +10,9 @@ export default function BeamlineActionForm(props) {
     actionArguments,
     handleStopAction,
     handleStartAction,
-    handleSetActionArgument,
   } = props;
+
+  const dispatch = useDispatch();
 
   return (
     <Row>
@@ -25,7 +28,7 @@ export default function BeamlineActionForm(props) {
               value={arg.value}
               disabled={isActionRunning}
               onChange={(e) => {
-                handleSetActionArgument(actionId, i, e.target.value);
+                dispatch(setArgumentValue(actionId, i, e.target.value));
               }}
             />
           </Col>

--- a/ui/src/containers/BeamlineActionsContainer.jsx
+++ b/ui/src/containers/BeamlineActionsContainer.jsx
@@ -1,164 +1,136 @@
-/* eslint-disable react/no-array-index-key */
-
-import React from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+import React, { useState, useCallback } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import {
   startBeamlineAction,
   stopBeamlineAction,
-  showActionOutput,
   hideActionOutput,
-  setArgumentValue,
 } from '../actions/beamlineActions';
 import { Dropdown } from 'react-bootstrap';
 import BeamlineActionControl from '../components/BeamlineActions/BeamlineActionControl';
 import BeamlineActionDialog from '../components/BeamlineActions/BeamlineActionDialog';
 import { RUNNING } from '../constants';
 
-class BeamlineActionsContainer extends React.Component {
-  constructor(props) {
-    super(props);
+function BeamlineActionsContainer(props) {
+  const { actionsList } = props;
 
-    this.plotIdByAction = {};
+  const dispatch = useDispatch();
+  const currentAction = useSelector(
+    (state) => state.beamline.currentBeamlineAction,
+  );
 
-    this.startAction = this.startAction.bind(this);
-    this.hideOutput = this.hideOutput.bind(this);
-    this.newPlotDisplayed = this.newPlotDisplayed.bind(this);
-  }
+  const [plotIdByAction, setPlotIdByAction] = useState({});
 
-  startAction(cmdName, showOutput = true) {
-    const parameters = [];
-
-    this.props.actionsList.some((cmd) => {
-      if (cmd.name === cmdName) {
-        cmd.arguments.forEach((arg) => {
-          if (arg.type === 'float') {
-            parameters.push(Number.parseFloat(arg.value));
-          } else {
-            parameters.push(arg.value);
-          }
-        });
-        return true;
+  const startAction = useCallback(
+    (cmdName, showOutput = true) => {
+      const cmd = actionsList.find((cmd) => cmd.name === cmdName);
+      if (!cmd) {
+        return;
       }
-      return false;
-    });
 
-    this.plotIdByAction[this.props.currentAction.name] = null;
-    this.props.startAction(cmdName, parameters, showOutput);
+      const parameters = cmd.arguments.map((arg) =>
+        arg.type === 'float' ? Number.parseFloat(arg.value) : arg.value,
+      );
+
+      setPlotIdByAction((prev) => ({ ...prev, [currentAction.name]: null }));
+      dispatch(startBeamlineAction(cmdName, parameters, showOutput));
+    },
+    [actionsList, currentAction.name, dispatch],
+  );
+
+  const hideOutput = useCallback(() => {
+    dispatch(hideActionOutput(currentAction.name));
+  }, [currentAction.name, dispatch]);
+
+  const newPlotDisplayed = useCallback(
+    (plotId) => {
+      setPlotIdByAction((prev) => ({ ...prev, [currentAction.name]: plotId }));
+    },
+    [currentAction.name],
+  );
+
+  if (actionsList.length === 0) {
+    return null;
   }
 
-  hideOutput() {
-    this.props.hideOutput(this.props.currentAction.name);
-  }
+  const currentActionRunning = currentAction.state === RUNNING;
+  const currentActionName = currentAction.name;
+  const defaultDialogPosition = { x: -100, y: 100 };
 
-  newPlotDisplayed(plotId) {
-    this.plotIdByAction[this.props.currentAction.name] = plotId;
-  }
-
-  render() {
-    const currentActionRunning = this.props.currentAction.state === RUNNING;
-    const currentActionName = this.props.currentAction.name;
-
-    const defaultDialogPosition = { x: -100, y: 100 };
-
-    if (this.props.actionsList.length === 0) {
-      return null;
-    }
-
-    return (
-      <>
-        <Dropdown
-          title="Beamline Actions"
-          id="beamline-actions-dropdown"
+  return (
+    <>
+      <Dropdown
+        title="Beamline Actions"
+        id="beamline-actions-dropdown"
+        variant="outline-secondary"
+        autoClose="outside"
+      >
+        <Dropdown.Toggle
           variant="outline-secondary"
-          autoClose="outside"
+          id="beamline-actions-dropdown"
+          size="sm"
+          style={{ width: '150px' }}
         >
-          <Dropdown.Toggle
-            variant="outline-secondary"
-            id="beamline-actions-dropdown"
-            size="sm"
-            style={{ width: '150px' }}
-          >
-            Beamline Actions
-          </Dropdown.Toggle>
-          <Dropdown.Menu>
-            {this.props.actionsList.map((cmd, i) => {
-              const cmdName = cmd.name;
-              const cmdUsername = cmd.username;
-              const cmdState = cmd.state;
-              let disabled = false;
-              if (currentActionRunning && currentActionName !== cmdName) {
-                disabled = true;
-              }
+          Beamline Actions
+        </Dropdown.Toggle>
+        <Dropdown.Menu>
+          {actionsList.map((cmd, i) => {
+            const cmdName = cmd.name;
+            const disabled =
+              currentActionRunning && currentActionName !== cmdName;
 
-              return (
-                <Dropdown.Item
-                  className="d-flex justify-content-between align-items-start"
-                  key={i}
-                >
-                  <div className="mx-2">
-                    <div className="fw-bold">{cmdUsername}</div>
-                  </div>
-                  <BeamlineActionControl
-                    actionId={cmdName}
-                    actionArguments={cmd.arguments}
-                    handleStartAction={
-                      cmd.argument_type === 'List'
-                        ? this.startAction
-                        : () => this.props.startAction(cmdName, {})
-                    }
-                    handleStopAction={this.props.stopAction}
-                    handleShowOutput={this.props.showOutput}
-                    state={cmdState}
-                    disabled={disabled}
-                    type={cmd.type}
-                    data={cmd.data}
-                  />
-                </Dropdown.Item>
-              );
-            })}
-          </Dropdown.Menu>
-        </Dropdown>
-        <BeamlineActionDialog
-          isDialogVisble={this.props.currentAction.show}
-          handleOnHide={this.hideOutput}
-          defaultPosition={defaultDialogPosition}
-          actionName={this.props.currentAction.username}
-          actionId={currentActionName}
-          actionSchema={this.props.currentAction.schema}
-          actionArguments={this.props.currentAction.arguments}
-          actionType={this.props.currentAction.argument_type}
-          isActionRunning={currentActionRunning}
-          actionMessages={this.props.currentAction.messages}
-          handleSetActionArgument={this.props.setArgumentValue}
-          handleStopAction={this.props.stopAction}
-          handleStartAction={this.startAction}
-          handleStartAnnotatedAction={this.props.startAction}
-          handleOnPlotDisplay={this.newPlotDisplayed}
-          plotId={this.plotIdByAction[currentActionName]}
-        />
-      </>
-    );
-  }
+            return (
+              <Dropdown.Item
+                className="d-flex justify-content-between align-items-start"
+                key={cmdName}
+              >
+                <div className="mx-2">
+                  <div className="fw-bold">{cmd.username}</div>
+                </div>
+                <BeamlineActionControl
+                  actionId={cmdName}
+                  actionArguments={cmd.arguments}
+                  handleStartAction={
+                    cmd.argument_type === 'List'
+                      ? startAction
+                      : (actionId, showOutput) =>
+                          dispatch(
+                            startBeamlineAction(actionId, {}, showOutput),
+                          )
+                  }
+                  handleStopAction={(actionId) =>
+                    dispatch(stopBeamlineAction(actionId))
+                  }
+                  state={cmd.state}
+                  disabled={disabled}
+                  type={cmd.type}
+                  data={cmd.data}
+                />
+              </Dropdown.Item>
+            );
+          })}
+        </Dropdown.Menu>
+      </Dropdown>
+      <BeamlineActionDialog
+        isDialogVisble={currentAction.show}
+        handleOnHide={hideOutput}
+        defaultPosition={defaultDialogPosition}
+        actionName={currentAction.username}
+        actionId={currentActionName}
+        actionSchema={currentAction.schema}
+        actionArguments={currentAction.arguments}
+        actionType={currentAction.argument_type}
+        isActionRunning={currentActionRunning}
+        actionMessages={currentAction.messages}
+        handleStopAction={(actionId) => dispatch(stopBeamlineAction(actionId))}
+        handleStartAction={startAction}
+        handleStartAnnotatedAction={(cmdName, params, showOutput) =>
+          dispatch(startBeamlineAction(cmdName, params, showOutput))
+        }
+        handleOnPlotDisplay={newPlotDisplayed}
+        plotId={plotIdByAction[currentActionName]}
+      />
+    </>
+  );
 }
 
-function mapStateToProps(state) {
-  return {
-    currentAction: state.beamline.currentBeamlineAction,
-  };
-}
-
-function mapDispatchToProps(dispatch) {
-  return {
-    startAction: bindActionCreators(startBeamlineAction, dispatch),
-    stopAction: bindActionCreators(stopBeamlineAction, dispatch),
-    showOutput: bindActionCreators(showActionOutput, dispatch),
-    hideOutput: bindActionCreators(hideActionOutput, dispatch),
-    setArgumentValue: bindActionCreators(setArgumentValue, dispatch),
-  };
-}
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(BeamlineActionsContainer);
+export default BeamlineActionsContainer;


### PR DESCRIPTION
This PR refactors the `BeamlineActionsContainer` to become a functional component. Additional changes include:

- Replacing `mapStateToProps`, `mapDispatchToProps` and connect functions with `useSelector` and `UseDispatch`
- Make use of `useCallback` for component functions
- dispatching specific functions in child components to cause less re-rendering (except for `startBeamlineAction` and `stopBeamlineAction`, which are used by multiple child components) and preventing props drilling.
- using more distinguishable keys for list items (action names/ids for dropdown actions instead of list index and timestamp for messages instead of objects (objects will all be mapped to same string key which resulted in every message element having the exact same key))
- destructuring `props` at the beginning of `BeamlineActionControl` component for better overview of props elements