### PR TITLE
New Sample Flex View  (Sample List #2 )

### DIFF
--- a/ui/src/components/SampleGrid/SampleGridTable.css
+++ b/ui/src/components/SampleGrid/SampleGridTable.css
@@ -281,8 +281,9 @@
   font-weight: bolder;
 }
 
-/* Graphical View / Flex grid css */
+/* Graphical View */
 
+/* ISARA  */
 .div-flex-pie-collapsible {
   width: 95%;
 }
@@ -295,47 +296,30 @@
   fill: #dfd1d9;
 }
 
-.has-sample {
+/* Flex */
+.cell_cicle_g,
+.puck_cicle {
   cursor: pointer;
 }
-.empty-cell {
-  cursor: not-allowed;
-  background: #000000;
-}
 
-.cell-cicle-empty :hover {
+.cell_cicle:hover {
+  paint-order: stroke;
   stroke: #ffffff;
+  stroke-width: 0.09;
 }
 
-.cell-cicle {
-  fill: #015f9d;
-  border: 2px solid #5cb85c;
+.cell_cicle_text:hover {
+  font-weight: bold;
 }
 
-.cell-cicle:hover {
-  stroke: #6cb0f5;
-  stroke-width: 9.5;
-  text-shadow: 0 0 30px #fdec6e;
-  transition: all 0.2s ease-in;
+.puck_cicle:hover > circle {
+  paint-order: stroke;
+  stroke: #ffffff;
+  stroke-width: 0.09;
 }
 
-.circle-text:hover > .cell-cicle:hover {
-  stroke: #63adf7;
-  text-shadow: 0 0 30px #fdec6e;
-  transition: all 0.2s ease-in;
-}
-
-.cell-cicle-activated {
-  stroke: #fa9f63;
-  stroke-opacity: 90%;
-}
-
-.cell-cicle-center {
-  fill: whitesmoke;
-  stroke: rgb(163, 161, 161);
-  stroke-width: 0.1%;
-}
-
-.circle-text {
-  fill: #273a44;
+.puck_cicle:hover > .text_puck_cicle {
+  paint-order: stroke;
+  fill: #ffffff;
+  stroke-width: 0.01;
 }

--- a/ui/src/containers/SampleGridTableContainer.jsx
+++ b/ui/src/containers/SampleGridTableContainer.jsx
@@ -1233,16 +1233,27 @@ class SampleGridTableContainer extends React.Component {
   }
 
   renderSampleChangerDrawing() {
-    if (this.props.type.includes('CATS')) {
+    if (this.props.type.includes('CATS') || this.isSingleCell()) {
       return <SampleIsaraView cellSampleList={this.getSampleListBydCell} />;
     }
-    if (this.props.type.includes('FLEX') || this.props.type.includes('Moc')) {
-      return <SampleFlexView cellSampleList={this.getSampleListBydCell} />;
+    if (this.props.type.includes('FLEX')) {
+      return (
+        <SampleFlexView
+          displayPuckCellContextMenu={this.displayPuckCellContextMenu}
+          cellMenuID={CELL_MENU_ID}
+          puckMenuID={PUCK_MENU_ID}
+          type={this.props.type}
+        />
+      );
     }
     return null;
   }
 
   render() {
+    if (Object.values(this.props.sampleList).length === 0) {
+      return null;
+    }
+
     return (
       <div>
         {this.props.contextMenu.show ? (
@@ -1257,7 +1268,7 @@ class SampleGridTableContainer extends React.Component {
           </MXContextMenu>
         ) : null}
         <Row
-          className="samples-grid-table justify-content-center"
+          className="samples-grid-table"
           onMouseDown={this.onMouseDown}
           onMouseUp={this.onMouseUp}
           onMouseMove={this.onMouseMove}

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -870,7 +870,7 @@ class SampleListViewContainer extends React.Component {
                     variant="outline-secondary"
                     id="dropdown-basic"
                   >
-                    <MdGridView size="1em" /> View Mode
+                    <MdGridView size="1em" /> {this.props.viewMode.mode}
                   </Dropdown.Toggle>
                   <Dropdown.Menu>
                     {this.props.viewMode.options.map((option) => (


### PR DESCRIPTION
This PR propose a complete remake of the SampleFlexView view
making the feature more accessible. 

- SampleFlexView was use as a Filter but it can now be use to collect easily a pre-filtered group of sample
the old code was useless because we could not view the pucks,  I'll suggest to focus on  the addition instead of the diff

- The Idea is to make this view useful enough  to be used in some beamline.
It allow you to navigate simpler from Cells and Pucks.
-  in the future and if necessary : when this view is active,  we could completely not display the table view  instead of applying a filter 
 


As the Mockup allow you to view only singleCell or only pucks samples.
you'll need to make some changes to SampleChangerMockup.py to be able to display this view. 

[Screencast from 2025-04-03 16-07-31.webm](https://github.com/user-attachments/assets/6a6c15c5-a620-4544-95a7-b05a991e454d)

- USECASE

[Screencast from 2025-04-03 16-51-36.webm](https://github.com/user-attachments/assets/381d7302-7fc2-45df-8e36-a81447eb5dbd)


