### PR TITLE
Remove X from Select Session modal

### DIFF
--- a/ui/src/components/LoginForm/SelectProposal.jsx
+++ b/ui/src/components/LoginForm/SelectProposal.jsx
@@ -65,7 +65,7 @@ function SelectProposal() {
         }
       }}
     >
-      <Modal.Header closeButton>
+      <Modal.Header closeButton={showProposalsForm}>
         <Modal.Title>Select a session</Modal.Title>
       </Modal.Header>
       <Modal.Body>


### PR DESCRIPTION
Clicking on `X` button of `Select a Session` modal should cause landing on login page similarly to `Sign out` button, accordingly to documentation https://github.com/mxcube/mxcubecore/blob/develop/docs/source/dev/user-based-login-details.md

Check attached screenshot.  
![Image](https://github.com/user-attachments/assets/d470e810-8753-4bb9-80f4-4341a720dbc0)

Unreproducible on demo - no `Select Session` modal shows up. Reproduced and tested at Max IV fork.

------------------------

Final decision was to remove misleading X button from modal showing up after logging in if no session is selected.

Provided small change in documentation regarding user-based login: https://github.com/mxcube/mxcubecore/pull/1234
