### PR TITLE
Make energy level read-only in UI

### DIFF
--- a/ui/src/components/Tasks/Helical.jsx
+++ b/ui/src/components/Tasks/Helical.jsx
@@ -149,7 +149,12 @@ class Helical extends React.Component {
               />
             </FieldsRow>
             <FieldsRow>
-              <InputField propName="energy" type="number" label="Energy" />
+              <InputField
+                disabled={this.props.beamline.hardwareObjects.energy.readonly}
+                propName="energy"
+                type="number"
+                label="Energy"
+              />
               <InputField
                 propName="resolution"
                 type="number"

--- a/ui/src/components/Tasks/Mesh.jsx
+++ b/ui/src/components/Tasks/Mesh.jsx
@@ -159,7 +159,12 @@ class Mesh extends React.Component {
               />
             </FieldsRow>
             <FieldsRow>
-              <InputField propName="energy" type="number" label="Energy" />
+              <InputField
+                disabled={this.props.beamline.hardwareObjects.energy.readonly}
+                propName="energy"
+                type="number"
+                label="Energy"
+              />
               <InputField
                 propName="resolution"
                 type="number"

--- a/ui/src/components/Tasks/fields.jsx
+++ b/ui/src/components/Tasks/fields.jsx
@@ -67,7 +67,8 @@ export function resetLastUsedParameters(formObj) {
 export function toFixed(state, hoName, parameterName = null) {
   const withTaskData =
     state.taskForm.sampleIds.constructor !== Array ||
-    state.queue.rememberParametersBetweenSamples;
+    (state.queue.rememberParametersBetweenSamples &&
+      !state.beamline.hardwareObjects[hoName].readonly);
 
   const pname = parameterName !== null ? parameterName : hoName;
 

--- a/ui/src/components/Tasks/fields.jsx
+++ b/ui/src/components/Tasks/fields.jsx
@@ -66,12 +66,10 @@ export function resetLastUsedParameters(formObj) {
 
 export function toFixed(state, hoName, parameterName = null) {
   //
-  // Check if 'remembered' value for this field will be used.
+  //  Use 'remembered' value if:
   //
-  // Don't use 'remembered' value if:
-  //  - dealing with multiple samples
-  //  - 'remember parameters between samples' option is disabled
-  //  - the field is marked as read-only
+  //  - we are dealing with a single sample
+  //  - 'remember parameters between samples' option is enabled AND the field is not marked as read-only
   //
   const withTaskData =
     !Array.isArray(state.taskForm.sampleIds) ||

--- a/ui/src/components/Tasks/fields.jsx
+++ b/ui/src/components/Tasks/fields.jsx
@@ -65,8 +65,16 @@ export function resetLastUsedParameters(formObj) {
 }
 
 export function toFixed(state, hoName, parameterName = null) {
+  //
+  // Check if 'remembered' value for this field will be used.
+  //
+  // Don't use 'remembered' value if:
+  //  - dealing with multiple samples
+  //  - 'remember parameters between samples' option is disabled
+  //  - the field is marked as read-only
+  //
   const withTaskData =
-    state.taskForm.sampleIds.constructor !== Array ||
+    !Array.isArray(state.taskForm.sampleIds) ||
     (state.queue.rememberParametersBetweenSamples &&
       !state.beamline.hardwareObjects[hoName].readonly);
 


### PR DESCRIPTION
In this merge request:
- all data collection task components are made sensitive to read-only property of Energy field
- all data collection task components show the current level of energy while in read-only mode