### PR TITLE
Fix linting issues (3) — `no-unused-vars`

### DIFF
--- a/docs/source/dev/tutorial.md
+++ b/docs/source/dev/tutorial.md
@@ -213,7 +213,6 @@ First, we need to create the React component.
 Create the new file `mxcubeweb/ui/src/components/SampleView/HumidityInput.js`:
 
 ```jsx
-import React from 'react';
 import '../MotorInput/motor.css';
 import '../input.css';
 import cx from 'classnames';
@@ -312,7 +311,6 @@ This shows how to create and use a minimal component.
 Don't pay too much attention to the functionality.
 
 ```jsx
-import React from 'react';
 import { Button } from 'react-bootstrap';
 
 function NewComponent(props) {

--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -8,7 +8,6 @@ const config = defineConfig([
   ...createConfig(opts),
   {
     rules: {
-      'no-unused-vars': 'off',
       'prefer-destructuring': 'off',
       'jsx-a11y/anchor-is-valid': 'off',
       'jsx-a11y/control-has-associated-label': 'off',

--- a/ui/src/components/App.jsx
+++ b/ui/src/components/App.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   createBrowserRouter,

--- a/ui/src/components/BeamlineActions/AnnotatedBeamlineActionForm.jsx
+++ b/ui/src/components/BeamlineActions/AnnotatedBeamlineActionForm.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Row, Col, Button } from 'react-bootstrap';
 import JSForm from '@rjsf/core';

--- a/ui/src/components/BeamlineActions/BeamlineActionControl.jsx
+++ b/ui/src/components/BeamlineActions/BeamlineActionControl.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Button, ButtonGroup, ButtonToolbar } from 'react-bootstrap';
 import { BiLinkExternal } from 'react-icons/bi';
 import {

--- a/ui/src/components/BeamlineActions/BeamlineActionDialog.jsx
+++ b/ui/src/components/BeamlineActions/BeamlineActionDialog.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { hideActionOutput } from '../../actions/beamlineActions';
 import { Row, Col, Modal, Button, Card } from 'react-bootstrap';

--- a/ui/src/components/BeamlineActions/BeamlineActionForm.jsx
+++ b/ui/src/components/BeamlineActions/BeamlineActionForm.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import { Fragment } from 'react';
 import { Row, Col, Button, Form } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 import {

--- a/ui/src/components/BeamlineAttribute/BeamlineAttribute.jsx
+++ b/ui/src/components/BeamlineAttribute/BeamlineAttribute.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 
 import BeamlineAttributeForm from './BeamlineAttributeForm';

--- a/ui/src/components/BeamlineAttribute/BeamlineAttributeForm.jsx
+++ b/ui/src/components/BeamlineAttribute/BeamlineAttributeForm.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { Button, ButtonToolbar, Form } from 'react-bootstrap';
 import { TiTick, TiTimes } from 'react-icons/ti';
 

--- a/ui/src/components/BeamlineCamera/BeamlineCamera.jsx
+++ b/ui/src/components/BeamlineCamera/BeamlineCamera.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Button, Dropdown, Card, Stack } from 'react-bootstrap';
 import Draggable from 'react-draggable';
 

--- a/ui/src/components/ChatWidget.jsx
+++ b/ui/src/components/ChatWidget.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   incChatMessageCount,

--- a/ui/src/components/CopyToClipboard/CopyToClipboard.jsx
+++ b/ui/src/components/CopyToClipboard/CopyToClipboard.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Button } from 'react-bootstrap';
 import { CopyToClipboard as TriggerCopyToClipboard } from 'react-copy-to-clipboard';
 import { MdContentCopy } from 'react-icons/md';

--- a/ui/src/components/DeviceState/DeviceState.jsx
+++ b/ui/src/components/DeviceState/DeviceState.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Badge } from 'react-bootstrap';
 
 import styles from './deviceState.module.css';

--- a/ui/src/components/DraggableModal.jsx
+++ b/ui/src/components/DraggableModal.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Modal } from 'react-bootstrap';
 import Draggable from 'react-draggable';
 

--- a/ui/src/components/Equipment/ActionButton.jsx
+++ b/ui/src/components/Equipment/ActionButton.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Button } from 'react-bootstrap';
 
 function ActionButton(props) {

--- a/ui/src/components/Equipment/ActionField.jsx
+++ b/ui/src/components/Equipment/ActionField.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Button, Card, Form, InputGroup } from 'react-bootstrap';
 
 function ActionField(props) {

--- a/ui/src/components/Equipment/ActionGroup.jsx
+++ b/ui/src/components/Equipment/ActionGroup.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ButtonGroup, Card } from 'react-bootstrap';
 
 function ActionGroup(props) {

--- a/ui/src/components/Equipment/EquipmentState.jsx
+++ b/ui/src/components/Equipment/EquipmentState.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Alert } from 'react-bootstrap';
 
 const VARIANTS = {

--- a/ui/src/components/Equipment/GenericEquipment.jsx
+++ b/ui/src/components/Equipment/GenericEquipment.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Row, Col } from 'react-bootstrap';
 import Collapsible from 'react-collapsible';
 import { BsChevronDown } from 'react-icons/bs';

