### PR TITLE
Making limits "Optional"

### DIFF
--- a/mxcubeweb/core/models/adaptermodels.py
+++ b/mxcubeweb/core/models/adaptermodels.py
@@ -25,7 +25,9 @@ class HOModel(BaseModel):
 
 class HOActuatorModel(HOModel):
     value: float = Field(0, description="Value of actuator (position)")
-    limits: tuple[float, float] = Field((-1, -1), description="Limits (min max)")
+    limits: tuple[float | None, float | None] = Field(
+        (-1, -1), description="Limits (min max)"
+    )
 
 
 class NStateModel(HOActuatorModel):


### PR DESCRIPTION
Limits used to be typed `Optional`, some hardware objects return None for limits. Using `| None` handle both values and `NoneType`