### PR TITLE
Fix custom tasks duplication issue

### DIFF
--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -1582,7 +1582,9 @@ class Queue(ComponentBase):
             )
 
         full_path, process_path = HWR.beamline.session.get_full_path(
-            os.path.join(params.get("subdir", ""), params.get("experiment_name", "")),
+            os.path.join(
+                params.get("subdir", ""), params.get("experiment_name", "") or ""
+            ),
             task_name,
         )
         acq.path_template.directory = full_path


### PR DESCRIPTION
Parameters of custom tasks differs in below situations:
1. If the task is added by right-click on data collection view the `experiment_name` is equal to empty string.

![image](https://github.com/user-attachments/assets/b5d5d25e-dc0a-4e90-afe7-22bf47d631ae)

2. In case of duplication `experiment_name` is equal to `None`. Next, calling [os.path.join]( https://github.com/mxcube/mxcubeweb/blob/a673fa/mxcubeweb/core/components/queue.py#L1585) with a string as first and `None` as second argument, causes the method to crush.

![image](https://github.com/user-attachments/assets/824cec6f-9cad-4c55-9e78-bcb13010a003)

With this change `""` is passed as a second argument to `os.path.join` in 2nd case.