### PR TITLE
Disallow cross-site requests by default

### DIFF
--- a/demo/mxcube-web/server.yaml
+++ b/demo/mxcube-web/server.yaml
@@ -8,13 +8,7 @@ server:
 
   DEBUG: false
 
-  ALLOWED_CORS_ORIGINS:
-    - http://localhost:8081
-    - http://127.0.0.1:8081
-    - http://localhost:5173
-    - http://127.0.0.1:5173
-    - ws://localhost:8000
-    - ws://127.0.0.1:8000
+  ALLOWED_CORS_ORIGINS: []
 
 sso:
   USE_SSO: false

--- a/docs/source/config/server.rst
+++ b/docs/source/config/server.rst
@@ -81,6 +81,15 @@ List of origins that are allowed to connect to this server.
 This list is passed via ``cors_allowed_origins`` parameter to the `SocketIO <https://flask-socketio.readthedocs.io/en/latest/api.html#flask_socketio.SocketIO>`_ class constructor.
 Note that if this list is too restrictive, the front-end will fail to create a SocketIO connection to the back-end.
 
+For most cases, the default behavior,
+which is provided by setting this value to an empty list ``[]``,
+is good enough.
+Indeed it disallows any cross-site requests,
+but of course it still allows same-site requests.
+For MXCuBE-Web, there is very likely no need for cross-site requests.
+Allowing cross-site requests can be a source of security issues.
+
+
 ``CERT``
 ~~~~~~~~
 

--- a/mxcubeweb/core/models/configmodels.py
+++ b/mxcubeweb/core/models/configmodels.py
@@ -16,7 +16,7 @@ class FlaskConfigModel(BaseModel):
         description="Flask secret key",
     )
     DEBUG: bool = Field(False, description="")
-    ALLOWED_CORS_ORIGINS: list[str] = Field(["*"], description="")
+    ALLOWED_CORS_ORIGINS: list[str] = Field([], description="")
     SECURITY_PASSWORD_SALT: str = Field("ASALT", description="")
     SECURITY_TRACKABLE: bool = Field(True, description="")
     USER_DB_PATH: str = Field("/tmp/mxcube-user.db", description="")


### PR DESCRIPTION
The default behavior for *CORS* was to allow all cross-site requests, because the default value was set to `["*"]`. This is obviously a very bad default from security point of view.

The default behavior should be to disallow all cross-site requests. For an application like MXCuBE-Web, allowing same-site requests only is usually good enough.