### PR TITLE
Remove obsolete browserslist config

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -74,18 +74,6 @@
     "vite-plugin-eslint": "1.8.1",
     "wait-on": "8.0.3"
   },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  },
   "pnpm": {
     "peerDependencyRules": {
       "allowedVersions": {


### PR DESCRIPTION
The `browserslist` config is a leftover from Create React App. Vite doesn't care about it and supports only [modern browsers](https://vite.dev/guide/build.html).

I don't think we've had bug reports related to old browser versions, which makes me think that all facilities use MXCuBE in up-to-date browsers. If it's not the case, then we should configure Vite accordingly, if needed by adding `@vitejs/plugin-legacy`.

There's also a [`.babelrc` file](https://github.com/mxcube/mxcubeweb/blob/develop/test/.babelrc) in the test folder. Not sure what it's doing there — is it still needed? :shrug: 