### PR TITLE
fix MXContextMenu y-offset

### DIFF
--- a/ui/src/components/GenericContextMenu/MXContextMenu.jsx
+++ b/ui/src/components/GenericContextMenu/MXContextMenu.jsx
@@ -18,17 +18,13 @@ export default function MXContextMenu(props) {
     if (show && menuRef.current) {
       const menu = menuRef.current;
       const windowWidth = document.body.offsetWidth;
-      const windowHeight = document.body.offsetHeight;
       const menuEndXPos = x + menu.offsetWidth;
-      const menuEndYPos = y + menu.offsetHeight;
 
       const posxoffset = menuEndXPos > windowWidth ? menu.offsetWidth + 10 : 10;
-      const posyoffset =
-        menuEndYPos > windowHeight ? menu.offsetHeight + 70 : 70;
 
       setPosition({
         x: x - posxoffset,
-        y: y - posyoffset,
+        y: y - 70,
       });
     }
   }, [show, x, y]);


### PR DESCRIPTION
The refactoring of `MXContextMenu` in #1626 introduced an offset in `y` direction, so that the user would not have to scroll down if part of the pop up menu would be outside the viewable window. However, there was an issue, that it was not correctly calculated if the user already scrolled down before. It also introduced the problem that since the menu might pop up to the top, that when you have a really long list of items in the menu, they might overflow to the top instead of the bottom.

Hence, I reverted this functionality, so that the y-coordinate of the context menu will be approx. where the user clicked