### PR TITLE
Latest user messages should be shown on top in UI

### DIFF
--- a/ui/src/components/Notify/UserMessage.jsx
+++ b/ui/src/components/Notify/UserMessage.jsx
@@ -1,19 +1,16 @@
+import { useSelector } from 'react-redux';
+
 import styles from './UserMessage.module.css';
 
-export default function UserMessage(props) {
-  const { messages } = props;
+export default function UserMessage() {
+  const messages = useSelector((state) => state.logger.logRecords);
 
-  function renderMessages() {
-    const msg = [];
-
-    for (const [idx, message] of messages.entries()) {
-      const messageClass = `${styles.message} ${styles[message.severity]}`;
-
-      msg.push(
+  return (
+    <div id="usermessages" className={styles.messageBody}>
+      {[...messages].reverse().map((message) => (
         <div
-          key={`${message.id}-${idx}`}
-          ref={message.id}
-          className={messageClass}
+          key={`${message.timestamp}`}
+          className={`${styles.message} ${styles[message.severity]}`}
         >
           {message.severity === 'INFO' ? (
             <span className="fas fa-lg fa-check-circle" />
@@ -23,14 +20,8 @@ export default function UserMessage(props) {
           <span className={styles.messageText}>
             {`[${message.timestamp.slice(11, 19)}]: ${message.message}`}
           </span>
-        </div>,
-      );
-    }
-    return msg;
-  }
-  return (
-    <div id="usermessages" className={styles.messageBody}>
-      {renderMessages()}
+        </div>
+      ))}
     </div>
   );
 }

--- a/ui/src/containers/SampleQueueContainer.jsx
+++ b/ui/src/containers/SampleQueueContainer.jsx
@@ -192,7 +192,7 @@ class SampleQueueContainer extends React.Component {
               Log messages:
             </div>
             <div className="queue-messages-body">
-              <UserMessage messages={this.props.logRecords} />
+              <UserMessage />
             </div>
           </div>
         </div>
@@ -217,7 +217,6 @@ function mapStateToProps(state) {
     rootPath: state.login.rootPath,
     displayData: state.queueGUI.displayData,
     loading: state.queueGUI.loading,
-    logRecords: state.logger.logRecords,
     plotsData: state.beamline.plotsData,
     plotsInfo: state.beamline.plotsInfo,
     selectedShapes: state.sampleview.selectedShapes,


### PR DESCRIPTION
The way the user messages were displayed in the UI was oldest on top and newest on bottom, which meant a lot of scrolling to see the latest logs.

I reversed the order of the messages in the UI and while at it I added the suggested change(#1546) to remove the render function in `UserMessage` component