### PR TITLE
Fix linting issues (4) — `simple-import-sort/imports`

### DIFF
--- a/ui/cypress/support.js
+++ b/ui/cypress/support.js
@@ -1,5 +1,6 @@
 /* global Cypress, cy, beforeEach */
 import '@testing-library/cypress/add-commands';
+
 import installLogsCollector from 'cypress-terminal-report/src/installLogsCollector.js';
 
 installLogsCollector();

--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -17,7 +17,6 @@ const config = defineConfig([
       'react/no-multi-comp': 'off',
       'react/no-unused-class-component-methods': 'off',
       'react/prop-types': 'off',
-      'simple-import-sort/imports': 'off',
       'unicorn/prefer-global-this': 'off',
 
       /* Default is "avoid", but there are lots of complicated `switch` statements,

--- a/ui/src/actions/beamline.js
+++ b/ui/src/actions/beamline.js
@@ -1,7 +1,7 @@
 import {
-  sendSetAttribute,
   sendExecuteCommand,
   sendPrepareBeamlineForNewSample,
+  sendSetAttribute,
 } from '../api/beamline';
 import { sendLogFrontEndTraceBack } from '../api/log';
 

--- a/ui/src/actions/beamlineActions.js
+++ b/ui/src/actions/beamlineActions.js
@@ -1,8 +1,8 @@
-import { RUNNING } from '../constants';
 import {
   sendAbortBeamlineAction,
   sendRunBeamlineAction,
 } from '../api/beamline';
+import { RUNNING } from '../constants';
 
 export function addUserMessage(data) {
   return {

--- a/ui/src/actions/harvester.js
+++ b/ui/src/actions/harvester.js
@@ -1,14 +1,13 @@
 import {
-  sendRefresh,
-  sendHarvestCrystal,
-  sendHarvestAndLoadCrystal,
-  sendCalibratePin,
-  sendValidateCalibration,
   sendAbortHarvester,
+  sendCalibratePin,
   sendDataCollectionInfoToCrims,
+  sendHarvestAndLoadCrystal,
+  sendHarvestCrystal,
   sendHarvesterCommand,
+  sendRefresh,
+  sendValidateCalibration,
 } from '../api/harvester';
-
 import { showErrorPanel } from './general';
 
 export function setContents(contents) {

--- a/ui/src/actions/login.js
+++ b/ui/src/actions/login.js
@@ -1,20 +1,19 @@
 /* eslint-disable promise/prefer-await-to-then */
 import { fetchBeamInfo, fetchBeamlineSetup } from '../api/beamline';
+import { fetchDetectorInfo } from '../api/detector';
 import { fetchDiffractometerInfo } from '../api/diffractometer';
+import { fetchHarvesterInitialState } from '../api/harvester';
+import { sendSelectProposal } from '../api/lims';
 import { fetchLogMessages } from '../api/log';
-import { fetchApplicationSettings, fetchUIProperties } from '../api/main';
-import { fetchAvailableWorkflows } from '../api/workflow';
-import { fetchAvailableTasks, fetchQueueState } from '../api/queue';
-
-import { showErrorPanel, applicationFetched } from './general';
 import { sendSignOut } from '../api/login';
 import { fetchLoginInfo, sendLogIn } from '../api/loginBase';
-import { fetchDetectorInfo } from '../api/detector';
-import { fetchSampleChangerInitialState } from '../api/sampleChanger';
-import { fetchHarvesterInitialState } from '../api/harvester';
-import { fetchImageData, fetchShapes } from '../api/sampleview';
+import { fetchApplicationSettings, fetchUIProperties } from '../api/main';
+import { fetchAvailableTasks, fetchQueueState } from '../api/queue';
 import { fetchRemoteAccessState } from '../api/remoteAccess';
-import { sendSelectProposal } from '../api/lims';
+import { fetchSampleChangerInitialState } from '../api/sampleChanger';
+import { fetchImageData, fetchShapes } from '../api/sampleview';
+import { fetchAvailableWorkflows } from '../api/workflow';
+import { applicationFetched, showErrorPanel } from './general';
 
 export function setLoginInfo(loginInfo) {
   return {

--- a/ui/src/actions/queue.js
+++ b/ui/src/actions/queue.js
@@ -1,8 +1,3 @@
-import { showErrorPanel } from './general';
-import { mountSample } from './sampleChanger';
-import { abortCentring, updateShapes } from './sampleview';
-import { selectSamplesAction, clearSampleGrid } from './sampleGrid';
-import { TASK_UNCOLLECTED } from '../constants';
 import {
   fetchQueueState,
   sendAddQueueItem,
@@ -24,6 +19,11 @@ import {
   sendUpdateQueueItem,
 } from '../api/queue';
 import { sendSetCentringMethod } from '../api/sampleview';
+import { TASK_UNCOLLECTED } from '../constants';
+import { showErrorPanel } from './general';
+import { mountSample } from './sampleChanger';
+import { clearSampleGrid, selectSamplesAction } from './sampleGrid';
+import { abortCentring, updateShapes } from './sampleview';
 
 export function queueLoading(loading) {
   return { type: 'QUEUE_LOADING', loading };

--- a/ui/src/actions/remoteAccess.js
+++ b/ui/src/actions/remoteAccess.js
@@ -5,11 +5,11 @@ import {
   sendLogoutUser,
   sendRequestControl,
   sendRespondToControlRequest,
+  sendSetAllMessagesRead,
   sendTakeControl,
   sendUpdateAllowRemote,
   sendUpdateNickname,
   sendUpdateTimeoutGivesControl,
-  sendSetAllMessagesRead,
 } from '../api/remoteAccess';
 import { showErrorPanel } from './general';
 import { getLoginInfo } from './login';

--- a/ui/src/actions/sampleChanger.js
+++ b/ui/src/actions/sampleChanger.js
@@ -1,5 +1,3 @@
-import { showErrorPanel } from './general';
-import { clearCurrentSample } from './queue';
 import {
   fetchLoadedSample,
   fetchSampleChangerContents,
@@ -10,6 +8,8 @@ import {
   sendSelectContainer,
   sendUnmountCurrentSample,
 } from '../api/sampleChanger';
+import { showErrorPanel } from './general';
+import { clearCurrentSample } from './queue';
 
 export function setContents(contents) {
   return { type: 'SET_SC_CONTENTS', data: { sampleChangerContents: contents } };

--- a/ui/src/actions/sampleGrid.js
+++ b/ui/src/actions/sampleGrid.js
@@ -1,7 +1,7 @@
+import { fetchLimsSamples } from '../api/lims';
+import { fetchSamplesList, sendSyncWithCrims } from '../api/sampleChanger';
 import { showErrorPanel } from './general';
 import { setQueue } from './queue';
-import { fetchSamplesList, sendSyncWithCrims } from '../api/sampleChanger';
-import { fetchLimsSamples } from '../api/lims';
 import { hideWaitDialog, showWaitDialog } from './waitDialog';
 
 export function updateSampleList(sampleList, order) {

--- a/ui/src/actions/sampleview.js
+++ b/ui/src/actions/sampleview.js
@@ -1,20 +1,20 @@
-import { showErrorPanel } from './general';
 import {
   sendUpdateAperture,
   sendUpdateCurrentPhase,
 } from '../api/diffractometer';
 import {
+  sendAbortCentring,
+  sendAcceptCentring,
   sendAddOrUpdateShapes,
   sendDeleteShape,
+  sendMoveToBeam,
+  sendMoveToPoint,
+  sendRecordCentringClick,
   sendRotateToShape,
   sendSetVideoSize,
-  sendRecordCentringClick,
-  sendAcceptCentring,
-  sendMoveToBeam,
   sendStartClickCentring,
-  sendAbortCentring,
-  sendMoveToPoint,
 } from '../api/sampleview';
+import { showErrorPanel } from './general';
 
 export function setMotorMoving(name, status) {
   return { type: 'SET_MOTOR_MOVING', name, status };

--- a/ui/src/api/api.js
+++ b/ui/src/api/api.js
@@ -1,7 +1,7 @@
 /* eslint-disable promise/prefer-await-to-callbacks */
+import { store } from '../store';
 import baseApi from './apiBase';
 import { fetchLoginInfo } from './loginBase';
-import { store } from '../store';
 
 const api = baseApi
   .options({ credendials: 'include' })

--- a/ui/src/api/apiBase.js
+++ b/ui/src/api/apiBase.js
@@ -1,4 +1,5 @@
 import wretch from 'wretch';
+
 import safeJsonAddon from './addons/safeJson';
 
 const baseApi = wretch('/mxcube/api/v0.1')

--- a/ui/src/components/App.jsx
+++ b/ui/src/components/App.jsx
@@ -1,25 +1,24 @@
 import { useEffect } from 'react';
+import { useErrorBoundary } from 'react-error-boundary';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   createBrowserRouter,
-  RouterProvider,
   Navigate,
+  RouterProvider,
 } from 'react-router-dom';
 
-import LoginContainer from '../containers/LoginContainer';
-import SampleViewContainer from '../containers/SampleViewContainer';
-import SampleListViewContainer from '../containers/SampleListViewContainer';
-import EquipmentContainer from '../containers/EquipmentContainer';
-import RemoteAccessContainer from '../containers/RemoteAccessContainer';
-import HelpContainer from '../containers/HelpContainer';
-import Main from './Main';
-import LoadingScreen from './LoadingScreen/LoadingScreen';
-
-import { serverIO } from '../serverIO';
 import { getLoginInfo } from '../actions/login';
-import PrivateOutlet from './PrivateOutlet';
 import { sendRefreshSession } from '../api/login';
-import { useErrorBoundary } from 'react-error-boundary';
+import EquipmentContainer from '../containers/EquipmentContainer';
+import HelpContainer from '../containers/HelpContainer';
+import LoginContainer from '../containers/LoginContainer';
+import RemoteAccessContainer from '../containers/RemoteAccessContainer';
+import SampleListViewContainer from '../containers/SampleListViewContainer';
+import SampleViewContainer from '../containers/SampleViewContainer';
+import { serverIO } from '../serverIO';
+import LoadingScreen from './LoadingScreen/LoadingScreen';
+import Main from './Main';
+import PrivateOutlet from './PrivateOutlet';
 
 const REFRESH_INTERVAL = 9000;
 

--- a/ui/src/components/BeamlineActions/AnnotatedBeamlineActionForm.jsx
+++ b/ui/src/components/BeamlineActions/AnnotatedBeamlineActionForm.jsx
@@ -1,10 +1,11 @@
-import { useDispatch, useSelector } from 'react-redux';
-import { Row, Col, Button } from 'react-bootstrap';
 import JSForm from '@rjsf/core';
 import validator from '@rjsf/validator-ajv8';
-import styles from './BeamlineActions.module.css';
+import { Button, Col, Row } from 'react-bootstrap';
+import { useDispatch, useSelector } from 'react-redux';
+
 import { stopBeamlineAction } from '../../actions/beamlineActions';
 import { RUNNING } from '../../constants';
+import styles from './BeamlineActions.module.css';
 
 export default function AnnotatedBeamlineActionForm(props) {
   const { handleStartAction } = props;

--- a/ui/src/components/BeamlineActions/BeamlineActionControl.jsx
+++ b/ui/src/components/BeamlineActions/BeamlineActionControl.jsx
@@ -1,15 +1,16 @@
 import { Button, ButtonGroup, ButtonToolbar } from 'react-bootstrap';
 import { BiLinkExternal } from 'react-icons/bi';
-import {
-  RUNNING,
-  twoStateActuatorIsActive,
-  TWO_STATE_ACTUATOR,
-} from '../../constants';
+import { useDispatch, useSelector } from 'react-redux';
+
 import {
   showActionOutput,
   stopBeamlineAction,
 } from '../../actions/beamlineActions';
-import { useDispatch, useSelector } from 'react-redux';
+import {
+  RUNNING,
+  TWO_STATE_ACTUATOR,
+  twoStateActuatorIsActive,
+} from '../../constants';
 
 export default function BeamlineActionControl(props) {
   const {

--- a/ui/src/components/BeamlineActions/BeamlineActionDialog.jsx
+++ b/ui/src/components/BeamlineActions/BeamlineActionDialog.jsx
@@ -1,11 +1,12 @@
+import { Button, Card, Col, Modal, Row } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
+
 import { hideActionOutput } from '../../actions/beamlineActions';
-import { Row, Col, Modal, Button, Card } from 'react-bootstrap';
-import Plot1D from '../Plot1D';
+import { RUNNING } from '../../constants';
 import { DraggableModal } from '../DraggableModal';
+import Plot1D from '../Plot1D';
 import AnnotatedBeamlineActionForm from './AnnotatedBeamlineActionForm';
 import BeamlineActionForm from './BeamlineActionForm';
-import { RUNNING } from '../../constants';
 
 const DEFAULT_DIALOG_POSITION = { x: -100, y: 100 };
 

--- a/ui/src/components/BeamlineActions/BeamlineActionForm.jsx
+++ b/ui/src/components/BeamlineActions/BeamlineActionForm.jsx
@@ -1,6 +1,7 @@
 import { Fragment } from 'react';
-import { Row, Col, Button, Form } from 'react-bootstrap';
+import { Button, Col, Form, Row } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
+
 import {
   setArgumentValue,
   stopBeamlineAction,

--- a/ui/src/components/BeamlineAttribute/BeamlineAttribute.jsx
+++ b/ui/src/components/BeamlineAttribute/BeamlineAttribute.jsx
@@ -1,9 +1,9 @@
 import { useRef } from 'react';
 import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 
-import BeamlineAttributeForm from './BeamlineAttributeForm';
-import styles from './BeamlineAttribute.module.css';
 import { HW_STATE } from '../../constants';
+import styles from './BeamlineAttribute.module.css';
+import BeamlineAttributeForm from './BeamlineAttributeForm';
 
 function BeamlineAttribute(props) {
   const { attribute, format, precision = 1, suffix, onSave, onCancel } = props;

--- a/ui/src/components/BeamlineCamera/BeamlineCamera.jsx
+++ b/ui/src/components/BeamlineCamera/BeamlineCamera.jsx
@@ -1,12 +1,11 @@
 import { useState } from 'react';
-import { Button, Dropdown, Card, Stack } from 'react-bootstrap';
+import { Button, Card, Dropdown, Stack } from 'react-bootstrap';
 import Draggable from 'react-draggable';
-
 import { MdClose } from 'react-icons/md';
+import { useSelector } from 'react-redux';
 
 import styles from './beamlineCamera.module.css';
 import pip from './picture_in_picture.svg';
-import { useSelector } from 'react-redux';
 
 function handleImageClick(url, width, height) {
   window.open(

--- a/ui/src/components/ChatWidget.jsx
+++ b/ui/src/components/ChatWidget.jsx
@@ -1,10 +1,4 @@
 import { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import {
-  incChatMessageCount,
-  resetChatMessageCount,
-} from '../actions/remoteAccess';
-import { fetchChatMessages, sendChatMessage } from '../api/remoteAccess';
 import {
   addResponseMessage,
   addUserMessage,
@@ -12,6 +6,13 @@ import {
   Widget,
 } from 'react-chat-widget';
 import Draggable from 'react-draggable';
+import { useDispatch, useSelector } from 'react-redux';
+
+import {
+  incChatMessageCount,
+  resetChatMessageCount,
+} from '../actions/remoteAccess';
+import { fetchChatMessages, sendChatMessage } from '../api/remoteAccess';
 import { store } from '../store';
 
 function ChatWidget() {

--- a/ui/src/components/Equipment/GenericEquipment.jsx
+++ b/ui/src/components/Equipment/GenericEquipment.jsx
@@ -1,6 +1,7 @@
-import { Row, Col } from 'react-bootstrap';
+import { Col, Row } from 'react-bootstrap';
 import Collapsible from 'react-collapsible';
 import { BsChevronDown } from 'react-icons/bs';
+
 import EquipmentState from './EquipmentState';
 import styles from './GenericEquipmentControl.module.css';
 

--- a/ui/src/components/Equipment/GenericEquipmentControl.jsx
+++ b/ui/src/components/Equipment/GenericEquipmentControl.jsx
@@ -1,11 +1,10 @@
-import { Row, Col, Button, OverlayTrigger, Popover } from 'react-bootstrap';
-
-import Collapsible from 'react-collapsible';
-import { BsChevronDown } from 'react-icons/bs';
-import EquipmentState from './EquipmentState';
 import Form from '@rjsf/core';
 import validator from '@rjsf/validator-ajv8';
+import { Button, Col, OverlayTrigger, Popover, Row } from 'react-bootstrap';
+import Collapsible from 'react-collapsible';
+import { BsChevronDown } from 'react-icons/bs';
 
+import EquipmentState from './EquipmentState';
 import styles from './GenericEquipmentControl.module.css';
 
 export default function GenericEquipmentControl(props) {

--- a/ui/src/components/Equipment/Harvester.jsx
+++ b/ui/src/components/Equipment/Harvester.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { Card, Button, Badge } from 'react-bootstrap';
-import { contextMenu, Menu, Item, Separator } from 'react-contexify';
-import { FcRefresh, FcUpload, FcCollect } from 'react-icons/fc';
+import { Badge, Button, Card } from 'react-bootstrap';
+import { contextMenu, Item, Menu, Separator } from 'react-contexify';
+import { FcCollect, FcRefresh, FcUpload } from 'react-icons/fc';
 
 import CopyToClipboard from '../CopyToClipboard/CopyToClipboard.jsx';
 import ImageViewer from '../ImageViewer/ImageViewer.jsx';
-
 import styles from './equipment.module.css';
 
 function sampleStateBackground(key) {

--- a/ui/src/components/Equipment/HarvesterMaintenance.jsx
+++ b/ui/src/components/Equipment/HarvesterMaintenance.jsx
@@ -1,10 +1,5 @@
-import { Row, Col, Button, Card } from 'react-bootstrap';
+import { Button, Card, Col, Row } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
-
-import ActionGroup from './ActionGroup';
-import ActionButton from './ActionButton';
-import ActionField from './ActionField';
-import InOutSwitch from '../InOutSwitch/InOutSwitch';
 
 import {
   calibratePin,
@@ -12,6 +7,10 @@ import {
   sendDataCollectionToCrims,
   validateCalibration,
 } from '../../actions/harvester';
+import InOutSwitch from '../InOutSwitch/InOutSwitch';
+import ActionButton from './ActionButton';
+import ActionField from './ActionField';
+import ActionGroup from './ActionGroup';
 import styles from './equipment.module.css';
 
 export default function HarvesterMaintenance() {

--- a/ui/src/components/Equipment/PlateManipulator.jsx
+++ b/ui/src/components/Equipment/PlateManipulator.jsx
@@ -1,17 +1,17 @@
 import { useEffect } from 'react';
 import {
-  Row,
-  Col,
   Button,
   ButtonToolbar,
+  Col,
   OverlayTrigger,
   Popover,
+  Row,
 } from 'react-bootstrap';
-import { contextMenu, Menu, Item, Separator } from 'react-contexify';
-
+import { contextMenu, Item, Menu, Separator } from 'react-contexify';
 import { MdSync } from 'react-icons/md';
-import styles from './equipment.module.css';
+
 import TooltipTrigger from '../TooltipTrigger';
+import styles from './equipment.module.css';
 
 const strokeColor = 'rgb(136, 136, 136)';
 

--- a/ui/src/components/Equipment/PlateManipulatorMaintenance.jsx
+++ b/ui/src/components/Equipment/PlateManipulatorMaintenance.jsx
@@ -1,11 +1,10 @@
 import { Card } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { sendCommand } from '../../actions/sampleChanger';
+import ActionButton from './ActionButton';
 import ActionField from './ActionField';
 import ActionGroup from './ActionGroup';
-import ActionButton from './ActionButton';
-
-import { sendCommand } from '../../actions/sampleChanger';
 import styles from './equipment.module.css';
 
 function PlateManipulatorMaintenance() {

--- a/ui/src/components/Equipment/SampleChanger.jsx
+++ b/ui/src/components/Equipment/SampleChanger.jsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
-import { Card, Dropdown, Form, Button, DropdownButton } from 'react-bootstrap';
-
-import { Menu, Item, Separator, contextMenu } from 'react-contexify';
+import { Button, Card, Dropdown, DropdownButton, Form } from 'react-bootstrap';
+import { contextMenu, Item, Menu, Separator } from 'react-contexify';
 
 import styles from './equipment.module.css';
 

--- a/ui/src/components/Equipment/SampleChangerMaintenance.jsx
+++ b/ui/src/components/Equipment/SampleChangerMaintenance.jsx
@@ -1,9 +1,9 @@
 import { Card } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 
-import ActionGroup from './ActionGroup';
-import ActionButton from './ActionButton';
 import { sendCommand } from '../../actions/sampleChanger';
+import ActionButton from './ActionButton';
+import ActionGroup from './ActionGroup';
 import styles from './equipment.module.css';
 
 function SampleChangerMaintenance() {

--- a/ui/src/components/GenericContextMenu/MXContextMenu.jsx
+++ b/ui/src/components/GenericContextMenu/MXContextMenu.jsx
@@ -1,7 +1,7 @@
+import './MXContextMenu.css';
+
 import React from 'react';
 import { Dropdown } from 'react-bootstrap';
-
-import './MXContextMenu.css';
 
 export default class MXContextMenu extends React.Component {
   constructor(props) {

--- a/ui/src/components/GenericDialog/ConfirmActionDialog.jsx
+++ b/ui/src/components/GenericDialog/ConfirmActionDialog.jsx
@@ -1,4 +1,4 @@
-import { Modal, Button } from 'react-bootstrap';
+import { Button, Modal } from 'react-bootstrap';
 
 function ConfirmActionDialog(props) {
   const {

--- a/ui/src/components/ImageViewer/ImageViewer.jsx
+++ b/ui/src/components/ImageViewer/ImageViewer.jsx
@@ -1,6 +1,7 @@
-import { useRef, useEffect, useState } from 'react';
-import { TransformWrapper, TransformComponent } from 'react-zoom-pan-pinch';
+import { useEffect, useRef, useState } from 'react';
 import { Modal } from 'react-bootstrap';
+import { TransformComponent, TransformWrapper } from 'react-zoom-pan-pinch';
+
 import styles from './imageViewer.module.css';
 
 function GalleryImage(props) {

--- a/ui/src/components/InOutSwitch/InOutSwitch.jsx
+++ b/ui/src/components/InOutSwitch/InOutSwitch.jsx
@@ -5,6 +5,7 @@ import {
   Popover,
   Spinner,
 } from 'react-bootstrap';
+
 import styles from './inOutStyle.module.css';
 
 export default function InOutSwitch(props) {

--- a/ui/src/components/Lims/LimsResultDialog.jsx
+++ b/ui/src/components/Lims/LimsResultDialog.jsx
@@ -1,11 +1,10 @@
-import React from 'react';
-import { Modal, Button } from 'react-bootstrap';
+import './LimsResultDialog.css';
 
-import { LimsResultSummary } from './LimsResultSummary';
+import React from 'react';
+import { Button, Modal } from 'react-bootstrap';
 
 import { TASK_COLLECTED } from '../../constants';
-
-import './LimsResultDialog.css';
+import { LimsResultSummary } from './LimsResultSummary';
 
 export class LimsResultDialog extends React.Component {
   constructor(props) {

--- a/ui/src/components/Lims/LimsResultSummary.jsx
+++ b/ui/src/components/Lims/LimsResultSummary.jsx
@@ -1,8 +1,8 @@
 /* eslint-disable promise/prefer-await-to-then */
 import React from 'react';
 
-import { isUnCollected, taskHasLimsData } from '../../constants';
 import { fetchLimsResults } from '../../api/lims';
+import { isUnCollected, taskHasLimsData } from '../../constants';
 
 export class LimsResultSummary extends React.Component {
   componentDidMount() {

--- a/ui/src/components/LoadingScreen/LoadingScreen.jsx
+++ b/ui/src/components/LoadingScreen/LoadingScreen.jsx
@@ -1,5 +1,5 @@
-import logo from '../../img/mxcube_logo20.png';
 import loadingAnimation from '../../img/loading-animation.gif';
+import logo from '../../img/mxcube_logo20.png';
 import styles from './LoadingScreen.module.css';
 
 function LoadingScreen() {

--- a/ui/src/components/LoginForm/LoginForm.jsx
+++ b/ui/src/components/LoginForm/LoginForm.jsx
@@ -1,13 +1,12 @@
 import { useState } from 'react';
-import { Form, InputGroup, Alert, Button } from 'react-bootstrap';
-
+import { Alert, Button, Form, InputGroup } from 'react-bootstrap';
 import { Controller, useForm } from 'react-hook-form';
-
-import logo from '../../img/mxcube_logo20.png';
-import loader from '../../img/loader.gif';
-import styles from './LoginForm.module.css';
 import { useDispatch, useSelector } from 'react-redux';
+
 import { logIn } from '../../actions/login';
+import loader from '../../img/loader.gif';
+import logo from '../../img/mxcube_logo20.png';
+import styles from './LoginForm.module.css';
 
 const SSO_PATH = '/mxcube/api/v0.1/login/ssologin';
 

--- a/ui/src/components/LoginForm/SelectProposal.jsx
+++ b/ui/src/components/LoginForm/SelectProposal.jsx
@@ -1,14 +1,15 @@
 import { useState } from 'react';
-import { Modal, Button, Tabs, Tab, Form } from 'react-bootstrap';
-import SessionTable from './SessionTable';
+import { Button, Form, Modal, Tab, Tabs } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
+
 import {
   hideProposalsForm,
   selectProposal,
   signOut,
 } from '../../actions/login';
-import styles from './SessionTable.module.css';
 import ActionButton from './ActionButton';
+import SessionTable from './SessionTable';
+import styles from './SessionTable.module.css';
 
 function SelectProposal() {
   const dispatch = useDispatch();

--- a/ui/src/components/MXNavbar/MXNavbar.jsx
+++ b/ui/src/components/MXNavbar/MXNavbar.jsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
-import { Container, Navbar, Nav } from 'react-bootstrap';
+import { Container, Nav, Navbar } from 'react-bootstrap';
 import { BsList } from 'react-icons/bs';
-import { NavLink, useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
+import { NavLink, useLocation } from 'react-router-dom';
+
 import { showProposalsForm, signOut } from '../../actions/login';
 import styles from './MXNavbar.module.css';
 

--- a/ui/src/components/MachInfo/MachInfo.jsx
+++ b/ui/src/components/MachInfo/MachInfo.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { OverlayTrigger, Popover, Badge, Row, Col } from 'react-bootstrap';
+import { Badge, Col, OverlayTrigger, Popover, Row } from 'react-bootstrap';
 
 import styles from './machineInfoStyle.module.css';
 

--- a/ui/src/components/Main.jsx
+++ b/ui/src/components/Main.jsx
@@ -1,31 +1,31 @@
-import { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { Stack } from 'react-bootstrap';
-import { Outlet, useLocation } from 'react-router-dom';
-
-import TaskContainer from '../containers/TaskContainer';
-import PleaseWaitDialog from '../containers/PleaseWaitDialog';
-import ErrorNotificationPanel from '../containers/ErrorNotificationPanel';
-import ResumeQueueDialog from '../containers/ResumeQueueDialog';
-import ConnectionLostDialog from '../containers/ConnectionLostDialog';
-import ObserverDialog from './RemoteAccess/ObserverDialog';
-import PassControlDialog from './RemoteAccess/PassControlDialog';
-import ConfirmCollectDialog from '../containers/ConfirmCollectDialog';
-import WorkflowParametersDialog from '../containers/WorkflowParametersDialog';
-import GphlWorkflowParametersDialog from '../containers/GphlWorkflowParametersDialog';
-import { LimsResultDialog } from './Lims/LimsResultDialog';
-import LoadingScreen from './LoadingScreen/LoadingScreen';
-import MXNavbar from './MXNavbar/MXNavbar';
-import ChatWidget from './ChatWidget';
-import ClearQueueDialog from './SampleGrid/ClearQueueDialog';
-import SelectProposal from './LoginForm/SelectProposal';
-import { getInitialState } from '../actions/login';
-import { showDialog } from '../actions/general';
-import diagonalNoise from '../img/diagonal-noise.png';
-import styles from './Main.module.css';
-
 import 'react-chat-widget/lib/styles.css';
 import './rachat.css';
+
+import { useEffect } from 'react';
+import { Stack } from 'react-bootstrap';
+import { useDispatch, useSelector } from 'react-redux';
+import { Outlet, useLocation } from 'react-router-dom';
+
+import { showDialog } from '../actions/general';
+import { getInitialState } from '../actions/login';
+import ConfirmCollectDialog from '../containers/ConfirmCollectDialog';
+import ConnectionLostDialog from '../containers/ConnectionLostDialog';
+import ErrorNotificationPanel from '../containers/ErrorNotificationPanel';
+import GphlWorkflowParametersDialog from '../containers/GphlWorkflowParametersDialog';
+import PleaseWaitDialog from '../containers/PleaseWaitDialog';
+import ResumeQueueDialog from '../containers/ResumeQueueDialog';
+import TaskContainer from '../containers/TaskContainer';
+import WorkflowParametersDialog from '../containers/WorkflowParametersDialog';
+import diagonalNoise from '../img/diagonal-noise.png';
+import ChatWidget from './ChatWidget';
+import { LimsResultDialog } from './Lims/LimsResultDialog';
+import LoadingScreen from './LoadingScreen/LoadingScreen';
+import SelectProposal from './LoginForm/SelectProposal';
+import styles from './Main.module.css';
+import MXNavbar from './MXNavbar/MXNavbar';
+import ObserverDialog from './RemoteAccess/ObserverDialog';
+import PassControlDialog from './RemoteAccess/PassControlDialog';
+import ClearQueueDialog from './SampleGrid/ClearQueueDialog';
 
 function Main() {
   const dispatch = useDispatch();

--- a/ui/src/components/MotorInput/BaseMotorInput.jsx
+++ b/ui/src/components/MotorInput/BaseMotorInput.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+
 import { HW_STATE } from '../../constants';
 
 function BaseMotorInput(props) {

--- a/ui/src/components/MotorInput/MotorInput.jsx
+++ b/ui/src/components/MotorInput/MotorInput.jsx
@@ -1,11 +1,11 @@
-import { useDispatch, useSelector } from 'react-redux';
 import { Button } from 'react-bootstrap';
+import { useDispatch, useSelector } from 'react-redux';
 
-import BaseMotorInput from './BaseMotorInput';
-import { stopBeamlineAction } from '../../actions/beamlineActions';
 import { setAttribute } from '../../actions/beamline';
+import { stopBeamlineAction } from '../../actions/beamlineActions';
 import { setMotorStep } from '../../actions/sampleview';
 import { HW_STATE, QUEUE_RUNNING } from '../../constants';
+import BaseMotorInput from './BaseMotorInput';
 import styles from './MotorInput.module.css';
 
 function MotorInput(props) {

--- a/ui/src/components/MotorInput/OneAxisTranslationControl.jsx
+++ b/ui/src/components/MotorInput/OneAxisTranslationControl.jsx
@@ -1,9 +1,9 @@
-import { useDispatch, useSelector } from 'react-redux';
 import { Button } from 'react-bootstrap';
+import { useDispatch, useSelector } from 'react-redux';
 
-import BaseMotorInput from './BaseMotorInput';
-import { HW_STATE, QUEUE_RUNNING } from '../../constants';
 import { setAttribute } from '../../actions/beamline';
+import { HW_STATE, QUEUE_RUNNING } from '../../constants';
+import BaseMotorInput from './BaseMotorInput';
 import styles from './OneAxisTranslationControl.module.css';
 
 function OneAxisTranslationControl(props) {

--- a/ui/src/components/MotorInput/TwoAxisTranslationControl.jsx
+++ b/ui/src/components/MotorInput/TwoAxisTranslationControl.jsx
@@ -1,9 +1,9 @@
 import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 
-import MotorInput from './MotorInput';
-import { HW_STATE, QUEUE_RUNNING } from '../../constants';
 import { setAttribute } from '../../actions/beamline';
+import { HW_STATE, QUEUE_RUNNING } from '../../constants';
+import MotorInput from './MotorInput';
 import styles from './TwoAxisTranslationControl.module.css';
 
 function TwoAxisTranslationControl(props) {

--- a/ui/src/components/Plot1D.jsx
+++ b/ui/src/components/Plot1D.jsx
@@ -1,7 +1,8 @@
+import 'dygraphs/dist/dygraph.min.css';
+
+import Dygraph from 'dygraphs';
 import React from 'react';
 import { connect } from 'react-redux';
-import Dygraph from 'dygraphs';
-import 'dygraphs/dist/dygraph.min.css';
 
 class Plot1D extends React.Component {
   static defaultProps = {

--- a/ui/src/components/RemoteAccess/ObserverDialog.jsx
+++ b/ui/src/components/RemoteAccess/ObserverDialog.jsx
@@ -1,8 +1,9 @@
 import { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { Modal, Button, Form } from 'react-bootstrap';
-import { updateNickname } from '../../actions/remoteAccess';
+import { Button, Form, Modal } from 'react-bootstrap';
 import { useForm } from 'react-hook-form';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { updateNickname } from '../../actions/remoteAccess';
 
 function ObserverDialog() {
   const dispatch = useDispatch();

--- a/ui/src/components/RemoteAccess/PassControlDialog.jsx
+++ b/ui/src/components/RemoteAccess/PassControlDialog.jsx
@@ -1,8 +1,9 @@
 import { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { Modal, Button, Form, Alert } from 'react-bootstrap';
-import { respondToControlRequest } from '../../actions/remoteAccess';
+import { Alert, Button, Form, Modal } from 'react-bootstrap';
 import { useForm } from 'react-hook-form';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { respondToControlRequest } from '../../actions/remoteAccess';
 import { hideWaitDialog } from '../../actions/waitDialog';
 
 function PassControlDialog() {

--- a/ui/src/components/RemoteAccess/RequestControlForm.jsx
+++ b/ui/src/components/RemoteAccess/RequestControlForm.jsx
@@ -1,5 +1,6 @@
+import { Button, Card, Form } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
-import { Form, Button, Card } from 'react-bootstrap';
+
 import { requestControl, takeControl } from '../../actions/remoteAccess';
 
 function RequestControlForm() {

--- a/ui/src/components/RemoteAccess/UserList.jsx
+++ b/ui/src/components/RemoteAccess/UserList.jsx
@@ -1,5 +1,6 @@
+import { Button, Card, Col, Row } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
-import { Row, Col, Button, Card } from 'react-bootstrap';
+
 import { giveControl, logoutUser } from '../../actions/remoteAccess';
 
 function UserList() {

--- a/ui/src/components/SSXChip/SSXChip.jsx
+++ b/ui/src/components/SSXChip/SSXChip.jsx
@@ -1,10 +1,11 @@
 /* eslint-disable react/jsx-key */
 /* eslint-disable react/no-unused-state */
-import React from 'react';
-import { Row, Col, Form, Button, Card } from 'react-bootstrap';
-import { Menu, Item, Separator, contextMenu } from 'react-contexify';
 import 'fabric';
 import './ssxchipcontrol.css';
+
+import React from 'react';
+import { Button, Card, Col, Form, Row } from 'react-bootstrap';
+import { contextMenu, Item, Menu, Separator } from 'react-contexify';
 
 import MotorInput from '../MotorInput/MotorInput';
 

--- a/ui/src/components/SSXChip/SSXChipControl.jsx
+++ b/ui/src/components/SSXChip/SSXChipControl.jsx
@@ -1,7 +1,9 @@
-import React from 'react';
 import 'fabric';
-import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 import './ssxchipcontrol.css';
+
+import React from 'react';
+import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
+
 import SSXChip from './SSXChip.jsx';
 
 export default class SSXChipControl extends React.Component {

--- a/ui/src/components/SampleControls/FocusControl.jsx
+++ b/ui/src/components/SampleControls/FocusControl.jsx
@@ -1,8 +1,8 @@
 import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
+import { useSelector } from 'react-redux';
 
 import OneAxisTranslationControl from '../MotorInput/OneAxisTranslationControl';
 import styles from './SampleControls.module.css';
-import { useSelector } from 'react-redux';
 
 function FocusControl() {
   const focusMotorProps = useSelector((state) =>

--- a/ui/src/components/SampleControls/LightControl.jsx
+++ b/ui/src/components/SampleControls/LightControl.jsx
@@ -1,8 +1,8 @@
 import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { HW_STATE } from '../../constants';
 import { setAttribute } from '../../actions/beamline';
+import { HW_STATE } from '../../constants';
 import styles from './SampleControls.module.css';
 
 function LightControl(props) {

--- a/ui/src/components/SampleControls/SampleControls.jsx
+++ b/ui/src/components/SampleControls/SampleControls.jsx
@@ -1,13 +1,12 @@
-import SnapshotControl from './SnapshotControl';
-import GridControl from './GridControl';
 import CentringControl from './CentringControl';
 import FocusControl from './FocusControl';
-import ZoomControl from './ZoomControl';
+import GridControl from './GridControl';
 import LightControl from './LightControl';
-import VideoSizeControl from './VideoSizeControl';
-
-import { useShowControl } from './utils';
 import styles from './SampleControls.module.css';
+import SnapshotControl from './SnapshotControl';
+import { useShowControl } from './utils';
+import VideoSizeControl from './VideoSizeControl';
+import ZoomControl from './ZoomControl';
 
 function SampleControls(props) {
   const { canvas } = props;

--- a/ui/src/components/SampleControls/SnapshotControl.jsx
+++ b/ui/src/components/SampleControls/SnapshotControl.jsx
@@ -1,10 +1,10 @@
 import { useCallback, useEffect } from 'react';
 import { Button } from 'react-bootstrap';
 import { useSelector } from 'react-redux';
-import { sendTakeSnapshot } from '../../api/sampleview';
-import { download } from './utils';
 
+import { sendTakeSnapshot } from '../../api/sampleview';
 import styles from './SampleControls.module.css';
+import { download } from './utils';
 
 const { fabric } = window;
 

--- a/ui/src/components/SampleControls/ZoomControl.jsx
+++ b/ui/src/components/SampleControls/ZoomControl.jsx
@@ -1,8 +1,8 @@
 import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { HW_STATE } from '../../constants';
 import { setAttribute } from '../../actions/beamline';
+import { HW_STATE } from '../../constants';
 import styles from './SampleControls.module.css';
 
 const ZOOM_HWO_ID = 'diffractometer.zoom';

--- a/ui/src/components/SampleGrid/ClearQueueDialog.jsx
+++ b/ui/src/components/SampleGrid/ClearQueueDialog.jsx
@@ -1,7 +1,8 @@
-import ConfirmActionDialog from '../GenericDialog/ConfirmActionDialog';
 import { useDispatch, useSelector } from 'react-redux';
-import { clearQueue } from '../../actions/queue';
+
 import { showConfirmClearQueueDialog } from '../../actions/general';
+import { clearQueue } from '../../actions/queue';
+import ConfirmActionDialog from '../GenericDialog/ConfirmActionDialog';
 
 function ClearQueueDialog() {
   const dispatch = useDispatch();

--- a/ui/src/components/SampleGrid/SampleGridTableItem.jsx
+++ b/ui/src/components/SampleGrid/SampleGridTableItem.jsx
@@ -1,19 +1,18 @@
+import './SampleGridTable.css';
+
+import cx from 'classnames';
 import React from 'react';
 import {
+  Badge,
+  Button,
   ListGroup,
   OverlayTrigger,
   Popover,
-  Badge,
-  Button,
 } from 'react-bootstrap';
-import cx from 'classnames';
+import { BsCheck2Square, BsSquare } from 'react-icons/bs';
 
 import CopyToClipboard from '../../components/CopyToClipboard/CopyToClipboard';
-
 import { isCollected } from '../../constants';
-
-import { BsSquare, BsCheck2Square } from 'react-icons/bs';
-import './SampleGridTable.css';
 import TooltipTrigger from '../TooltipTrigger';
 
 export class SampleGridTableItem extends React.Component {

--- a/ui/src/components/SampleGrid/TaskItem.jsx
+++ b/ui/src/components/SampleGrid/TaskItem.jsx
@@ -1,18 +1,18 @@
-import React from 'react';
-import { OverlayTrigger, Popover, Badge } from 'react-bootstrap';
-import { LimsResultSummary } from '../Lims/LimsResultSummary';
-
 import './SampleGridTable.css';
+
+import React from 'react';
+import { Badge, OverlayTrigger, Popover } from 'react-bootstrap';
+
 import {
-  TASK_COLLECTED,
-  TASK_UNCOLLECTED,
+  isUnCollected,
   TASK_COLLECT_FAILED,
   TASK_COLLECT_WARNING,
+  TASK_COLLECTED,
   TASK_RUNNING,
-  isUnCollected,
+  TASK_UNCOLLECTED,
 } from '../../constants';
-
 import loader from '../../img/busy-indicator.gif';
+import { LimsResultSummary } from '../Lims/LimsResultSummary';
 
 export class TaskItem extends React.Component {
   static defaultProps = {

--- a/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
+++ b/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
@@ -3,14 +3,15 @@
 
 /* eslint-disable react/no-array-index-key */
 
-import { Component } from 'react';
 import PropTypes from 'prop-types';
-import { ProgressBar, Button, Collapse, Table } from 'react-bootstrap';
+import { Component } from 'react';
+import { Button, Collapse, ProgressBar, Table } from 'react-bootstrap';
+
 import {
-  TASK_UNCOLLECTED,
-  TASK_COLLECTED,
   TASK_COLLECT_FAILED,
+  TASK_COLLECTED,
   TASK_RUNNING,
+  TASK_UNCOLLECTED,
 } from '../../constants';
 import TooltipTrigger from '../TooltipTrigger';
 

--- a/ui/src/components/SampleQueue/CurrentTree.jsx
+++ b/ui/src/components/SampleQueue/CurrentTree.jsx
@@ -1,13 +1,14 @@
 /* eslint-disable react/no-unused-state */
+import './app.css';
 
 import React from 'react';
-import './app.css';
-import { Menu, Item, contextMenu } from 'react-contexify';
-import TaskItem from './TaskItem';
-import XRFTaskItem from './XRFTaskItem';
-import EnergyScanTaskItem from './EnergyScanTaskItem';
-import WorkflowTaskItem from './WorkflowTaskItem';
+import { contextMenu, Item, Menu } from 'react-contexify';
+
 import CharacterisationTaskItem from './CharacterisationTaskItem';
+import EnergyScanTaskItem from './EnergyScanTaskItem';
+import TaskItem from './TaskItem';
+import WorkflowTaskItem from './WorkflowTaskItem';
+import XRFTaskItem from './XRFTaskItem';
 
 export default class CurrentTree extends React.Component {
   constructor(props) {

--- a/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
+++ b/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
@@ -1,20 +1,21 @@
 /* eslint-disable react/no-unused-prop-types */
 /* eslint-disable react/no-unused-state */
 
-import { Component } from 'react';
 import PropTypes from 'prop-types';
+import { Component } from 'react';
 import {
-  ProgressBar,
   Button,
   Collapse,
   OverlayTrigger,
   Popover,
+  ProgressBar,
 } from 'react-bootstrap';
+
 import {
-  TASK_UNCOLLECTED,
-  TASK_COLLECTED,
   TASK_COLLECT_FAILED,
+  TASK_COLLECTED,
   TASK_RUNNING,
+  TASK_UNCOLLECTED,
 } from '../../constants';
 
 export default class EnergyScanTaskItem extends Component {

--- a/ui/src/components/SampleQueue/QueueControl.jsx
+++ b/ui/src/components/SampleQueue/QueueControl.jsx
@@ -1,13 +1,14 @@
-import React from 'react';
 import './app.css';
-import { Button, Navbar, Nav } from 'react-bootstrap';
-import {
-  QUEUE_RUNNING,
-  QUEUE_PAUSED,
-  QUEUE_STOPPED,
-  QUEUE_STARTED,
-} from '../../constants';
 
+import React from 'react';
+import { Button, Nav, Navbar } from 'react-bootstrap';
+
+import {
+  QUEUE_PAUSED,
+  QUEUE_RUNNING,
+  QUEUE_STARTED,
+  QUEUE_STOPPED,
+} from '../../constants';
 import QueueSettings from '../../containers/QueueSettings';
 import loader from '../../img/busy-indicator.gif';
 

--- a/ui/src/components/SampleQueue/TaskItem.jsx
+++ b/ui/src/components/SampleQueue/TaskItem.jsx
@@ -2,14 +2,15 @@
 /* eslint-disable react/no-unused-prop-types */
 /* eslint-disable react/no-unused-state */
 
-import { Component } from 'react';
 import PropTypes from 'prop-types';
-import { ProgressBar, Button, Collapse, Table } from 'react-bootstrap';
+import { Component } from 'react';
+import { Button, Collapse, ProgressBar, Table } from 'react-bootstrap';
+
 import {
-  TASK_UNCOLLECTED,
-  TASK_COLLECTED,
   TASK_COLLECT_FAILED,
+  TASK_COLLECTED,
   TASK_RUNNING,
+  TASK_UNCOLLECTED,
 } from '../../constants';
 import TooltipTrigger from '../TooltipTrigger';
 

--- a/ui/src/components/SampleQueue/TodoTree.jsx
+++ b/ui/src/components/SampleQueue/TodoTree.jsx
@@ -1,8 +1,9 @@
 /* eslint-disable react/no-array-index-key */
+import './app.css';
 
 import React from 'react';
-import './app.css';
-import { ListGroup, Form, Button } from 'react-bootstrap';
+import { Button, Form, ListGroup } from 'react-bootstrap';
+
 import { QUEUE_RUNNING } from '../../constants';
 
 export default class TodoTree extends React.Component {

--- a/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
+++ b/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
@@ -1,14 +1,15 @@
 /* eslint-disable react/no-unused-prop-types */
 /* eslint-disable react/no-unused-state */
 
-import { Component } from 'react';
 import PropTypes from 'prop-types';
-import { ProgressBar, Button, Collapse } from 'react-bootstrap';
+import { Component } from 'react';
+import { Button, Collapse, ProgressBar } from 'react-bootstrap';
+
 import {
-  TASK_UNCOLLECTED,
-  TASK_COLLECTED,
   TASK_COLLECT_FAILED,
+  TASK_COLLECTED,
   TASK_RUNNING,
+  TASK_UNCOLLECTED,
 } from '../../constants';
 import TooltipTrigger from '../TooltipTrigger';
 

--- a/ui/src/components/SampleQueue/XRFTaskItem.jsx
+++ b/ui/src/components/SampleQueue/XRFTaskItem.jsx
@@ -1,22 +1,22 @@
 /* eslint-disable react/no-unused-state */
-import { Component } from 'react';
 import PropTypes from 'prop-types';
+import { Component } from 'react';
 import {
-  ProgressBar,
   Button,
   Collapse,
+  Modal,
   OverlayTrigger,
   Popover,
-  Modal,
+  ProgressBar,
 } from 'react-bootstrap';
-import Plot1D from '../Plot1D';
 
 import {
-  TASK_UNCOLLECTED,
-  TASK_COLLECTED,
   TASK_COLLECT_FAILED,
+  TASK_COLLECTED,
   TASK_RUNNING,
+  TASK_UNCOLLECTED,
 } from '../../constants';
+import Plot1D from '../Plot1D';
 
 export default class XRFTaskItem extends Component {
   static propTypes = {

--- a/ui/src/components/SampleView/ContextMenu.jsx
+++ b/ui/src/components/SampleView/ContextMenu.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { createPortal } from 'react-dom';
 import { Dropdown } from 'react-bootstrap';
+import { createPortal } from 'react-dom';
+
 import { getLastUsedParameters } from '../Tasks/fields';
 
 const BESPOKE_TASK_NAMES = new Set([

--- a/ui/src/components/SampleView/GridForm.jsx
+++ b/ui/src/components/SampleView/GridForm.jsx
@@ -1,9 +1,10 @@
-import { useEffect, useRef, useState } from 'react';
-import { Row, Col, Form, Button, Table } from 'react-bootstrap';
-import Draggable from 'react-draggable';
-
 import './SampleView.css';
+
+import { useEffect, useRef, useState } from 'react';
+import { Button, Col, Form, Row, Table } from 'react-bootstrap';
+import Draggable from 'react-draggable';
 import { useSelector } from 'react-redux';
+
 import TooltipTrigger from '../TooltipTrigger';
 
 function handleContextMenu(e) {

--- a/ui/src/components/SampleView/MotorControls.jsx
+++ b/ui/src/components/SampleView/MotorControls.jsx
@@ -3,10 +3,9 @@ import { Button } from 'react-bootstrap';
 import { useSelector } from 'react-redux';
 
 import MotorInput from '../MotorInput/MotorInput';
-import TwoAxisTranslationControl from '../MotorInput/TwoAxisTranslationControl';
-
-import styles from './MotorControls.module.css';
 import motorInputStyles from '../MotorInput/MotorInput.module.css';
+import TwoAxisTranslationControl from '../MotorInput/TwoAxisTranslationControl';
+import styles from './MotorControls.module.css';
 
 function MotorControls() {
   const [showAll, setShowAll] = useState(false);

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -1,19 +1,20 @@
-import React from 'react';
-import { HW_STATE } from '../../constants';
-import {
-  makePoints,
-  makeTwoDPoints,
-  makeLines,
-  makeImageOverlay,
-  makeCentringHorizontalLine,
-  makeCentringVerticalLine,
-} from './shapes';
-import DrawGridPlugin from './DrawGridPlugin';
-import SampleControls from '../SampleControls/SampleControls';
-import GridForm from './GridForm';
 import 'fabric';
 
+import React from 'react';
+
+import { HW_STATE } from '../../constants';
+import SampleControls from '../SampleControls/SampleControls';
+import DrawGridPlugin from './DrawGridPlugin';
+import GridForm from './GridForm';
 import { JSMpeg } from './jsmpeg.min.js';
+import {
+  makeCentringHorizontalLine,
+  makeCentringVerticalLine,
+  makeImageOverlay,
+  makeLines,
+  makePoints,
+  makeTwoDPoints,
+} from './shapes';
 
 const { fabric } = window;
 fabric.Group.prototype.hasControls = false;

--- a/ui/src/components/Tasks/AddSample.jsx
+++ b/ui/src/components/Tasks/AddSample.jsx
@@ -1,11 +1,12 @@
 import { useEffect } from 'react';
+import { Button, ButtonToolbar, Col, Form, Modal, Row } from 'react-bootstrap';
+import { useForm } from 'react-hook-form';
 import { useDispatch } from 'react-redux';
-import { Modal, ButtonToolbar, Button, Form, Row, Col } from 'react-bootstrap';
-import { addSamplesToList } from '../../actions/sampleGrid';
+import { useLocation } from 'react-router-dom';
+
 import { addSampleAndMount, addSamplesToQueue } from '../../actions/queue';
 import { showList } from '../../actions/queueGUI';
-import { useLocation } from 'react-router-dom';
-import { useForm } from 'react-hook-form';
+import { addSamplesToList } from '../../actions/sampleGrid';
 import { hideTaskParametersForm } from '../../actions/taskForm';
 
 const REQUIRED_MSG = 'This field is required';

--- a/ui/src/components/Tasks/Characterisation.jsx
+++ b/ui/src/components/Tasks/Characterisation.jsx
@@ -1,26 +1,25 @@
 import React from 'react';
+import { Button, ButtonToolbar, Col, Form, Modal, Row } from 'react-bootstrap';
 import { connect } from 'react-redux';
-import { reduxForm, formValueSelector } from 'redux-form';
-import { Modal, Button, Form, Row, Col, ButtonToolbar } from 'react-bootstrap';
-import { DraggableModal } from '../DraggableModal';
-import asyncValidate from './asyncValidate';
-import validate from './validate';
-import warn from './warning';
-
-import {
-  FieldsHeader,
-  StaticField,
-  InputField,
-  CheckboxField,
-  SelectField,
-  FieldsRow,
-  CollapsableRows,
-  toFixed,
-  saveToLastUsedParameters,
-  resetLastUsedParameters,
-} from './fields';
+import { formValueSelector, reduxForm } from 'redux-form';
 
 import { SPACE_GROUPS } from '../../constants';
+import { DraggableModal } from '../DraggableModal';
+import asyncValidate from './asyncValidate';
+import {
+  CheckboxField,
+  CollapsableRows,
+  FieldsHeader,
+  FieldsRow,
+  InputField,
+  resetLastUsedParameters,
+  saveToLastUsedParameters,
+  SelectField,
+  StaticField,
+  toFixed,
+} from './fields';
+import validate from './validate';
+import warn from './warning';
 
 class Characterisation extends React.Component {
   constructor(props) {

--- a/ui/src/components/Tasks/DataCollection.jsx
+++ b/ui/src/components/Tasks/DataCollection.jsx
@@ -1,25 +1,24 @@
 import React from 'react';
+import { Button, ButtonToolbar, Col, Form, Modal, Row } from 'react-bootstrap';
 import { connect } from 'react-redux';
-import { reduxForm, formValueSelector } from 'redux-form';
-import { Modal, Button, Form, Row, Col, ButtonToolbar } from 'react-bootstrap';
-import { DraggableModal } from '../DraggableModal';
-import asyncValidate from './asyncValidate';
-import validate from './validate';
-import warn from './warning';
-
-import {
-  FieldsHeader,
-  StaticField,
-  InputField,
-  SelectField,
-  FieldsRow,
-  CollapsableRows,
-  toFixed,
-  saveToLastUsedParameters,
-  resetLastUsedParameters,
-} from './fields';
+import { formValueSelector, reduxForm } from 'redux-form';
 
 import { SPACE_GROUPS } from '../../constants';
+import { DraggableModal } from '../DraggableModal';
+import asyncValidate from './asyncValidate';
+import {
+  CollapsableRows,
+  FieldsHeader,
+  FieldsRow,
+  InputField,
+  resetLastUsedParameters,
+  saveToLastUsedParameters,
+  SelectField,
+  StaticField,
+  toFixed,
+} from './fields';
+import validate from './validate';
+import warn from './warning';
 
 class DataCollection extends React.Component {
   constructor(props) {

--- a/ui/src/components/Tasks/EnergyScan.jsx
+++ b/ui/src/components/Tasks/EnergyScan.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import { Button, ButtonToolbar, Form, Modal, Row } from 'react-bootstrap';
 import { connect } from 'react-redux';
-import { reduxForm, formValueSelector } from 'redux-form';
+import { formValueSelector, reduxForm } from 'redux-form';
+
 import { DraggableModal } from '../DraggableModal';
-import { Modal, Button, Form, Row, ButtonToolbar } from 'react-bootstrap';
-import validate from './validate';
-import { FieldsHeader, StaticField, InputField, toFixed } from './fields';
 import PeriodicTable from '../PeriodicTable/PeriodicTable';
+import { FieldsHeader, InputField, StaticField, toFixed } from './fields';
+import validate from './validate';
 
 class EnergyScan extends React.Component {
   constructor(props) {

--- a/ui/src/components/Tasks/GenericTaskForm.jsx
+++ b/ui/src/components/Tasks/GenericTaskForm.jsx
@@ -1,23 +1,24 @@
-import React from 'react';
-import { connect } from 'react-redux';
-import { reduxForm, formValueSelector } from 'redux-form';
-import { Modal, Button, Form, Row, Col, ButtonToolbar } from 'react-bootstrap';
-import { DraggableModal } from '../DraggableModal';
-import validate from './validate';
-import warn from './warning';
-import JSForm from '@rjsf/core';
-import validator from '@rjsf/validator-ajv8';
 import './style.css';
 
+import JSForm from '@rjsf/core';
+import validator from '@rjsf/validator-ajv8';
+import React from 'react';
+import { Button, ButtonToolbar, Col, Form, Modal, Row } from 'react-bootstrap';
+import { connect } from 'react-redux';
+import { formValueSelector, reduxForm } from 'redux-form';
+
+import { sendUpdateDependentFields } from '../../api/queue';
+import { DraggableModal } from '../DraggableModal';
 import {
   FieldsHeader,
-  StaticField,
   InputField,
-  saveToLastUsedParameters,
   resetLastUsedParameters,
+  saveToLastUsedParameters,
+  StaticField,
   toFixed,
 } from './fields';
-import { sendUpdateDependentFields } from '../../api/queue';
+import validate from './validate';
+import warn from './warning';
 
 class GenericTaskForm extends React.Component {
   constructor(props) {

--- a/ui/src/components/Tasks/Helical.jsx
+++ b/ui/src/components/Tasks/Helical.jsx
@@ -1,26 +1,25 @@
 import React from 'react';
+import { Button, ButtonToolbar, Form, Modal, Row } from 'react-bootstrap';
 import { connect } from 'react-redux';
-import { reduxForm, formValueSelector } from 'redux-form';
-import { Modal, Button, Form, Row, ButtonToolbar } from 'react-bootstrap';
-import { DraggableModal } from '../DraggableModal';
-import asyncValidate from './asyncValidate';
-import validate from './validate';
-import warn from './warning';
-
-import {
-  FieldsHeader,
-  StaticField,
-  InputField,
-  CheckboxField,
-  SelectField,
-  FieldsRow,
-  CollapsableRows,
-  toFixed,
-  saveToLastUsedParameters,
-  resetLastUsedParameters,
-} from './fields';
+import { formValueSelector, reduxForm } from 'redux-form';
 
 import { SPACE_GROUPS } from '../../constants';
+import { DraggableModal } from '../DraggableModal';
+import asyncValidate from './asyncValidate';
+import {
+  CheckboxField,
+  CollapsableRows,
+  FieldsHeader,
+  FieldsRow,
+  InputField,
+  resetLastUsedParameters,
+  saveToLastUsedParameters,
+  SelectField,
+  StaticField,
+  toFixed,
+} from './fields';
+import validate from './validate';
+import warn from './warning';
 
 class Helical extends React.Component {
   constructor(props) {

--- a/ui/src/components/Tasks/Interleaved.jsx
+++ b/ui/src/components/Tasks/Interleaved.jsx
@@ -1,17 +1,18 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import { reduxForm, formValueSelector } from 'redux-form';
-import { DraggableModal } from '../DraggableModal';
 import {
-  Modal,
   Button,
-  Form,
-  Row,
-  Col,
   ButtonToolbar,
+  Col,
+  Form,
+  Modal,
+  Row,
   Table,
 } from 'react-bootstrap';
-import { FieldsHeader, StaticField, InputField } from './fields';
+import { connect } from 'react-redux';
+import { formValueSelector, reduxForm } from 'redux-form';
+
+import { DraggableModal } from '../DraggableModal';
+import { FieldsHeader, InputField, StaticField } from './fields';
 
 const wedgeColorTable = {
   0: 'rgba(175,238,238, 0.1)',

--- a/ui/src/components/Tasks/Mesh.jsx
+++ b/ui/src/components/Tasks/Mesh.jsx
@@ -1,27 +1,26 @@
 import React from 'react';
+import { Button, ButtonToolbar, Col, Form, Modal, Row } from 'react-bootstrap';
 import { connect } from 'react-redux';
-import { reduxForm, formValueSelector } from 'redux-form';
-import { Modal, Button, Form, Row, Col, ButtonToolbar } from 'react-bootstrap';
-import { DraggableModal } from '../DraggableModal';
-import asyncValidate from './asyncValidate';
-import validate from './validate';
-import warn from './warning';
-
-import {
-  FieldsHeader,
-  StaticField,
-  InputField,
-  CheckboxField,
-  SelectField,
-  FieldsRow,
-  CollapsableRows,
-  DisplayField,
-  toFixed,
-  saveToLastUsedParameters,
-  resetLastUsedParameters,
-} from './fields';
+import { formValueSelector, reduxForm } from 'redux-form';
 
 import { SPACE_GROUPS } from '../../constants';
+import { DraggableModal } from '../DraggableModal';
+import asyncValidate from './asyncValidate';
+import {
+  CheckboxField,
+  CollapsableRows,
+  DisplayField,
+  FieldsHeader,
+  FieldsRow,
+  InputField,
+  resetLastUsedParameters,
+  saveToLastUsedParameters,
+  SelectField,
+  StaticField,
+  toFixed,
+} from './fields';
+import validate from './validate';
+import warn from './warning';
 
 class Mesh extends React.Component {
   constructor(props) {

--- a/ui/src/components/Tasks/Workflow.jsx
+++ b/ui/src/components/Tasks/Workflow.jsx
@@ -1,9 +1,10 @@
+import { Button, ButtonToolbar, Modal, Row } from 'react-bootstrap';
 import { connect } from 'react-redux';
-import { reduxForm, Form, formValueSelector } from 'redux-form';
+import { Form, formValueSelector, reduxForm } from 'redux-form';
+
 import { DraggableModal } from '../DraggableModal';
-import { Modal, Button, Row, ButtonToolbar } from 'react-bootstrap';
+import { InputField, SelectField, StaticField } from './fields';
 import validate from './validate';
-import { StaticField, InputField, SelectField } from './fields';
 
 function Workflow(props) {
   const isGphlWorkflow = props.wfpath === 'Gphl';

--- a/ui/src/components/Tasks/XRFScan.jsx
+++ b/ui/src/components/Tasks/XRFScan.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import { Button, ButtonToolbar, Form, Modal, Row } from 'react-bootstrap';
 import { connect } from 'react-redux';
-import { reduxForm, formValueSelector } from 'redux-form';
+import { formValueSelector, reduxForm } from 'redux-form';
+
 import { DraggableModal } from '../DraggableModal';
-import { Modal, Button, Form, Row, ButtonToolbar } from 'react-bootstrap';
+import { InputField, StaticField } from './fields';
 import validate from './validate';
-import { StaticField, InputField } from './fields';
 
 class XRFScan extends React.Component {
   constructor(props) {

--- a/ui/src/components/Tasks/fields.jsx
+++ b/ui/src/components/Tasks/fields.jsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import { Field } from 'redux-form';
-import { Row, Col, Form, Button } from 'react-bootstrap';
-import { TiWarning, TiTimes } from 'react-icons/ti';
-
 import './style.css';
+
+import React from 'react';
+import { Button, Col, Form, Row } from 'react-bootstrap';
+import { TiTimes, TiWarning } from 'react-icons/ti';
+import { Field } from 'redux-form';
 
 export function getLastUsedParameters(type, newParams) {
   const lastParameters = localStorage.getItem(`last${type}Parameters`);

--- a/ui/src/containers/BeamlineActionsContainer.jsx
+++ b/ui/src/containers/BeamlineActionsContainer.jsx
@@ -1,9 +1,10 @@
-import { useState, useCallback } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useCallback, useState } from 'react';
 import { Dropdown } from 'react-bootstrap';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { startBeamlineAction } from '../actions/beamlineActions';
 import BeamlineActionControl from '../components/BeamlineActions/BeamlineActionControl';
 import BeamlineActionDialog from '../components/BeamlineActions/BeamlineActionDialog';
-import { startBeamlineAction } from '../actions/beamlineActions';
 
 function BeamlineActionsContainer() {
   const dispatch = useDispatch();

--- a/ui/src/containers/BeamlineSetupContainer.jsx
+++ b/ui/src/containers/BeamlineSetupContainer.jsx
@@ -1,18 +1,17 @@
+import { filter, find } from 'lodash';
+import { Nav, Navbar, Popover, Table } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
-import { Navbar, Nav, Table, Popover } from 'react-bootstrap';
-import { find, filter } from 'lodash';
-
-import BeamlineAttribute from '../components/BeamlineAttribute/BeamlineAttribute';
-import BeamlineActions from './BeamlineActionsContainer';
-import BeamlineCamera from '../components/BeamlineCamera/BeamlineCamera';
-import InOutSwitch from '../components/InOutSwitch/InOutSwitch';
-import DeviceState from '../components/DeviceState/DeviceState';
-import MachInfo from '../components/MachInfo/MachInfo';
-import OneAxisTranslationControl from '../components/MotorInput/OneAxisTranslationControl';
 
 import { setAttribute } from '../actions/beamline';
-import { sendCommand } from '../actions/sampleChanger';
 import { stopBeamlineAction } from '../actions/beamlineActions';
+import { sendCommand } from '../actions/sampleChanger';
+import BeamlineAttribute from '../components/BeamlineAttribute/BeamlineAttribute';
+import BeamlineCamera from '../components/BeamlineCamera/BeamlineCamera';
+import DeviceState from '../components/DeviceState/DeviceState';
+import InOutSwitch from '../components/InOutSwitch/InOutSwitch';
+import MachInfo from '../components/MachInfo/MachInfo';
+import OneAxisTranslationControl from '../components/MotorInput/OneAxisTranslationControl';
+import BeamlineActions from './BeamlineActionsContainer';
 
 function BeamlineSetupContainer() {
   const dispatch = useDispatch();

--- a/ui/src/containers/ConfirmCollectDialog.jsx
+++ b/ui/src/containers/ConfirmCollectDialog.jsx
@@ -1,33 +1,31 @@
+import './ConfirmCollectDialog.css';
+
 import React from 'react';
+import {
+  Button,
+  Form,
+  Modal,
+  OverlayTrigger,
+  Popover,
+  Table,
+} from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
 import {
-  Modal,
-  Button,
-  Table,
-  OverlayTrigger,
-  Popover,
-  Form,
-} from 'react-bootstrap';
-
-import {
-  startQueue,
   runSample,
   setAutoMountSample,
   setCentringMethod,
   setNumSnapshots,
+  startQueue,
 } from '../actions/queue';
-
-import NumSnapshotsDropDown from './NumSnapshotsDropDown.jsx';
 import { showConfirmCollectDialog } from '../actions/queueGUI';
 import {
-  TASK_UNCOLLECTED,
   AUTO_LOOP_CENTRING,
   CLICK_CENTRING,
+  TASK_UNCOLLECTED,
 } from '../constants';
-
-import './ConfirmCollectDialog.css';
+import NumSnapshotsDropDown from './NumSnapshotsDropDown.jsx';
 
 export class ConfirmCollectDialog extends React.Component {
   constructor(props) {

--- a/ui/src/containers/ConnectionLostDialog.jsx
+++ b/ui/src/containers/ConnectionLostDialog.jsx
@@ -1,5 +1,5 @@
+import { Button, Modal } from 'react-bootstrap';
 import { useSelector } from 'react-redux';
-import { Modal, Button } from 'react-bootstrap';
 
 export function ConnectionLostDialog() {
   const show = useSelector((state) => state.general.showConnectionLostDialog);

--- a/ui/src/containers/DefaultErrorBoundary.jsx
+++ b/ui/src/containers/DefaultErrorBoundary.jsx
@@ -1,8 +1,8 @@
+import { Button } from 'react-bootstrap';
 import { ErrorBoundary } from 'react-error-boundary';
+import { useDispatch } from 'react-redux';
 
 import { logFrontEndTraceBack } from '../actions/beamline';
-import { Button } from 'react-bootstrap';
-import { useDispatch } from 'react-redux';
 
 function DefaultErrorBoundary(props) {
   const { children } = props;

--- a/ui/src/containers/EquipmentContainer.jsx
+++ b/ui/src/containers/EquipmentContainer.jsx
@@ -1,45 +1,36 @@
+import { Col, Container, Row } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
-import { Container, Row, Col } from 'react-bootstrap';
-
-import {
-  select,
-  mountSample,
-  unmountSample,
-  scan,
-  abort,
-  sendCommand,
-  refresh,
-  selectWell,
-  setPlate,
-  selectDrop,
-} from '../actions/sampleChanger';
-
+import { executeCommand } from '../actions/beamline';
+import { showErrorPanel } from '../actions/general';
 import {
   abort as haAbort,
-  refresh as haRefresh,
-  harvestCrystal,
   harvestAndLoadCrystal,
+  harvestCrystal,
+  refresh as haRefresh,
 } from '../actions/harvester';
-
-import { showErrorPanel } from '../actions/general';
-
+import {
+  abort,
+  mountSample,
+  refresh,
+  scan,
+  select,
+  selectDrop,
+  selectWell,
+  sendCommand,
+  setPlate,
+  unmountSample,
+} from '../actions/sampleChanger';
 import { syncWithCrims } from '../actions/sampleGrid';
-
-import { executeCommand } from '../actions/beamline';
-
-import SampleChanger from '../components/Equipment/SampleChanger';
-import SampleChangerMaintenance from '../components/Equipment/SampleChangerMaintenance';
-
-import PlateManipulator from '../components/Equipment/PlateManipulator';
-import PlateManipulatorMaintenance from '../components/Equipment/PlateManipulatorMaintenance';
-
-import Harvester from '../components/Equipment/Harvester';
-import HarvesterMaintenance from '../components/Equipment/HarvesterMaintenance';
-
 import GenericEquipment from '../components/Equipment/GenericEquipment';
 import GenericEquipmentControl from '../components/Equipment/GenericEquipmentControl';
+import Harvester from '../components/Equipment/Harvester';
+import HarvesterMaintenance from '../components/Equipment/HarvesterMaintenance';
+import PlateManipulator from '../components/Equipment/PlateManipulator';
+import PlateManipulatorMaintenance from '../components/Equipment/PlateManipulatorMaintenance';
+import SampleChanger from '../components/Equipment/SampleChanger';
+import SampleChangerMaintenance from '../components/Equipment/SampleChangerMaintenance';
 
 function EquipmentContainer(props) {
   return (

--- a/ui/src/containers/ErrorNotificationPanel.jsx
+++ b/ui/src/containers/ErrorNotificationPanel.jsx
@@ -1,5 +1,6 @@
+import { Alert, Modal } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
-import { Modal, Alert } from 'react-bootstrap';
+
 import { showErrorPanel } from '../actions/general';
 
 function ErrorNotificationPanel() {

--- a/ui/src/containers/GphlWorkflowParametersDialog.jsx
+++ b/ui/src/containers/GphlWorkflowParametersDialog.jsx
@@ -1,15 +1,14 @@
-import { useState, useEffect, useCallback } from 'react';
-import { bindActionCreators } from 'redux';
+import { useCallback, useEffect, useState } from 'react';
+import { Button, Col, Form, Modal, Row, Stack, Table } from 'react-bootstrap';
 import { connect } from 'react-redux';
-import { Modal, Row, Col, Form, Table, Button, Stack } from 'react-bootstrap';
-
-import styles from './WorkflowParametersDialog.module.css';
+import { bindActionCreators } from 'redux';
 
 import {
   showGphlWorkflowParametersDialog,
   updateGphlWorkflowParameters,
   updateGphlWorkflowParametersDialog,
 } from '../actions/workflow';
+import styles from './WorkflowParametersDialog.module.css';
 
 const uiOptions = 'ui:options';
 

--- a/ui/src/containers/GroupFolderInput.jsx
+++ b/ui/src/containers/GroupFolderInput.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { Button, Form } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { Form, Button } from 'react-bootstrap';
+
 import { setGroupFolder } from '../actions/queue';
 
 class GroupFolderInput extends React.Component {

--- a/ui/src/containers/HelpContainer.jsx
+++ b/ui/src/containers/HelpContainer.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
+import { Button, Card, Col, Container, Form, Row } from 'react-bootstrap';
 import { connect } from 'react-redux';
-import { Container, Card, Row, Col, Button, Form } from 'react-bootstrap';
 
 import { sendFeedback } from '../api/login';
-
 import characterisation from '../help_videos/mx3-characterisation.ogv';
 import interleaved from '../help_videos/mx3-interleaved.ogv';
 import mesh from '../help_videos/mx3-mesh.ogv';

--- a/ui/src/containers/LoginContainer.jsx
+++ b/ui/src/containers/LoginContainer.jsx
@@ -1,5 +1,6 @@
-import { Navigate, useLocation } from 'react-router-dom';
 import { useSelector } from 'react-redux';
+import { Navigate, useLocation } from 'react-router-dom';
+
 import LoginForm from '../components/LoginForm/LoginForm';
 
 function LoginContainer() {

--- a/ui/src/containers/NumSnapshotsDropDown.jsx
+++ b/ui/src/containers/NumSnapshotsDropDown.jsx
@@ -1,5 +1,6 @@
-import { useDispatch, useSelector } from 'react-redux';
 import { Dropdown, DropdownButton } from 'react-bootstrap';
+import { useDispatch, useSelector } from 'react-redux';
+
 import { setNumSnapshots } from '../actions/queue';
 
 function NumSnapshotsDropDown(props) {

--- a/ui/src/containers/PleaseWaitDialog.jsx
+++ b/ui/src/containers/PleaseWaitDialog.jsx
@@ -1,5 +1,6 @@
-import { Modal, ProgressBar, Button } from 'react-bootstrap';
+import { Button, Modal, ProgressBar } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
+
 import { hideWaitDialog } from '../actions/waitDialog';
 
 function PleaseWaitDialog() {

--- a/ui/src/containers/QueueSettings.jsx
+++ b/ui/src/containers/QueueSettings.jsx
@@ -1,21 +1,19 @@
 /* eslint-disable react/no-unused-state */
 import React from 'react';
+import { Dropdown, Form } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { Form, Dropdown } from 'react-bootstrap';
-
-import { AUTO_LOOP_CENTRING, CLICK_CENTRING } from '../constants';
-
-import GroupFolderInput from './GroupFolderInput.jsx';
-import NumSnapshotsDropDown from './NumSnapshotsDropDown.jsx';
 
 import {
+  setAutoAddDiffPlan,
+  setAutoMountSample,
   setCentringMethod,
   setGroupFolder,
   setQueueSettings,
-  setAutoAddDiffPlan,
-  setAutoMountSample,
 } from '../actions/queue';
+import { AUTO_LOOP_CENTRING, CLICK_CENTRING } from '../constants';
+import GroupFolderInput from './GroupFolderInput.jsx';
+import NumSnapshotsDropDown from './NumSnapshotsDropDown.jsx';
 
 class QueueSettings extends React.Component {
   constructor(props) {

--- a/ui/src/containers/RemoteAccessContainer.jsx
+++ b/ui/src/containers/RemoteAccessContainer.jsx
@@ -1,4 +1,4 @@
-import { Container, Card, Form, Row, Col } from 'react-bootstrap';
+import { Card, Col, Container, Form, Row } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {

--- a/ui/src/containers/ResumeQueueDialog.jsx
+++ b/ui/src/containers/ResumeQueueDialog.jsx
@@ -1,5 +1,6 @@
+import { Button, Modal } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
-import { Modal, Button } from 'react-bootstrap';
+
 import { showResumeQueueDialog } from '../actions/queueGUI';
 
 function ResumeQueueDialog() {

--- a/ui/src/containers/SampleFlexView.jsx
+++ b/ui/src/containers/SampleFlexView.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import { Col } from 'react-bootstrap';
+import { connect } from 'react-redux';
 
 import { filterAction } from '../actions/sampleGrid';
 

--- a/ui/src/containers/SampleGridTableContainer.jsx
+++ b/ui/src/containers/SampleGridTableContainer.jsx
@@ -1,55 +1,42 @@
 /* eslint-disable react/no-array-index-key */
-import React from 'react';
-import withNavigate from '../components/withNavigate';
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
-import { Row, Col, Table, Button, Dropdown } from 'react-bootstrap';
-
-import LazyLoad, { forceVisible } from 'react-lazyload';
-import Collapsible from 'react-collapsible';
-
-import { MdRemove, MdFlare, Md360 } from 'react-icons/md';
-import {
-  BsSquare,
-  BsCheck2Square,
-  BsDashSquare,
-  BsChevronUp,
-  BsChevronDown,
-} from 'react-icons/bs';
-
-import { BiMenu } from 'react-icons/bi';
-
-import MXContextMenu from '../components/GenericContextMenu/MXContextMenu';
-
-import cx from 'classnames';
-
-import Slider from 'react-slick';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 
-import { QUEUE_STOPPED, QUEUE_RUNNING, isCollected } from '../constants';
-
+import cx from 'classnames';
+import React from 'react';
+import { Button, Col, Dropdown, Row, Table } from 'react-bootstrap';
+import Collapsible from 'react-collapsible';
+import { BiMenu } from 'react-icons/bi';
 import {
-  toggleMovableAction,
-  selectSamplesAction,
-  showGenericContextMenu,
-} from '../actions/sampleGrid';
-
-import { deleteTask } from '../actions/queue';
-
-import { unmountSample, mountSample } from '../actions/sampleChanger';
-
-import { showTaskForm } from '../actions/taskForm';
+  BsCheck2Square,
+  BsChevronDown,
+  BsChevronUp,
+  BsDashSquare,
+  BsSquare,
+} from 'react-icons/bs';
+import { Md360, MdFlare, MdRemove } from 'react-icons/md';
+import LazyLoad, { forceVisible } from 'react-lazyload';
+import { connect } from 'react-redux';
+import Slider from 'react-slick';
+import { bindActionCreators } from 'redux';
 
 import { showDialog } from '../actions/general';
-
-import SampleFlexView from './SampleFlexView';
-import SampleIsaraView from './SampleIsaraView';
-
+import { deleteTask } from '../actions/queue';
+import { mountSample, unmountSample } from '../actions/sampleChanger';
+import {
+  selectSamplesAction,
+  showGenericContextMenu,
+  toggleMovableAction,
+} from '../actions/sampleGrid';
+import { showTaskForm } from '../actions/taskForm';
+import MXContextMenu from '../components/GenericContextMenu/MXContextMenu';
 import { SampleGridTableItem } from '../components/SampleGrid/SampleGridTableItem';
-
 import { TaskItem } from '../components/SampleGrid/TaskItem';
 import TooltipTrigger from '../components/TooltipTrigger';
+import withNavigate from '../components/withNavigate';
+import { isCollected, QUEUE_RUNNING, QUEUE_STOPPED } from '../constants';
+import SampleFlexView from './SampleFlexView';
+import SampleIsaraView from './SampleIsaraView';
 
 const SETTINGS = {
   dots: false,

--- a/ui/src/containers/SampleIsaraView.jsx
+++ b/ui/src/containers/SampleIsaraView.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import { Col } from 'react-bootstrap';
-
-import { BsChevronUp, BsChevronDown } from 'react-icons/bs';
+import { BsChevronDown, BsChevronUp } from 'react-icons/bs';
+import { connect } from 'react-redux';
 
 import { filterAction } from '../actions/sampleGrid';
 

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -1,58 +1,49 @@
+import '../components/SampleGrid/SampleGridTable.css';
+
 import React from 'react';
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
-import ReactDOM from 'react-dom';
-import withNavigate from '../components/withNavigate.jsx';
-import loader from '../img/loader.gif';
-
 import {
-  Container,
-  Card,
-  Row,
-  Col,
-  Form,
   Button,
-  DropdownButton,
-  InputGroup,
+  Card,
+  Col,
+  Container,
   Dropdown,
+  DropdownButton,
+  Form,
+  InputGroup,
+  Row,
 } from 'react-bootstrap';
-
-import { MdGridView } from 'react-icons/md';
-
+import ReactDOM from 'react-dom';
 import { LuSettings2 } from 'react-icons/lu';
+import { MdGridView } from 'react-icons/md';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 
-import { QUEUE_RUNNING, isCollected, hasLimsData } from '../constants';
-
+import { showConfirmClearQueueDialog } from '../actions/general';
 import {
-  getSamplesList,
-  setViewModeAction,
-  syncSamples,
-  syncWithCrims,
-  filterAction,
-  selectSamplesAction,
-  showGenericContextMenu,
-} from '../actions/sampleGrid';
-
-import {
-  deleteSamplesFromQueue,
-  setEnabledSample,
   addSamplesToQueue,
-  stopQueue,
+  deleteSamplesFromQueue,
   deleteTask,
   deleteTaskList,
+  setEnabledSample,
+  stopQueue,
 } from '../actions/queue';
-
 import { showConfirmCollectDialog } from '../actions/queueGUI';
-import { showConfirmClearQueueDialog } from '../actions/general';
-
+import {
+  filterAction,
+  getSamplesList,
+  selectSamplesAction,
+  setViewModeAction,
+  showGenericContextMenu,
+  syncSamples,
+  syncWithCrims,
+} from '../actions/sampleGrid';
 import { showTaskForm } from '../actions/taskForm';
-
-import SampleGridTableContainer from './SampleGridTableContainer';
-
-import QueueSettings from './QueueSettings.jsx';
-
-import '../components/SampleGrid/SampleGridTable.css';
 import TooltipTrigger from '../components/TooltipTrigger.jsx';
+import withNavigate from '../components/withNavigate.jsx';
+import { hasLimsData, isCollected, QUEUE_RUNNING } from '../constants';
+import loader from '../img/loader.gif';
+import QueueSettings from './QueueSettings.jsx';
+import SampleGridTableContainer from './SampleGridTableContainer';
 
 class SampleListViewContainer extends React.Component {
   constructor(props) {

--- a/ui/src/containers/SampleQueueContainer.jsx
+++ b/ui/src/containers/SampleQueueContainer.jsx
@@ -1,22 +1,23 @@
 import React from 'react';
-import { bindActionCreators } from 'redux';
+import { Nav } from 'react-bootstrap';
 import { connect } from 'react-redux';
-import CurrentTree from '../components/SampleQueue/CurrentTree';
-import TodoTree from '../components/SampleQueue/TodoTree';
-import QueueControl from '../components/SampleQueue/QueueControl';
+import { bindActionCreators } from 'redux';
+
+import { prepareBeamlineForNewSample } from '../actions/beamline';
+import { showDialog } from '../actions/general';
 import {
-  toggleCheckBox,
-  pauseQueue,
-  resumeQueue,
-  stopQueue,
+  addTask,
   changeTaskOrderAction,
   deleteTask,
-  addTask,
   moveTask,
-  setAutoMountSample,
-  setAutoAddDiffPlan,
+  pauseQueue,
+  resumeQueue,
   runSample,
+  setAutoAddDiffPlan,
+  setAutoMountSample,
   setEnabledSample,
+  stopQueue,
+  toggleCheckBox,
 } from '../actions/queue';
 import {
   collapseItem,
@@ -24,15 +25,14 @@ import {
   showConfirmCollectDialog,
   showList,
 } from '../actions/queueGUI';
-import { showTaskForm } from '../actions/taskForm';
-import { Nav } from 'react-bootstrap';
-import { showDialog } from '../actions/general';
-import { showWorkflowParametersDialog } from '../actions/workflow';
-
-import UserMessage from '../components/Notify/UserMessage';
-import loader from '../img/loader.gif';
-import { prepareBeamlineForNewSample } from '../actions/beamline';
 import { mountSample, unmountSample } from '../actions/sampleChanger';
+import { showTaskForm } from '../actions/taskForm';
+import { showWorkflowParametersDialog } from '../actions/workflow';
+import UserMessage from '../components/Notify/UserMessage';
+import CurrentTree from '../components/SampleQueue/CurrentTree';
+import QueueControl from '../components/SampleQueue/QueueControl';
+import TodoTree from '../components/SampleQueue/TodoTree';
+import loader from '../img/loader.gif';
 
 class SampleQueueContainer extends React.Component {
   constructor(props) {

--- a/ui/src/containers/SampleViewContainer.jsx
+++ b/ui/src/containers/SampleViewContainer.jsx
@@ -1,41 +1,41 @@
+import '../components/SampleView/SampleView.css';
+
 import { Component } from 'react';
-import { bindActionCreators } from 'redux';
+import { Col, Container, Row } from 'react-bootstrap';
 import { connect } from 'react-redux';
-import { Row, Col, Container } from 'react-bootstrap';
-import SampleImage from '../components/SampleView/SampleImage';
-import MotorControls from '../components/SampleView/MotorControls';
-import PhaseInput from '../components/SampleView/PhaseInput';
-import ApertureInput from '../components/SampleView/ApertureInput';
-import SSXChipControl from '../components/SSXChip/SSXChipControl';
-import PlateManipulator from '../components/Equipment/PlateManipulator';
-import ContextMenu from '../components/SampleView/ContextMenu';
-import * as sampleViewActions from '../actions/sampleview'; // eslint-disable-line import/no-namespace
-import { showErrorPanel, displayImage } from '../actions/general';
-import { updateTask } from '../actions/queue';
-import { showTaskForm } from '../actions/taskForm';
-import BeamlineSetupContainer from './BeamlineSetupContainer';
-import SampleQueueContainer from './SampleQueueContainer';
-import { QUEUE_RUNNING } from '../constants';
-import DefaultErrorBoundary from './DefaultErrorBoundary';
-import { syncWithCrims } from '../actions/sampleGrid';
-import {
-  mountSample,
-  refresh,
-  selectWell,
-  setPlate,
-  selectDrop,
-  sendCommand,
-} from '../actions/sampleChanger';
+import { bindActionCreators } from 'redux';
 
 import {
   executeCommand,
   logFrontEndTraceBack,
   setAttribute,
 } from '../actions/beamline';
-
-import '../components/SampleView/SampleView.css';
-import styles from './SampleViewContainer.module.css';
+import { displayImage, showErrorPanel } from '../actions/general';
+import { updateTask } from '../actions/queue';
+import {
+  mountSample,
+  refresh,
+  selectDrop,
+  selectWell,
+  sendCommand,
+  setPlate,
+} from '../actions/sampleChanger';
+import { syncWithCrims } from '../actions/sampleGrid';
+import * as sampleViewActions from '../actions/sampleview'; // eslint-disable-line import/no-namespace
+import { showTaskForm } from '../actions/taskForm';
+import PlateManipulator from '../components/Equipment/PlateManipulator';
 import motorInputStyles from '../components/MotorInput/MotorInput.module.css';
+import ApertureInput from '../components/SampleView/ApertureInput';
+import ContextMenu from '../components/SampleView/ContextMenu';
+import MotorControls from '../components/SampleView/MotorControls';
+import PhaseInput from '../components/SampleView/PhaseInput';
+import SampleImage from '../components/SampleView/SampleImage';
+import SSXChipControl from '../components/SSXChip/SSXChipControl';
+import { QUEUE_RUNNING } from '../constants';
+import BeamlineSetupContainer from './BeamlineSetupContainer';
+import DefaultErrorBoundary from './DefaultErrorBoundary';
+import SampleQueueContainer from './SampleQueueContainer';
+import styles from './SampleViewContainer.module.css';
 
 class SampleViewContainer extends Component {
   constructor(props) {

--- a/ui/src/containers/TaskContainer.jsx
+++ b/ui/src/containers/TaskContainer.jsx
@@ -1,18 +1,17 @@
 import { useDispatch, useSelector } from 'react-redux';
-import Characterisation from '../components/Tasks/Characterisation';
-import DataCollection from '../components/Tasks/DataCollection';
-import Helical from '../components/Tasks/Helical';
-import Mesh from '../components/Tasks/Mesh';
-import AddSample from '../components/Tasks/AddSample';
-import Workflow from '../components/Tasks/Workflow';
-import Interleaved from '../components/Tasks/Interleaved';
-import XRFScan from '../components/Tasks/XRFScan';
-import EnergyScan from '../components/Tasks/EnergyScan';
-import GenericTaskForm from '../components/Tasks/GenericTaskForm';
-
-import { hideTaskParametersForm } from '../actions/taskForm';
 
 import { addTask, updateTask } from '../actions/queue';
+import { hideTaskParametersForm } from '../actions/taskForm';
+import AddSample from '../components/Tasks/AddSample';
+import Characterisation from '../components/Tasks/Characterisation';
+import DataCollection from '../components/Tasks/DataCollection';
+import EnergyScan from '../components/Tasks/EnergyScan';
+import GenericTaskForm from '../components/Tasks/GenericTaskForm';
+import Helical from '../components/Tasks/Helical';
+import Interleaved from '../components/Tasks/Interleaved';
+import Mesh from '../components/Tasks/Mesh';
+import Workflow from '../components/Tasks/Workflow';
+import XRFScan from '../components/Tasks/XRFScan';
 
 function TaskContainer() {
   const dispatch = useDispatch();

--- a/ui/src/containers/WorkflowParametersDialog.jsx
+++ b/ui/src/containers/WorkflowParametersDialog.jsx
@@ -1,12 +1,12 @@
-import { useDispatch, useSelector } from 'react-redux';
-import { Modal } from 'react-bootstrap';
 import Form from '@rjsf/core';
 import validator from '@rjsf/validator-ajv8';
+import { Modal } from 'react-bootstrap';
+import { useDispatch, useSelector } from 'react-redux';
+
 import {
   showWorkflowParametersDialog,
   submitWorkflowParameters,
 } from '../actions/workflow';
-
 import styles from './WorkflowParametersDialog.module.css';
 
 function WorkflowParametersDialog() {

--- a/ui/src/index.jsx
+++ b/ui/src/index.jsx
@@ -1,14 +1,14 @@
 import 'bootstrap/dist/css/bootstrap.css';
 import './main.css';
+import '@fortawesome/fontawesome-free/css/all.min.css';
+import 'react-contexify/ReactContexify.css';
 
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-import App from './components/App';
-import { store } from './store';
-import DefaultErrorBoundary from './containers/DefaultErrorBoundary';
 
-import '@fortawesome/fontawesome-free/css/all.min.css';
-import 'react-contexify/ReactContexify.css';
+import App from './components/App';
+import DefaultErrorBoundary from './containers/DefaultErrorBoundary';
+import { store } from './store';
 
 function Root() {
   return (

--- a/ui/src/reducers/beamline.js
+++ b/ui/src/reducers/beamline.js
@@ -1,4 +1,4 @@
-import { RUNNING, HW_STATE } from '../constants';
+import { HW_STATE, RUNNING } from '../constants';
 
 // The different states a beamline attribute can assume.
 export const STATE = {

--- a/ui/src/reducers/index.js
+++ b/ui/src/reducers/index.js
@@ -1,24 +1,25 @@
 import { reducer as formReducer } from 'redux-form';
+
+import beamline from './beamline';
+import contextMenu from './contextMenu';
+import general from './general';
+import harvester from './harvester';
+import harvesterMaintenance from './harvesterMaintenance';
+import logger from './logger';
 import login from './login';
 import queue from './queue';
 import queueGUI from './queueGUI';
-import sampleGrid from './sampleGrid';
+import remoteAccess from './remoteAccess';
 import sampleChanger from './sampleChanger';
 import sampleChangerMaintenance from './sampleChangerMaintenance';
-import harvester from './harvester';
-import harvesterMaintenance from './harvesterMaintenance';
-import taskForm from './taskForm';
+import sampleGrid from './sampleGrid';
 import sampleview from './sampleview';
-import general from './general';
-import beamline from './beamline';
-import logger from './logger';
-import contextMenu from './contextMenu';
-import remoteAccess from './remoteAccess';
 import shapes from './shapes';
-import workflow from './workflow';
+import taskForm from './taskForm';
 import taskResult from './taskResult';
 import uiproperties from './uiproperties';
 import waitDialog from './waitDialog';
+import workflow from './workflow';
 
 const rootReducer = {
   login,

--- a/ui/src/reducers/queue.js
+++ b/ui/src/reducers/queue.js
@@ -1,6 +1,7 @@
 import update from 'immutability-helper';
-import { QUEUE_STOPPED, CLICK_CENTRING } from '../constants';
+
 import { clearAllLastUsedParameters } from '../components/Tasks/fields';
+import { CLICK_CENTRING, QUEUE_STOPPED } from '../constants';
 
 const INITIAL_STATE = {
   queue: [],

--- a/ui/src/reducers/uiproperties.js
+++ b/ui/src/reducers/uiproperties.js
@@ -1,4 +1,4 @@
-import { findIndex, setWith, clone } from 'lodash';
+import { clone, findIndex, setWith } from 'lodash';
 
 const INITIAL_STATE = {};
 

--- a/ui/src/reducers/workflow.js
+++ b/ui/src/reducers/workflow.js
@@ -1,6 +1,6 @@
 import {
-  saveToLastUsedParameters,
   getLastUsedParameters,
+  saveToLastUsedParameters,
 } from '../components/Tasks/fields';
 
 const INITIAL_STATE = {

--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -1,70 +1,64 @@
 /* eslint-disable promise/prefer-await-to-callbacks */
-import { connect } from 'socket.io-client';
 import { addResponseMessage } from 'react-chat-widget';
-import { addLogRecord } from './actions/logger';
-import {
-  setShapes,
-  saveMotorPosition,
-  updateMotorState,
-  setBeamInfo,
-  startClickCentringAction,
-  updateShapesAction,
-  setPixelsPerMm,
-  videoMessageOverlay,
-  setCurrentPhase,
-} from './actions/sampleview';
+import { connect } from 'socket.io-client';
+
 import {
   updateBeamlineHardwareObjectAction,
-  updateBeamlineHardwareObjectValueAction,
   updateBeamlineHardwareObjectAttributeAction,
+  updateBeamlineHardwareObjectValueAction,
 } from './actions/beamline';
 import {
-  setActionState,
   addUserMessage,
   newPlot,
   plotData,
   plotEnd,
+  setActionState,
 } from './actions/beamlineActions';
-import {
-  setStatus,
-  addTaskResultAction,
-  updateTaskLimsData,
-  addTaskAction,
-  stopQueue,
-  setCurrentSample,
-  addDiffractionPlanAction,
-  setSampleAttribute,
-  getQueue,
-} from './actions/queue';
-import { collapseItem, showResumeQueueDialog } from './actions/queueGUI';
 import { showConnectionLostDialog } from './actions/general';
-
-import {
-  showWorkflowParametersDialog,
-  showGphlWorkflowParametersDialog,
-  updateGphlWorkflowParametersDialog,
-} from './actions/workflow';
-
-import { getRaState, incChatMessageCount } from './actions/remoteAccess';
-
-import { signOut, getLoginInfo } from './actions/login';
-
-import {
-  setSCState,
-  setLoadedSample,
-  setSCGlobalState,
-} from './actions/sampleChanger';
-
 import {
   setHarvesterState,
   updateHarvesterContents,
 } from './actions/harvester';
-
+import { addLogRecord } from './actions/logger';
+import { getLoginInfo, signOut } from './actions/login';
+import {
+  addDiffractionPlanAction,
+  addTaskAction,
+  addTaskResultAction,
+  getQueue,
+  setCurrentSample,
+  setSampleAttribute,
+  setStatus,
+  stopQueue,
+  updateTaskLimsData,
+} from './actions/queue';
+import { collapseItem, showResumeQueueDialog } from './actions/queueGUI';
+import { getRaState, incChatMessageCount } from './actions/remoteAccess';
+import {
+  setLoadedSample,
+  setSCGlobalState,
+  setSCState,
+} from './actions/sampleChanger';
+import {
+  saveMotorPosition,
+  setBeamInfo,
+  setCurrentPhase,
+  setPixelsPerMm,
+  setShapes,
+  startClickCentringAction,
+  updateMotorState,
+  updateShapesAction,
+  videoMessageOverlay,
+} from './actions/sampleview';
 import { setEnergyScanResult } from './actions/taskResults';
-
+import { hideWaitDialog, showWaitDialog } from './actions/waitDialog';
+import {
+  showGphlWorkflowParametersDialog,
+  showWorkflowParametersDialog,
+  updateGphlWorkflowParametersDialog,
+} from './actions/workflow';
 import { CLICK_CENTRING } from './constants';
 import { store } from './store';
-import { hideWaitDialog, showWaitDialog } from './actions/waitDialog';
 
 const { dispatch } = store;
 

--- a/ui/src/store.js
+++ b/ui/src/store.js
@@ -1,5 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { createLogger } from 'redux-logger';
+
 import rootReducer from './reducers';
 
 const middleware = [


### PR DESCRIPTION
Sort imports automatically with [`eslint-plugin-simple-import-sort`](https://github.com/lydell/eslint-plugin-simple-import-sort/).

Long overdue! :grin: 

Note that the plugin moves global CSS imports to the top. For instance, in `index.js`, the FontAwesome and ReactContextify styles imports move before the `App` component import, which means they'll end up before other components' global styles in the DOM.

This is a good thing but there's a very, very slight risk that this may lead to visual regressions. I highly doubt it, though — if anything, it's more likely that some global component styles will no longer need to overcome font awesome styles with `!important`, for instance.

Anyway, I didn't notice any regression, but I wouldn't mind another pair of eyes.