### PR TITLE
BeamlineActions entierly handled by BeamlineActionAdapter

### DIFF
--- a/docs/source/dev/front-end.md
+++ b/docs/source/dev/front-end.md
@@ -64,7 +64,7 @@ To debug state management issues, you can either install the [Redux devtools ext
 ### Fetching layer
 
 - For each back-end API called by the front-end, there is a file under `src/api/` named after that API (e.g. `beamline.js`, `login.js` ...)
-- For each endpoint, there is a function in the API's front-end file dedicated to making HTTP requests to that endpoint (e.g. `fetchLoginInfo`, `sendRunBeamlineAction` ...)
+- For each endpoint, there is a function in the API's front-end file dedicated to making HTTP requests to that endpoint (e.g. `fetchLoginInfo`, `fetchBeamInfo` ...)
   - Functions that retrieve resources are named `fetch<Something>`.
   - Functions that perform actions are named `send<DoSomething>`.
 - The [wretch](https://github.com/elbywan/wretch) library is used to make HTTP requests; it is a thin wrapper around the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API>).

--- a/mxcubeweb/core/adapter/beamline_action_adapter.py
+++ b/mxcubeweb/core/adapter/beamline_action_adapter.py
@@ -4,17 +4,54 @@ from typing import ClassVar
 
 from mxcubecore.BaseHardwareObjects import HardwareObject
 from mxcubecore.HardwareObjects.BeamlineActions import BeamlineActions
+from pydantic.v1 import (
+    BaseModel,
+)
 
 from mxcubeweb.core.adapter.adapter_base import AdapterBase
+from mxcubeweb.core.components.queue import (
+    FAILED,
+    READY,
+    RUNNING,
+)
 from mxcubeweb.core.models.adaptermodels import (
+    BeamlineActionInputModel,
     HOActuatorValueChangeModel,
     NStateModel,
 )
 from mxcubeweb.core.models.configmodels import AdapterResourceHandlerConfigModel
 
 resource_handler_config = AdapterResourceHandlerConfigModel(
-    commands=["stop"], attributes=["data"]
+    commands=["stop", "run_action"], attributes=["data", "get_all_actions"]
 )
+
+
+class Argument(BaseModel):
+    name: str
+    type: str
+    items: list[str] | None = None
+
+
+class JSONSchemaArgument(BaseModel):
+    name: str
+    type: str
+    jsonschema: str = ""
+    signature: list[str]
+
+
+class Action(BaseModel):
+    name: str
+    username: str
+    state: int
+    arguments: list[JSONSchemaArgument | Argument]
+    argument_type: str
+    messages: list[str]
+    type: str
+    data: str | dict | None
+
+
+class ActionsList(BaseModel):
+    actions_list: list[Action]
 
 
 class BeamlineActionAdapter(AdapterBase):
@@ -37,29 +74,44 @@ class BeamlineActionAdapter(AdapterBase):
         ho.connect("valueChanged", self._value_change)
         ho.connect("stateChanged", self.state_change)
 
-    def _value_change(self, value):
-        v = value.name if isinstance(value, Enum) else value
-
-        self.value_change(v)
-
-    def commands(self):
-        return [
-            attribute
-            for attribute in dir(self._ho.__class__)
-            if callable(getattr(self._ho.__class__, attribute))
-            and attribute.startswith("_") is False
-        ]
-
-    def msg(self):
-        try:
-            msg = self._ho.get_value().name
-        except Exception:
-            msg = "---"
-            logging.getLogger("MX3.HWR").error(
-                "Failed to get beamline attribute message"
+        for cmd in ho.get_commands() + ho.get_annotated_commands():
+            cmd.connect(
+                "commandBeginWaitReply",
+                self._beamline_action_start,
+            )
+            cmd.connect(
+                "commandReplyArrived",
+                self._beamline_action_done,
+            )
+            cmd.connect(
+                "commandFailed",
+                self._beamline_action_failed,
             )
 
-        return msg
+    def _value_change(self, value):
+        v = value.name if isinstance(value, Enum) else value
+        self.value_change(v)
+
+    def _emit_beamline_action(self, msg):
+        self.app.server.emit("beamline_action", msg, namespace="/hwr")
+
+    def _beamline_action_start(self, name):
+        msg = {"name": name, "state": RUNNING}
+        self._emit_beamline_action(msg)
+        logging.getLogger("user_level_log").info("Command %s started.", name)
+
+    def _beamline_action_done(self, name, result):
+        msg = {"name": name, "state": READY, "data": result}
+        self._emit_beamline_action(msg)
+        logging.getLogger("user_level_log").info("Command %s done.", name)
+
+    def _beamline_action_failed(self, name):
+        msg = {"name": name, "state": FAILED}
+        self._emit_beamline_action(msg)
+        logging.getLogger("user_level_log").error("Action %s failed!", name)
+
+    def msg(self):
+        return ""
 
     def stop(self):
         """
@@ -67,6 +119,114 @@ class BeamlineActionAdapter(AdapterBase):
         """
         for cmd in self._ho.get_commands():
             self._ho.abort_command(cmd.name())
+
+    def _valid_action_input(self, value: dict | list) -> bool:
+        """
+        Validates that the the action input value structure is
+        flat and contains only valid types (str, int, float, bool).
+
+        Args:
+            value The structure to validate.
+        Returns:
+            bool: True if valid, False otherwise.
+        """
+        allowed_types = (str, int, float, bool)
+
+        if isinstance(value, list):
+            return all(isinstance(item, allowed_types) for item in value)
+        if isinstance(value, dict):
+            return all(isinstance(item, allowed_types) for item in value.values())
+        return False
+
+    def run_action(self, value: BeamlineActionInputModel):
+        """
+        Starts beamline action
+        """
+        # Beamline actions are retrieved from a finite list of commands
+        # its either a simple command name or an annotated command
+        # Getting the KeyError means that the command is not annotated
+        try:
+            self._ho.get_annotated_command(value.cmd)
+        except KeyError:
+            annotated_cmd = False
+        else:
+            annotated_cmd = True
+
+        # Annotated commands are validated against their Pydantic model
+        # Simple comamands are validated with _valid_action_input
+        if not annotated_cmd and self._valid_action_input(value.parameters) is False:
+            msg = (
+                f"Action '{value.cmd}' cannot run: parameters must contain"
+                " (str, int, float, bool)"
+                f" but got '{type(value.parameters)}'"
+            )
+            logging.getLogger("MX3.HWR").error(msg)
+            raise ValueError(msg)
+
+        try:
+            self._ho.execute_command(value.cmd, value.parameters)
+        except Exception:
+            msg = f"Action cannot run: command {value.cmd} does not exist"
+            logging.getLogger("MX3.HWR").exception(msg)
+            raise
+
+    def get_all_actions(self) -> ActionsList:
+        actions: list[Action] = []
+
+        try:
+            cmds = self._ho.get_commands()
+        except Exception:
+            cmds = []
+
+        for cmd in cmds:
+            args: list[Argument] = []
+            for arg in cmd.get_arguments():
+                argname = arg[0]
+                argtype = arg[1]
+
+                argument_data = {"name": argname, "type": argtype}
+                if argtype == "combo":
+                    argument_data["items"] = cmd.get_combo_argument_items(argname)
+                args.append(Argument(**argument_data))
+
+            action = Action(
+                name=cmd.name(),
+                username=cmd.name(),
+                state=READY,
+                arguments=args,
+                argument_type=cmd.argument_type,
+                messages=[],
+                type=cmd.type,
+                data=cmd.value(),
+            )
+            actions.append(action)
+
+        if getattr(self._ho, "pydantic_model", None):
+            for cmd_name in self._ho.exported_attributes:
+                cmd_object = self._ho.get_annotated_command(cmd_name)
+                exported = self._ho.exported_attributes[cmd_name]
+
+                json_arg = JSONSchemaArgument(
+                    name=cmd_name,
+                    type="JSONSchema",
+                    jsonschema=exported["schema"],
+                    signature=exported["signature"],
+                )
+
+                action = Action(
+                    name=cmd_name,
+                    username=cmd_object.name(),
+                    state=READY,
+                    arguments=[json_arg],
+                    argument_type="JSONSchema",
+                    jsonschema=exported["schema"],
+                    messages=[],
+                    type="JSONSchema",
+                    data="",
+                )
+                actions.append(action)
+
+        return ActionsList(actions_list=actions)
 
     def data(self) -> NStateModel:
         return NStateModel(**self._dict_repr())

--- a/mxcubeweb/core/adapter/energy_adapter.py
+++ b/mxcubeweb/core/adapter/energy_adapter.py
@@ -8,7 +8,7 @@ from mxcubeweb.core.adapter.wavelength_adapter import WavelengthAdapter
 from mxcubeweb.core.models.configmodels import AdapterResourceHandlerConfigModel
 
 resource_handler_config = AdapterResourceHandlerConfigModel(
-    commands=["get_value", "set_value"], attributes=["data"]
+    commands=["get_value", "set_value", "stop"], attributes=["data"]
 )
 
 

--- a/mxcubeweb/core/adapter/motor_adapter.py
+++ b/mxcubeweb/core/adapter/motor_adapter.py
@@ -32,7 +32,7 @@ class MotorAdapter(ActuatorAdapterBase):
     def _value_change(self, *args, **kwargs):
         self.value_change(*args, **kwargs)
 
-    def set_value(self, value: FloatValueModel):
+    def set_value(self, value: float):
         """
         Set the detector distance.
         Args:
@@ -44,7 +44,7 @@ class MotorAdapter(ActuatorAdapterBase):
             RuntimeError: Timeout while setting the value.
             StopItteration: When a value change was interrupted (abort/cancel).
         """
-        self._ho.set_value(float(value.value))
+        self._ho.set_value(float(value))
         return self.get_value()
 
     def get_value(self) -> FloatValueModel:

--- a/mxcubeweb/core/models/adaptermodels.py
+++ b/mxcubeweb/core/models/adaptermodels.py
@@ -75,3 +75,8 @@ class FloatValueModel(BaseModel):
 
 class StrValueModel(BaseModel):
     value: str = Field("", description="Value of actuator (position)")
+
+
+class BeamlineActionInputModel(BaseModel):
+    cmd: str
+    parameters: dict | list

--- a/mxcubeweb/routes/beamline.py
+++ b/mxcubeweb/routes/beamline.py
@@ -4,10 +4,7 @@ from flask import (
     Blueprint,
     Response,
     jsonify,
-    make_response,
-    request,
 )
-from markupsafe import escape
 from mxcubecore import HardwareRepository as HWR
 
 
@@ -18,31 +15,6 @@ def init_route(app, server, url_prefix):
     @server.restrict
     def beamline_get_all_attributes():
         return jsonify(app.beamline.beamline_get_all_attributes())
-
-    @bp.route("/<name>/run", methods=["POST"])
-    @server.require_control
-    @server.restrict
-    def beamline_run_action(name):
-        """
-        Starts a beamline action; POST payload is a json-encoded object with
-        'parameters' as a list of parameters
-
-        :param str name: action to run
-
-        Replies with status code 200 on success and 500 on exceptions.
-        """
-        try:
-            params = request.get_json()["parameters"]
-        except Exception:
-            params = []
-
-        try:
-            app.beamline.beamline_run_action(name, params)
-        except Exception:
-            logging.getLogger("MX3.HWR").exception("Cannot run action %s", name)
-            return make_response(f"Cannot run action {escape(name)}", 500)
-        else:
-            return make_response("{}", 200)
 
     @bp.route("/beam/info", methods=["GET"])
     @server.restrict

--- a/mxcubeweb/routes/signals.py
+++ b/mxcubeweb/routes/signals.py
@@ -13,7 +13,6 @@ from mxcubeweb.app import MXCUBEApplication as mxcube
 from mxcubeweb.core.components.queue import (
     COLLECTED,
     FAILED,
-    READY,
     RUNNING,
     WARNING,
 )
@@ -623,40 +622,6 @@ def beam_changed(*args, **kwargs):
         logging.getLogger("HWR").exception(
             "error sending beam_changed signal: %s" % beam_info_dict
         )
-
-
-def beamline_action_start(name):
-    msg = {"name": name, "state": RUNNING}
-
-    try:
-        server.emit("beamline_action", msg, namespace="/hwr")
-    except Exception:
-        logging.getLogger("HWR").exception(
-            "error sending beamline action message: %s", msg
-        )
-
-
-def beamline_action_done(name, result):
-    try:
-        logging.getLogger("user_level_log").info("Command %s done.", name)
-        msg = {"name": name, "state": READY, "data": result}
-        server.emit("beamline_action", msg, namespace="/hwr")
-    except Exception:
-        logging.getLogger("HWR").exception(
-            "error sending beamline action message: %s", msg
-        )
-
-
-def beamline_action_failed(name):
-    msg = {"name": name, "state": FAILED}
-    try:
-        server.emit("beamline_action", msg, namespace="/hwr")
-    except Exception:
-        logging.getLogger("HWR").exception(
-            "error sending beamline action message: %s", msg
-        )
-    else:
-        logging.getLogger("user_level_log").error("Action %s failed !", name)
 
 
 def new_plot(plot_info):

--- a/ui/src/actions/beamline.js
+++ b/ui/src/actions/beamline.js
@@ -1,5 +1,5 @@
 import { sendPrepareBeamlineForNewSample } from '../api/beamline';
-import { sendExecuteCommand, sendSetAttribute } from '../api/hardware-object';
+import { sendExecuteCommand, sendSetValue } from '../api/hardware-object';
 import { sendLogFrontEndTraceBack } from '../api/log';
 
 // Action types
@@ -40,7 +40,7 @@ export function setAttribute(name, value) {
   return async (_, getState) => {
     const state = getState();
     const type = state.beamline.hardwareObjects[name].type.toLowerCase();
-    await sendSetAttribute(name, type, value);
+    await sendSetValue(name, type, value);
   };
 }
 

--- a/ui/src/actions/beamlineActions.js
+++ b/ui/src/actions/beamlineActions.js
@@ -1,5 +1,8 @@
-import { sendRunBeamlineAction } from '../api/beamline';
-import { sendStop } from '../api/hardware-object';
+import {
+  sendExecuteCommand,
+  sendGetAttribute,
+  sendStop,
+} from '../api/hardware-object';
 import { RUNNING } from '../constants';
 
 export function addUserMessage(data) {
@@ -43,8 +46,19 @@ export function startBeamlineAction(cmdName, parameters, showOutput = true) {
       dispatch(showActionOutput(cmdName));
     }
 
-    sendRunBeamlineAction(cmdName, parameters);
+    sendExecuteCommand('beamlineaction', 'beamline_actions', 'run_action', {
+      cmd: cmdName,
+      parameters,
+    });
   };
+}
+
+export function fetchGetAllActions() {
+  return sendGetAttribute(
+    'beamlineaction',
+    'beamline_actions',
+    'get_all_actions',
+  );
 }
 
 export function stopBeamlineAction(name) {

--- a/ui/src/actions/login.js
+++ b/ui/src/actions/login.js
@@ -13,6 +13,7 @@ import { fetchRemoteAccessState } from '../api/remoteAccess';
 import { fetchSampleChangerInitialState } from '../api/sampleChanger';
 import { fetchImageData, fetchShapes } from '../api/sampleview';
 import { fetchAvailableWorkflows } from '../api/workflow';
+import { fetchGetAllActions } from './beamlineActions';
 import { applicationFetched, showErrorPanel } from './general';
 
 export function setLoginInfo(loginInfo) {
@@ -101,6 +102,9 @@ export function getInitialState() {
           beamlineSetup,
           datapath: beamlineSetup.path,
         }))
+        .catch(notify),
+      fetchGetAllActions()
+        .then((actionsList) => actionsList)
         .catch(notify),
       fetchImageData()
         .then((Camera) => ({ Camera }))

--- a/ui/src/api/beamline.js
+++ b/ui/src/api/beamline.js
@@ -13,11 +13,3 @@ export function fetchBeamInfo() {
 export function sendPrepareBeamlineForNewSample() {
   return endpoint.put(undefined, '/prepare_beamline').res();
 }
-
-export function sendRunBeamlineAction(name, parameters) {
-  return endpoint.post({ parameters }, `/${name}/run`).res();
-}
-
-export function sendAbortBeamlineAction(name) {
-  return endpoint.get(`/${name}/abort`).res();
-}

--- a/ui/src/api/hardware-object.js
+++ b/ui/src/api/hardware-object.js
@@ -2,18 +2,24 @@ import api from './api';
 
 const endpoint = api.url('/hwobj');
 
-export function sendExecuteCommand(objectType, objectId, command, args) {
-  return endpoint.put({ args }, `/${objectType}/${objectId}/${command}`).res();
+export function sendExecuteCommand(objectType, objectId, command, value) {
+  return endpoint
+    .put({ value }, `/${objectType}/${objectId}/${command}`)
+    .safeJson();
 }
 
-export function sendSetAttribute(objectId, type, value) {
-  return endpoint.put({ value }, `/${type}/${objectId}/set_value`).res();
+export function sendGetAttribute(objectType, objectId, attributeName) {
+  return endpoint.get(`/${objectType}/${objectId}/${attributeName}`).safeJson();
 }
 
-export function sendGetAttribute(objectId, type) {
-  return endpoint.put({}, `/${type}/${objectId}/get_value`).res();
+export function sendSetValue(objectId, objectType, value) {
+  return sendExecuteCommand(objectType, objectId, 'set_value', value);
 }
 
-export function sendStop(objectId, type) {
-  return endpoint.put({}, `/${type}/${objectId}/stop`).res();
+export function sendGetValue(objectId, objectType) {
+  return sendExecuteCommand(objectType, objectId, 'get_value', {});
+}
+
+export function sendStop(objectId, objectType) {
+  return sendExecuteCommand(objectType, objectId, 'stop', {});
 }

--- a/ui/src/components/BeamlineActions/AnnotatedBeamlineActionForm.jsx
+++ b/ui/src/components/BeamlineActions/AnnotatedBeamlineActionForm.jsx
@@ -24,7 +24,7 @@ export default function AnnotatedBeamlineActionForm(props) {
           <JSForm
             liveValidate
             validator={validator}
-            schema={JSON.parse(currentAction.schema)}
+            schema={JSON.parse(currentAction.arguments[0].jsonschema)}
             onSubmit={({ formData }) => {
               handleStartAction(actionId, formData);
             }}

--- a/ui/src/components/Tasks/asyncValidate.js
+++ b/ui/src/components/Tasks/asyncValidate.js
@@ -1,7 +1,7 @@
-import { sendGetAttribute } from '../../api/hardware-object';
+import { sendExecuteCommand } from '../../api/hardware-object';
 
 async function get_resolution_limits_for_energy(energy) {
-  const result = await sendGetAttribute(
+  const result = await sendExecuteCommand(
     'energy',
     'energy',
     'get_resolution_limits_for_energy',

--- a/ui/src/reducers/beamline.js
+++ b/ui/src/reducers/beamline.js
@@ -272,16 +272,11 @@ function beamlineReducer(state = INITIAL_STATE, action = {}) {
     case 'SET_INITIAL_STATE': {
       return {
         ...INITIAL_STATE,
-        //        motors: { ...INITIAL_STATE.motors, ...action.data.Motors },
         hardwareObjects: {
           ...INITIAL_STATE.actuators,
           ...action.data.beamlineSetup.hardwareObjects,
         },
-        //        motorsLimits: {
-        //          ...INITIAL_STATE.motorsLimits,
-        //          ...action.data.motorsLimits
-        //        },
-        beamlineActionsList: [...action.data.beamlineSetup.actionsList],
+        beamlineActionsList: [...action.data.actions_list],
         energyScanElements: action.data.beamlineSetup.energyScanElements,
       };
     }


### PR DESCRIPTION
Continuing the cleanup of the BeamlineActions, all aspects of BeamlineActions are now handled with `BeamlineActionAdapter`. The corresponding logic have been moved/removed from the beamline "component" (which we eventually can remove)

 - The execute/run action is now handled by the `BeamlineActionAdapter` just like `stop`.
 - The retrieval of all beamline actions are done via  `BeamlineActionAdapter`
