### PR TITLE
[Sample List Graphical view ] Add Circular Display Mode for Single Cell in SampleFlexView

### DIFF
--- a/ui/src/components/SampleGrid/SampleCircleView.jsx
+++ b/ui/src/components/SampleGrid/SampleCircleView.jsx
@@ -1,0 +1,117 @@
+import { useEffect } from 'react';
+import { Col } from 'react-bootstrap';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { filterAction } from '../../actions/sampleGrid';
+
+export default function SampleCircleView(props) {
+  const { displayPuckCellContextMenu, puckMenuID, type = 'Mockup' } = props;
+
+  const filterOptions = useSelector((state) => state.sampleGrid.filterOptions);
+
+  const pucks = useSelector((state) => state.sampleChanger.contents.children);
+
+  const cellID = 1;
+
+  const dispatch = useDispatch();
+
+  function handleClickOnCellPuck(event, puckID) {
+    dispatch(
+      filterAction({ cellFilter: `${cellID}`, puckFilter: `${puckID}` }),
+    );
+    event.stopPropagation();
+  }
+
+  useEffect(() => {
+    if (filterOptions.cellFilter === '') {
+      dispatch(filterAction({ cellFilter: '1', puckFilter: '1' }));
+    }
+  }, [filterOptions.cellFilter, dispatch]);
+
+  function handleDisplayPuckCellContextMenu(e, menuID, puckID) {
+    e.preventDefault();
+    handleClickOnCellPuck(e, cellID, puckID === null ? '' : puckID);
+    displayPuckCellContextMenu(e, menuID, cellID, puckID);
+    e.stopPropagation();
+  }
+
+  function getSingleCellAsCircle(centerX, centerY) {
+    const totalPucks = pucks.length;
+
+    // Adjust angle range based on puck count
+    const useFullCircle = totalPucks >= 8;
+    const angleRange = useFullCircle ? 2 * Math.PI : Math.PI * 1.5;
+    const startAngle = useFullCircle ? 0 : (Math.PI - angleRange) / 2;
+
+    // Circle size and spacing
+    const baseRadius = 4;
+    const placementRadius = baseRadius + Math.max(0, (totalPucks - 16) * 0.3);
+    const puckRadius = Math.min(
+      0.7,
+      (2 * Math.PI * placementRadius) / (totalPucks * 2),
+    );
+
+    // Fix angle spacing: avoid skipping puck 1 or overlapping at end
+    const angleDivisor = useFullCircle
+      ? totalPucks
+      : Math.max(1, totalPucks - 1);
+
+    return pucks.map((_, i) => {
+      const angle = startAngle + (angleRange * i) / angleDivisor;
+      const x = centerX + placementRadius * Math.cos(angle);
+      const y = centerY + placementRadius * Math.sin(angle);
+      const puckID = i + 1;
+
+      const isPuckSelected =
+        Number(filterOptions.cellFilter) === cellID &&
+        Number(filterOptions.puckFilter) === puckID;
+
+      return (
+        <g
+          key={`single_cell_puck_${puckID}`}
+          onClick={(e) => handleClickOnCellPuck(e, puckID)}
+          onContextMenu={(e) =>
+            handleDisplayPuckCellContextMenu(e, puckMenuID, puckID)
+          }
+          fill={isPuckSelected ? '#015f9d' : '#cdced1'}
+          className="puck_cicle"
+        >
+          <circle
+            cx={x}
+            cy={y}
+            r={puckRadius}
+            stroke="#01011ba2"
+            strokeWidth="0.05"
+          />
+          <text
+            x={x}
+            y={y}
+            fontSize="0.3"
+            textAnchor="middle"
+            dominantBaseline="middle"
+            fill={isPuckSelected ? 'white' : 'black'}
+          >
+            Puck {puckID}
+          </text>
+          <title>
+            Cell: {cellID}, Puck: {puckID}
+          </title>
+        </g>
+      );
+    });
+  }
+
+  return (
+    <Col sm={6}>
+      <div className="div-svg-flex">
+        <svg height="100%" width="100%" viewBox="0 1 20 20">
+          <circle fill="#6cb0f5" r="8" cx="10" cy="10" />
+          {getSingleCellAsCircle(10, 10)}
+          <text x="10" y="10" fontSize="0.5" textAnchor="middle" fill="black">
+            {type}
+          </text>
+        </svg>
+      </div>
+    </Col>
+  );
+}

--- a/ui/src/containers/SampleGridTableContainer.jsx
+++ b/ui/src/containers/SampleGridTableContainer.jsx
@@ -29,6 +29,7 @@ import {
 } from '../actions/sampleGrid';
 import { showTaskForm } from '../actions/taskForm';
 import MXContextMenu from '../components/GenericContextMenu/MXContextMenu';
+import SampleCircleView from '../components/SampleGrid/SampleCircleView';
 import { SampleGridTableItem } from '../components/SampleGrid/SampleGridTableItem';
 import { TaskItem } from '../components/SampleGrid/TaskItem';
 import TooltipTrigger from '../components/TooltipTrigger';
