### PR TITLE
Prevent undefined property error

### DIFF
--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -425,7 +425,7 @@ export default function SampleListViewContainer() {
    * @return {boolean} true if sample with sampleID is in queue otherwise false
    */
   function inQueue(sampleID) {
-    return queue.queue.includes(sampleID) && sampleList[sampleID].checked;
+    return queue.queue.includes(sampleID) && sampleList[sampleID]?.checked;
   }
 
   /**


### PR DESCRIPTION
ISSUE : to reproduce add a manual sample  - > "Create new sample " Button
then click on " get Samples " Button

- new Sample list state does not contain old manual sampleID