### PR TITLE
refactor QueueSettings

### DIFF
--- a/ui/src/components/SampleQueue/app.css
+++ b/ui/src/components/SampleQueue/app.css
@@ -6,9 +6,6 @@
 .f-no-select {
   user-select: none;
 }
-.queue-settings .dropdown-menu {
-  margin-left: -250px !important;
-}
 .dropdown-menu > li > span {
   display: block;
   padding: 3px 20px;

--- a/ui/src/containers/QueueSettings.jsx
+++ b/ui/src/containers/QueueSettings.jsx
@@ -1,150 +1,91 @@
-/* eslint-disable react/destructuring-assignment */
-/* eslint-disable react/no-unused-state */
-import React from 'react';
 import { Dropdown, Form } from 'react-bootstrap';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import {
   setAutoAddDiffPlan,
   setAutoMountSample,
   setCentringMethod,
-  setGroupFolder,
   setQueueSettings,
 } from '../actions/queue';
 import { AUTO_LOOP_CENTRING, CLICK_CENTRING } from '../constants';
 import GroupFolderInput from './GroupFolderInput.jsx';
 import NumSnapshotsDropDown from './NumSnapshotsDropDown.jsx';
+import styles from './QueueSettings.module.css';
 
-class QueueSettings extends React.Component {
-  constructor(props) {
-    super(props);
-    this.inputOnChangeHandler = this.inputOnChangeHandler.bind(this);
-    this.setGroupFolderInput = this.setGroupFolderInput.bind(this);
-    this.autoMountNextOnClick = this.autoMountNextOnClick.bind(this);
-    this.setAutoAddDiffPlan = this.setAutoAddDiffPlan.bind(this);
-    this.autoLoopCentringOnClick = this.autoLoopCentringOnClick.bind(this);
+export default function QueueSettings() {
+  const dispatch = useDispatch();
+  const queueState = useSelector((state) => state.queue);
 
-    this.inputValue = '';
-    this.state = { validationState: 'success' };
-  }
-
-  setGroupFolderInput() {
-    this.setState({ validationState: 'success' });
-    this.props.setGroupFolder(this.inputValue.value);
-  }
-
-  setAutoAddDiffPlan(e) {
-    this.props.setAutoAddDiffPlan(e.target.checked);
-  }
-
-  inputOnChangeHandler() {
-    this.setState({ validationState: 'warning' });
-  }
-
-  autoMountNextOnClick(e) {
-    e.preventDefault();
-    this.props.setAutoMountSample(e.target.checked);
-  }
-
-  // eslint-disable-next-line react/no-unused-class-component-methods
-  inputOnSelectHandler(e) {
-    e.stopPropagation();
-    e.nativeEvent.stopImmediatePropagation();
-  }
-
-  autoLoopCentringOnClick(e) {
-    if (e.target.checked) {
-      this.props.setCentringMethod(AUTO_LOOP_CENTRING);
-    } else {
-      this.props.setCentringMethod(CLICK_CENTRING);
-    }
-  }
-
-  render() {
-    return (
-      <Dropdown className="queue-settings" autoClose="outside">
-        <Dropdown.Toggle variant="outline-secondary">
-          <span>
-            <i className="fas fa-1x fa-cog" /> Settings
-          </span>
-        </Dropdown.Toggle>
-        <Dropdown.Menu>
-          <Dropdown.Item>
-            <Form.Check
-              type="checkbox"
-              name="autoMountNext"
-              onChange={this.autoMountNextOnClick}
-              checked={this.props.queueState.autoMountNext}
-              label="Automount next sample"
-              id="auto-mount-next"
-            />
-          </Dropdown.Item>
-          <Dropdown.Item>
-            <Form.Check
-              type="checkbox"
-              onChange={this.autoLoopCentringOnClick}
-              name="autoLoopCentring"
-              checked={
-                this.props.queueState.centringMethod === AUTO_LOOP_CENTRING
-              }
-              label="Auto loop centring"
-              id="auto-loop-centring"
-            />
-          </Dropdown.Item>
-          <Dropdown.Item>
-            <Form.Check
-              type="checkbox"
-              name="autoAddDiffPlan"
-              onChange={this.setAutoAddDiffPlan}
-              checked={this.props.queueState.autoAddDiffplan}
-              label="Auto add diffraction plan"
-              id="auto-add-diff-plan"
-            />
-          </Dropdown.Item>
-          <Dropdown.Item>
-            <Form.Check
-              type="checkbox"
-              name="rememberParametersBetweenSamples"
-              onChange={(e) => {
-                this.props.setQueueSettings(
+  return (
+    <Dropdown autoClose="outside">
+      <Dropdown.Toggle variant="outline-secondary">
+        <span>
+          <i className="fas fa-1x fa-cog" /> Settings
+        </span>
+      </Dropdown.Toggle>
+      <Dropdown.Menu className={styles.dropdownMenu}>
+        <Dropdown.Item>
+          <Form.Check
+            type="checkbox"
+            name="autoMountNext"
+            onChange={(e) => dispatch(setAutoMountSample(e.target.checked))}
+            checked={queueState.autoMountNext}
+            label="Automount next sample"
+            id="auto-mount-next"
+          />
+        </Dropdown.Item>
+        <Dropdown.Item>
+          <Form.Check
+            type="checkbox"
+            onChange={(e) => {
+              dispatch(
+                setCentringMethod(
+                  e.target.checked ? AUTO_LOOP_CENTRING : CLICK_CENTRING,
+                ),
+              );
+            }}
+            name="autoLoopCentring"
+            checked={queueState.centringMethod === AUTO_LOOP_CENTRING}
+            label="Auto loop centring"
+            id="auto-loop-centring"
+          />
+        </Dropdown.Item>
+        <Dropdown.Item>
+          <Form.Check
+            type="checkbox"
+            name="autoAddDiffPlan"
+            onChange={(e) => dispatch(setAutoAddDiffPlan(e.target.checked))}
+            checked={queueState.autoAddDiffplan}
+            label="Auto add diffraction plan"
+            id="auto-add-diff-plan"
+          />
+        </Dropdown.Item>
+        <Dropdown.Item>
+          <Form.Check
+            type="checkbox"
+            name="rememberParametersBetweenSamples"
+            onChange={(e) => {
+              dispatch(
+                setQueueSettings(
                   'rememberParametersBetweenSamples',
                   e.target.checked,
-                );
-              }}
-              checked={this.props.queueState.rememberParametersBetweenSamples}
-              label="Remember parameters between samples"
-              id="remember-params"
-            />
-          </Dropdown.Item>
-          <Dropdown.Divider />
-          <Dropdown.Item>
-            <NumSnapshotsDropDown align="end" />
-          </Dropdown.Item>
-          <Dropdown.Divider />
-          <Dropdown.Item>
-            <GroupFolderInput />
-          </Dropdown.Item>
-        </Dropdown.Menu>
-      </Dropdown>
-    );
-  }
+                ),
+              );
+            }}
+            checked={queueState.rememberParametersBetweenSamples}
+            label="Remember parameters between samples"
+            id="remember-params"
+          />
+        </Dropdown.Item>
+        <Dropdown.Divider />
+        <Dropdown.Item>
+          <NumSnapshotsDropDown align="end" />
+        </Dropdown.Item>
+        <Dropdown.Divider />
+        <Dropdown.Item>
+          <GroupFolderInput />
+        </Dropdown.Item>
+      </Dropdown.Menu>
+    </Dropdown>
+  );
 }
-
-function mapStateToProps(state) {
-  return {
-    queueState: state.queue,
-  };
-}
-
-function mapDispatchToProps(dispatch) {
-  return {
-    setGroupFolder: bindActionCreators(setGroupFolder, dispatch),
-    setAutoAddDiffPlan: bindActionCreators(setAutoAddDiffPlan, dispatch),
-    setAutoMountSample: bindActionCreators(setAutoMountSample, dispatch),
-    setCentringMethod: bindActionCreators(setCentringMethod, dispatch),
-    setQueueSettings: bindActionCreators(setQueueSettings, dispatch),
-  };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(QueueSettings);

--- a/ui/src/containers/QueueSettings.module.css
+++ b/ui/src/containers/QueueSettings.module.css
@@ -1,0 +1,3 @@
+.dropdownMenu {
+  margin-left: -250px !important;
+}


### PR DESCRIPTION
This PR refactors QueueSettings into a functional component and removes some dead Code, namely functions regarding the GroupfolderInput field, which are handled inside the `GroupFolderInput`.
Additionally removed the .queue-settings css style, which is only used inside this component, from the global style sheet and created a module for it