### PR TITLE
Fix linting issues (5) — `unicorn/prefer-global-this`

### DIFF
--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -17,7 +17,6 @@ const config = defineConfig([
       'react/no-multi-comp': 'off',
       'react/no-unused-class-component-methods': 'off',
       'react/prop-types': 'off',
-      'unicorn/prefer-global-this': 'off',
 
       /* Default is "avoid", but there are lots of complicated `switch` statements,
        * notably in Redux reducers, which benefit from clear case blocks. */

--- a/ui/src/actions/sampleview.js
+++ b/ui/src/actions/sampleview.js
@@ -132,7 +132,7 @@ export function setVideoSize(width, height) {
       sourceScale: json.scale,
     });
 
-    window.initJSMpeg();
+    globalThis.initJSMpeg();
   };
 }
 

--- a/ui/src/components/LoginForm/LoginForm.jsx
+++ b/ui/src/components/LoginForm/LoginForm.jsx
@@ -43,7 +43,7 @@ function LoginForm() {
 
   async function handleSubmit(data) {
     if (useSSO) {
-      window.location.assign(SSO_PATH);
+      globalThis.location.assign(SSO_PATH);
       return;
     }
 

--- a/ui/src/components/SSXChip/SSXChip.jsx
+++ b/ui/src/components/SSXChip/SSXChip.jsx
@@ -9,7 +9,7 @@ import { contextMenu, Item, Menu, Separator } from 'react-contexify';
 
 import MotorInput from '../MotorInput/MotorInput';
 
-const { fabric } = window;
+const { fabric } = globalThis;
 
 function _GridData(fabricObject) {
   return {

--- a/ui/src/components/SampleControls/SnapshotControl.jsx
+++ b/ui/src/components/SampleControls/SnapshotControl.jsx
@@ -6,7 +6,7 @@ import { sendTakeSnapshot } from '../../api/sampleview';
 import styles from './SampleControls.module.css';
 import { download } from './utils';
 
-const { fabric } = window;
+const { fabric } = globalThis;
 
 function SnapshotControl(props) {
   const { canvas } = props;
@@ -45,13 +45,13 @@ function SnapshotControl(props) {
     const processedImgBlob = await sendTakeSnapshot(imgDataURI);
     download(
       filename,
-      window.URL.createObjectURL(new Blob([processedImgBlob])),
+      globalThis.URL.createObjectURL(new Blob([processedImgBlob])),
     );
   }, [canvas, currentSampleName, ratio, proposal]);
 
   useEffect(() => {
     // Allow server to trigger snapshots (cf. `serverIO`)
-    window.takeSnapshot = takeSnapshot;
+    globalThis.takeSnapshot = takeSnapshot;
   }, [takeSnapshot]);
 
   return (

--- a/ui/src/components/SampleView/DrawGridPlugin.jsx
+++ b/ui/src/components/SampleView/DrawGridPlugin.jsx
@@ -2,7 +2,7 @@ import 'fabric';
 
 const TAU = Math.PI * 2;
 
-const { fabric } = window;
+const { fabric } = globalThis;
 
 /**
  * Based on cell width and height in pixels,

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -16,7 +16,7 @@ import {
   makeTwoDPoints,
 } from './shapes';
 
-const { fabric } = window;
+const { fabric } = globalThis;
 fabric.Group.prototype.hasControls = false;
 fabric.Group.prototype.hasBorders = false;
 
@@ -95,7 +95,7 @@ export default class SampleImage extends React.Component {
     document.addEventListener('keydown', this.keyDown, false);
     document.addEventListener('keyup', this.keyUp, false);
 
-    window.initJSMpeg = this.initJSMpeg;
+    globalThis.initJSMpeg = this.initJSMpeg;
     this.initJSMpeg();
   }
 
@@ -152,7 +152,7 @@ export default class SampleImage extends React.Component {
     imageOverlay.removeEventListener('wheel', this.wheel);
     imageOverlay.removeEventListener('dblclick', this.goToBeam);
 
-    window.initJSMpeg = null;
+    globalThis.initJSMpeg = null;
   }
 
   onMouseMove(options) {

--- a/ui/src/components/SampleView/shapes.js
+++ b/ui/src/components/SampleView/shapes.js
@@ -1,6 +1,6 @@
 import 'fabric';
 
-const { fabric } = window;
+const { fabric } = globalThis;
 
 export function makeRectangle(posX, posY, sizeX, sizeY, color) {
   return new fabric.Rect({

--- a/ui/src/containers/ConnectionLostDialog.jsx
+++ b/ui/src/containers/ConnectionLostDialog.jsx
@@ -16,7 +16,7 @@ export function ConnectionLostDialog() {
         the page.
       </Modal.Body>
       <Modal.Footer>
-        <Button onClick={() => window.location.reload(true)}> Reload </Button>
+        <Button onClick={() => globalThis.location.reload(true)}>Reload</Button>
       </Modal.Footer>
     </Modal>
   );

--- a/ui/src/containers/DefaultErrorBoundary.jsx
+++ b/ui/src/containers/DefaultErrorBoundary.jsx
@@ -21,7 +21,7 @@ function DefaultErrorBoundary(props) {
             Reloading the page might fix the issue. If it remains, please
             contact support.
           </p>
-          <Button onClick={() => window.location.reload()}>Reload</Button>
+          <Button onClick={() => globalThis.location.reload()}>Reload</Button>
         </div>
       )}
       onError={(_, { componentStack }) => {

--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -384,7 +384,7 @@ class ServerIO {
     });
 
     this.hwrSocket.on('take_xtal_snapshot', (cb) => {
-      cb(window.takeSnapshot());
+      cb(globalThis.takeSnapshot());
     });
 
     this.hwrSocket.on('beamline_action', (data) => {


### PR DESCRIPTION
Replace `window` with [`globalThis`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis), which is widely supported (FF 65+).