### PR TITLE
Prevent negative clicks during manual centering and display a UI message

### DIFF
--- a/mxcubeweb/core/components/sampleview.py
+++ b/mxcubeweb/core/components/sampleview.py
@@ -413,9 +413,11 @@ class SampleView(ComponentBase):
 
     def centring_handle_click(self, x, y):
         if HWR.beamline.diffractometer.current_centring_procedure:
-            if not HWR.beamline.diffractometer.is_moving():
+            try:
                 HWR.beamline.diffractometer.imageClicked(x, y, x, y)
                 self.centring_click()
+            except Exception:
+                return {"clicksLeft": -1}
         else:
             if not self.centring_clicks_left():
                 self.centring_reset_click_count()

--- a/mxcubeweb/core/components/sampleview.py
+++ b/mxcubeweb/core/components/sampleview.py
@@ -413,8 +413,9 @@ class SampleView(ComponentBase):
 
     def centring_handle_click(self, x, y):
         if HWR.beamline.diffractometer.current_centring_procedure:
-            HWR.beamline.diffractometer.imageClicked(x, y, x, y)
-            self.centring_click()
+            if not HWR.beamline.diffractometer.is_moving():
+                HWR.beamline.diffractometer.imageClicked(x, y, x, y)
+                self.centring_click()
         else:
             if not self.centring_clicks_left():
                 self.centring_reset_click_count()

--- a/ui/src/actions/sampleview.js
+++ b/ui/src/actions/sampleview.js
@@ -194,16 +194,16 @@ export function recordCentringClick(x, y) {
 
     const { clicksLeft } = json;
     dispatch(centringClicksLeft(clicksLeft));
-    dispatch(
-      videoMessageOverlay(
-        true,
-        `3-Click Centring: <br />${
-          clicksLeft === 0
-            ? 'Save centring or clicking on screen to restart'
-            : `Clicks left: ${clicksLeft}`
-        }`,
-      ),
-    );
+
+    let msg = '3-Click Centring: <br />';
+    if (clicksLeft === 0) {
+      msg += 'Save centring or clicking on screen to restart';
+    } else if (clicksLeft === -1) {
+      msg += 'Please wait, the centring movement is not completed yet';
+    } else {
+      msg += `Clicks left: ${clicksLeft}`;
+    }
+    dispatch(videoMessageOverlay(true, msg));
   };
 }
 


### PR DESCRIPTION
The feature/fix allows handling user clicks that happen while a manual centering step is still in progress. A message is shown on the UI to inform the user.

### The issue 
After the first manual centering click, if the user clicks again before the first step is completed, a message appears on the UI and the number of available clicks is reduced by one. If the user keeps clicking, the click count can go negative, as shown in the screenshot:
![image](https://github.com/user-attachments/assets/33d6d43c-7eb4-4ce9-a72d-ba301ff8e1be)

This behavior can be tested adding a `time.sleep(3)` in the `manual_centring` method of the `DiffractometerMockup` HWO
```diff
    def manual_centring(self):
        """
        Descript. :
        """
        for click in range(3):
            self.user_clicked_event = AsyncResult()
            #self.waiting_for_click = True
            x, y = self.user_clicked_event.get()
            if click < 2:
+                time.sleep(3)
                self.motor_hwobj_dict["phi"].set_value_relative(90)
        self.last_centred_position[0] = x
        self.last_centred_position[1] = y
        centred_pos_dir = self._get_random_centring_position()
        return centred_pos_dir 
```
### The proposed change

In `mxcubeweb/core/components/sampleview.py`

```diff
    def centring_handle_click(self, x, y):
        if HWR.beamline.diffractometer.current_centring_procedure:
+            try:
                HWR.beamline.diffractometer.imageClicked(x, y, x, y)
                self.centring_click()
+            except Exception:
+                return {"clicksLeft": -1}
        else:
            if not self.centring_clicks_left():
                self.centring_reset_click_count()
```

The change allows, raising an Exception from `.imageClicked(...)`, to inform the frontend that the centering step is still in progress. If the frontend receives a negative click (i.e. "-1")  it will show the following message:
![image](https://github.com/user-attachments/assets/947017cf-a052-4d94-acc8-82e4efb5ceea)


#### Test the feature:
Just apply the following changes in the `DiffractometerMockup`:
```diff
...
+from gevent.lock import Semaphore

from mxcubecore import HardwareRepository as HWR
from mxcubecore.HardwareObjects.GenericDiffractometer import (
    GenericDiffractometer,
    PhaseEnum,
)


class DiffractometerMockup(GenericDiffractometer):
...

    def init(self):
        """
        Descript. :
        """
        # self.image_width = 100
        # self.image_height = 100

        GenericDiffractometer.init(self)
+      self.waiting_for_click = False
+      self.click_lock = Semaphore()
        self.x_calib = 0.000444

...
    
+    def image_clicked(self, x, y, xi=None, yi=None):
+        with self.click_lock:
+            if self.waiting_for_click:
+                self.waiting_for_click = False
+                self.user_clicked_event.set((x, y))
+            else:
+                self.log.warning("User click but the last centring operation"
+                                              " was still in progress")
+                raise RuntimeError("Last centring operation is still in "
+                                                   "progress, click will be ignored")

    def manual_centring(self):
        """
        Descript. :
        """
        for click in range(3):
            self.user_clicked_event = AsyncResult()
+          self.waiting_for_click = True
            x, y = self.user_clicked_event.get()
            if click < 2:
+              time.sleep(3)
                self.motor_hwobj_dict["phi"].set_value_relative(90)

...
```

#### Thoughts

- Maybe the Exception could be a more specific User-defined Exception ? Should we use user-defined Exceptions in mxcube ?
- Is there a better solution ? Maybe with a new signal o something like that ?

