### PR TITLE
Fix: Invalid HSpace / VSpace value causes UI crash

### DIFF
--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -207,7 +207,7 @@ export default class SampleImage extends React.Component {
   setVCellSpacing(e) {
     let value = Number.parseFloat(e.target.value);
     if (Number.isNaN(value)) {
-      value = '';
+      value = 0;
     }
 
     const gridData = this.selectedGrid();
@@ -233,7 +233,7 @@ export default class SampleImage extends React.Component {
   setHCellSpacing(e) {
     let value = Number.parseFloat(e.target.value);
     if (Number.isNaN(value)) {
-      value = '';
+      value = 0;
     }
 
     const gridData = this.selectedGrid();


### PR DESCRIPTION
The bug occured, because when clearing the value of the input, `grid.cell[H|V]Space` was set to an empty string. Then attempt to call method `toFixed` of aforementioned value failed, because it's a method of type number, not string.

More specifically, the problem was the way how values were coerced from input string into a floating point value.
```javascript
    let value = Number.parseFloat(e.target.value);
    if (Number.isNaN(value)) {
      value = '';
    }
```
For an impossible coercion; that is string not representing a number (including an empty string) it returned an empty string, which later caused the crash.