### PR TITLE
fix Dependabot failed to update your dependencies poetry version

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -47,6 +47,14 @@ jobs:
         with:
           version: "2.1.3"
 
+      - name: "Cache Poetry dependencies"
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pypoetry
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-
+
       - name: "Install dependencies with Poetry"
         run: "${MAMBA_EXE} run --name mxcubeweb poetry install --only=docs,main"
 

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -42,6 +42,11 @@ jobs:
           environment-file: "conda-environment.yml"
           micromamba-version: 1.5.10-0
 
+      - name: "Install Poetry"
+        uses: "snok/install-poetry@v1"
+        with:
+          version: "2.1.3"
+
       - name: "Install dependencies with Poetry"
         run: "${MAMBA_EXE} run --name mxcubeweb poetry install --only=docs,main"
 


### PR DESCRIPTION
There are two vulnerability alerts in Dependabot with the following error:

**Dependabot encountered an unknown error:
Dependabot failed to update your dependencies because an unexpected error occurred. See the logs for more details.**

https://github.com/mxcube/mxcubeweb/security/dependabot/151

https://github.com/mxcube/mxcubeweb/security/dependabot/152

The issue was caused by a mismatch between the Poetry version installed in the environment (2.1.1) and the version specified in the workflow (2.1.3).
To resolve this, I added the Poetry version explicitly in pages.yaml to ensure consistency across environments and allow Dependabot to proceed with the updates.