### PR TITLE
replace createStore by configureStore

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
-    "@redux-devtools/extension": "3.3.0",
+    "@reduxjs/toolkit": "2.6.1",
     "@rjsf/core": "5.13.1",
     "@rjsf/utils": "5.13.1",
     "@rjsf/validator-ajv8": "5.13.1",
@@ -50,7 +50,6 @@
     "redux": "4.1.2",
     "redux-form": "^8.3.10",
     "redux-logger": "3.0.6",
-    "redux-thunk": "^2.4.2",
     "slick-carousel": "^1.8.1",
     "socket.io-client": "^4.8.1",
     "wretch": "2.7.0"

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -11,9 +11,9 @@ importers:
       '@fortawesome/fontawesome-free':
         specifier: ^5.15.4
         version: 5.15.4
-      '@redux-devtools/extension':
-        specifier: 3.3.0
-        version: 3.3.0(redux@4.1.2)
+      '@reduxjs/toolkit':
+        specifier: 2.6.1
+        version: 2.6.1(react-redux@7.2.6(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)
       '@rjsf/core':
         specifier: 5.13.1
         version: 5.13.1(@rjsf/utils@5.13.1(react@17.0.2))(react@17.0.2)
@@ -101,9 +101,6 @@ importers:
       redux-logger:
         specifier: 3.0.6
         version: 3.0.6
-      redux-thunk:
-        specifier: ^2.4.2
-        version: 2.4.2(redux@4.1.2)
       slick-carousel:
         specifier: ^1.8.1
         version: 1.8.1(jquery@3.7.1)
@@ -607,10 +604,16 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
 
-  '@redux-devtools/extension@3.3.0':
-    resolution: {integrity: sha512-X34S/rC8S/M1BIrkYD1mJ5f8vlH0BDqxXrs96cvxSBo4FhMdbhU+GUGsmNYov1xjSyLMHgo8NYrUG8bNX7525g==}
+  '@reduxjs/toolkit@2.6.1':
+    resolution: {integrity: sha512-SSlIqZNYhqm/oMkXbtofwZSt9lrncblzo6YcZ9zoX+zLngRBrCOjK4lNLdkNucJF58RHOWrD9txT3bT3piH7Zw==}
     peerDependencies:
-      redux: ^3.1.0 || ^4.0.0 || ^5.0.0
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
 
   '@remix-run/router@1.12.0':
     resolution: {integrity: sha512-2hXv036Bux90e1GXTWSMfNzfDDK8LA8JYEWfyHxzvwdp6GyoWEovKc9cotb3KCKmkdwsIBuFGX7ScTWyiHv7Eg==}
@@ -2255,6 +2258,9 @@ packages:
     resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
     engines: {node: '>= 4'}
 
+  immer@10.1.1:
+    resolution: {integrity: sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==}
+
   immutability-helper@3.1.1:
     resolution: {integrity: sha512-Q0QaXjPjwIju/28TsugCHNEASwoCcJSyJV3uO1sOIQGI0jKgm9f41Lvz0DZj3n46cNCyAZTsEYoY4C2bVRUzyQ==}
 
@@ -3207,13 +3213,16 @@ packages:
   redux-logger@3.0.6:
     resolution: {integrity: sha512-JoCIok7bg/XpqA1JqCqXFypuqBbQzGQySrhFzewB7ThcnysTO30l4VCst86AuB9T9tuT03MAA56Jw2PNhRSNCg==}
 
-  redux-thunk@2.4.2:
-    resolution: {integrity: sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==}
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
     peerDependencies:
-      redux: ^4
+      redux: ^5.0.0
 
   redux@4.1.2:
     resolution: {integrity: sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==}
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
@@ -3250,6 +3259,9 @@ packages:
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resize-observer-polyfill@1.5.1:
     resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
@@ -4392,11 +4404,15 @@ snapshots:
       '@swc/helpers': 0.4.14
       react: 17.0.2
 
-  '@redux-devtools/extension@3.3.0(redux@4.1.2)':
+  '@reduxjs/toolkit@2.6.1(react-redux@7.2.6(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)':
     dependencies:
-      '@babel/runtime': 7.25.0
-      immutable: 4.3.7
-      redux: 4.1.2
+      immer: 10.1.1
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 17.0.2
+      react-redux: 7.2.6(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
 
   '@remix-run/router@1.12.0': {}
 
@@ -6405,9 +6421,12 @@ snapshots:
 
   ignore@5.2.4: {}
 
+  immer@10.1.1: {}
+
   immutability-helper@3.1.1: {}
 
-  immutable@4.3.7: {}
+  immutable@4.3.7:
+    optional: true
 
   import-fresh@3.3.0:
     dependencies:
@@ -7380,13 +7399,15 @@ snapshots:
     dependencies:
       deep-diff: 0.3.8
 
-  redux-thunk@2.4.2(redux@4.1.2):
+  redux-thunk@3.1.0(redux@5.0.1):
     dependencies:
-      redux: 4.1.2
+      redux: 5.0.1
 
   redux@4.1.2:
     dependencies:
       '@babel/runtime': 7.22.3
+
+  redux@5.0.1: {}
 
   regenerator-runtime@0.13.11: {}
 
@@ -7416,6 +7437,8 @@ snapshots:
   requireindex@1.2.0: {}
 
   requires-port@1.0.0: {}
+
+  reselect@5.1.1: {}
 
   resize-observer-polyfill@1.5.1: {}
 

--- a/ui/src/reducers/index.js
+++ b/ui/src/reducers/index.js
@@ -1,4 +1,3 @@
-import { combineReducers } from 'redux';
 import { reducer as formReducer } from 'redux-form';
 import login from './login';
 import queue from './queue';
@@ -21,7 +20,7 @@ import taskResult from './taskResult';
 import uiproperties from './uiproperties';
 import waitDialog from './waitDialog';
 
-const mxcubeReducer = combineReducers({
+const rootReducer = {
   login,
   queue,
   uiproperties,
@@ -43,10 +42,6 @@ const mxcubeReducer = combineReducers({
   taskResult,
   form: formReducer,
   waitDialog,
-});
-
-const rootReducer = (state, action) => {
-  return mxcubeReducer(state, action);
 };
 
 export default rootReducer;

--- a/ui/src/store.js
+++ b/ui/src/store.js
@@ -1,20 +1,22 @@
-import { createStore, applyMiddleware } from 'redux';
+import { configureStore } from '@reduxjs/toolkit';
 import { createLogger } from 'redux-logger';
-import thunk from 'redux-thunk';
 import rootReducer from './reducers';
-import { composeWithDevTools } from '@redux-devtools/extension';
 
 const middleware = [
-  thunk,
   ...(import.meta.env.VITE_REDUX_LOGGER_ENABLED === 'true'
     ? [createLogger()]
     : []),
 ];
 
-export const store = createStore(
-  rootReducer,
-  composeWithDevTools(applyMiddleware(...middleware)),
-);
+export const store = configureStore({
+  reducer: rootReducer,
+  middleware: (getDefaultMiddleware) => [
+    ...getDefaultMiddleware({
+      immutableCheck: false,
+    }),
+    ...middleware,
+  ],
+});
 
 // Enable Hot Module Replacement for reducers
 // https://vitejs.dev/guide/api-hmr


### PR DESCRIPTION
This PR replaces the `createStore` function call with `configureStore`. It would be a first step into modernizing the `Redux` logic in the code. The goal of the modernized (recommended) `Redux` code would be to have a smaller and easier to maintain Codebase. Modern `Redux` still allows old code and the migration can be made step by step (This [document](https://redux.js.org/usage/migrating-to-modern-redux) explains the major implications and guides through different steps of moving to modern `Redux` patterns).

The changes in this PR include the replacement of `createStore`, `applyMiddleware`, `combineReducers`, `thunk` and `composeWithDevtools` logic by one call to `configureStore`

 In addition, per default `configureStore` adds three middleware options to the development environment. These are:
 - Immutability Check: Throws an error if state mutations happen in reducer logic
 - Serializability Check: Adds a warning to the console if state contains a non-serializable object
 - Action Creator Check: logs a warning if an action creator is dispatched without being called
More information about these checks can be found [here](https://redux-toolkit.js.org/api/getDefaultMiddleware#development)

For now I disabled the immutability check, as the thrown errors could intervene with current developments, however this option should be used in the future as well