--- a/ui/src/components/Equipment/GenericEquipmentControl.jsx
+++ b/ui/src/components/Equipment/GenericEquipmentControl.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Row, Col, Button, OverlayTrigger, Popover } from 'react-bootstrap';
 
 import Collapsible from 'react-collapsible';
@@ -26,7 +25,7 @@ export default function GenericEquipmentControl(props) {
         <div>
           <Form
             validator={validator}
-            onSubmit={(formData, e) => handleRunCommand(key, formData.formData)}
+            onSubmit={(formData) => handleRunCommand(key, formData.formData)}
             disabled={equipment.state !== 'READY'}
             schema={schema}
           >
@@ -45,7 +44,7 @@ export default function GenericEquipmentControl(props) {
           className="mt-3"
           variant="outline-secondary"
           type="submit"
-          onClick={(e) => handleRunCommand(key, {})}
+          onClick={() => handleRunCommand(key, {})}
         >
           <b>Run {key}</b>
         </Button>

--- a/ui/src/components/Equipment/HarvesterMaintenance.jsx
+++ b/ui/src/components/Equipment/HarvesterMaintenance.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Row, Col, Button, Card } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 

--- a/ui/src/components/Equipment/PlateManipulator.jsx
+++ b/ui/src/components/Equipment/PlateManipulator.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import {
   Row,
   Col,

--- a/ui/src/components/Equipment/PlateManipulatorMaintenance.jsx
+++ b/ui/src/components/Equipment/PlateManipulatorMaintenance.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Card } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 

--- a/ui/src/components/Equipment/SampleChanger.jsx
+++ b/ui/src/components/Equipment/SampleChanger.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Card, Dropdown, Form, Button, DropdownButton } from 'react-bootstrap';
 
 import { Menu, Item, Separator, contextMenu } from 'react-contexify';

--- a/ui/src/components/Equipment/SampleChangerMaintenance.jsx
+++ b/ui/src/components/Equipment/SampleChangerMaintenance.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Card } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 

--- a/ui/src/components/GenericDialog/ConfirmActionDialog.jsx
+++ b/ui/src/components/GenericDialog/ConfirmActionDialog.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Modal, Button } from 'react-bootstrap';
 
 function ConfirmActionDialog(props) {

--- a/ui/src/components/ImageViewer/ImageViewer.jsx
+++ b/ui/src/components/ImageViewer/ImageViewer.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useState } from 'react';
+import { useRef, useEffect, useState } from 'react';
 import { TransformWrapper, TransformComponent } from 'react-zoom-pan-pinch';
 import { Modal } from 'react-bootstrap';
 import styles from './imageViewer.module.css';

--- a/ui/src/components/InOutSwitch/InOutSwitch.jsx
+++ b/ui/src/components/InOutSwitch/InOutSwitch.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   Badge,
   Button,

--- a/ui/src/components/LoadingScreen/LoadingScreen.jsx
+++ b/ui/src/components/LoadingScreen/LoadingScreen.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import logo from '../../img/mxcube_logo20.png';
 import loadingAnimation from '../../img/loading-animation.gif';
 import styles from './LoadingScreen.module.css';

