### PR TITLE
Get Sample List + Sync LIMS Behavior - >  Avoid Empty Sample Table by Syncing on Login

### DIFF
--- a/ui/cypress/e2e/app.cy.js
+++ b/ui/cypress/e2e/app.cy.js
@@ -14,7 +14,9 @@ describe('app', () => {
 
     // Samples list
     cy.findByRole('link', { name: 'Samples' }).click();
-    cy.findByRole('button', { name: 'Get Samples' }).should('be.visible');
+    cy.findByRole('button', { name: 'Add Task to Samples' }).should(
+      'be.visible',
+    );
 
     // Equipment
     cy.findByRole('link', { name: 'Equipment' }).click();

--- a/ui/src/actions/login.js
+++ b/ui/src/actions/login.js
@@ -14,6 +14,7 @@ import { fetchSampleChangerInitialState } from '../api/sampleChanger';
 import { fetchImageData, fetchShapes } from '../api/sampleview';
 import { fetchAvailableWorkflows } from '../api/workflow';
 import { applicationFetched, showErrorPanel } from './general';
+import { syncSampleListWithLims } from './sampleGrid';
 
 export function setLoginInfo(loginInfo) {
   return {
@@ -85,7 +86,7 @@ export function signOut() {
 }
 
 export function getInitialState() {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
     const initialStateSlices = await Promise.all([
       fetchUIProperties()
         .then((uiproperties) => ({ uiproperties }))
@@ -154,6 +155,18 @@ export function getInitialState() {
 
     dispatch(setInitialState(Object.assign({}, ...initialStateSlices)));
     dispatch(applicationFetched(true));
+
+    const state = getState();
+    const { sampleList } = state.sampleGrid;
+    const { loginInfo } = state.login;
+    if (Object.keys(sampleList).length === 0) {
+      // If the sample list is empty, synchronize it with LIMS
+      // Use the first LIMS available as default
+      // This is done here to ensure that the sample list is populated
+      // when the application is initialized
+      // and the user is logged in
+      dispatch(syncSampleListWithLims(loginInfo?.limsName[0]?.name));
+    }
   };
 }
 

--- a/ui/src/actions/sampleGrid.js
+++ b/ui/src/actions/sampleGrid.js
@@ -80,6 +80,13 @@ export function getSamplesList() {
   };
 }
 
+export function syncSampleListWithLims(lims) {
+  return async (dispatch) => {
+    await dispatch(syncSamples(lims)); // sync samples with LIMS
+    dispatch(filterAction({ limsSamples: true })); // auto filter samples to show only LIMS samples
+  };
+}
+
 export function syncSamples(lims) {
   return async (dispatch) => {
     dispatch(showWaitDialog('Please wait', 'Synchronizing with LIMS', true));

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -789,12 +789,12 @@ export default function SampleListViewContainer() {
                   className="nowrap-style"
                   variant="outline-secondary"
                   onClick={() => dispatch(showConfirmClearQueueDialog())}
-                  disabled={queue.queueStatus === QUEUE_RUNNING}
+                  disabled={
+                    queue.queueStatus === QUEUE_RUNNING ||
+                    Object.keys(sampleList).length === 0
+                  }
                 >
-                  <i
-                    className="fas fa-minus"
-                    style={{ marginRight: '0.5em' }}
-                  />
+                  <i className="fas fa-trash-alt me-1" />
                   Clear sample list
                 </Button>
               </TooltipTrigger>

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -31,7 +31,7 @@ import {
   selectSamplesAction,
   setViewModeAction,
   showGenericContextMenu,
-  syncSamples,
+  syncSampleListWithLims,
 } from '../actions/sampleGrid';
 import { showTaskForm } from '../actions/taskForm';
 import TooltipTrigger from '../components/TooltipTrigger';
@@ -215,33 +215,22 @@ export default function SampleListViewContainer() {
     }
   }
 
-  async function getSamplesFromSC() {
-    const manualSamples = [];
-    Object.values(sampleList).forEach((sample) => {
-      if (sample.location === 'Manual') {
-        manualSamples.push(sample.sampleID);
-      }
-    });
-    // first need to remove manual sample from queue
-    // because they will be remove from sample List
-    await dispatch(setEnabledSample(manualSamples, false));
-
+  function getSamplesFromSC() {
     dispatch(getSamplesList());
+    sampleGridClearFilter();
   }
 
   /**
    * Synchronises samples with LIMS
-   *
-   * @property {Object} loginData
+   * @param {string} lims - LIMS name to synchronise with
+   * this also automatically filters the sample list to only show samples
+   * that have LIMS data
+   * @see syncSamples
+   * @see filterAction
+   * @see syncSampleListWithLims
    */
-  async function handleSyncSamples(lims) {
-    if (Object.keys(sampleList).length === 0) {
-      await getSamplesFromSC();
-      dispatch(syncSamples(lims));
-    } else {
-      dispatch(syncSamples(lims));
-    }
-    dispatch(filterAction({ limsSamples: true }));
+  function handleSyncSamples(lims) {
+    dispatch(syncSampleListWithLims(lims));
   }
 
   /**

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -800,12 +800,17 @@ export default function SampleListViewContainer() {
               </TooltipTrigger>
               <span style={{ marginLeft: '1.5em' }} />
               <Dropdown>
-                <Dropdown.Toggle
-                  variant="outline-secondary"
-                  id="dropdown-basic"
+                <TooltipTrigger
+                  id="sync-samples-tooltip"
+                  tooltipContent="Change Samples List View Mode"
                 >
-                  <MdGridView size="1em" /> {viewMode.mode}
-                </Dropdown.Toggle>
+                  <Dropdown.Toggle
+                    variant="outline-secondary"
+                    id="dropdown-basic"
+                  >
+                    <MdGridView size="1em" /> {viewMode.mode}
+                  </Dropdown.Toggle>
+                </TooltipTrigger>
                 <Dropdown.Menu>
                   {viewMode.options.map((option) => (
                     <Dropdown.Item

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import {
   Button,
+  ButtonGroup,
   Card,
   Col,
   Container,
@@ -547,43 +548,62 @@ export default function SampleListViewContainer() {
   }
 
   function getSynchronizationDropDownList() {
-    if (loginData.limsName.length === 1) {
-      return (
+    return (
+      <Dropdown as={ButtonGroup}>
         <TooltipTrigger
           id="sync-samples-tooltip"
-          tooltipContent={`Synchronise sample list with ${loginData.limsName[0].name}`}
+          tooltipContent={`Synchronise sample list with ${loginData.limsName[0].name},
+          and apply filter to only show with LIMS samples`}
         >
           <Button
-            className="nowrap-style"
             variant="outline-secondary"
+            className="nowrap-style"
             onClick={() => handleSyncSamples(loginData.limsName[0].name)}
           >
             <i className="fas fa-sync-alt" style={{ marginRight: '0.5em' }} />
-            Get Samples
+            Get Samples & Sync {loginData.limsName[0].name}
           </Button>
         </TooltipTrigger>
-      );
-    }
-    return (
-      <Dropdown>
-        <Dropdown.Toggle variant="outline-secondary" id="dropdown-lims">
-          <i className="fas fa-sync-alt" style={{ marginRight: '0.5em' }} />{' '}
-          Synchronize with
-        </Dropdown.Toggle>
+        <Dropdown.Toggle
+          split
+          variant="outline-secondary"
+          id="dropdown-split-samples"
+          title="Other LIMS Options"
+        />
         <Dropdown.Menu>
-          {loginData.limsName.map((lims) => (
-            <TooltipTrigger
-              key={lims.name}
-              tooltipContent={`Synchronise sample list with ${lims.name}`}
+          <TooltipTrigger tooltipContent="get samples from sample changer">
+            <Dropdown.Item
+              onClick={() => getSamplesFromSC()}
+              variant="outline-secondary"
+              className="nowrap-style"
             >
-              <Dropdown.Item
-                key={lims.name}
-                onClick={() => handleSyncSamples(lims.name)}
-              >
-                {lims.name}
-              </Dropdown.Item>
-            </TooltipTrigger>
-          ))}
+              Get Samples from SC
+            </Dropdown.Item>
+          </TooltipTrigger>
+          {loginData.limsName.length > 1 && <Dropdown.Divider />}
+          {loginData.limsName.map((lims, lindex) => {
+            if (lindex === 0) {
+              // Skip the first LIMS as it is already included in the button above
+              return null;
+            }
+
+            return (
+              <React.Fragment key={lims.name}>
+                <TooltipTrigger
+                  tooltipContent={`Synchronise sample list with ${lims.name}`}
+                >
+                  <Dropdown.Item
+                    variant="outline-secondary"
+                    className="nowrap-style"
+                    onClick={() => handleSyncSamples(lims.name)}
+                  >
+                    Get Samples & Sync {lims.name}
+                  </Dropdown.Item>
+                </TooltipTrigger>
+                {loginData.limsName.length < lindex && <Dropdown.Divider />}
+              </React.Fragment>
+            );
+          })}
         </Dropdown.Menu>
       </Dropdown>
     );


### PR DESCRIPTION
*** EDITED ***
This PR addresses [issue #1658](https://github.com/mxcube/mxcubeweb/issues/1658) and implements the following improvements:

The sample list is automatically fetched when a session is selected / on Login
and the Lims Filter is also automatically apply. 

For a next iteration we could define a default lims in the config .
but for now we use the fist availble "ISPYB" As it was before. 

- User still have the options to Sync with other  LIMS options or just get Sample from SC.

I also add some little side improvement. ( i add them in their own commit )
 -  Added Tooltip to view mode
 - Disable Clear Samples when Sample List is Empty
 - Add "Get Samples & Sync with LIMS" as a split button:
     - Clicking the main button performs the default sync using the first available LIMS (e.g. ISPyB).
     - The dropdown menu allows users to manually choose other sources like:
          - Sample Changer (SC)
          - Other LIMS backends (if available)

[Screencast from 2025-06-17 10-10-08.webm](https://github.com/user-attachments/assets/b6543529-86e7-4a9c-b5d3-b779ec2d5800)



**PS :  The original PR Content, tittle and description has be update after the following suggestion in the conversation Bellow.** 