### PR TITLE
Stop relying on `available_methods` config in UI

### DIFF
--- a/mxcubeweb/core/adapter/beamline_adapter.py
+++ b/mxcubeweb/core/adapter/beamline_adapter.py
@@ -78,14 +78,6 @@ class _BeamlineAdapter:
 
         return {"hardwareObjects": attributes}
 
-    def get_available_methods(self):
-        """
-        Get the available methods.
-        Returns:
-            (list): The methods.
-        """
-        return self._bl.config.available_methods
-
     def get_available_elements(self):
         escan = self._bl.energy_scan
         elements = []

--- a/mxcubeweb/core/components/beamline.py
+++ b/mxcubeweb/core/components/beamline.py
@@ -167,8 +167,6 @@ class Beamline(ComponentBase):
 
         actions.extend(self.beamline_get_actions())
 
-        data.update({"availableMethods": ho.get_available_methods()})
-
         data.update(
             {
                 "path": HWR.beamline.session.get_base_image_directory(),

--- a/test/test_beamline_routes.py
+++ b/test/test_beamline_routes.py
@@ -49,7 +49,6 @@ def test_beamline_get_all_attribute(client):
     assert isinstance(data["actionsList"], list)
     assert isinstance(data["path"], str)
     assert len(data["energyScanElements"]) == 31
-    assert isinstance(data["availableMethods"], dict)
     assert len(actual) == len(expected)
 
 

--- a/ui/src/components/SampleView/ContextMenu.jsx
+++ b/ui/src/components/SampleView/ContextMenu.jsx
@@ -39,9 +39,7 @@ export default function ContextMenu(props) {
   const workflows = useSelector((state) => state.workflow.workflows);
   const enableNativeMesh = useSelector((state) => state.general.useNativeMesh);
   const enable2DPoints = useSelector((state) => state.general.enable2DPoints);
-  const availableMethods = useSelector(
-    (state) => state.beamline.availableMethods,
-  );
+  const availableMethods = new Set(Object.keys(defaultParameters));
   const sampleID = useSelector((state) => state.queue.currentSampleID);
   const sampleData = useSelector(
     (state) => state.sampleGrid.sampleList[sampleID],
@@ -53,6 +51,7 @@ export default function ContextMenu(props) {
 
   const dispatch = useDispatch();
 
+  // eslint-disable-next-line complexity
   function menuOptions() {
     const generalTaskNames = Object.keys(defaultParameters).filter(
       (tname) => !BESPOKE_TASK_NAMES.has(tname),
@@ -160,28 +159,36 @@ export default function ContextMenu(props) {
       }
     });
 
-    const options = {
+    return {
       SAVED: [
-        {
-          text: 'Add Datacollection',
-          action: () => showModal('DataCollection'),
-          key: 'datacollection',
-        },
-        {
-          text: 'Add Characterisation',
-          action: () => showModal('Characterisation'),
-          key: 'characterisation',
-        },
-        {
-          text: 'Add XRF Scan',
-          action: () => showModal('xrf_spectrum'),
-          key: 'xrf_spectrum',
-        },
-        {
-          text: 'Add Energy Scan',
-          action: () => showModal('energy_scan'),
-          key: 'energy_scan',
-        },
+        availableMethods.has('datacollection')
+          ? {
+              text: 'Add Datacollection',
+              action: () => showModal('DataCollection'),
+              key: 'datacollection',
+            }
+          : {},
+        availableMethods.has('characterisation')
+          ? {
+              text: 'Add Characterisation',
+              action: () => showModal('Characterisation'),
+              key: 'characterisation',
+            }
+          : {},
+        availableMethods.has('xrf_spectrum')
+          ? {
+              text: 'Add XRF Scan',
+              action: () => showModal('xrf_spectrum'),
+              key: 'xrf_spectrum',
+            }
+          : {},
+        availableMethods.has('energy_scan')
+          ? {
+              text: 'Add Energy Scan',
+              action: () => showModal('energy_scan'),
+              key: 'energy_scan',
+            }
+          : {},
         {
           text: 'Go to Point',
           action: () => {
@@ -198,26 +205,34 @@ export default function ContextMenu(props) {
         { text: 'Delete Point', action: () => removeShape(), key: 8 },
       ],
       TMP: [
-        {
-          text: 'Add Datacollection',
-          action: () => showModal('DataCollection'),
-          key: 'datacollection',
-        },
-        {
-          text: 'Add Characterisation',
-          action: () => showModal('Characterisation'),
-          key: 'characterisation',
-        },
-        {
-          text: 'Add XRF Scan',
-          action: () => showModal('xrf_spectrum'),
-          key: 'xrf_spectrum',
-        },
-        {
-          text: 'Add Energy Scan',
-          action: () => showModal('energy_scan'),
-          key: 'energy_scan',
-        },
+        availableMethods.has('datacollection')
+          ? {
+              text: 'Add Datacollection',
+              action: () => showModal('DataCollection'),
+              key: 'datacollection',
+            }
+          : {},
+        availableMethods.has('characterisation')
+          ? {
+              text: 'Add Characterisation',
+              action: () => showModal('Characterisation'),
+              key: 'characterisation',
+            }
+          : {},
+        availableMethods.has('xrf_spectrum')
+          ? {
+              text: 'Add XRF Scan',
+              action: () => showModal('xrf_spectrum'),
+              key: 'xrf_spectrum',
+            }
+          : {},
+        availableMethods.has('energy_scan')
+          ? {
+              text: 'Add Energy Scan',
+              action: () => showModal('energy_scan'),
+              key: 'energy_scan',
+            }
+          : {},
         { text: 'divider', key: 5 },
         ...genericTasks.point,
         genericTasks.point.length > 0 ? { text: 'divider', key: 6 } : {},
@@ -225,57 +240,67 @@ export default function ContextMenu(props) {
         { text: 'Delete Point', action: () => removeShape(), key: 8 },
       ],
       GROUP: [
-        {
-          text: 'Add Datacollections',
-          action: () => showModal('DataCollection'),
-          key: 'datacollection',
-        },
-        {
-          text: 'Add Characterisations',
-          action: () => showModal('Characterisation'),
-          key: 'characterisation',
-        },
+        availableMethods.has('datacollection')
+          ? {
+              text: 'Add Datacollections',
+              action: () => showModal('DataCollection'),
+              key: 'datacollection',
+            }
+          : {},
+        availableMethods.has('characterisation')
+          ? {
+              text: 'Add Characterisations',
+              action: () => showModal('Characterisation'),
+              key: 'characterisation',
+            }
+          : {},
         ...genericTasks.point,
       ],
       HELICAL: [
-        {
-          text: 'Add Datacollections',
-          action: () => showModal('DataCollection'),
-          key: 'datacollection',
-        },
-        {
-          text: 'Add Characterisations',
-          action: () => showModal('Characterisation'),
-          key: 'characterisation',
-        },
-        {
-          text: 'Add Helical Scan',
-          action: () => createLine('Helical'),
-          key: 'helical',
-        },
+        availableMethods.has('datacollection')
+          ? {
+              text: 'Add Datacollections',
+              action: () => showModal('DataCollection'),
+              key: 'datacollection',
+            }
+          : {},
+        availableMethods.has('characterisation')
+          ? {
+              text: 'Add Characterisations',
+              action: () => showModal('Characterisation'),
+              key: 'characterisation',
+            }
+          : {},
+        availableMethods.has('helical')
+          ? {
+              text: 'Add Helical Scan',
+              action: () => createLine('Helical'),
+              key: 'helical',
+            }
+          : {},
         ...genericTasks.line,
       ],
       LINE: [
-        {
-          text: 'Add Helical Scan',
-          action: () => showModal('Helical'),
-          key: 'helical',
-        },
+        availableMethods.has('helical')
+          ? {
+              text: 'Add Helical Scan',
+              action: () => showModal('Helical'),
+              key: 'helical',
+            }
+          : {},
         ...genericTasks.line,
         genericTasks.line.length > 0 ? { text: 'divider', key: 3 } : {},
         { text: 'Delete Line', action: () => removeShape(), key: 4 },
       ],
       GridGroup: [{ text: 'Save Grid', action: () => saveGrid(), key: 1 }],
       GridGroupSaved: [
-        ...(enableNativeMesh
-          ? [
-              {
-                text: 'Mesh Scan',
-                action: () => showModal('Mesh'),
-                key: 'mesh_scan',
-              },
-            ]
-          : []),
+        enableNativeMesh
+          ? {
+              text: 'Mesh Scan',
+              action: () => showModal('Mesh'),
+              key: 'mesh_scan',
+            }
+          : {},
         {
           text: 'Centring Point on Cell',
           action: () => {
@@ -314,19 +339,23 @@ export default function ContextMenu(props) {
         ...(enable2DPoints
           ? [
               { text: 'divider', key: 4 },
-              {
-                text: 'Data Collection (Limited OSC)',
-                action: () => createPointAndShowModal('DataCollection'),
-                key: 5,
-              },
-              {
-                text: 'Characterisation (1 Image)',
-                action: () =>
-                  createPointAndShowModal('Characterisation', {
-                    num_imags: 1,
-                  }),
-                key: 6,
-              },
+              availableMethods.has('datacollection')
+                ? {
+                    text: 'Data Collection (Limited OSC)',
+                    action: () => createPointAndShowModal('DataCollection'),
+                    key: 5,
+                  }
+                : {},
+              availableMethods.has('characterisation')
+                ? {
+                    text: 'Characterisation (1 Image)',
+                    action: () =>
+                      createPointAndShowModal('Characterisation', {
+                        num_imags: 1,
+                      }),
+                    key: 6,
+                  }
+                : {},
               {
                 text: 'Create 2D Point',
                 action: () => createTwoDPoint(),
@@ -338,22 +367,6 @@ export default function ContextMenu(props) {
         ...genericTasks.none,
       ],
     };
-
-    Object.keys(availableMethods).forEach((key) => {
-      if (!availableMethods[key]) {
-        Object.keys(options).forEach((k) => {
-          options[k] = options[k].filter((e) => {
-            let res = true;
-            if (Object.keys(availableMethods).includes(e.key)) {
-              res = availableMethods[e.key];
-            }
-            return res;
-          });
-        });
-      }
-    });
-
-    return options;
   }
 
   function showModal(modalName, extraParams = {}, _shape = null) {

--- a/ui/src/reducers/beamline.js
+++ b/ui/src/reducers/beamline.js
@@ -143,7 +143,6 @@ export const INITIAL_STATE = {
   lastPlotId: null,
   plotsInfo: {},
   plotsData: {},
-  availableMethods: {},
   energyScanElements: [],
 };
 
@@ -283,7 +282,6 @@ function beamlineReducer(state = INITIAL_STATE, action = {}) {
         //          ...action.data.motorsLimits
         //        },
         beamlineActionsList: [...action.data.beamlineSetup.actionsList],
-        availableMethods: action.data.beamlineSetup.availableMethods,
         energyScanElements: action.data.beamlineSetup.energyScanElements,
       };
     }


### PR DESCRIPTION
Addresses #1485

### Background

The `available_methods` object in `beamline_config.yml` is used to build the `available_tasks` object in the back-end (which ends up being called `defaultParameters` in the front-end). As discussed in #1485, `available_methods` is meant as an opt-in mechanism: a method/task is available if it is defined and set to `true` — e.g. `characterisation: true`.

### Problem

Previously, as explained in #1485, the `ContextMenu` used the `available_methods` config directly to decide which options to hide from the context menu. It was an opt-out algorithm in the sense that if a method/task was not specified at all in the `available_methods` config, then the option would appear in the context menu...

Additionally, there were some unwanted (I think) side effects. For instance, one could hide a workflow option from the context menu by adding `wf-<workflow-name>: false` to `available_methods` as I had suggested in https://github.com/mxcube/mxcubeweb/issues/1485#issuecomment-2456496415.

### Proposed solution

With this PR, the `ContextMenu` now relies solely on the `defaultParameters` state (i.e. `available_tasks`) to decide which options to show — e.g. if this object has a `characterisation` property, then the "Characterisation" options show up in the context menu.

Since this component was the only one relying on the `availableMethods` state directly instead of via `defaultParameters` state, and to avoid re-introducing the issue in the future, I remove this state from the front-end entirely.

---

I'm not closing the issue for now, as there's also the problem that setting some methods/tasks to `false` in `available_methods` does not have the intended effect and may even cause errors.
