### PR TITLE
Adds option to draw a line between 2d points

### DIFF
--- a/ui/src/components/SampleView/ContextMenu.jsx
+++ b/ui/src/components/SampleView/ContextMenu.jsx
@@ -278,6 +278,11 @@ export default function ContextMenu(props) {
               key: 'helical',
             }
           : {},
+        {
+          text: 'Add Line',
+          action: () => createLineOnCanvas(shape.id),
+          key: 'create_line',
+        },
         ...genericTasks.line,
       ],
       LINE: [
@@ -442,6 +447,10 @@ export default function ContextMenu(props) {
         sid,
       ),
     );
+  }
+
+  function createLineOnCanvas(refs) {
+    dispatch(addShape({ t: 'L', refs }));
   }
 
   function savePoint() {

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -409,7 +409,7 @@ export default class SampleImage extends React.Component {
           .filter((shape) => this.props.lines[shape.id] !== undefined)
           .map((shape) => shape.id);
 
-        if (threeDpointList.length === 2) {
+        if (threeDpointList.length === 2 || twoDPointList.length === 2) {
           ctxMenuObj = { type: 'HELICAL', id: this.props.selectedShapes };
         } else if (
           threeDpointList.length === 1 &&

--- a/ui/src/components/Tasks/warning.js
+++ b/ui/src/components/Tasks/warning.js
@@ -58,9 +58,16 @@ function warn(values, props) {
       'Entered Oscillation start angle is different from current omega';
   }
 
+  const shapeID = Array.isArray(props.pointID)
+    ? props.pointID[0]
+    : props.pointID;
+
+  const is2DPoint = shapeID !== -1 && shapeID.includes('2D');
+  // lines property is only present for helical
+  const line = props.lines?.[shapeID];
+  const is2DLine = line && line.refs.some((ref) => ref.includes('2D'));
   if (
-    props.pointID !== -1 &&
-    props.pointID.includes('2D') &&
+    (is2DPoint || is2DLine) &&
     Number.parseFloat(values.osc_range) * Number.parseFloat(values.num_images) >
       5
   ) {


### PR DESCRIPTION
This is a feature used in MAXIV for some of the custom tasks. It adds an object type in context menu for a pair of 2D Points. Existing `HELICAL` object type did not work, as it works for a pair of 3D Point.
I could alternatively change context menu code, so that `HELICAL` object type would be common across 2D and 3D point, I am not sure if such behaviour would be desirable though.