### PR TITLE
adding unique identifiers to user-level logs

### DIFF
--- a/mxcubeweb/logging_handler.py
+++ b/mxcubeweb/logging_handler.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 
 
 class MX3LoggingHandler(logging.handlers.BufferingHandler):
@@ -18,6 +19,7 @@ class MX3LoggingHandler(logging.handlers.BufferingHandler):
             record.asctime = logging._defaultFormatter.formatTime(record)
 
         return {
+            "id": str(uuid.uuid4()),
             "message": record.getMessage(),
             "severity": record.levelname,
             "timestamp": record.asctime,

--- a/ui/src/components/Notify/UserMessage.jsx
+++ b/ui/src/components/Notify/UserMessage.jsx
@@ -9,7 +9,7 @@ export default function UserMessage() {
     <div id="usermessages" className={styles.messageBody}>
       {[...messages].reverse().map((message) => (
         <div
-          key={`${message.timestamp}`}
+          key={`${message.id}`}
           className={`${styles.message} ${styles[message.severity]}`}
         >
           {message.severity === 'INFO' ? (


### PR DESCRIPTION
In #1614, I changed the key of the log messages shown to the user to be the timestamp, as the messages did not have a more unique identifier. However, this could lead to a problem when multiple log messages were added at the same time. 
See below a video on what happens if such a scenario is triggered:

![problem_log_keys](https://github.com/user-attachments/assets/f970256c-8260-4ccd-87d0-00b91b18a833)

In this case I added a second test log to the 3-click-centring cancelation message. As one can see the message gets duplicated and stays on top of the list. This is due to how React is updating components. Since there are multiple components with the same key, only one gets re-rendered, the others remain.
To fix this, I added a unique identifier id to each log that gets added, and use this id as key for the rendered items
 See result:
![solved_log_keys](https://github.com/user-attachments/assets/0d7a9384-5e42-456e-a929-ab9897665331)