@@ -967,11 +968,15 @@ export default function SampleGridTableContainer(props) {
   }
 
   function getSampleListAsDrawing() {
-    if (type.includes('CATS')) {
+    const isCATS = type.includes('CATS');
+    const isFLEX = type.includes('FLEX');
+    const isMOCK = type.includes('Mock');
+
+    if (isCATS) {
       return <SampleIsaraView />;
     }
 
-    if (type.includes('FLEX') || type.includes('Moc')) {
+    if (isFLEX) {
       return (
         <SampleFlexView
           displayPuckCellContextMenu={displayPuckCellContextMenu}
@@ -981,6 +986,16 @@ export default function SampleGridTableContainer(props) {
         />
       );
     }
+    if (isSingleCell || isMOCK) {
+      return (
+        <SampleCircleView
+          displayPuckCellContextMenu={displayPuckCellContextMenu}
+          puckMenuID={PUCK_MENU_ID}
+          type={type}
+        />
+      );
+    }
+
     return null;
   }
 

--- a/ui/src/containers/SampleGridTableContainer.jsx
+++ b/ui/src/containers/SampleGridTableContainer.jsx
@@ -130,8 +130,8 @@ function checkForOverlap(el1, el2) {
 }
 
 // Helper function to determine puck colsm value
-function getColsm(singleCell, puckCount) {
-  if (singleCell) {
+function getColsm(isSingleCell, puckCount) {
+  if (isSingleCell) {
     return puckCount <= 4 ? 3 : true;
   }
   return puckCount === 1 ? 2 : puckCount === 2 ? 4 : puckCount === 3 ? 6 : true;
@@ -169,6 +169,10 @@ export default function SampleGridTableContainer(props) {
   } = props;
 
   const [rubberBandVisible, setRubberBandVisible] = useState(false);
+
+  const isSingleCell = Object.values(sampleList).every(
+    (sample) => sample.cell_no === 1 || sample.cell_no === 0,
+  );
 
   // this supose to replace old shouldComponentUpdate , not sure we need it
   useEffect(() => {
@@ -480,16 +484,10 @@ export default function SampleGridTableContainer(props) {
     e.stopPropagation();
   }
 
-  function isSingleCell() {
-    return Object.values(sampleList).every(
-      (sample) => sample.cell_no === 1 || sample.cell_no === 0,
-    );
-  }
-
   function getSampleItemCollapsibleHeaderActions(cellID) {
     return (
       <div className="sample-items-collapsible-header-actions">
-        <b className="me-2 mt-1">{isSingleCell() ? null : `Cell ${cellID}`}</b>
+        <b className="me-2 mt-1">{isSingleCell ? null : `Cell ${cellID}`}</b>
         {sampleItemsControls(cellID, null)}
         <span
           title="Cell Options"
@@ -612,7 +610,7 @@ export default function SampleGridTableContainer(props) {
     const puckFilterValue = Number(filterOptions.puckFilter); // Ensure numeric comparison
 
     return scContent.children.filter((puck, puckidx) => {
-      const puckID = isSingleCell() ? Number(puck.name) : puckidx + 1;
+      const puckID = isSingleCell ? Number(puck.name) : puckidx + 1;
       const [filterList] = getSampleListFilteredByCellPuck(cellID, puckID);
 
       return (
@@ -682,7 +680,7 @@ export default function SampleGridTableContainer(props) {
       <tr>
         {puckList.map((puck) => {
           const puckidx = cell.children.findIndex((p) => p.name === puck.name);
-          const puckID = isSingleCell() ? Number(puck.name) : puckidx + 1;
+          const puckID = isSingleCell ? Number(puck.name) : puckidx + 1;
           return (
             <td
               key={`${cellID}-td-${puckID}`}
@@ -701,7 +699,7 @@ export default function SampleGridTableContainer(props) {
       <tr>
         {puckList.map((puck) => {
           const puckidx = cell.children.findIndex((p) => p.name === puck.name);
-          const puckID = isSingleCell() ? Number(puck.name) : puckidx + 1;
+          const puckID = isSingleCell ? Number(puck.name) : puckidx + 1;
 
           return (
             <th
@@ -809,8 +807,7 @@ export default function SampleGridTableContainer(props) {
       return null;
     }
 
-    const singleCell = isSingleCell();
-    if (singleCell) {
+    if (isSingleCell) {
       scContent = { children: [{ name: 1, children: scContent.children }] };
     }
 
@@ -821,9 +818,9 @@ export default function SampleGridTableContainer(props) {
         return null;
       }
 
-      const colsm = getColsm(singleCell, puckList.length);
+      const colsm = getColsm(isSingleCell, puckList.length);
 
-      return singleCell
+      return isSingleCell
         ? getSingleCellPucks(cell, cellID, puckList, colsm)
         : getMultipleCellPucks(cell, cellID, puckList, colsm);
     });


### PR DESCRIPTION
The current implementation of SampleFlexView works well for visualizing multiple cells containing multiple pucks. This update introduces a new circular layout optimized for displaying a single cell, where its pucks are arranged in a circle for easier filtering and visual clarity.

- putting it in a new component/file

🔍 Targeted primarily at mockup/testing mode, but can  also  be useful for facilities using single-cell puck sample changers.

-  I also  Turn isSingleCell into a variable

![image](https://github.com/user-attachments/assets/9e884267-2eba-44c5-993e-b12a5fb95d31)
