### PR TITLE
Compare the entered oscillation with the current one using motor precision (In Task components)

### DIFF
--- a/ui/src/components/Tasks/Characterisation.jsx
+++ b/ui/src/components/Tasks/Characterisation.jsx
@@ -518,6 +518,7 @@ export default connect((state) => {
     opt_sad: selector(state, 'opt_sad'),
     use_min_dose: selector(state, 'use_min_dose'),
     use_min_time: selector(state, 'use_min_time'),
+    components: state.uiproperties.sample_view.components,
     initialValues: {
       ...parameters,
       beam_size: state.sampleview.currentAperture,

--- a/ui/src/components/Tasks/DataCollection.jsx
+++ b/ui/src/components/Tasks/DataCollection.jsx
@@ -381,6 +381,7 @@ export default connect((state) => {
     filename: fname,
     acqParametersLimits: limits,
     beamline: state.beamline,
+    components: state.uiproperties.sample_view.components,
     initialValues: {
       ...parameters,
       beam_size: state.sampleview.currentAperture,

--- a/ui/src/components/Tasks/GenericTaskForm.jsx
+++ b/ui/src/components/Tasks/GenericTaskForm.jsx
@@ -407,6 +407,7 @@ export default connect((state) => {
     schema,
     uiSchema,
     beamline: state.beamline,
+    components: state.uiproperties.sample_view.components,
     initialValues: {
       ...state.taskForm.taskData.parameters,
       type,

--- a/ui/src/components/Tasks/Helical.jsx
+++ b/ui/src/components/Tasks/Helical.jsx
@@ -293,6 +293,7 @@ export default connect((state) => {
     filename: fname,
     acqParametersLimits: limits,
     beamline: state.beamline,
+    components: state.uiproperties.sample_view.components,
     initialValues: {
       ...state.taskForm.taskData.parameters,
       beam_size: state.sampleview.currentAperture,

--- a/ui/src/components/Tasks/Mesh.jsx
+++ b/ui/src/components/Tasks/Mesh.jsx
@@ -306,6 +306,7 @@ export default connect((state) => {
     filename: fname,
     acqParametersLimits: limits,
     beamline: state.beamline,
+    components: state.uiproperties.sample_view.components,
     initialValues: {
       ...state.taskForm.taskData.parameters,
       beam_size: state.sampleview.currentAperture,

--- a/ui/src/components/Tasks/warning.js
+++ b/ui/src/components/Tasks/warning.js
@@ -43,18 +43,16 @@ function warn(values, props) {
   }
 
   const phiPrecision =
-    props.components.find(
-      (el) => el.attribute === 'diffractometer.phi'
-    )?.precision ?? 2;
+    props.components.find((el) => el.attribute === 'diffractometer.phi')
+      ?.precision ?? 2;
 
   if (
     Number.parseFloat(
-      props.beamline.hardwareObjects['diffractometer.phi'].value
-        .toFixed(phiPrecision)
+      props.beamline.hardwareObjects['diffractometer.phi'].value.toFixed(
+        phiPrecision,
+      ),
     ) !==
-    Number.parseFloat(
-      Number.parseFloat(values.osc_start).toFixed(phiPrecision)
-    )
+    Number.parseFloat(Number.parseFloat(values.osc_start).toFixed(phiPrecision))
   ) {
     warnings.osc_start =
       'Entered Oscillation start angle is different from current omega';

--- a/ui/src/components/Tasks/warning.js
+++ b/ui/src/components/Tasks/warning.js
@@ -42,10 +42,19 @@ function warn(values, props) {
       'Entered transmission is different from current transmission';
   }
 
+  const phiPrecision =
+    props.components.find(
+      (el) => el.attribute === 'diffractometer.phi'
+    )?.precision ?? 2;
+
   if (
     Number.parseFloat(
-      props.beamline.hardwareObjects['diffractometer.phi'].value.toFixed(2),
-    ) !== Number.parseFloat(values.osc_start)
+      props.beamline.hardwareObjects['diffractometer.phi'].value
+        .toFixed(phiPrecision)
+    ) !==
+    Number.parseFloat(
+      Number.parseFloat(values.osc_start).toFixed(phiPrecision)
+    )
   ) {
     warnings.osc_start =
       'Entered Oscillation start angle is different from current omega';


### PR DESCRIPTION
This fix prevents the warning "Entered Oscillation start angle is different from current omega" from appearing when the omega motor has a precision greater than 2 and the entered value is actually the same as the current one.

If the motor is in this position:
![image](https://github.com/user-attachments/assets/0eda7699-1b81-49e2-81aa-334fb4a4f09a)

The current behavior is this:
![image](https://github.com/user-attachments/assets/4837beed-7217-4237-91ca-445b73a047af)

This happens because the comparison uses a fixed precision.