--- a/ui/src/components/LoginForm/ActionButton.jsx
+++ b/ui/src/components/LoginForm/ActionButton.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Button } from 'react-bootstrap';
 
 function ActionButton(props) {

--- a/ui/src/components/LoginForm/LoginForm.jsx
+++ b/ui/src/components/LoginForm/LoginForm.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Form, InputGroup, Alert, Button } from 'react-bootstrap';
 
 import { Controller, useForm } from 'react-hook-form';

--- a/ui/src/components/LoginForm/SelectProposal.jsx
+++ b/ui/src/components/LoginForm/SelectProposal.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Modal, Button, Tabs, Tab, Form } from 'react-bootstrap';
 import SessionTable from './SessionTable';
 import { useDispatch, useSelector } from 'react-redux';

--- a/ui/src/components/LoginForm/SessionDateTime.jsx
+++ b/ui/src/components/LoginForm/SessionDateTime.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styles from './SessionTable.module.css';
 
 function SessionDateTime(props) {

--- a/ui/src/components/LoginForm/SessionTable.jsx
+++ b/ui/src/components/LoginForm/SessionTable.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Table } from 'react-bootstrap';
 import { LuExternalLink } from 'react-icons/lu';
 

--- a/ui/src/components/MXNavbar/MXNavbar.jsx
+++ b/ui/src/components/MXNavbar/MXNavbar.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Container, Navbar, Nav } from 'react-bootstrap';
 import { BsList } from 'react-icons/bs';
 import { NavLink, useLocation } from 'react-router-dom';

--- a/ui/src/components/Main.jsx
+++ b/ui/src/components/Main.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Stack } from 'react-bootstrap';
 import { Outlet, useLocation } from 'react-router-dom';

--- a/ui/src/components/MotorInput/BaseMotorInput.jsx
+++ b/ui/src/components/MotorInput/BaseMotorInput.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { HW_STATE } from '../../constants';
 
 function BaseMotorInput(props) {

--- a/ui/src/components/MotorInput/MotorInput.jsx
+++ b/ui/src/components/MotorInput/MotorInput.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Button } from 'react-bootstrap';
 

--- a/ui/src/components/MotorInput/OneAxisTranslationControl.jsx
+++ b/ui/src/components/MotorInput/OneAxisTranslationControl.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Button } from 'react-bootstrap';
 

--- a/ui/src/components/MotorInput/TwoAxisTranslationControl.jsx
+++ b/ui/src/components/MotorInput/TwoAxisTranslationControl.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 

--- a/ui/src/components/Notify/UserMessage.jsx
+++ b/ui/src/components/Notify/UserMessage.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styles from './UserMessage.module.css';
 
 export default function UserMessage(props) {

--- a/ui/src/components/PrivateOutlet.jsx
+++ b/ui/src/components/PrivateOutlet.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useSelector } from 'react-redux';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
 

--- a/ui/src/components/RemoteAccess/ObserverDialog.jsx
+++ b/ui/src/components/RemoteAccess/ObserverDialog.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Modal, Button, Form } from 'react-bootstrap';
 import { updateNickname } from '../../actions/remoteAccess';

--- a/ui/src/components/RemoteAccess/PassControlDialog.jsx
+++ b/ui/src/components/RemoteAccess/PassControlDialog.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Modal, Button, Form, Alert } from 'react-bootstrap';
 import { respondToControlRequest } from '../../actions/remoteAccess';

--- a/ui/src/components/RemoteAccess/RequestControlForm.jsx
+++ b/ui/src/components/RemoteAccess/RequestControlForm.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Form, Button, Card } from 'react-bootstrap';
 import { requestControl, takeControl } from '../../actions/remoteAccess';

--- a/ui/src/components/RemoteAccess/UserList.jsx
+++ b/ui/src/components/RemoteAccess/UserList.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Row, Col, Button, Card } from 'react-bootstrap';
 import { giveControl, logoutUser } from '../../actions/remoteAccess';

