### PR TITLE
SelectProposal: Add a way to show/hide tabs

### DIFF
--- a/demo/mxcube-web/ui.yaml
+++ b/demo/mxcube-web/ui.yaml
@@ -159,3 +159,11 @@ camera_setup:
       url: http://localhost:9090/mjpg/video.mjpg?streamprofile=mxcube
       width: 800
       height: 450
+
+session_picker:
+  id: session_picker
+  tabs:
+    active: true
+    scheduled: true
+    other_beamlines: true
+    all_sessions: false

--- a/docs/source/config/ui.rst
+++ b/docs/source/config/ui.rst
@@ -9,6 +9,7 @@ The ``ui.yaml`` contains following sections:
 * sample_view_video_controls_
 * beamline_setup_
 * camera_setup_
+* session_picker_
 
 Each section groups settings for related UI features.
 See below an `example  ui.yaml <ui_yaml_example_>`_ file.
@@ -273,3 +274,25 @@ Below is an example of a UI configuration file ``ui.yaml``, as used by the mocku
 
 .. literalinclude:: ../../../demo/mxcube-web/ui.yaml
    :language: yaml
+
+.. _session_picker:
+
+Configures the "Select session" dialog.
+It controls which of the tabs are shown in the dialog.
+Possible tabs are:
+* "Active"
+* "Scheduled"
+* "Other beamlines"
+* "All"
+
+By default all tabs, except the last one, are shown.
+The section has the following syntax:
+.. code-block:: yaml
+
+    session_picker:
+      id: session_picker
+      tabs:
+        active: <show>
+        scheduled: <show>
+        other_beamlines: <show>
+        all_sessions: <show>

--- a/mxcubeweb/app.py
+++ b/mxcubeweb/app.py
@@ -305,7 +305,7 @@ class MXCUBEApplication:
         # (either via config or via mxcubecore.beamline)
 
         for _id, section in MXCUBEApplication.CONFIG.app.ui_properties:
-            if section:
+            if section and hasattr(section, "components"):
                 for component in section.components:
                     # Check that the component, if it's a UIComponentModel, corresponds
                     # to a HardwareObjects that is available and that it can be

--- a/mxcubeweb/core/models/configmodels.py
+++ b/mxcubeweb/core/models/configmodels.py
@@ -108,11 +108,24 @@ class UISampleViewVideoControlsModel(UIPropertiesModel):
     ]
 
 
+class UiSessionPickerTabs(BaseModel):
+    active: bool = True
+    scheduled: bool = True
+    other_beamlines: bool = True
+    all_sessions: bool = False
+
+
+class UISessionPickerModel(BaseModel):
+    id: Literal["session_picker"] = "session_picker"
+    tabs: UiSessionPickerTabs = UiSessionPickerTabs()
+
+
 class UIPropertiesListModel(BaseModel):
     sample_view: UIPropertiesModel
     beamline_setup: UIPropertiesModel
     camera_setup: UICameraConfigModel | None
     sample_view_video_controls: UISampleViewVideoControlsModel | None
+    session_picker: UISessionPickerModel = UISessionPickerModel()
 
 
 class UserManagerUserConfigModel(BaseModel):

--- a/ui/src/components/LoginForm/SelectProposal.jsx
+++ b/ui/src/components/LoginForm/SelectProposal.jsx
@@ -11,6 +11,12 @@ import ActionButton from './ActionButton';
 import SessionTable from './SessionTable';
 import styles from './SessionTable.module.css';
 
