### PR TITLE
[Sample List] Refactor Sample Grid Table [part 4]

### DIFF
--- a/ui/src/components/SampleGrid/SampleGridTable.css
+++ b/ui/src/components/SampleGrid/SampleGridTable.css
@@ -80,8 +80,13 @@
   padding: 0.3em !important;
 }
 
+.sample-items-col {
+  max-width: 365px;
+}
+
 .samples-grid-table-li {
   min-width: 283px;
+  max-width: 365px;
   margin: auto auto 6px 0;
   z-index: 2 !important;
   list-style-type: none;

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -297,7 +297,13 @@ export default function SampleListViewContainer() {
    *
    * return {boolean} true if item is to be excluded otherwise false
    */
-  function applyFilter(key) {
+  function applyFilter(key, cellID = null, puckID = null) {
+    const { cellFilter, puckFilter } = filterOptions;
+
+    // we either use the store value or  Pass the intended filter parameters manually
+    const cellNo = cellID ?? Number(cellFilter);
+    const puckNo = puckID ?? Number(puckFilter);
+
     const sample = sampleList[key];
     let fi = false;
     if (sample) {
@@ -322,13 +328,13 @@ export default function SampleListViewContainer() {
       );
       // eslint-disable-next-line no-bitwise
       fi &= mutualExclusiveFilterOption(sample, 'limsSamples', '', hasLimsData);
-      if (filterOptions.cellFilter !== '') {
+      if (cellFilter !== '') {
         // eslint-disable-next-line no-bitwise
-        fi &= sample.cell_no === Number(filterOptions.cellFilter);
+        fi &= sample.cell_no === cellNo;
       }
-      if (filterOptions.puckFilter !== '') {
+      if (puckFilter !== '' && puckID !== null) {
         // eslint-disable-next-line no-bitwise
-        fi &= sample.puck_no === Number(filterOptions.puckFilter);
+        fi &= sample.puck_no === puckNo;
       }
     }
 
@@ -798,7 +804,7 @@ export default function SampleListViewContainer() {
                   variant="outline-secondary"
                   id="dropdown-basic"
                 >
-                  <MdGridView size="1em" /> View Mode
+                  <MdGridView size="1em" /> {viewMode.mode}
                 </Dropdown.Toggle>
                 <Dropdown.Menu>
                   {viewMode.options.map((option) => (


### PR DESCRIPTION
This PR refactors the SampleGridTable  and should close this [issue](https://github.com/mxcube/mxcubeweb/issues/1175)

- Transform to functional  component 
- reduce filter cognitive complexity (getSampleListFilteredByCellPuck)
- Decouple the function to reduce complexity and merge some function to avoid redundant logic 

- Some function can be extracted into smaller components later  
- Minimal CSS modifications, just enforce a max-width to avoid loosing responsiveness .
 
The diff in the [SampleGridTableContainer.jsx] are a bit big but making the changes in one PR is my opinion easier to deploy and debug / revert in case of regressions.

the file is much more simpler now and it will be more simpler when we extract the utility function and component .  