### PR TITLE
prevent prop drilling in beamlineAction components

### DIFF
--- a/ui/src/components/BeamlineActions/AnnotatedBeamlineActionForm.jsx
+++ b/ui/src/components/BeamlineActions/AnnotatedBeamlineActionForm.jsx
@@ -1,17 +1,21 @@
 import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { Row, Col, Button } from 'react-bootstrap';
 import JSForm from '@rjsf/core';
 import validator from '@rjsf/validator-ajv8';
 import styles from './BeamlineActions.module.css';
+import { stopBeamlineAction } from '../../actions/beamlineActions';
+import { RUNNING } from '../../constants';
 
 export default function AnnotatedBeamlineActionForm(props) {
-  const {
-    actionId,
-    actionSchema,
-    isActionRunning,
-    handleStopAction,
-    handleStartAction,
-  } = props;
+  const { handleStartAction } = props;
+  const dispatch = useDispatch();
+  const currentAction = useSelector(
+    (state) => state.beamline.currentBeamlineAction,
+  );
+
+  const isActionRunning = currentAction.state === RUNNING;
+  const actionId = currentAction.name;
 
   return (
     <Row className="py-2">
@@ -20,7 +24,7 @@ export default function AnnotatedBeamlineActionForm(props) {
           <JSForm
             liveValidate
             validator={validator}
-            schema={JSON.parse(actionSchema)}
+            schema={JSON.parse(currentAction.schema)}
             onSubmit={({ formData }) => {
               handleStartAction(actionId, formData);
             }}
@@ -30,7 +34,7 @@ export default function AnnotatedBeamlineActionForm(props) {
                 className={styles.submitButton}
                 variant="danger"
                 onClick={() => {
-                  handleStopAction(actionId);
+                  dispatch(stopBeamlineAction(actionId));
                 }}
               >
                 Abort

--- a/ui/src/components/BeamlineActions/BeamlineActionControl.jsx
+++ b/ui/src/components/BeamlineActions/BeamlineActionControl.jsx
@@ -6,24 +6,27 @@ import {
   twoStateActuatorIsActive,
   TWO_STATE_ACTUATOR,
 } from '../../constants';
-import { showActionOutput } from '../../actions/beamlineActions';
-import { useDispatch } from 'react-redux';
+import {
+  showActionOutput,
+  stopBeamlineAction,
+} from '../../actions/beamlineActions';
+import { useDispatch, useSelector } from 'react-redux';
 
 export default function BeamlineActionControl(props) {
-  const {
-    actionId,
-    actionArguments,
-    handleStartAction,
-    handleStopAction,
-    state,
-    disabled,
-    type,
-    data,
-  } = props;
+  const { actionId, actionArguments, state, type, data, handleStartAction } =
+    props;
   let variant = state === RUNNING ? 'danger' : 'primary';
   let label = state === RUNNING ? 'Stop' : 'Run';
   const showOutput = type !== TWO_STATE_ACTUATOR;
   const dispatch = useDispatch();
+  const currentActionName = useSelector(
+    (state) => state.beamline.currentBeamlineAction.name,
+  );
+  const currentActionState = useSelector(
+    (state) => state.beamline.currentBeamlineAction.state,
+  );
+  const disabled =
+    currentActionName !== actionId && currentActionState === RUNNING;
 
   if (type === 'INOUT') {
     label = String(data).toUpperCase();
@@ -33,7 +36,7 @@ export default function BeamlineActionControl(props) {
   return (
     <ButtonToolbar>
       <ButtonGroup className="d-flex flex-row" aria-label="First group">
-        {actionArguments.length === 0 ? (
+        {actionArguments.length === 0 && (
           <Button
             size="sm"
             className="me-1"
@@ -41,16 +44,14 @@ export default function BeamlineActionControl(props) {
             disabled={disabled}
             onClick={
               state !== RUNNING
-                ? () => handleStartAction(actionId, showOutput)
-                : () => handleStopAction(actionId)
+                ? () => handleStartAction(actionId, {}, showOutput)
+                : () => dispatch(stopBeamlineAction(actionId))
             }
           >
             {label}
           </Button>
-        ) : (
-          ''
         )}
-        {showOutput ? (
+        {showOutput && (
           <Button
             variant="outline-secondary"
             disabled={disabled}
@@ -59,8 +60,6 @@ export default function BeamlineActionControl(props) {
           >
             <BiLinkExternal />
           </Button>
-        ) : (
-          ''
         )}
       </ButtonGroup>
     </ButtonToolbar>

--- a/ui/src/components/BeamlineActions/BeamlineActionDialog.jsx
+++ b/ui/src/components/BeamlineActions/BeamlineActionDialog.jsx
@@ -1,57 +1,44 @@
 import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { hideActionOutput } from '../../actions/beamlineActions';
 import { Row, Col, Modal, Button, Card } from 'react-bootstrap';
 import Plot1D from '../Plot1D';
 import { DraggableModal } from '../DraggableModal';
 import AnnotatedBeamlineActionForm from './AnnotatedBeamlineActionForm';
 import BeamlineActionForm from './BeamlineActionForm';
+import { RUNNING } from '../../constants';
+
+const DEFAULT_DIALOG_POSITION = { x: -100, y: 100 };
 
 export default function BeamlineActionDialog(props) {
-  const {
-    isDialogVisble,
-    handleOnHide,
-    defaultPosition,
-    actionName,
-    actionId,
-    actionType,
-    actionArguments,
-    actionSchema,
-    isActionRunning,
-    actionMessages,
-    handleStopAction,
-    handleStartAction,
-    handleStartAnnotatedAction,
-    handleOnPlotDisplay,
-    plotId,
-  } = props;
+  const { handleStartAction, plotId, handleOnPlotDisplay } = props;
+  const dispatch = useDispatch();
+  const currentAction = useSelector(
+    (state) => state.beamline.currentBeamlineAction,
+  );
+
+  const handleOnHide = () => {
+    dispatch(hideActionOutput(currentAction.name));
+  };
+
+  const isActionRunning = currentAction.state === RUNNING;
 
   return (
     <DraggableModal
       id="beamlineActionOutput"
-      show={isDialogVisble}
+      show={currentAction.show}
       onHide={handleOnHide}
-      defaultpos={defaultPosition}
+      defaultpos={DEFAULT_DIALOG_POSITION}
     >
       <Modal.Header>
-        <Modal.Title>{actionName}</Modal.Title>
+        <Modal.Title>{currentAction.username}</Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        {actionType === 'List' && (
-          <BeamlineActionForm
-            actionId={actionId}
-            isActionRunning={isActionRunning}
-            actionArguments={actionArguments}
-            handleStopAction={handleStopAction}
-            handleStartAction={handleStartAction}
-          />
+        {currentAction.argument_type === 'List' && (
+          <BeamlineActionForm handleStartAction={handleStartAction} />
         )}
-        {actionType === 'JSONSchema' && (
-          <AnnotatedBeamlineActionForm
-            actionId={actionId}
-            actionSchema={actionSchema}
-            isActionRunning={isActionRunning}
-            handleStopAction={handleStopAction}
-            handleStartAction={handleStartAnnotatedAction}
-          />
+        {currentAction.argument_type === 'JSONSchema' && (
+          <AnnotatedBeamlineActionForm handleStartAction={handleStartAction} />
         )}
         <Row className="py-2">
           <Col>
@@ -60,10 +47,10 @@ export default function BeamlineActionDialog(props) {
               plotId={plotId}
               autoNext={isActionRunning}
             />
-            {actionMessages.length > 0 && (
+            {currentAction.messages.length > 0 && (
               <Card>
-                {actionMessages.map((message) => (
-                  <p key={`message- ${message.timestamp}`}>{message.message}</p>
+                {currentAction.messages.map((message) => (
+                  <p key={message.timestamp}>{message.message}</p>
                 ))}
               </Card>
             )}

--- a/ui/src/components/BeamlineActions/BeamlineActionForm.jsx
+++ b/ui/src/components/BeamlineActions/BeamlineActionForm.jsx
@@ -1,22 +1,25 @@
 import React, { Fragment } from 'react';
 import { Row, Col, Button, Form } from 'react-bootstrap';
-import { useDispatch } from 'react-redux';
-import { setArgumentValue } from '../../actions/beamlineActions';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  setArgumentValue,
+  stopBeamlineAction,
+} from '../../actions/beamlineActions';
+import { RUNNING } from '../../constants';
 
 export default function BeamlineActionForm(props) {
-  const {
-    actionId,
-    isActionRunning,
-    actionArguments,
-    handleStopAction,
-    handleStartAction,
-  } = props;
-
+  const { handleStartAction } = props;
   const dispatch = useDispatch();
+  const currentAction = useSelector(
+    (state) => state.beamline.currentBeamlineAction,
+  );
+
+  const isActionRunning = currentAction.state === RUNNING;
+  const actionId = currentAction.name;
 
   return (
     <Row>
-      {actionArguments.map((arg, i) => (
+      {currentAction.arguments.map((arg, i) => (
         <Fragment key={arg.name}>
           <Col className="mt-2" xs={1} style={{ whiteSpace: 'nowrap' }}>
             {arg.name}
@@ -39,7 +42,7 @@ export default function BeamlineActionForm(props) {
           <Button
             variant="danger"
             onClick={() => {
-              handleStopAction(actionId);
+              dispatch(stopBeamlineAction(actionId));
             }}
           >
             Abort

--- a/ui/src/containers/BeamlineActionsContainer.css
+++ b/ui/src/containers/BeamlineActionsContainer.css
@@ -1,3 +1,0 @@
-.beamline-action-form-container .rjsf #root__title {
-  display: none;
-}

--- a/ui/src/containers/BeamlineActionsContainer.jsx
+++ b/ui/src/containers/BeamlineActionsContainer.jsx
@@ -1,61 +1,50 @@
 import React, { useState, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import {
-  startBeamlineAction,
-  stopBeamlineAction,
-  hideActionOutput,
-} from '../actions/beamlineActions';
 import { Dropdown } from 'react-bootstrap';
 import BeamlineActionControl from '../components/BeamlineActions/BeamlineActionControl';
 import BeamlineActionDialog from '../components/BeamlineActions/BeamlineActionDialog';
-import { RUNNING } from '../constants';
+import { startBeamlineAction } from '../actions/beamlineActions';
 
-function BeamlineActionsContainer(props) {
-  const { actionsList } = props;
-
+function BeamlineActionsContainer() {
   const dispatch = useDispatch();
-  const currentAction = useSelector(
-    (state) => state.beamline.currentBeamlineAction,
+  const actionsList = useSelector(
+    (state) => state.beamline.beamlineActionsList,
+  );
+  const currentActionName = useSelector(
+    (state) => state.beamline.currentBeamlineAction.name,
   );
 
   const [plotIdByAction, setPlotIdByAction] = useState({});
 
-  const startAction = useCallback(
-    (cmdName, showOutput = true) => {
-      const cmd = actionsList.find((cmd) => cmd.name === cmdName);
-      if (!cmd) {
-        return;
-      }
+  const startAction = (cmdName, params = {}, showOutput = true) => {
+    const cmd = actionsList.find((cmd) => cmd.name === cmdName);
+    if (!cmd) {
+      return;
+    }
 
+    setPlotIdByAction((prev) => ({ ...prev, [currentActionName]: null }));
+
+    if (cmd.argument_type === 'List') {
       const parameters = cmd.arguments.map((arg) =>
         arg.type === 'float' ? Number.parseFloat(arg.value) : arg.value,
       );
-
-      setPlotIdByAction((prev) => ({ ...prev, [currentAction.name]: null }));
       dispatch(startBeamlineAction(cmdName, parameters, showOutput));
-    },
-    [actionsList, currentAction.name, dispatch],
-  );
+      return;
+    }
 
-  const hideOutput = useCallback(() => {
-    dispatch(hideActionOutput(currentAction.name));
-  }, [currentAction.name, dispatch]);
+    dispatch(startBeamlineAction(cmdName, params, showOutput));
+  };
 
   const newPlotDisplayed = useCallback(
     (plotId) => {
-      setPlotIdByAction((prev) => ({ ...prev, [currentAction.name]: plotId }));
+      setPlotIdByAction((prev) => ({ ...prev, [currentActionName]: plotId }));
     },
-    [currentAction.name],
+    [currentActionName],
   );
 
   if (actionsList.length === 0) {
     return null;
   }
-
-  const currentActionRunning = currentAction.state === RUNNING;
-  const currentActionName = currentAction.name;
-  const defaultDialogPosition = { x: -100, y: 100 };
-
   return (
     <>
       <Dropdown
@@ -75,8 +64,6 @@ function BeamlineActionsContainer(props) {
         <Dropdown.Menu>
           {actionsList.map((cmd, i) => {
             const cmdName = cmd.name;
-            const disabled =
-              currentActionRunning && currentActionName !== cmdName;
 
             return (
               <Dropdown.Item
@@ -89,21 +76,10 @@ function BeamlineActionsContainer(props) {
                 <BeamlineActionControl
                   actionId={cmdName}
                   actionArguments={cmd.arguments}
-                  handleStartAction={
-                    cmd.argument_type === 'List'
-                      ? startAction
-                      : (actionId, showOutput) =>
-                          dispatch(
-                            startBeamlineAction(actionId, {}, showOutput),
-                          )
-                  }
-                  handleStopAction={(actionId) =>
-                    dispatch(stopBeamlineAction(actionId))
-                  }
                   state={cmd.state}
-                  disabled={disabled}
                   type={cmd.type}
                   data={cmd.data}
+                  handleStartAction={startAction}
                 />
               </Dropdown.Item>
             );
@@ -111,23 +87,9 @@ function BeamlineActionsContainer(props) {
         </Dropdown.Menu>
       </Dropdown>
       <BeamlineActionDialog
-        isDialogVisble={currentAction.show}
-        handleOnHide={hideOutput}
-        defaultPosition={defaultDialogPosition}
-        actionName={currentAction.username}
-        actionId={currentActionName}
-        actionSchema={currentAction.schema}
-        actionArguments={currentAction.arguments}
-        actionType={currentAction.argument_type}
-        isActionRunning={currentActionRunning}
-        actionMessages={currentAction.messages}
-        handleStopAction={(actionId) => dispatch(stopBeamlineAction(actionId))}
         handleStartAction={startAction}
-        handleStartAnnotatedAction={(cmdName, params, showOutput) =>
-          dispatch(startBeamlineAction(cmdName, params, showOutput))
-        }
-        handleOnPlotDisplay={newPlotDisplayed}
         plotId={plotIdByAction[currentActionName]}
+        handleOnPlotDisplay={newPlotDisplayed}
       />
     </>
   );

--- a/ui/src/containers/BeamlineSetupContainer.jsx
+++ b/ui/src/containers/BeamlineSetupContainer.jsx
@@ -172,7 +172,7 @@ function BeamlineSetupContainer(props) {
         <Nav className="d-flex me-auto">
           <Nav.Item className="justify-content-start">
             <BeamlineCamera cameraSetup={uiproperties.camera_setup} />
-            <BeamlineActions actionsList={beamline.beamlineActionsList} />
+            <BeamlineActions />
           </Nav.Item>
         </Nav>
         <Nav className="me-auto my-2 my-lg-0">


### PR DESCRIPTION
This PR is a continuation of the work initialized in #1585 . It mainly focuses on removing props drilling for `BeamlineActions` components in an addition to a few smaller adjustments.

Small adjustments:

- Remove `BeamlineActionsContainer.css` file. It only consisted of one class, that was not used in the code.
- Remove `useCallback` for functions except `handleOnPlotDisplay` (here it was needed as otherwise re-renders would enter an endless loop. To fix this a refactoring of `Plot1D.jsx` is needed, but this would leave the scope of this PR)
- Replacing ternary operators with `null` on the false branch by `&&` operations
- key of messages was chopped to only contain the timestamp
- a `DEFAULT_DIALOG_POSITION` constant was added to `BeamlineActionsDialog`

Prop drilling Reducement:

- moving functions (`hideOutput` and `newPlotDisplayed` ) previously defined `BeamlineActionsContainer` down into `BeamlineActionsDialog` (where they are actually getting called)
- `stopBeamlineActions` and `startBeamlineActions` are now dispatched where needed and not in container functions that is passed through the tree
- `BeamlineActionsContainer` takes `actionsList` directly from state
- `BeamlineActionsContainer` no longer synchronizes on state changes to the `currentAction`. Instead child component do this where needed, reducing the props exchanged between components to a minimum (0 for most)
- `BeamlineActionsContainer` previously had a function attribute called `startAction` this function did 3 different things before dispatching `startBeamlineAction`:
      - Check if action is in `actionlist`
      -  filter arguments of `List` type actions
      -  update internal `plotIDByAction` state. A dictionary that keeps track of all plotIds for every action (probably needs to be revisited during the above mentioned refactoring of `Plot1D`)
    This logic has been moved into the `startBeamlineAction` thunk instead of being passed down the component tree. This also meant the addition of `plotIDByAction` into the state, including necessary reducer and action