### PR TITLE
Add permissions to workflow

### DIFF
--- a/.github/workflows/bump_version_and_tag.yaml
+++ b/.github/workflows/bump_version_and_tag.yaml
@@ -8,6 +8,11 @@ name: Create/Update Tag
     branches:
       - develop
 
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
 jobs:
   create-version-tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -8,6 +8,10 @@ concurrency:
   pull_request: null
   push: null
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   "pages-build":
     runs-on: "ubuntu-22.04"

--- a/.github/workflows/ui.yaml
+++ b/.github/workflows/ui.yaml
@@ -10,6 +10,11 @@ name: UI
   pull_request: null
   push: null
 
+permissions:
+  contents: read    # Required for checkout
+  actions: read     # for cache
+  packages: read    # for package access
+
 jobs:
   format:
     name: JS-Format
@@ -83,6 +88,9 @@ jobs:
   e2e:
     name: E2E-Test
     runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write       # for artifact upload
 
     # Skip `pull_request` runs on local PRs for which `push` runs are already triggered
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository


### PR DESCRIPTION
Adding security permissions to our workflow file. This makes sure each job has exactly what it needs

https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions

I think all the necessary permissions are given but if you think I missed one, tell me.