### PR TITLE
Handling stop/abort actions and movements with adapters

### DIFF
--- a/mxcubeweb/core/adapter/motor_adapter.py
+++ b/mxcubeweb/core/adapter/motor_adapter.py
@@ -11,10 +11,7 @@ from mxcubeweb.core.util.networkutils import RateLimited
 
 resource_handler_config = AdapterResourceHandlerConfigModel(
     url_prefix="/mxcube/api/v0.1/motor_test",
-    commands=[
-        "set_value",
-        "get_value",
-    ],
+    commands=["set_value", "get_value", "stop"],
     attributes=["data"],
 )
 

--- a/mxcubeweb/core/adapter/nstate_adapter.py
+++ b/mxcubeweb/core/adapter/nstate_adapter.py
@@ -16,7 +16,7 @@ from mxcubeweb.core.models.adaptermodels import (
 from mxcubeweb.core.models.configmodels import AdapterResourceHandlerConfigModel
 
 resource_handler_config = AdapterResourceHandlerConfigModel(
-    commands=["get_value", "set_value"], attributes=["data"]
+    commands=["get_value", "set_value", "stop"], attributes=["data"]
 )
 
 
@@ -63,6 +63,12 @@ class NStateAdapter(ActuatorAdapterBase):
 
     def get_value(self) -> StrValueModel:
         return StrValueModel(value=self._ho.get_value().name)
+
+    def stop(self):
+        """
+        Stop the execution.
+        """
+        self._ho.abort()
 
     def msg(self):
         try:

--- a/mxcubeweb/core/components/beamline.py
+++ b/mxcubeweb/core/components/beamline.py
@@ -210,27 +210,6 @@ class Beamline(ComponentBase):
 
         return actions
 
-    def beamline_abort_action(self, name):
-        """
-        Aborts an action in progress.
-
-        :param str name: Owner / Actuator of the process/action to abort
-
-        """
-        beamline_action_names = [
-            cmd.name() for cmd in HWR.beamline.beamline_actions.get_commands()
-        ]
-
-        if name in beamline_action_names:
-            HWR.beamline.beamline_actions.abort_command(name)
-        else:
-            try:
-                ho = HWR.beamline.get_hardware_object(name.lower())
-            except AttributeError:
-                pass
-            else:
-                ho.stop()
-
     def beamline_run_action(self, name, params):
         """
         Starts beamline action with name <name> and passes params as arguments

--- a/mxcubeweb/routes/beamline.py
+++ b/mxcubeweb/routes/beamline.py
@@ -19,26 +19,6 @@ def init_route(app, server, url_prefix):
     def beamline_get_all_attributes():
         return jsonify(app.beamline.beamline_get_all_attributes())
 
-    @bp.route("/<name>/abort", methods=["GET"])
-    @server.require_control
-    @server.restrict
-    def beamline_abort_action(name):
-        """
-        Aborts an action in progress.
-
-        :param str name: Owner / Actuator of the process/action to abort
-
-        Replies with status code 200 on success and 500 on exceptions.
-        """
-        try:
-            app.beamline.beamline_abort_action(name)
-        except Exception:
-            logging.getLogger("MX3.HWR").exception("Could not abort %s", name)
-            return make_response(f"Could not abort {escape(name)}", 500)
-        else:
-            logging.getLogger("user_level_log").error("%s, aborted" % name)
-            return make_response("{}", 200)
-
     @bp.route("/<name>/run", methods=["POST"])
     @server.require_control
     @server.restrict

--- a/test/test_beamline_routes.py
+++ b/test/test_beamline_routes.py
@@ -43,6 +43,7 @@ def test_beamline_get_all_attribute(client):
         "resolution",
         "safety_shutter",
         "transmission",
+        "beamline_actions",
     ]
 
     assert isinstance(data["hardwareObjects"], dict)

--- a/ui/src/actions/beamlineActions.js
+++ b/ui/src/actions/beamlineActions.js
@@ -1,7 +1,5 @@
-import {
-  sendAbortBeamlineAction,
-  sendRunBeamlineAction,
-} from '../api/beamline';
+import { sendRunBeamlineAction } from '../api/beamline';
+import { sendStop } from '../api/hardware-object';
 import { RUNNING } from '../constants';
 
 export function addUserMessage(data) {
@@ -49,8 +47,12 @@ export function startBeamlineAction(cmdName, parameters, showOutput = true) {
   };
 }
 
-export function stopBeamlineAction(cmdName) {
-  return () => sendAbortBeamlineAction(cmdName);
+export function stopBeamlineAction(name) {
+  return async (_, getState) => {
+    const state = getState();
+    const type = state.beamline.hardwareObjects[name].type.toLowerCase();
+    await sendStop(name, type);
+  };
 }
 
 export function newPlot(plotInfo) {

--- a/ui/src/api/hardware-object.js
+++ b/ui/src/api/hardware-object.js
@@ -13,3 +13,7 @@ export function sendSetAttribute(objectId, type, value) {
 export function sendGetAttribute(objectId, type) {
   return endpoint.put({}, `/${type}/${objectId}/get_value`).res();
 }
+
+export function sendStop(objectId, type) {
+  return endpoint.put({}, `/${type}/${objectId}/stop`).res();
+}

--- a/ui/src/components/BeamlineActions/AnnotatedBeamlineActionForm.jsx
+++ b/ui/src/components/BeamlineActions/AnnotatedBeamlineActionForm.jsx
@@ -34,7 +34,7 @@ export default function AnnotatedBeamlineActionForm(props) {
                 className={styles.submitButton}
                 variant="danger"
                 onClick={() => {
-                  dispatch(stopBeamlineAction(actionId));
+                  dispatch(stopBeamlineAction('beamline_actions'));
                 }}
               >
                 Abort

--- a/ui/src/components/BeamlineActions/BeamlineActionControl.jsx
+++ b/ui/src/components/BeamlineActions/BeamlineActionControl.jsx
@@ -54,7 +54,7 @@ export default function BeamlineActionControl(props) {
             onClick={
               objState !== RUNNING
                 ? () => handleStartAction(actionId, {}, showOutput)
-                : () => dispatch(stopBeamlineAction(actionId))
+                : () => dispatch(stopBeamlineAction('beamline_actions'))
             }
           >
             {label}

--- a/ui/src/components/BeamlineActions/BeamlineActionForm.jsx
+++ b/ui/src/components/BeamlineActions/BeamlineActionForm.jsx
@@ -43,7 +43,7 @@ export default function BeamlineActionForm(props) {
           <Button
             variant="danger"
             onClick={() => {
-              dispatch(stopBeamlineAction(actionId));
+              dispatch(stopBeamlineAction('beamline_actions'));
             }}
           >
             Abort


### PR DESCRIPTION
Stopping or aborting a movement/action was previously handled via `beamline.beamline_abort_action`, which delegated the stop action to the right hardware object. This was a big source of confusion as we have the adapter concepts that does the same for most other functions. 

_Right @walesch-yan, (wink wink ;), Yan wont answer because he is on vacation in Japan :ninja: but he might appreciate this PR :)_

Abort/stop is with this PR handle via the `stop` method of the corresponding adapter object.

This PR introduces a `BeamlineActionsAdapter` that will also implement the rest of the functions related to beamline actions in `beamline.py`;  `beamline_get_actions` and `beamline_rut_actions`". This PR only deals with stop the rest is handled in a separate PR.
