### PR TITLE
Add domain-based check to distinguish local and remote clients

### DIFF
--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -540,9 +540,10 @@ class UserManager(BaseUserManager):
             LimsSessionManager object with login information.
         """
         self._debug("_login. login_id=%s" % login_id)
+        local_domains = self.app.CONFIG.app.LOCAL_DOMAINS
         try:
             session_manager: LimsSessionManager = HWR.beamline.lims.login(
-                login_id, password, is_local_host()
+                login_id, password, is_local_host(local_domains)
             )
         except Exception as e:
             logging.getLogger("MX3.HWR").error(e)
@@ -568,12 +569,12 @@ class UserManager(BaseUserManager):
                 raise Exception(msg)
 
         # Only allow in-house log-in from local host
-        if self.is_inhouse_user(login_id) and not is_local_host():
+        if self.is_inhouse_user(login_id) and not is_local_host(local_domains):
             msg = "In-house only allowed from localhost"
             raise Exception(msg)
 
         # Only allow local login when remote is disabled
-        if not self.app.ALLOW_REMOTE and not is_local_host():
+        if not self.app.ALLOW_REMOTE and not is_local_host(local_domains):
             msg = "Remote access disabled"
             raise Exception(msg)
 

--- a/mxcubeweb/core/models/configmodels.py
+++ b/mxcubeweb/core/models/configmodels.py
@@ -156,7 +156,7 @@ class MXCUBEAppConfigModel(BaseModel):
     LOCAL_DOMAINS: list[str] = Field(
         [],
         description="If the connected client's hostname ends with one of these domains"
-                    ", it will be considered 'local'"
+        ", it will be considered 'local'",
     )
     usermanager: UserManagerConfigModel
     ui_properties: dict[str, UIPropertiesModel] = {}

--- a/mxcubeweb/core/models/configmodels.py
+++ b/mxcubeweb/core/models/configmodels.py
@@ -156,7 +156,8 @@ class MXCUBEAppConfigModel(BaseModel):
     LOCAL_DOMAINS: list[str] = Field(
         [],
         description="If the connected client's hostname ends with one of these domains"
-                    ", it will be considered \"local\"")
+                    ", it will be considered 'local'"
+    )
     usermanager: UserManagerConfigModel
     ui_properties: dict[str, UIPropertiesModel] = {}
 

--- a/mxcubeweb/core/models/configmodels.py
+++ b/mxcubeweb/core/models/configmodels.py
@@ -153,6 +153,10 @@ class MXCUBEAppConfigModel(BaseModel):
     mode: ModeEnum = Field(
         ModeEnum.OSC, description="MXCuBE mode OSC, SSX-CHIP or SSX-INJECTOR"
     )
+    LOCAL_DOMAINS: list[str] = Field(
+        [],
+        description="If the connected client's hostname ends with one of these domains"
+                    ", it will be considered \"local\"")
     usermanager: UserManagerConfigModel
     ui_properties: dict[str, UIPropertiesModel] = {}
 

--- a/mxcubeweb/core/util/networkutils.py
+++ b/mxcubeweb/core/util/networkutils.py
@@ -46,15 +46,24 @@ def remote_addr():
     return str(hdr).split(",")[-1]
 
 
-def is_local_network(ip):
+def is_local_network(ip, local_domains=[]):
     localhost = socket.gethostbyname_ex(socket.gethostname())[2][0]
     localhost_range = ".".join(localhost.split(".")[0:2])
     private_address = ".".join(ip.split(".")[0:2])
+    try:
+        private_hostname = socket.gethostbyaddr(ip)[0]
+    except (socket.herror, socket.gaierror):
+        logging.getLogger("MX3.HWR").warning(
+            "Failed to resolve the client IP: %s" % ip)
+        private_hostname = ''
 
-    return private_address == localhost_range
+    return private_address == localhost_range or \
+        any(map(lambda domain: private_hostname and
+                               private_hostname.endswith(domain),
+                local_domains))
 
 
-def is_local_host():
+def is_local_host(local_domains):
     try:
         localhost_list = socket.gethostbyname_ex(socket.gethostname())[2]
     except Exception:
@@ -69,7 +78,8 @@ def is_local_host():
     if remote_address in [None, "None", ""]:
         remote_address = "127.0.0.1"
 
-    return remote_address in localhost_list or is_local_network(remote_address)
+    return remote_address in localhost_list or \
+        is_local_network(remote_address, local_domains)
 
 
 def valid_login_only(f):

--- a/mxcubeweb/core/util/networkutils.py
+++ b/mxcubeweb/core/util/networkutils.py
@@ -46,7 +46,7 @@ def remote_addr():
     return str(hdr).split(",")[-1]
 
 
-def is_local_network(ip, local_domains=[]):
+def is_local_network(ip, local_domains):
     localhost = socket.gethostbyname_ex(socket.gethostname())[2][0]
     localhost_range = ".".join(localhost.split(".")[0:2])
     private_address = ".".join(ip.split(".")[0:2])
@@ -58,9 +58,8 @@ def is_local_network(ip, local_domains=[]):
         private_hostname = ''
 
     return private_address == localhost_range or \
-        any(map(lambda domain: private_hostname and
-                               private_hostname.endswith(domain),
-                local_domains))
+        any(private_hostname and private_hostname.endswith(domain)
+            for domain in local_domains)
 
 
 def is_local_host(local_domains):

--- a/mxcubeweb/core/util/networkutils.py
+++ b/mxcubeweb/core/util/networkutils.py
@@ -53,13 +53,13 @@ def is_local_network(ip, local_domains):
     try:
         private_hostname = socket.gethostbyaddr(ip)[0]
     except (socket.herror, socket.gaierror):
-        logging.getLogger("MX3.HWR").warning(
-            "Failed to resolve the client IP: %s" % ip)
+        logging.getLogger("MX3.HWR").warning("Failed to resolve the client IP: %s" % ip)
         private_hostname = ""
 
-    return private_address == localhost_range or \
-        any(private_hostname and private_hostname.endswith(domain)
-            for domain in local_domains)
+    return private_address == localhost_range or any(
+        private_hostname and private_hostname.endswith(domain)
+        for domain in local_domains
+    )
 
 
 def is_local_host(local_domains):
@@ -77,8 +77,9 @@ def is_local_host(local_domains):
     if remote_address in [None, "None", ""]:
         remote_address = "127.0.0.1"
 
-    return remote_address in localhost_list or \
-        is_local_network(remote_address, local_domains)
+    return remote_address in localhost_list or is_local_network(
+        remote_address, local_domains
+    )
 
 
 def valid_login_only(f):

--- a/mxcubeweb/core/util/networkutils.py
+++ b/mxcubeweb/core/util/networkutils.py
@@ -55,7 +55,7 @@ def is_local_network(ip, local_domains):
     except (socket.herror, socket.gaierror):
         logging.getLogger("MX3.HWR").warning(
             "Failed to resolve the client IP: %s" % ip)
-        private_hostname = ''
+        private_hostname = ""
 
     return private_address == localhost_range or \
         any(private_hostname and private_hostname.endswith(domain)

--- a/mxcubeweb/core/util/networkutils.py
+++ b/mxcubeweb/core/util/networkutils.py
@@ -46,7 +46,24 @@ def remote_addr():
     return str(hdr).split(",")[-1]
 
 
-def is_local_network(ip, local_domains):
+def is_local_network(ip: str, local_domains: list):
+    """
+    Determines whether a given IP address belongs to the local network.
+
+    The function compares the first two octets of the given IP address with the
+    local host's IP address. It also checks if the reverse-resolved hostname of
+    the IP ends with any of the specified local domains.
+
+    Args:
+        ip (str): The IP address to check.
+        local_domains (list): A list of domain suffixes that are considered local
+            (e.g. ['beamline1.site.eu', 'control.site.eu']).
+
+    Returns:
+        bool: True if the IP is in the same network range as the local host
+              (i.e. mxcube server) or its hostname ends with any of the specified
+              local domains; False otherwise.
+    """
     localhost = socket.gethostbyname_ex(socket.gethostname())[2][0]
     localhost_range = ".".join(localhost.split(".")[0:2])
     private_address = ".".join(ip.split(".")[0:2])
@@ -62,7 +79,21 @@ def is_local_network(ip, local_domains):
     )
 
 
-def is_local_host(local_domains):
+def is_local_host(local_domains: list):
+    """
+    Determines whether the remote client making the request is a "local host".
+
+    A client is considered a "local host" if it runs on the same host as the
+    mxcube-server, or if it belongs to the local network. The local network can
+    also be identified by providing a list of domain suffixes considered local.
+
+    Args:
+        local_domains (list): A list of domain suffixes that are considered local
+            (e.g. ['beamline1.site.eu', 'control.site.eu']).
+
+    Returns:
+        bool: True if the client's host is considered a local host; False otherwise.
+    """
     try:
         localhost_list = socket.gethostbyname_ex(socket.gethostname())[2]
     except Exception:


### PR DESCRIPTION
This feature allows distinguishing local network clients from external ones based on their domain names. A client is considered local if the final part of its domain (i.e. the base domain or subdomain) matches an entry from a predefined list.

To configure this, just add the list of "local" domains in the `.../mxcube-web/server.yaml` file, under the `mxcube` section.

E.g.
```
...
mxcube:
  USE_EXTERNAL_STREAMER: true
  ...
  LOCAL_DOMAINS: [ 'elettra.eu' ]
  
  usermanager:
...
```
