### PR TITLE
Fix Characterization error

### DIFF
--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -707,14 +707,9 @@ class Queue(ComponentBase):
         Retrieves the model and the queue entry for the model node with id <id>
 
         :param int _id: Node id of node to retrieve
-        :returns: The tuple model, entry or the root node and QueueManger if _id is None
+        :returns: The tuple of model and entry
         :rtype: Tuple
         """
-        if _id is None:
-            return (
-                HWR.beamline.queue_model.get_model_root(),
-                HWR.beamline.queue_manager,
-            )
         model = HWR.beamline.queue_model.get_node(int(_id))
         entry = HWR.beamline.queue_manager.get_entry_with_model(model)
         return model, entry
@@ -1504,7 +1499,6 @@ class Queue(ComponentBase):
 
         HWR.beamline.queue_model.add_child(sample_model, refgroup_model)
         HWR.beamline.queue_model.add_child(refgroup_model, char_model)
-        refdc_model._node_id = char_model._node_id
         refgroup_entry = qe.TaskGroupQueueEntry(Mock(), refgroup_model)
 
         refgroup_entry.set_enabled(True)

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -1504,6 +1504,7 @@ class Queue(ComponentBase):
 
         HWR.beamline.queue_model.add_child(sample_model, refgroup_model)
         HWR.beamline.queue_model.add_child(refgroup_model, char_model)
+        refdc_model._node_id = char_model._node_id
         refgroup_entry = qe.TaskGroupQueueEntry(Mock(), refgroup_model)
 
         refgroup_entry.set_enabled(True)


### PR DESCRIPTION
When adding a `Characterisation (1 image)` task, you get an ‘Error: The task could not be added to the server’. See the attached screenshot.

![image](https://github.com/user-attachments/assets/86157b84-a649-4661-b31a-1e242ccef080)

To reproduce: right click and pick `Characterisation (1 image)` option. Click `Run Now` button.

## More detailed description of what causes the issue
Adding new Characterisation task to queue launches [`sendAddQueueItem`](https://github.com/mxcube/mxcubeweb/blob/504e2e9316a5f9082eff1106f4b8276f94fb0a99/ui/src/actions/queue.js#L401) method that tries to post data but processing them (described below) does not succeed and application shows the attached error panel. 

[Add characterization](https://github.com/mxcube/mxcubeweb/blob/504e2e9316a5f9082eff1106f4b8276f94fb0a99/mxcubeweb/core/components/queue.py#L945) creates [`refdc_model`](https://github.com/mxcube/mxcubeweb/blob/504e2e9316a5f9082eff1106f4b8276f94fb0a99/mxcubeweb/core/components/queue.py#L1482) which is a `DataCollection` model object assigned to `Characterization` model at its [`reference_image_collection`](https://github.com/mxcube/mxcubecore/blob/1e3a5c87fc4a32bdfa2f3c01b03df739fcaeb7c0/mxcubecore/model/queue_model_objects.py#L834C14-L834C40) attribute. By default those two models haven't got `_node_id`. This attribute is initialized for `Characterization` model within [`HWR.beamline.queue_model.add_child`](https://github.com/mxcube/mxcubeweb/blob/504e2e9316a5f9082eff1106f4b8276f94fb0a99/mxcubeweb/core/components/queue.py#L1506) call. But that is not happening for DataCollection, so it's `_node_id` is `None`.

The last line of [`queue_add_item`](https://github.com/mxcube/mxcubeweb/blob/504e2e9316a5f9082eff1106f4b8276f94fb0a99/mxcubeweb/core/components/queue.py#L897) causes to call sequentially: `queue_to_dict`, `queue_to_dict_rec`, `_handle_char` at some point reaching the Characterization model, `_handle_dc` with `Characterisation.reference_image_collection` with assigned the `DataModel` as the second argument,  `get_node_state` with `None` and finally `get_entry` also with `None`. `get_entry` returns [`QueueManager` object](https://github.com/mxcube/mxcubeweb/blob/504e2e9316a5f9082eff1106f4b8276f94fb0a99/mxcubeweb/core/components/queue.py#L716) and that causes the error when [program is trying to read it's `status` field](https://github.com/mxcube/mxcubeweb/blob/504e2e9316a5f9082eff1106f4b8276f94fb0a99/mxcubeweb/core/components/queue.py#L221). 

Some time ago there was no [`if-else` clause in `get_entry`](https://github.com/mxcube/mxcubeweb/blob/ea31f09/mxcubeweb/core/components/queue.py#L705) and `TypeError` raised over there (when `None` was passed instead of a number to `int` method) was caught by [`try-except Exception`](https://github.com/mxcube/mxcubeweb/blob/ea31f09/mxcubeweb/core/components/queue.py#L222) and all the following lines were not called. 

I thought also about different approach to solve this issue:
```python
def  get_node_state(self, node_id):
        """ ... """
        if not node_id:
            return (True, UNCOLLECTED)
        self.get_entry(node_id)
```
Optionally, removing try-except. But this requires clarification: what this `try-except Exception` is designed to catch (except mentioned TypeError)? Now the application may hide some important tracebacks. Maybe since there is `if-else` introduced in `get_entry` it is time to remove it?