--- a/ui/src/components/SSXChip/SSXChip.jsx
+++ b/ui/src/components/SSXChip/SSXChip.jsx
@@ -394,14 +394,14 @@ export default class SSXChip extends React.Component {
       }
     });
 
-    this.fc.on('selection:created', ({ selected, target }) => {
+    this.fc.on('selection:created', () => {
       if (this.fc.getActiveObject()) {
         this.fc.getActiveObject().lockMovementY = true;
         this.fc.getActiveObject().lockMovementX = true;
       }
     });
 
-    this.fc.on('selection:updated', ({ selected, target }) => {
+    this.fc.on('selection:updated', () => {
       if (this.fc.getActiveObject()) {
         this.fc.getActiveObject().lockMovementY = true;
         this.fc.getActiveObject().lockMovementX = true;
@@ -502,7 +502,7 @@ export default class SSXChip extends React.Component {
       this.freeFormCanvas.renderAll();
     });
 
-    this.freeFormCanvas.on('mouse:up', (evnt) => {
+    this.freeFormCanvas.on('mouse:up', () => {
       if (this.isDown) {
         this.isDown = false;
         this.props.onAddGrid(_GridData(this.freeFormCanvas.getActiveObject()));

--- a/ui/src/components/SSXChip/SSXChipControl.jsx
+++ b/ui/src/components/SSXChip/SSXChipControl.jsx
@@ -11,7 +11,7 @@ export default class SSXChipControl extends React.Component {
     this.handleAddGrid = this.handleAddGrid.bind(this);
   }
 
-  handleAddTask(triggerEvent, event, props, data) {
+  handleAddTask(triggerEvent) {
     const { currentSampleID, sampleData, defaultParameters } = this.props;
     const sid = -1;
 

--- a/ui/src/components/SampleControls/CentringControl.jsx
+++ b/ui/src/components/SampleControls/CentringControl.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Button } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 

--- a/ui/src/components/SampleControls/FocusControl.jsx
+++ b/ui/src/components/SampleControls/FocusControl.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 
 import OneAxisTranslationControl from '../MotorInput/OneAxisTranslationControl';

--- a/ui/src/components/SampleControls/GridControl.jsx
+++ b/ui/src/components/SampleControls/GridControl.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Button } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 

--- a/ui/src/components/SampleControls/LightControl.jsx
+++ b/ui/src/components/SampleControls/LightControl.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 

--- a/ui/src/components/SampleControls/SampleControls.jsx
+++ b/ui/src/components/SampleControls/SampleControls.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import SnapshotControl from './SnapshotControl';
 import GridControl from './GridControl';
 import CentringControl from './CentringControl';

--- a/ui/src/components/SampleControls/SnapshotControl.jsx
+++ b/ui/src/components/SampleControls/SnapshotControl.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { Button } from 'react-bootstrap';
 import { useSelector } from 'react-redux';
 import { sendTakeSnapshot } from '../../api/sampleview';

--- a/ui/src/components/SampleControls/VideoSizeControl.jsx
+++ b/ui/src/components/SampleControls/VideoSizeControl.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Dropdown } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 

--- a/ui/src/components/SampleControls/ZoomControl.jsx
+++ b/ui/src/components/SampleControls/ZoomControl.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 

--- a/ui/src/components/SampleGrid/ClearQueueDialog.jsx
+++ b/ui/src/components/SampleGrid/ClearQueueDialog.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ConfirmActionDialog from '../GenericDialog/ConfirmActionDialog';
 import { useDispatch, useSelector } from 'react-redux';
 import { clearQueue } from '../../actions/queue';

--- a/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
+++ b/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
@@ -3,7 +3,7 @@
 
 /* eslint-disable react/no-array-index-key */
 
-import React, { Component } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { ProgressBar, Button, Collapse, Table } from 'react-bootstrap';
 import {
@@ -37,7 +37,7 @@ export default class TaskItem extends Component {
     };
   }
 
-  getResult(state, data) {
+  getResult(_state, data) {
     if (this.props.data.state !== TASK_COLLECTED) {
       return <span />;
     }

--- a/ui/src/components/SampleQueue/CurrentTree.jsx
+++ b/ui/src/components/SampleQueue/CurrentTree.jsx
@@ -102,7 +102,7 @@ export default class CurrentTree extends React.Component {
     }
   }
 
-  taskHeaderOnContextMenuHandler(e, index) {
+  taskHeaderOnContextMenuHandler(_e, index) {
     this.setState({ showContextMenu: true, taskIndex: index });
   }
 

--- a/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
+++ b/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-unused-prop-types */
 /* eslint-disable react/no-unused-state */
 
-import React, { Component } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
   ProgressBar,

--- a/ui/src/components/SampleQueue/TaskItem.jsx
+++ b/ui/src/components/SampleQueue/TaskItem.jsx
@@ -2,7 +2,7 @@
 /* eslint-disable react/no-unused-prop-types */
 /* eslint-disable react/no-unused-state */
 
-import React, { Component } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { ProgressBar, Button, Collapse, Table } from 'react-bootstrap';
 import {

--- a/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
+++ b/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-unused-prop-types */
 /* eslint-disable react/no-unused-state */
 
-import React, { Component } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { ProgressBar, Button, Collapse } from 'react-bootstrap';
 import {

--- a/ui/src/components/SampleQueue/XRFTaskItem.jsx
+++ b/ui/src/components/SampleQueue/XRFTaskItem.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-unused-state */
-import React, { Component } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
   ProgressBar,

--- a/ui/src/components/SampleView/ApertureInput.jsx
+++ b/ui/src/components/SampleView/ApertureInput.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Form } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 

--- a/ui/src/components/SampleView/DrawGridPlugin.jsx
+++ b/ui/src/components/SampleView/DrawGridPlugin.jsx
@@ -381,7 +381,7 @@ export default class DrawGridPlugin {
     }
   }
 
-  heatMapColorForValue(gd, value) {
+  heatMapColorForValue(_gd, value) {
     let dataFill = `rgba(${Number.parseInt(value[0], 10)}, ${Number.parseInt(
       value[1],
       10,
@@ -390,7 +390,7 @@ export default class DrawGridPlugin {
     return dataFill;
   }
 
-  initializeCellFilling(gd, col, row) {
+  initializeCellFilling(_gd, col, row) {
     const level = this.overlayLevel || 0.2;
     const fill = `rgba(0, 0, 200, ${level})`;
     return Array.from({ length: col }).map(() =>
@@ -865,7 +865,7 @@ export default class DrawGridPlugin {
   /**
    * zig-zag indexing of cells (see countCells for doc)
    */
-  zigZagCellCount(currentRow, currentCol, numRows, numCols) {
+  zigZagCellCount(currentRow, currentCol, _numRows, numCols) {
     let cellCount = currentRow * numCols + (currentCol + 1);
 
     if (currentRow % 2 !== 0) {
@@ -878,7 +878,7 @@ export default class DrawGridPlugin {
   /**
    * left-to-right indexing of cells (see countCells for doc)
    */
-  leftRightCellCount(currentRow, currentCol, numRows, numCols) {
+  leftRightCellCount(currentRow, currentCol, _numRows, numCols) {
     return currentRow + 1 + currentCol * numCols;
   }
 

--- a/ui/src/components/SampleView/GridForm.jsx
+++ b/ui/src/components/SampleView/GridForm.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Row, Col, Form, Button, Table } from 'react-bootstrap';
 import Draggable from 'react-draggable';
 
@@ -203,7 +203,7 @@ export default function GridForm(props) {
   return (
     <Draggable
       position={position}
-      onDrag={(e, data) => setPosition({ x: data.x, y: data.y })}
+      onDrag={(_e, data) => setPosition({ x: data.x, y: data.y })}
       cancel="form"
     >
       <Row className="gridform" ref={draggableRef}>

--- a/ui/src/components/SampleView/MotorControls.jsx
+++ b/ui/src/components/SampleView/MotorControls.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Button } from 'react-bootstrap';
 import { useSelector } from 'react-redux';
 

--- a/ui/src/components/SampleView/PhaseInput.jsx
+++ b/ui/src/components/SampleView/PhaseInput.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Form } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -193,7 +193,7 @@ export default class SampleImage extends React.Component {
     this.drawGridPlugin.onCellMouseOver(options, this.canvas);
   }
 
-  onMouseUp(e) {
+  onMouseUp() {
     this.drawGridPlugin.endDrawing();
   }
 

--- a/ui/src/components/SampleView/shapes.js
+++ b/ui/src/components/SampleView/shapes.js
@@ -107,7 +107,7 @@ export function makeLine(
   });
 }
 
-export function makeArrow(line, col, select, id, hover = 'crosshair') {
+export function makeArrow(line, col, _select, _id, hover = 'crosshair') {
   const dist = Math.hypot(line.x1 - line.x2, line.y1 - line.y2);
   const angledeg =
     (Math.atan2(line.y1 - line.y2, line.x1 - line.x2) * 180) / Math.PI;
@@ -134,7 +134,7 @@ export function makeArrow(line, col, select, id, hover = 'crosshair') {
   });
 }
 
-export function makeAnchor(line, col, select, id, hover = 'crosshair') {
+export function makeAnchor(line, col, _select, _id, hover = 'crosshair') {
   const angledeg =
     (Math.atan2(line.y1 - line.y2, line.x1 - line.x2) * 180) / Math.PI;
   return new fabric.Rect({
@@ -219,7 +219,7 @@ export function makeCross(x, y, imageRatio, width, height) {
   ];
 }
 
-export function makeCentringVerticalLine(x, y, imageRatio, height) {
+export function makeCentringVerticalLine(x, _y, imageRatio, height) {
   return makeLine(
     x * imageRatio,
     0,
@@ -231,7 +231,7 @@ export function makeCentringVerticalLine(x, y, imageRatio, height) {
   );
 }
 
-export function makeCentringHorizontalLine(x, y, imageRatio, width) {
+export function makeCentringHorizontalLine(_x, y, imageRatio, width) {
   return makeLine(
     0,
     y * imageRatio,

--- a/ui/src/components/Tasks/AddSample.jsx
+++ b/ui/src/components/Tasks/AddSample.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { Modal, ButtonToolbar, Button, Form, Row, Col } from 'react-bootstrap';
 import { addSamplesToList } from '../../actions/sampleGrid';

--- a/ui/src/components/Tasks/Workflow.jsx
+++ b/ui/src/components/Tasks/Workflow.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { connect } from 'react-redux';
 import { reduxForm, Form, formValueSelector } from 'redux-form';
 import { DraggableModal } from '../DraggableModal';

--- a/ui/src/components/TooltipTrigger.jsx
+++ b/ui/src/components/TooltipTrigger.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 
 function TooltipTrigger(props) {

--- a/ui/src/containers/BeamlineActionsContainer.jsx
+++ b/ui/src/containers/BeamlineActionsContainer.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { Dropdown } from 'react-bootstrap';
 import BeamlineActionControl from '../components/BeamlineActions/BeamlineActionControl';
@@ -62,7 +62,7 @@ function BeamlineActionsContainer() {
           Beamline Actions
         </Dropdown.Toggle>
         <Dropdown.Menu>
-          {actionsList.map((cmd, i) => {
+          {actionsList.map((cmd) => {
             const cmdName = cmd.name;
 
             return (

--- a/ui/src/containers/BeamlineSetupContainer.jsx
+++ b/ui/src/containers/BeamlineSetupContainer.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Navbar, Nav, Table, Popover } from 'react-bootstrap';
 import { find, filter } from 'lodash';

--- a/ui/src/containers/ConnectionLostDialog.jsx
+++ b/ui/src/containers/ConnectionLostDialog.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useSelector } from 'react-redux';
 import { Modal, Button } from 'react-bootstrap';
 

--- a/ui/src/containers/DefaultErrorBoundary.jsx
+++ b/ui/src/containers/DefaultErrorBoundary.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
 import { logFrontEndTraceBack } from '../actions/beamline';

--- a/ui/src/containers/EquipmentContainer.jsx
+++ b/ui/src/containers/EquipmentContainer.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 

--- a/ui/src/containers/ErrorNotificationPanel.jsx
+++ b/ui/src/containers/ErrorNotificationPanel.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Modal, Alert } from 'react-bootstrap';
 import { showErrorPanel } from '../actions/general';

--- a/ui/src/containers/GphlWorkflowParametersDialog.jsx
+++ b/ui/src/containers/GphlWorkflowParametersDialog.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { Modal, Row, Col, Form, Table, Button, Stack } from 'react-bootstrap';

--- a/ui/src/containers/LoginContainer.jsx
+++ b/ui/src/containers/LoginContainer.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import LoginForm from '../components/LoginForm/LoginForm';

--- a/ui/src/containers/NumSnapshotsDropDown.jsx
+++ b/ui/src/containers/NumSnapshotsDropDown.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Dropdown, DropdownButton } from 'react-bootstrap';
 import { setNumSnapshots } from '../actions/queue';

--- a/ui/src/containers/PleaseWaitDialog.jsx
+++ b/ui/src/containers/PleaseWaitDialog.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Modal, ProgressBar, Button } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 import { hideWaitDialog } from '../actions/waitDialog';

--- a/ui/src/containers/RemoteAccessContainer.jsx
+++ b/ui/src/containers/RemoteAccessContainer.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Container, Card, Form, Row, Col } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 

--- a/ui/src/containers/ResumeQueueDialog.jsx
+++ b/ui/src/containers/ResumeQueueDialog.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Modal, Button } from 'react-bootstrap';
 import { showResumeQueueDialog } from '../actions/queueGUI';

--- a/ui/src/containers/SampleGridTableContainer.jsx
+++ b/ui/src/containers/SampleGridTableContainer.jsx
@@ -762,7 +762,7 @@ class SampleGridTableContainer extends React.Component {
         this.props.filterOptions.cellFilter.toLowerCase() === ''
       ) {
         const nbpuck = [];
-        cell.children.forEach((puck, puckidx) => {
+        cell.children.forEach((_, puckidx) => {
           if (
             this.getSampleListFilteredByCellPuck(
               Number(cell.name),

--- a/ui/src/containers/SampleIsaraView.jsx
+++ b/ui/src/containers/SampleIsaraView.jsx
@@ -52,7 +52,7 @@ class NewSampleIsaraView extends React.Component {
     );
   }
 
-  getContainerCoordinates(cell, position) {
+  getContainerCoordinates(_cell, position) {
     const r = this.sampleChangerRadius / 8;
     const x = this.getX(position) + 10;
     const y = this.getY(position) + 10;

--- a/ui/src/containers/SampleViewContainer.jsx
+++ b/ui/src/containers/SampleViewContainer.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { Row, Col, Container } from 'react-bootstrap';

--- a/ui/src/containers/TaskContainer.jsx
+++ b/ui/src/containers/TaskContainer.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Characterisation from '../components/Tasks/Characterisation';
 import DataCollection from '../components/Tasks/DataCollection';

--- a/ui/src/containers/WorkflowParametersDialog.jsx
+++ b/ui/src/containers/WorkflowParametersDialog.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Modal } from 'react-bootstrap';
 import Form from '@rjsf/core';

--- a/ui/src/index.jsx
+++ b/ui/src/index.jsx
@@ -1,7 +1,6 @@
 import 'bootstrap/dist/css/bootstrap.css';
 import './main.css';
 
-import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import App from './components/App';

--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -454,7 +454,7 @@ class ServerIO {
       console.error('loggingSocket connection error:', error.message); // eslint-disable-line no-console
     });
 
-    this.loggingSocket.on('disconnect', (reason) => {
+    this.loggingSocket.on('disconnect', () => {
       console.log('loggingSocket disconnected!'); // eslint-disable-line no-console
     });
 


### PR DESCRIPTION
That's a big one but easy-enough. It's mostly about removing default `React` imports, which are not needed except when accessing `React.Component` (although I'd usually go with importing `{ Component } directly — but I didn't bother refactoring this since it concerns only class components).

For unused parameters that can't be removed because they come before a parameter that _is_ used, it's as easy as prefixing the parameter name with `_` or just naming it `_`.