### PR TITLE
Add option to invert 'success'/'danger' background colors in InOutSwitch

### DIFF
--- a/mxcubeweb/core/models/configmodels.py
+++ b/mxcubeweb/core/models/configmodels.py
@@ -62,7 +62,7 @@ class UIComponentModel(BaseModel):
     value_type: str | None
     object_type: str | None
     format: str | None
-    invert_bg_color: bool | None
+    invert_color_semantics: bool | None
 
 
 class _UICameraConfigModel(BaseModel):

--- a/mxcubeweb/core/models/configmodels.py
+++ b/mxcubeweb/core/models/configmodels.py
@@ -64,6 +64,7 @@ class UIComponentModel(BaseModel):
     format: str | None
     invert_bg_color: bool | None
 
+
 class _UICameraConfigModel(BaseModel):
     label: str
     url: str

--- a/mxcubeweb/core/models/configmodels.py
+++ b/mxcubeweb/core/models/configmodels.py
@@ -62,7 +62,7 @@ class UIComponentModel(BaseModel):
     value_type: str | None
     object_type: str | None
     format: str | None
-
+    invert_bg_color: bool | None
 
 class _UICameraConfigModel(BaseModel):
     label: str

--- a/ui/src/components/InOutSwitch/InOutSwitch.jsx
+++ b/ui/src/components/InOutSwitch/InOutSwitch.jsx
@@ -19,6 +19,7 @@ export default function InOutSwitch(props) {
     openValue,
     offValue,
     optionsOverlay,
+    invertBgColor,
     labelText,
     isBtnLabel,
     overlayPlacement,
@@ -77,7 +78,7 @@ export default function InOutSwitch(props) {
   switch (value) {
     case openValue:
     case 'READY': {
-      msgBgStyle = 'success';
+      msgBgStyle = invertBgColor ? 'danger' : 'success';
       btn = (
         <Button
           variant="outline-secondary"
@@ -92,7 +93,7 @@ export default function InOutSwitch(props) {
     case offValue:
     case 'DISABLED':
     case 'CLOSED': {
-      msgBgStyle = 'danger';
+      msgBgStyle = invertBgColor ? 'success' : 'danger';
       btn = (
         <Button
           variant="outline-secondary"

--- a/ui/src/components/InOutSwitch/InOutSwitch.jsx
+++ b/ui/src/components/InOutSwitch/InOutSwitch.jsx
@@ -19,7 +19,7 @@ export default function InOutSwitch(props) {
     openValue,
     offValue,
     optionsOverlay,
-    invertBgColor,
+    invertBgColor = false,
     labelText,
     isBtnLabel,
     overlayPlacement,

--- a/ui/src/containers/BeamlineSetupContainer.jsx
+++ b/ui/src/containers/BeamlineSetupContainer.jsx
@@ -63,7 +63,7 @@ function BeamlineSetupContainer() {
                     offText={hardwareObjects[key].commands[1]}
                     openValue={hardwareObjects[key].commands[0]}
                     offValue={hardwareObjects[key].commands[1]}
-                    invertBgColor={uiprop.invert_bg_color}
+                    invertBgColor={uiprop.invert_color_semantics}
                     labelText={uiprop.label}
                     pkey={key}
                     value={hardwareObjects[key].value}
@@ -82,7 +82,7 @@ function BeamlineSetupContainer() {
                     offText={hardwareObjects[key].commands[1]}
                     openValue={hardwareObjects[key].commands[0]}
                     offValue={hardwareObjects[key].commands[1]}
-                    invertBgColor={uiprop.invert_bg_color}
+                    invertBgColor={uiprop.invert_color_semantics}
                     labelText={uiprop.label}
                     pkey={key}
                     value={hardwareObjects[key].value}

--- a/ui/src/containers/BeamlineSetupContainer.jsx
+++ b/ui/src/containers/BeamlineSetupContainer.jsx
@@ -63,6 +63,7 @@ function BeamlineSetupContainer() {
                     offText={hardwareObjects[key].commands[1]}
                     openValue={hardwareObjects[key].commands[0]}
                     offValue={hardwareObjects[key].commands[1]}
+                    invertBgColor={uiprop.invert_bg_color}
                     labelText={uiprop.label}
                     pkey={key}
                     value={hardwareObjects[key].value}
@@ -81,6 +82,7 @@ function BeamlineSetupContainer() {
                     offText={hardwareObjects[key].commands[1]}
                     openValue={hardwareObjects[key].commands[0]}
                     offValue={hardwareObjects[key].commands[1]}
+                    invertBgColor={uiprop.invert_bg_color}
                     labelText={uiprop.label}
                     pkey={key}
                     value={hardwareObjects[key].value}

--- a/ui/src/reducers/beamline.js
+++ b/ui/src/reducers/beamline.js
@@ -26,7 +26,6 @@ export const INITIAL_STATE = {
       state: 'undefined',
       msg: 'UNKNOWN',
       readonly: false,
-      invert_bg_color: false,
     },
     safety_shutter: {
       limits: [0, 1, 1],
@@ -35,7 +34,6 @@ export const INITIAL_STATE = {
       state: 'undefined',
       msg: 'UNKNOWN',
       readonly: false,
-      invert_bg_color: false,
     },
     beamstop: {
       limits: [0, 1, 1],
@@ -44,7 +42,6 @@ export const INITIAL_STATE = {
       state: 'undefined',
       msg: 'UNKNOWN',
       readonly: false,
-      invert_bg_color: false,
     },
     capillary: {
       limits: [0, 1, 1],

--- a/ui/src/reducers/beamline.js
+++ b/ui/src/reducers/beamline.js
@@ -26,6 +26,7 @@ export const INITIAL_STATE = {
       state: 'undefined',
       msg: 'UNKNOWN',
       readonly: false,
+      invert_bg_color: false,
     },
     safety_shutter: {
       limits: [0, 1, 1],
@@ -34,6 +35,7 @@ export const INITIAL_STATE = {
       state: 'undefined',
       msg: 'UNKNOWN',
       readonly: false,
+      invert_bg_color: false,
     },
     beamstop: {
       limits: [0, 1, 1],
@@ -42,6 +44,7 @@ export const INITIAL_STATE = {
       state: 'undefined',
       msg: 'UNKNOWN',
       readonly: false,
+      invert_bg_color: false,
     },
     capillary: {
       limits: [0, 1, 1],


### PR DESCRIPTION
### Feature
This PR introduces a new option to the InOutSwitch component that allows inverting the default background color logic based on the component’s state.

#### Current behavior:
- offValue → danger (red background)
- onValue → success (green background)

#### New behavior (when invertColors is enabled):
- offValue → success (green background)
- onValue → danger (red background)

### How to test:

Open the file `../mxcube-web/ui.yaml` and add the field `invert_bg_color` to an "InOutSwitch" element.
Example configuration (e.g. for the Fast Shutter component):
```
...
beamline_setup:
  id: beamline_setup
  components:
    ...
    - label: Fast Shutter
      attribute: fast_shutter
      invert_bg_color: true     
    ...
```