### PR TITLE
Remove GET from /clear endpoint

### DIFF
--- a/mxcubeweb/routes/queue.py
+++ b/mxcubeweb/routes/queue.py
@@ -89,7 +89,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
         server.emit("queue", msg, namespace="/hwr")
         return Response(status=200)
 
-    @bp.route("/clear", methods=["PUT", "GET"])
+    @bp.route("/clear", methods=["PUT"])
     @server.require_control
     @server.restrict
     def queue_clear():


### PR DESCRIPTION
Removing GET method from /clear endpoint since it performs a destructive operation (clearing the queue). Only PUT should be used for state-modifying operations..
the methods use were PUT and GET and it's unsafe to allow both of them in the same time. 
