### PR TITLE
UI: mark visually motor positions outside of limits

### DIFF
--- a/ui/src/actions/beamline.js
+++ b/ui/src/actions/beamline.js
@@ -40,10 +40,10 @@ export function updateBeamlineHardwareObjectStateAction(data) {
 }
 
 export function setAttribute(name, value) {
-  return (_, getState) => {
+  return async (_, getState) => {
     const state = getState();
     const type = state.beamline.hardwareObjects[name].type.toLowerCase();
-    sendSetAttribute(name, type, value);
+    await sendSetAttribute(name, type, value);
   };
 }
 

--- a/ui/src/components/MotorInput/BaseMotorInput.jsx
+++ b/ui/src/components/MotorInput/BaseMotorInput.jsx
@@ -19,6 +19,7 @@ function BaseMotorInput(props) {
 
   const [inputValue, setInputValue] = useState(value.toFixed(precision));
   const [isEdited, setEdited] = useState(false);
+  const [isInsideLimits, setInsideLimits] = useState(true);
 
   useEffect(() => {
     setInputValue(value.toFixed(precision));
@@ -52,6 +53,24 @@ function BaseMotorInput(props) {
     }
   }
 
+  function handleBlur() {
+    //
+    // restore widget to display motor's current position,
+    // when focus is lost
+    //
+    setInsideLimits(true);
+    setEdited(false);
+    setInputValue(value.toFixed(precision));
+  }
+
+  function handleChange(evt) {
+    const newValue = evt.target.value;
+
+    setInputValue(newValue);
+    setEdited(true);
+    setInsideLimits(min <= newValue && newValue <= max);
+  }
+
   const isReady = state === HW_STATE.READY;
   const isBusy = state === HW_STATE.BUSY;
   const isWarning = state === HW_STATE.WARNING;
@@ -71,15 +90,14 @@ function BaseMotorInput(props) {
         max={max}
         min={min}
         disabled={disabled || !isReady}
+        data-invalid={!isInsideLimits || undefined}
         data-dirty={isEdited || undefined}
         data-busy={isBusy || undefined}
         data-warning={isWarning || undefined}
         data-fault={isFault || undefined}
         onKeyDown={handleKey}
-        onChange={(evt) => {
-          setInputValue(evt.target.value);
-          setEdited(true);
-        }}
+        onBlur={handleBlur}
+        onChange={handleChange}
       />
       <input type="submit" hidden /> {/* allow submit on Enter */}
     </form>

--- a/ui/src/components/MotorInput/MotorInput.jsx
+++ b/ui/src/components/MotorInput/MotorInput.jsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { setAttribute } from '../../actions/beamline';
 import { stopBeamlineAction } from '../../actions/beamlineActions';
+import { showErrorPanel } from '../../actions/general';
 import { setMotorStep } from '../../actions/sampleview';
 import { HW_STATE, QUEUE_RUNNING } from '../../constants';
 import BaseMotorInput from './BaseMotorInput';
@@ -35,6 +36,14 @@ function MotorInput(props) {
     return null;
   }
 
+  async function handleChange(val) {
+    try {
+      await dispatch(setAttribute(attribute, val));
+    } catch (error) {
+      dispatch(showErrorPanel(true, error.message));
+    }
+  }
+
   return (
     <div className={styles.container}>
       <label className={styles.label} htmlFor={id}>
@@ -52,7 +61,7 @@ function MotorInput(props) {
           precision={precision}
           step={step}
           disabled={disabled}
-          onChange={(val) => dispatch(setAttribute(attribute, val))}
+          onChange={handleChange}
         />
 
         <div className={styles.arrows}>
@@ -61,7 +70,7 @@ function MotorInput(props) {
             className={styles.arrowBtn}
             data-testid={`${id}_up`}
             disabled={!isReady || disabled}
-            onClick={() => dispatch(setAttribute(attribute, value + step))}
+            onClick={() => handleChange(value + step)}
           >
             <i aria-hidden="true" className="fas fa-caret-up" />
           </button>
@@ -70,7 +79,7 @@ function MotorInput(props) {
             className={styles.arrowBtn}
             data-testid={`${id}_down`}
             disabled={!isReady || disabled}
-            onClick={() => dispatch(setAttribute(attribute, value - step))}
+            onClick={() => handleChange(value - step)}
           >
             <i aria-hidden="true" className="fas fa-caret-down" />
           </button>

--- a/ui/src/components/MotorInput/MotorInput.jsx
+++ b/ui/src/components/MotorInput/MotorInput.jsx
@@ -43,6 +43,8 @@ function MotorInput(props) {
 
       <div className={styles.wrapper}>
         <BaseMotorInput
+          min={motor.limits[0]}
+          max={motor.limits[1]}
           id={id}
           className={styles.valueInput}
           value={value}

--- a/ui/src/components/MotorInput/MotorInput.module.css
+++ b/ui/src/components/MotorInput/MotorInput.module.css
@@ -40,6 +40,10 @@
   background-color: var(--field-dirty--bg) !important;
 }
 
+.valueInput[data-invalid] {
+  background-color: var(--hw-invalid--bg) !important;
+}
+
 .arrows {
   display: flex;
   flex-direction: column;

--- a/ui/src/main.css
+++ b/ui/src/main.css
@@ -2,6 +2,7 @@
   --hw-ready--bg: #9bce7b;
   --hw-busy--bg: #ffff99;
   --hw-warning--bg: #ffc499;
+  --hw-invalid--bg: #d9534f;
   --hw-fault--bg: #ff9999;
   --field-dirty--bg: #ec971f;
 }


### PR DESCRIPTION
Changes behavior of motor widgets when position outside of motor limits is entered.

If entered position is outside of limits, change the widget style to _invalid_ mode. Block sending the _invalid_ position to the back-end. When focus is lost, restore widget to display motor's real position.

This changes the current behavior, where it's possible to enter and send a position outside of limits. The motor can refuse to move to that position, but the widget will still display the invalid value. Thus the displayed value in the UI will be different from the motor's real position, without any visual indications.