+/**
+ * @typedef {"active"|"scheduled"|"other_beamlines"|"all_sessions"} TabId
+ */
+
+const TAB_PRIORITY = ['scheduled', 'active', 'all_sessions', 'other_beamlines'];
+
 function SelectProposal() {
   const dispatch = useDispatch();
 
@@ -27,6 +33,17 @@ function SelectProposal() {
   const selectedSessionId = selectedSession ? selectedSession.session_id : null;
 
   const [filter, setFilter] = useState('');
+
+  /**
+   * @type {Record<TabId, boolean>}
+   */
+  const showTab = useSelector(
+    (state) => state.uiproperties.session_picker.tabs,
+  );
+
+  const defaultActiveTab =
+    TAB_PRIORITY.find((tabId) => showTab[tabId]) ?? TAB_PRIORITY[0];
+
   const filteredSessions = proposalList.filter(
     ({ title, number, code }) =>
       title.includes(filter) ||
@@ -78,42 +95,65 @@ function SelectProposal() {
           onChange={(evt) => setFilter(evt.target.value)}
         />
 
-        <Tabs id="scheduled-tab" defaultActiveKey="scheduled">
-          <Tab eventKey="active" title={`Active (${scheduledSessions.length})`}>
-            <div className={styles.table}>
-              <SessionTable
-                sessions={scheduledSessions}
-                selectedSessionId={selectedSessionId}
-                onSessionSelected={setSelectedSession}
-              />
-            </div>
-          </Tab>
-          <Tab
-            eventKey="scheduled"
-            title={`Scheduled (${unscheduledSessions.length})`}
-          >
-            <div className={styles.table}>
-              <SessionTable
-                showBeamline
-                sessions={unscheduledSessions}
-                selectedSessionId={selectedSessionId}
-                onSessionSelected={setSelectedSession}
-              />
-            </div>
-          </Tab>
-          <Tab
-            eventKey="other-unscheduled"
-            title={`Other beamlines (${otherBeamlineSessions.length})`}
-          >
-            <div className={styles.table}>
-              <SessionTable
-                showBeamline
-                sessions={otherBeamlineSessions}
-                selectedSessionId={selectedSessionId}
-                onSessionSelected={setSelectedSession}
-              />
-            </div>
-          </Tab>
+        <Tabs id="scheduled-tab" defaultActiveKey={defaultActiveTab}>
+          {showTab.active && (
+            <Tab
+              eventKey="active"
+              title={`Active (${scheduledSessions.length})`}
+            >
+              <div className={styles.table}>
+                <SessionTable
+                  sessions={scheduledSessions}
+                  selectedSessionId={selectedSessionId}
+                  onSessionSelected={setSelectedSession}
+                />
+              </div>
+            </Tab>
+          )}
+          {showTab.scheduled && (
+            <Tab
+              eventKey="scheduled"
+              title={`Scheduled (${unscheduledSessions.length})`}
+            >
+              <div className={styles.table}>
+                <SessionTable
+                  showBeamline
+                  sessions={unscheduledSessions}
+                  selectedSessionId={selectedSessionId}
+                  onSessionSelected={setSelectedSession}
+                />
+              </div>
+            </Tab>
+          )}
+          {showTab.other_beamlines && (
+            <Tab
+              eventKey="other_beamlines"
+              title={`Other beamlines (${otherBeamlineSessions.length})`}
+            >
+              <div className={styles.table}>
+                <SessionTable
+                  showBeamline
+                  sessions={otherBeamlineSessions}
+                  selectedSessionId={selectedSessionId}
+                  onSessionSelected={setSelectedSession}
+                />
+              </div>
+            </Tab>
+          )}
+          {showTab.all_sessions && (
+            <Tab
+              eventKey="all_sessions"
+              title={`All sessions (${proposalList.length})`}
+            >
+              <div className={styles.table}>
+                <SessionTable
+                  sessions={filteredSessions}
+                  selectedSessionId={selectedSessionId}
+                  onSessionSelected={setSelectedSession}
+                />
+              </div>
+            </Tab>
+          )}
         </Tabs>
       </Modal.Body>
       <Modal.Footer>


### PR DESCRIPTION
At MAX IV we don't distinguish between different types of sessions (scheduled, unscheduled, other beamline session).
Our sessions are created "on the fly" and are not tied to a particular beam time, thus it's not necessary to split them.

This commit makes it possible to opt-out of displaying some of the tabs via `ui.yaml` config file.