### PR TITLE
Adds support for `create_point` acquisition parameter

### DIFF
--- a/ui/src/components/SampleView/ContextMenu.jsx
+++ b/ui/src/components/SampleView/ContextMenu.jsx
@@ -79,6 +79,17 @@ export default class ContextMenu extends React.Component {
           key: `${task.name}`,
         });
       }
+
+      if (task.requires.includes('no_shape_2d')) {
+        genericTasks.none.push({
+          text: task.name,
+          action: () =>
+            this.createPointAndShowModal('Generic', {
+              type: tname,
+            }),
+          key: `${task.name}`,
+        });
+      }
     });
 
     Object.values(this.props.workflows).forEach((wf) => {
@@ -438,7 +449,7 @@ export default class ContextMenu extends React.Component {
       sampleViewX,
       sampleViewY,
       'SAVED',
-      (shape) => this.showModal(name, {}, shape, extraParams),
+      (shape) => this.showModal(name, extraParams, shape),
     );
   }
 


### PR DESCRIPTION
Generic tasks may define `create_point` parameter, which will trigger creating 2d point on the backend.

It's purpose is an quality of life improvement, in which user may click on a point on canvas, where no shape is defined, in order to create point and run a task on the created point.

Also it fixes order of parameters that are passed to `ContextMenu.showModal` in `createPointAndShowModal` function.


