### PR TITLE
Adds a way to split custom form fields into groups

### DIFF
--- a/ui/src/components/Tasks/CustomObjectFieldTemplate.jsx
+++ b/ui/src/components/Tasks/CustomObjectFieldTemplate.jsx
@@ -1,0 +1,43 @@
+import groupBy from 'lodash/groupBy';
+
+import { CollapsableRows, FieldsHeader } from './fields';
+/**
+ * @param {import('@rjsf/utils').ObjectFieldTemplateProps} props
+ * @returns {JSX.Element}
+ */
+export default function CustomObjectFieldTemplate({
+  properties,
+  uiSchema = {},
+}) {
+  const groups = groupBy(
+    properties,
+    (field) => uiSchema[field.name]?.['ui:options'].group,
+  );
+
+  const { undefined: ungroupedFields = [], ...groupedFieldsMap } = groups;
+  const groupNames = Object.keys(groupedFieldsMap);
+
+  return (
+    <div>
+      {ungroupedFields.length > 0 && (
+        <>
+          <FieldsHeader title="Acquisition" />
+          <div className="row">
+            {ungroupedFields.map(({ content }) => content)}
+          </div>
+        </>
+      )}
+      {groupNames.map((group) => {
+        const fields = groupedFieldsMap[group];
+        return (
+          <div key={group}>
+            <FieldsHeader title={group} />
+            <CollapsableRows>
+              <div className="row">{fields.map(({ content }) => content)}</div>
+            </CollapsableRows>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/ui/src/components/Tasks/GenericTaskForm.jsx
+++ b/ui/src/components/Tasks/GenericTaskForm.jsx
@@ -12,8 +12,8 @@ import { sendUpdateDependentFields } from '../../api/queue';
 import { DraggableModal } from '../DraggableModal';
 import CustomFieldErrorTemplate from './CustomFieldErrorTemplate';
 import CustomFieldTemplate from './CustomFieldTemplate';
+import CustomObjectFieldTemplate from './CustomObjectFieldTemplate';
 import {
-  FieldsHeader,
   InputField,
   resetLastUsedParameters,
   saveToLastUsedParameters,
@@ -207,15 +207,6 @@ class GenericTaskForm extends React.Component {
     return s;
   }
 
-  columnsObjectFieldTemplate({ properties, description }) {
-    return (
-      <div>
-        <div className="row">{properties.map((prop) => prop.content)}</div>
-        {description}
-      </div>
-    );
-  }
-
   updateFromRemoteValidation(formData) {
     // eslint-disable-next-line promise/prefer-await-to-then, promise/catch-or-return
     sendUpdateDependentFields(this.props.taskData.type, formData).then((_d) => {
@@ -296,7 +287,6 @@ class GenericTaskForm extends React.Component {
             </Row>
           </Form>
 
-          <FieldsHeader title="Acquisition" />
           <div className="json-schema-form-container">
             <JSForm
               liveValidate
@@ -310,7 +300,7 @@ class GenericTaskForm extends React.Component {
                 this.jsformData = formData;
               }}
               templates={{
-                ObjectFieldTemplate: this.columnsObjectFieldTemplate,
+                ObjectFieldTemplate: CustomObjectFieldTemplate,
                 FieldTemplate: CustomFieldTemplate,
                 FieldErrorTemplate: CustomFieldErrorTemplate,
               }}


### PR DESCRIPTION
Based on the `ui:options.group` key in the `uiSchema` form fields will be assigned to groups.

This group-assignment is done via the `uiSchema` key instead of seemingly more obvious way - creating nested objects. In some places MXCuBE expects form to have some top-level parameters; e.g. here https://github.com/mxcube/mxcubeweb/blob/680078bcdd5e780a982585b800f866da17dff291/ui/src/components/Tasks/GenericTaskForm.jsx#L380-L384 and here: https://github.com/mxcube/mxcubeweb/blob/680078bcdd5e780a982585b800f866da17dff291/mxcubeweb/core/components/queue.py#L1020-L1027 It seems the most reasonable, to keep the form parameters flat, at least for now. Otherwise many custom forms using this feature would suffer from the problem state above.
This requires defining the form groups in some other place, like uiSchema.


This is how it looks:


![image](https://github.com/user-attachments/assets/863f33e6-a3fc-45ae-9e5c-c1135a5e10b7)
