### PR TITLE
Disable remaining linting violations in legacy code

### DIFF
--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -8,12 +8,7 @@ const config = defineConfig([
   ...createConfig(opts),
   {
     rules: {
-      'jsx-a11y/anchor-is-valid': 'off',
-      'jsx-a11y/control-has-associated-label': 'off',
-      'react/destructuring-assignment': 'off',
-      'react/no-multi-comp': 'off',
-      'react/no-unused-class-component-methods': 'off',
-      'react/prop-types': 'off',
+      'react/prop-types': 'off', // too ambitious; better to switch to TypeScript anyway
 
       /* Default is "avoid", but there are lots of complicated `switch` statements,
        * notably in Redux reducers, which benefit from clear case blocks. */

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,7 +14,7 @@
     "format": "pnpm prettier --write",
     "fix": "pnpm eslint --fix",
     "prettier": "prettier . --cache --check",
-    "eslint": "eslint",
+    "eslint": "eslint --max-warnings=0",
     "e2e": "cypress run --e2e --browser firefox",
     "cypress": "cypress open --e2e --browser firefox"
   },

--- a/ui/src/components/DraggableModal.jsx
+++ b/ui/src/components/DraggableModal.jsx
@@ -11,6 +11,7 @@ function DraggableModalDialog(props) {
   );
 }
 
+// eslint-disable-next-line react/no-multi-comp
 export function DraggableModal(props) {
   const { children } = props;
 

--- a/ui/src/components/Equipment/Harvester.jsx
+++ b/ui/src/components/Equipment/Harvester.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import React from 'react';
 import { Badge, Button, Card } from 'react-bootstrap';
 import { contextMenu, Item, Menu, Separator } from 'react-contexify';

--- a/ui/src/components/Equipment/SampleChanger.jsx
+++ b/ui/src/components/Equipment/SampleChanger.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable jsx-a11y/control-has-associated-label */
 import { useState } from 'react';
 import { Button, Card, Dropdown, DropdownButton, Form } from 'react-bootstrap';
 import { contextMenu, Item, Menu, Separator } from 'react-contexify';
@@ -128,6 +130,7 @@ function SampleChangerTreeItem(props) {
   );
 }
 
+// eslint-disable-next-line react/no-multi-comp
 export default function SampleChanger(props) {
   function scan() {
     props.scan('');

--- a/ui/src/components/ImageViewer/ImageViewer.jsx
+++ b/ui/src/components/ImageViewer/ImageViewer.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import { useEffect, useRef, useState } from 'react';
 import { Modal } from 'react-bootstrap';
 import { TransformComponent, TransformWrapper } from 'react-zoom-pan-pinch';
@@ -14,6 +15,7 @@ function GalleryImage(props) {
   );
 }
 
+// eslint-disable-next-line react/no-multi-comp
 function GalleryModal(props) {
   const { isOpen, drawTarget } = props;
   const canvasRef = useRef(null);
@@ -76,6 +78,7 @@ function GalleryModal(props) {
   );
 }
 
+// eslint-disable-next-line react/no-multi-comp
 export default function ImageViewer(props) {
   const [showModal, setShowModal] = useState('');
   const [imgUrl, setImgUrl] = useState('');

--- a/ui/src/components/Lims/LimsResultDialog.jsx
+++ b/ui/src/components/Lims/LimsResultDialog.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import './LimsResultDialog.css';
 
 import React from 'react';

--- a/ui/src/components/Lims/LimsResultSummary.jsx
+++ b/ui/src/components/Lims/LimsResultSummary.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 /* eslint-disable promise/prefer-await-to-then */
 import React from 'react';
 
@@ -71,7 +72,7 @@ export class LimsResultSummary extends React.Component {
       <div
         // ref="limsResultSummary"
         ref={(ref) => {
-          this.limsResultSummary = ref;
+          this.limsResultSummary = ref; // eslint-disable-line react/no-unused-class-component-methods
         }}
         className="lims-result-summary"
         style={style}

--- a/ui/src/components/MotorInput/BaseMotorInput.jsx
+++ b/ui/src/components/MotorInput/BaseMotorInput.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/control-has-associated-label */
 import { useEffect, useState } from 'react';
 
 import { HW_STATE } from '../../constants';

--- a/ui/src/components/MotorInput/MotorInput.jsx
+++ b/ui/src/components/MotorInput/MotorInput.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/control-has-associated-label */
 import { Button } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 

--- a/ui/src/components/MotorInput/OneAxisTranslationControl.jsx
+++ b/ui/src/components/MotorInput/OneAxisTranslationControl.jsx
@@ -7,7 +7,8 @@ import BaseMotorInput from './BaseMotorInput';
 import styles from './OneAxisTranslationControl.module.css';
 
 function OneAxisTranslationControl(props) {
-  const { attribute, step, precision } = props.motorProps;
+  const { motorProps } = props;
+  const { attribute, step, precision } = motorProps;
   const dispatch = useDispatch();
 
   const motor = useSelector(

--- a/ui/src/components/PeriodicTable/PeriodicTable.jsx
+++ b/ui/src/components/PeriodicTable/PeriodicTable.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import React from 'react';
 
 import styles from './PeriodicTable.module.css';

--- a/ui/src/components/Plot1D.jsx
+++ b/ui/src/components/Plot1D.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import 'dygraphs/dist/dygraph.min.css';
 
 import Dygraph from 'dygraphs';

--- a/ui/src/components/SSXChip/SSXChip.jsx
+++ b/ui/src/components/SSXChip/SSXChip.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable jsx-a11y/control-has-associated-label */
 /* eslint-disable react/jsx-key */
 /* eslint-disable react/no-unused-state */
 import 'fabric';
@@ -50,6 +52,7 @@ function ChipContextMenu(props) {
   );
 }
 
+// eslint-disable-next-line react/no-multi-comp
 export default class SSXChip extends React.Component {
   constructor(props) {
     super(props);
@@ -81,8 +84,8 @@ export default class SSXChip extends React.Component {
     // Fix
     this.rect = null;
     this.isDown = false;
-    this.origX = 0;
-    this.origY = 0;
+    this.origX = 0; // eslint-disable-line react/no-unused-class-component-methods
+    this.origY = 0; // eslint-disable-line react/no-unused-class-component-methods
   }
 
   componentDidMount() {
@@ -527,6 +530,7 @@ export default class SSXChip extends React.Component {
     this.freeFormCanvas.renderAll();
   }
 
+  // eslint-disable-next-line react/no-unused-class-component-methods
   renderChipInterface() {
     return [
       <div className="chip-canvas-container">

--- a/ui/src/components/SSXChip/SSXChipControl.jsx
+++ b/ui/src/components/SSXChip/SSXChipControl.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import 'fabric';
 import './ssxchipcontrol.css';
 

--- a/ui/src/components/SampleControls/LightControl.jsx
+++ b/ui/src/components/SampleControls/LightControl.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/control-has-associated-label */
 import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 

--- a/ui/src/components/SampleControls/ZoomControl.jsx
+++ b/ui/src/components/SampleControls/ZoomControl.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/control-has-associated-label */
 import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 

--- a/ui/src/components/SampleGrid/SampleGridTableItem.jsx
+++ b/ui/src/components/SampleGrid/SampleGridTableItem.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import './SampleGridTable.css';
 
 import cx from 'classnames';
@@ -161,7 +162,7 @@ export class SampleGridTableItem extends React.Component {
         variant="flush"
         id={this.props.sampleData.sampleID}
         ref={(ref) => {
-          this.sampleItem = ref;
+          this.sampleItem = ref; // eslint-disable-line react/no-unused-class-component-methods
         }}
         onClick={this.handleItemClick}
       >
@@ -190,7 +191,7 @@ export class SampleGridTableItem extends React.Component {
                   bg="light"
                   text="primary"
                   ref={(ref) => {
-                    this.pacronym = ref;
+                    this.pacronym = ref; // eslint-disable-line react/no-unused-class-component-methods
                   }}
                   className="samples-grid-table-item-name-protein-acronym ms-1 mt-2"
                   data-type="text"

--- a/ui/src/components/SampleGrid/TaskItem.jsx
+++ b/ui/src/components/SampleGrid/TaskItem.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import './SampleGridTable.css';
 
 import React from 'react';

--- a/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
+++ b/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable react/no-unused-prop-types */
 /* eslint-disable react/no-unused-state */
 
@@ -128,6 +130,7 @@ export default class TaskItem extends Component {
     this.props.deleteTask(this.props.sampleId, this.props.index);
   }
 
+  // eslint-disable-next-line react/no-unused-class-component-methods
   deleteButton() {
     let content = (
       <Button size="sm" onClick={this.deleteTask}>

--- a/ui/src/components/SampleQueue/CurrentTree.jsx
+++ b/ui/src/components/SampleQueue/CurrentTree.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 /* eslint-disable react/no-unused-state */
 import './app.css';
 

--- a/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
+++ b/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
@@ -1,3 +1,6 @@
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable jsx-a11y/control-has-associated-label */
+/* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable react/no-unused-prop-types */
 /* eslint-disable react/no-unused-state */
 
@@ -82,6 +85,7 @@ export default class EnergyScanTaskItem extends Component {
     this.props.deleteTask(this.props.sampleId, this.props.index);
   }
 
+  // eslint-disable-next-line react/no-unused-class-component-methods
   deleteButton() {
     let content = (
       <Button size="sm" onClick={this.deleteTask}>

--- a/ui/src/components/SampleQueue/QueueControl.jsx
+++ b/ui/src/components/SampleQueue/QueueControl.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import './app.css';
 
 import React from 'react';

--- a/ui/src/components/SampleQueue/TaskItem.jsx
+++ b/ui/src/components/SampleQueue/TaskItem.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable react/no-array-index-key */
 /* eslint-disable react/no-unused-prop-types */
 /* eslint-disable react/no-unused-state */
@@ -88,6 +90,7 @@ export default class TaskItem extends Component {
     this.props.deleteTask(this.props.sampleId, this.props.index);
   }
 
+  // eslint-disable-next-line react/no-unused-class-component-methods
   deleteButton() {
     let content = (
       <Button size="sm" onClick={this.deleteTask}>

--- a/ui/src/components/SampleQueue/TodoTree.jsx
+++ b/ui/src/components/SampleQueue/TodoTree.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 /* eslint-disable react/no-array-index-key */
 import './app.css';
 

--- a/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
+++ b/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable react/no-unused-prop-types */
 /* eslint-disable react/no-unused-state */
 
@@ -77,6 +79,7 @@ export default class WorkflowTaskItem extends Component {
     this.props.deleteTask(this.props.sampleId, this.props.index);
   }
 
+  // eslint-disable-next-line react/no-unused-class-component-methods
   deleteButton() {
     let content = (
       <Button size="sm" onClick={this.deleteTask}>

--- a/ui/src/components/SampleQueue/XRFTaskItem.jsx
+++ b/ui/src/components/SampleQueue/XRFTaskItem.jsx
@@ -1,3 +1,6 @@
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable jsx-a11y/control-has-associated-label */
+/* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable react/no-unused-state */
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -71,6 +74,7 @@ export default class XRFTaskItem extends Component {
     );
   }
 
+  // eslint-disable-next-line react/no-unused-class-component-methods
   getIspybLink(state) {
     if (state !== TASK_COLLECTED) {
       return <span />;
@@ -79,6 +83,7 @@ export default class XRFTaskItem extends Component {
     return <a href={this.props.data.limstResultData}> ISPyB link</a>;
   }
 
+  // eslint-disable-next-line react/no-unused-class-component-methods
   getPlot(state) {
     if (state === TASK_UNCOLLECTED) {
       return <span />;
@@ -145,6 +150,7 @@ export default class XRFTaskItem extends Component {
     this.props.deleteTask(this.props.sampleId, this.props.index);
   }
 
+  // eslint-disable-next-line react/no-unused-class-component-methods
   deleteButton() {
     let content = (
       <Button size="sm" onClick={this.deleteTask}>

--- a/ui/src/components/SampleView/GridForm.jsx
+++ b/ui/src/components/SampleView/GridForm.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/control-has-associated-label */
 import './SampleView.css';
 
 import { useEffect, useRef, useState } from 'react';

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable jsx-a11y/control-has-associated-label */
 import 'fabric';
 
 import React from 'react';
@@ -52,11 +54,11 @@ export default class SampleImage extends React.Component {
     this.drawGridPlugin = new DrawGridPlugin();
     this.drawGridPlugin.setGridResultFormat(props.meshResultFormat);
     this._keyPressed = null;
-    this.gridStarted = false;
-    this.girdOrigin = null;
-    this.lineGroup = null;
+    this.gridStarted = false; // eslint-disable-line react/no-unused-class-component-methods
+    this.girdOrigin = null; // eslint-disable-line react/no-unused-class-component-methods
+    this.lineGroup = null; // eslint-disable-line react/no-unused-class-component-methods
     this.player = null;
-    this.centringCross = [];
+    this.centringCross = []; // eslint-disable-line react/no-unused-class-component-methods
     this.removeShapes = this.removeShapes.bind(this);
   }
 
@@ -812,6 +814,7 @@ export default class SampleImage extends React.Component {
     }
   }
 
+  // eslint-disable-next-line react/no-unused-class-component-methods
   preventAction(e) {
     e.preventDefault();
     e.stopPropagation();

--- a/ui/src/components/Tasks/Characterisation.jsx
+++ b/ui/src/components/Tasks/Characterisation.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import React from 'react';
 import { Button, ButtonToolbar, Col, Form, Modal, Row } from 'react-bootstrap';
 import { connect } from 'react-redux';

--- a/ui/src/components/Tasks/DataCollection.jsx
+++ b/ui/src/components/Tasks/DataCollection.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import React from 'react';
 import { Button, ButtonToolbar, Col, Form, Modal, Row } from 'react-bootstrap';
 import { connect } from 'react-redux';

--- a/ui/src/components/Tasks/EnergyScan.jsx
+++ b/ui/src/components/Tasks/EnergyScan.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import React from 'react';
 import { Button, ButtonToolbar, Form, Modal, Row } from 'react-bootstrap';
 import { connect } from 'react-redux';

--- a/ui/src/components/Tasks/GenericTaskForm.jsx
+++ b/ui/src/components/Tasks/GenericTaskForm.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import './style.css';
 
 import JSForm from '@rjsf/core';

--- a/ui/src/components/Tasks/Helical.jsx
+++ b/ui/src/components/Tasks/Helical.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import React from 'react';
 import { Button, ButtonToolbar, Form, Modal, Row } from 'react-bootstrap';
 import { connect } from 'react-redux';

--- a/ui/src/components/Tasks/Interleaved.jsx
+++ b/ui/src/components/Tasks/Interleaved.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import React from 'react';
 import {
   Button,

--- a/ui/src/components/Tasks/Mesh.jsx
+++ b/ui/src/components/Tasks/Mesh.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import React from 'react';
 import { Button, ButtonToolbar, Col, Form, Modal, Row } from 'react-bootstrap';
 import { connect } from 'react-redux';

--- a/ui/src/components/Tasks/Workflow.jsx
+++ b/ui/src/components/Tasks/Workflow.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import { Button, ButtonToolbar, Modal, Row } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { Form, formValueSelector, reduxForm } from 'redux-form';

--- a/ui/src/components/Tasks/XRFScan.jsx
+++ b/ui/src/components/Tasks/XRFScan.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import React from 'react';
 import { Button, ButtonToolbar, Form, Modal, Row } from 'react-bootstrap';
 import { connect } from 'react-redux';

--- a/ui/src/components/Tasks/fields.jsx
+++ b/ui/src/components/Tasks/fields.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable react/no-multi-comp */
 import './style.css';
 
 import React from 'react';

--- a/ui/src/containers/BeamlineSetupContainer.jsx
+++ b/ui/src/containers/BeamlineSetupContainer.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/control-has-associated-label */
 import { filter, find } from 'lodash';
 import { Nav, Navbar, Popover, Table } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';

--- a/ui/src/containers/ConfirmCollectDialog.jsx
+++ b/ui/src/containers/ConfirmCollectDialog.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import './ConfirmCollectDialog.css';
 
 import React from 'react';

--- a/ui/src/containers/EquipmentContainer.jsx
+++ b/ui/src/containers/EquipmentContainer.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import { Col, Container, Row } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';

--- a/ui/src/containers/GphlWorkflowParametersDialog.jsx
+++ b/ui/src/containers/GphlWorkflowParametersDialog.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/control-has-associated-label */
 import { useCallback, useEffect, useState } from 'react';
 import { Button, Col, Form, Modal, Row, Stack, Table } from 'react-bootstrap';
 import { connect } from 'react-redux';

--- a/ui/src/containers/GroupFolderInput.jsx
+++ b/ui/src/containers/GroupFolderInput.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import React from 'react';
 import { Button, Form } from 'react-bootstrap';
 import { connect } from 'react-redux';

--- a/ui/src/containers/HelpContainer.jsx
+++ b/ui/src/containers/HelpContainer.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable jsx-a11y/control-has-associated-label */
 import React from 'react';
 import { Button, Card, Col, Container, Form, Row } from 'react-bootstrap';
 import { connect } from 'react-redux';

--- a/ui/src/containers/NumSnapshotsDropDown.jsx
+++ b/ui/src/containers/NumSnapshotsDropDown.jsx
@@ -4,6 +4,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import { setNumSnapshots } from '../actions/queue';
 
 function NumSnapshotsDropDown(props) {
+  const { align } = props;
+
   const dispatch = useDispatch();
   const numSnapshots = useSelector((state) => state.queue.numSnapshots);
 
@@ -11,7 +13,7 @@ function NumSnapshotsDropDown(props) {
     <DropdownButton
       id="numSnapshotsDropDown"
       variant="outline-secondary"
-      align={{ sm: props.align }}
+      align={{ sm: align }}
       title={
         <span>
           <i className="fas fa-1x fa-camera" /> &nbsp; Crystal snapshots (

--- a/ui/src/containers/QueueSettings.jsx
+++ b/ui/src/containers/QueueSettings.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 /* eslint-disable react/no-unused-state */
 import React from 'react';
 import { Dropdown, Form } from 'react-bootstrap';
@@ -46,6 +47,7 @@ class QueueSettings extends React.Component {
     this.props.setAutoMountSample(e.target.checked);
   }
 
+  // eslint-disable-next-line react/no-unused-class-component-methods
   inputOnSelectHandler(e) {
     e.stopPropagation();
     e.nativeEvent.stopImmediatePropagation();

--- a/ui/src/containers/SampleGridTableContainer.jsx
+++ b/ui/src/containers/SampleGridTableContainer.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 /* eslint-disable react/no-array-index-key */
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
@@ -257,6 +258,7 @@ class SampleGridTableContainer extends React.Component {
   /**
    * @param {MouseEvent} e
    */
+  // eslint-disable-next-line react/no-unused-class-component-methods
   onKeyDown(e) {
     switch (e.key) {
       case 'Escape': {

--- a/ui/src/containers/SampleIsaraView.jsx
+++ b/ui/src/containers/SampleIsaraView.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import React from 'react';
 import { Col } from 'react-bootstrap';
 import { BsChevronDown, BsChevronUp } from 'react-icons/bs';
@@ -18,6 +19,7 @@ class NewSampleIsaraView extends React.Component {
     document.addEventListener('keydown', this.onKeyDown, false);
   }
 
+  // eslint-disable-next-line react/no-unused-class-component-methods
   onClickCell(event, idx, disabled) {
     if (!disabled) {
       this.props.filter({ cellFilter: `${idx + 1}` });
@@ -33,6 +35,7 @@ class NewSampleIsaraView extends React.Component {
     return isPuckSelected;
   }
 
+  // eslint-disable-next-line react/no-unused-class-component-methods
   getCollapsibleHeaderOpen(cssClass) {
     return (
       <div className="sample-items-collapsible-header">
@@ -42,6 +45,7 @@ class NewSampleIsaraView extends React.Component {
     );
   }
 
+  // eslint-disable-next-line react/no-unused-class-component-methods
   getCollapsibleHeaderClose(cssClass) {
     return (
       <div className="sample-items-collapsible-header">

--- a/ui/src/containers/SampleQueueContainer.jsx
+++ b/ui/src/containers/SampleQueueContainer.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import React from 'react';
 import { Nav } from 'react-bootstrap';
 import { connect } from 'react-redux';

--- a/ui/src/containers/SampleViewContainer.jsx
+++ b/ui/src/containers/SampleViewContainer.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import '../components/SampleView/SampleView.css';
 
 import { Component } from 'react';


### PR DESCRIPTION
The remaining rules that are disabled in `eslint.config.js` are, in my opinion, not worth fixing on existing code. They can wait until the affected code is refactored (e.g. class components to function components, `useSelector`, UI revamp, etc.)

As written in the new [linting documentation](https://github.com/mxcube/mxcubeweb/pull/1630/files#diff-425da2324e83ab4adea4825089d26a6b2b0d0dc15cbd54a452499c1f4445909f), disabling a rule in `eslint.config.js` means that the rule is not applied to new code. So as a final step, I re-enable the rules and disable every violation explicitly with `eslint-disable` directives. I mostly use file-level directives to avoid cluttering the codebase.