### PR TITLE
Get sample list when no sample changer HWO loaded

### DIFF
--- a/mxcubeweb/core/components/samplechanger.py
+++ b/mxcubeweb/core/components/samplechanger.py
@@ -42,13 +42,21 @@ class SampleChanger(ComponentBase):
             )
 
     def get_sample_list(self):
-        samples_list = HWR.beamline.sample_changer.get_sample_list()
+        samples_list = (
+            HWR.beamline.sample_changer.get_sample_list()
+            if HWR.beamline.sample_changer
+            else []
+        )
         samples = {}
         samplesByCoords = {}
         order = []
         current_sample = {}
 
-        loaded_sample = HWR.beamline.sample_changer.get_loaded_sample()
+        loaded_sample = (
+            HWR.beamline.sample_changer.get_loaded_sample()
+            if HWR.beamline.sample_changer
+            else None
+        )
 
         for s in samples_list:
             if not s.is_present():


### PR DESCRIPTION
If the hardware object for the sample changer is not loaded properly, it is not possible for a user to authenticate properly. Actually the authentication is fine and it is possible to use MXCuBE, but the redirect from authentication page to main page is not done. The redirect is not done because it is not possible to get sample list.