### PR TITLE
New layout for generic task forms

### DIFF
--- a/ui/src/components/Tasks/CustomFieldErrorTemplate.jsx
+++ b/ui/src/components/Tasks/CustomFieldErrorTemplate.jsx
@@ -1,0 +1,26 @@
+import { BsExclamationTriangle } from 'react-icons/bs';
+
+import styles from './CustomFieldErrorTemplate.module.css';
+
+/**
+ *
+ * @param {import('@rjsf/utils').FieldErrorProps} props
+ * @returns
+ */
+export default function CustomFieldErrorTemplate(props) {
+  const { errors = [] } = props;
+  if (errors.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={styles.fieldErrorContainer}>
+      {errors.map((error) => (
+        <div key={error} className={styles.errorMessage}>
+          <BsExclamationTriangle className={styles.errorIcon} />
+          {error}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/ui/src/components/Tasks/CustomFieldErrorTemplate.module.css
+++ b/ui/src/components/Tasks/CustomFieldErrorTemplate.module.css
@@ -1,0 +1,19 @@
+.fieldErrorContainer {
+  border-left: 2px solid rgba(var(--bs-danger-rgb), 0.5);
+  padding: 0.25rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: start;
+}
+
+.errorMessage {
+  display: flex;
+  align-items: center;
+  color: var(--bs-danger);
+  font-size: 0.875rem;
+}
+
+.errorIcon {
+  margin-right: 0.25rem;
+  color: var(--bs-danger);
+}

--- a/ui/src/components/Tasks/CustomFieldTemplate.jsx
+++ b/ui/src/components/Tasks/CustomFieldTemplate.jsx
@@ -1,0 +1,75 @@
+import { BsInfoCircleFill } from 'react-icons/bs';
+
+import TooltipTrigger from '../TooltipTrigger';
+import styles from './CustomFieldTemplate.module.css';
+
+/**
+ * @typedef {Object} CustomFieldTemplateProps
+ * @property {string} id
+ * @property {Object} schema - The JSON schema for the field.
+ * @property {string} classNames - CSS classes passed to the field from RJSF.
+ * @property {Object} uiSchema - The UI schema for the field.
+ * @property {string} label - The label for the field.
+ * @property {string} rawDescription - The description for the field (from the UI Schema)
+ * @property {React.ReactNode} children - Contains the field input element.
+ * @property {React.ReactNode} errors - Contains any validation errors. (<ul> tag)
+ * @property {React.ReactNode} help - Contains help text for the field (from UI Schema).
+ * @property {boolean} required - Indicates if the field is required.
+ */
+
+/**
+ * CustomFieldTemplate is a custom field template for React JSON Schema Form (RJSF).
+ * It is used to render fields with a specific layout and styling.
+ * @param {CustomFieldTemplateProps} props
+ * @return {JSX.Element} The rendered custom field template.
+ */
+export default function CustomFieldTemplate(props) {
+  const {
+    id,
+    schema,
+    classNames,
+    uiSchema = {},
+    label,
+    rawDescription,
+    children,
+    errors,
+    help,
+    required,
+  } = props;
+
+  if (schema.type === 'object') {
+    return <div className={classNames}>{children}</div>;
+  }
+
+  const span = Number(uiSchema['ui:options']?.col) || 6;
+  const gridClass = `col-${span}`;
+
+  return (
+    <div className={`${gridClass} ${classNames}`.trim()}>
+      <div className={styles.fieldTitle}>
+        {label && (
+          <label htmlFor={id} className={styles.fieldLabel}>
+            {label}
+            {required && <span className="text-danger">*</span>}
+          </label>
+        )}
+        {rawDescription && (
+          <TooltipTrigger
+            tooltipContent={rawDescription}
+            id={`${id}_tooltip`}
+            inModal
+          >
+            <span>
+              <BsInfoCircleFill />
+            </span>
+          </TooltipTrigger>
+        )}
+      </div>
+      <div className={styles.fieldInput}>
+        {children}
+        <small className={styles.fieldHelp}>{help}</small>
+      </div>
+      <div className={styles.fieldError}>{errors}</div>
+    </div>
+  );
+}

--- a/ui/src/components/Tasks/CustomFieldTemplate.jsx
+++ b/ui/src/components/Tasks/CustomFieldTemplate.jsx
@@ -4,23 +4,9 @@ import TooltipTrigger from '../TooltipTrigger';
 import styles from './CustomFieldTemplate.module.css';
 
 /**
- * @typedef {Object} CustomFieldTemplateProps
- * @property {string} id
- * @property {Object} schema - The JSON schema for the field.
- * @property {string} classNames - CSS classes passed to the field from RJSF.
- * @property {Object} uiSchema - The UI schema for the field.
- * @property {string} label - The label for the field.
- * @property {string} rawDescription - The description for the field (from the UI Schema)
- * @property {React.ReactNode} children - Contains the field input element.
- * @property {React.ReactNode} errors - Contains any validation errors. (<ul> tag)
- * @property {React.ReactNode} help - Contains help text for the field (from UI Schema).
- * @property {boolean} required - Indicates if the field is required.
- */
-
-/**
  * CustomFieldTemplate is a custom field template for React JSON Schema Form (RJSF).
  * It is used to render fields with a specific layout and styling.
- * @param {CustomFieldTemplateProps} props
+ * @param {import('@rjsf/utils').FieldTemplateProps} props
  * @return {JSX.Element} The rendered custom field template.
  */
 export default function CustomFieldTemplate(props) {

--- a/ui/src/components/Tasks/CustomFieldTemplate.module.css
+++ b/ui/src/components/Tasks/CustomFieldTemplate.module.css
@@ -1,13 +1,14 @@
 .fieldTitle {
   display: flex;
-  align-items: start;
-  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
 }
 .fieldTitle .fieldLabel {
   font-weight: bold;
   font-size: 1rem;
   line-height: 1.2;
   margin-bottom: 0;
+  margin-top: 0.5rem;
 }
 
 .fieldInput {

--- a/ui/src/components/Tasks/CustomFieldTemplate.module.css
+++ b/ui/src/components/Tasks/CustomFieldTemplate.module.css
@@ -17,6 +17,10 @@
   row-gap: 0.25rem;
 }
 
+:global(.has-error) .fieldInput input {
+  border-color: var(--bs-danger);
+}
+
 .fieldDescription,
 .fieldHelp {
   font-size: 0.875rem;
@@ -30,4 +34,8 @@
 
 .fieldErrors li {
   line-height: 1.3;
+}
+
+.fieldHelp p {
+  margin-bottom: 0;
 }

--- a/ui/src/components/Tasks/GenericTaskForm.jsx
+++ b/ui/src/components/Tasks/GenericTaskForm.jsx
@@ -10,6 +10,7 @@ import { formValueSelector, reduxForm } from 'redux-form';
 
 import { sendUpdateDependentFields } from '../../api/queue';
 import { DraggableModal } from '../DraggableModal';
+import CustomFieldTemplate from './CustomFieldTemplate';
 import {
   FieldsHeader,
   InputField,
@@ -18,7 +19,6 @@ import {
   StaticField,
   toFixed,
 } from './fields';
-import styles from './GenericTaskForm.module.css';
 import validate from './validate';
 import warn from './warning';
 
@@ -206,49 +206,6 @@ class GenericTaskForm extends React.Component {
     return s;
   }
 
-  customFieldTemplate = ({
-    schema,
-    classNames,
-    uiSchema = {},
-    label,
-    rawDescription,
-    children,
-    errors,
-    help,
-    required,
-    id,
-  }) => {
-    if (schema.type === 'object') {
-      return <div className={classNames}>{children}</div>;
-    }
-
-    // Form fields can be displayed in a grid layout, using bootstrap `col-x` classes.
-    const span = uiSchema['ui:options']?.col || 6;
-    const gridClass = `col-${span}`;
-    return (
-      <div className={`${gridClass} ${classNames}`.trim()}>
-        <div className={styles.fieldTitle}>
-          {label ? (
-            <label htmlFor={id} className={styles.fieldLabel}>
-              {label}
-              {required ? <span className="text-danger">*</span> : null}
-            </label>
-          ) : null}
-          {rawDescription ? (
-            <small className={styles.fieldDescription}>{rawDescription}</small>
-          ) : null}
-        </div>
-
-        <div className={styles.fieldInput}>
-          {children}
-          <small className={styles.fieldHelp}>{help}</small>
-        </div>
-
-        {errors ? <div className={styles.fieldError}>{errors}</div> : null}
-      </div>
-    );
-  };
-
   columnsObjectFieldTemplate({ properties, description }) {
     return (
       <div>
@@ -352,7 +309,7 @@ class GenericTaskForm extends React.Component {
               }}
               templates={{
                 ObjectFieldTemplate: this.columnsObjectFieldTemplate,
-                FieldTemplate: this.customFieldTemplate,
+                FieldTemplate: CustomFieldTemplate,
               }}
             />
           </div>

--- a/ui/src/components/Tasks/GenericTaskForm.jsx
+++ b/ui/src/components/Tasks/GenericTaskForm.jsx
@@ -18,6 +18,7 @@ import {
   StaticField,
   toFixed,
 } from './fields';
+import styles from './GenericTaskForm.module.css';
 import validate from './validate';
 import warn from './warning';
 
@@ -205,48 +206,53 @@ class GenericTaskForm extends React.Component {
     return s;
   }
 
-  customFieldTemplate(props) {
-    const {
-      id,
-      classNames,
-      label,
-      help,
-      required,
-      rawDescription,
-      description,
-      errors,
-      children,
-    } = props;
+  customFieldTemplate = ({
+    schema,
+    classNames,
+    uiSchema = {},
+    label,
+    rawDescription,
+    children,
+    errors,
+    help,
+    required,
+    id,
+  }) => {
+    if (schema.type === 'object') {
+      return <div className={classNames}>{children}</div>;
+    }
+
+    // Form fields can be displayed in a grid layout, using bootstrap `col-x` classes.
+    const span = uiSchema['ui:options']?.col || 6;
+    const gridClass = `col-${span}`;
     return (
-      <div className={classNames}>
-        {id !== 'root' && (
-          <label htmlFor={id}>
-            {label}
-            {required ? '*' : null}
-            {rawDescription ? ` (${rawDescription})` : null}
-          </label>
-        )}
-        {description}
-        {children}
-        {errors}
-        {help}
+      <div className={`${gridClass} ${classNames}`.trim()}>
+        <div className={styles.fieldTitle}>
+          {label ? (
+            <label htmlFor={id} className={styles.fieldLabel}>
+              {label}
+              {required ? <span className="text-danger">*</span> : null}
+            </label>
+          ) : null}
+          {rawDescription ? (
+            <small className={styles.fieldDescription}>{rawDescription}</small>
+          ) : null}
+        </div>
+
+        <div className={styles.fieldInput}>
+          {children}
+          <small className={styles.fieldHelp}>{help}</small>
+        </div>
+
+        {errors ? <div className={styles.fieldError}>{errors}</div> : null}
       </div>
     );
-  }
+  };
 
   columnsObjectFieldTemplate({ properties, description }) {
     return (
       <div>
-        <div className="row">
-          {properties.map((prop) => {
-            const className = 'col-6 json-schema-form-group-div';
-            return (
-              <div key={prop.content.key} className={className}>
-                {prop.content}
-              </div>
-            );
-          })}
-        </div>
+        <div className="row">{properties.map((prop) => prop.content)}</div>
         {description}
       </div>
     );

--- a/ui/src/components/Tasks/GenericTaskForm.jsx
+++ b/ui/src/components/Tasks/GenericTaskForm.jsx
@@ -10,6 +10,7 @@ import { formValueSelector, reduxForm } from 'redux-form';
 
 import { sendUpdateDependentFields } from '../../api/queue';
 import { DraggableModal } from '../DraggableModal';
+import CustomFieldErrorTemplate from './CustomFieldErrorTemplate';
 import CustomFieldTemplate from './CustomFieldTemplate';
 import {
   FieldsHeader,
@@ -302,6 +303,7 @@ class GenericTaskForm extends React.Component {
               validator={validator}
               schema={schema}
               uiSchema={uiSchema}
+              showErrorList={false}
               onChange={({ formData }) => {
                 this.updateFromRemoteValidation(formData);
                 this.saveCurrentJSFormParameters(formData);
@@ -310,6 +312,7 @@ class GenericTaskForm extends React.Component {
               templates={{
                 ObjectFieldTemplate: this.columnsObjectFieldTemplate,
                 FieldTemplate: CustomFieldTemplate,
+                FieldErrorTemplate: CustomFieldErrorTemplate,
               }}
             />
           </div>

--- a/ui/src/components/Tasks/GenericTaskForm.module.css
+++ b/ui/src/components/Tasks/GenericTaskForm.module.css
@@ -1,0 +1,32 @@
+.fieldTitle {
+  display: flex;
+  align-items: start;
+  flex-direction: column;
+}
+.fieldTitle .fieldLabel {
+  font-weight: bold;
+  font-size: 1rem;
+  line-height: 1.2;
+  margin-bottom: 0;
+}
+
+.fieldInput {
+  display: flex;
+  flex-direction: column;
+  row-gap: 0.25rem;
+}
+
+.fieldDescription,
+.fieldHelp {
+  font-size: 0.875rem;
+  line-height: 1.25;
+  color: var(--bs-secondary);
+}
+
+.fieldErrors ul {
+  padding-left: 1rem;
+}
+
+.fieldErrors li {
+  line-height: 1.3;
+}

--- a/ui/src/components/Tasks/style.css
+++ b/ui/src/components/Tasks/style.css
@@ -22,3 +22,7 @@
   display: grid;
   grid-template-rows: auto auto auto;
 }
+
+.tooltip[data-tooltip-in-modal='true'] {
+  z-index: 100001; /* Ensures that it is 'above' Bootstrap's model, which has z-index: 10000 */
+}

--- a/ui/src/components/Tasks/style.css
+++ b/ui/src/components/Tasks/style.css
@@ -20,9 +20,9 @@
 }
 .form-group .field:not(.field-object) {
   display: grid;
-  grid-template-rows: auto auto auto;
+  grid-template-rows: min-content min-content 1fr;
 }
 
-.tooltip[data-tooltip-in-modal='true'] {
+.tooltip[data-tooltip-in-modal] {
   z-index: 100001; /* Ensures that it is 'above' Bootstrap's model, which has z-index: 10000 */
 }

--- a/ui/src/components/Tasks/style.css
+++ b/ui/src/components/Tasks/style.css
@@ -18,33 +18,7 @@
 .json-schema-form-container .rjsf [type='submit'] {
   display: none;
 }
-
-.json-schema-form-group-div .form-group {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 1em;
-}
-
-.json-schema-form-group-div label {
-  font-weight: bolder;
-}
-
-.json-schema-form-group-div input {
-  width: 7em;
-  margin-right: 3em;
-}
-
-.json-schema-form-group-div select {
-  width: 7em;
-  margin-right: 3em;
-}
-
-.json-schema-form-group-div .checkbox > label > span {
-  display: none;
-}
-
-.json-schema-form-group-div .field-description {
-  display: none;
+.form-group .field:not(.field-object) {
+  display: grid;
+  grid-template-rows: auto auto auto;
 }

--- a/ui/src/components/TooltipTrigger.jsx
+++ b/ui/src/components/TooltipTrigger.jsx
@@ -15,7 +15,7 @@ function TooltipTrigger(props) {
       rootClose={rootClose} // ensures whether focus is removed from child (and tooltip closed) when clicking anywhere else
       placement={placement}
       overlay={
-        <Tooltip data-tooltip-in-modal={inModal} id={id}>
+        <Tooltip data-tooltip-in-modal={inModal || undefined} id={id}>
           {tooltipContent}
         </Tooltip>
       }

--- a/ui/src/components/TooltipTrigger.jsx
+++ b/ui/src/components/TooltipTrigger.jsx
@@ -7,13 +7,18 @@ function TooltipTrigger(props) {
     placement = 'bottom',
     tooltipContent,
     children,
+    inModal = false,
   } = props;
 
   return (
     <OverlayTrigger
       rootClose={rootClose} // ensures whether focus is removed from child (and tooltip closed) when clicking anywhere else
       placement={placement}
-      overlay={<Tooltip id={id}>{tooltipContent}</Tooltip>}
+      overlay={
+        <Tooltip data-tooltip-in-modal={inModal} id={id}>
+          {tooltipContent}
+        </Tooltip>
+      }
     >
       {children}
     </OverlayTrigger>


### PR DESCRIPTION
The layout of the form was fixed to be a 2-column grid. Now it's still the default behaviour, but it can be changed. For each field it is possible to specify `uiSchema['ui:options'].col` parameter, to a number between 1 and 12 (or auto), see [bootstrap grid system](https://getbootstrap.com/docs/4.0/layout/grid/)

This way some more sophisticated form layouts can be achieved, like using some full-width custom widgets in future.

Most importantly, it fixes some visual bugs that were present in the past, like errors breaking the UI layout.

The form fields also got changed, from having labels on the left of input fields, to having them on top of the inputs. This makes it clearer when using more than 2 columns.


**Before**
![image](https://github.com/user-attachments/assets/cc2bdfa7-c6e0-4d42-b31f-db4c825e02a5)


**After** 
![image](https://github.com/user-attachments/assets/26c2ef9c-89fc-4110-8898-8fb05ff1e371)
