### PR TITLE
Make phase control optional

### DIFF
--- a/demo/beamline_config.yml
+++ b/demo/beamline_config.yml
@@ -82,6 +82,7 @@ configuration:
   mesh_result_format: PNG
   use_native_mesh: true
   enable_2d_points: true
+  enable_phase_control: true
 
   default_acquisition_parameters:
     default:

--- a/mxcubeweb/core/models/generic.py
+++ b/mxcubeweb/core/models/generic.py
@@ -25,12 +25,18 @@ class AppSettingsModel(BaseModel):
             "be dis-activated to not clash with i.e workflow mesh,"
         ),
     )
-
     enable_2d_points: bool = Field(
         True,
         description=(
             " Enable features to work with points in the plane, called2D-points,"
             " (none centred positions)"
+        ),
+    )
+    enable_phase_control: bool = Field(
+        True,
+        description=(
+            "Allow to hide or show the PhaseControl object in the frontend,"
+            " True by default"
         ),
     )
 

--- a/mxcubeweb/routes/main.py
+++ b/mxcubeweb/routes/main.py
@@ -50,6 +50,7 @@ def init_route(app, server, url_prefix):
                 "mesh_result_format": _blc.mesh_result_format,
                 "use_native_mesh": _blc.use_native_mesh,
                 "enable_2d_points": _blc.enable_2d_points,
+                "enable_phase_control": _blc.enable_phase_control,
             }
         )
 

--- a/ui/src/containers/SampleViewContainer.jsx
+++ b/ui/src/containers/SampleViewContainer.jsx
@@ -117,7 +117,10 @@ class SampleViewContainer extends Component {
             <DefaultErrorBoundary>
               {this.props.enablePhaseControl && (
                 <div className={motorInputStyles.container}>
-                  <label className={motorInputStyles.label} htmlFor="PhaseInput">
+                  <label
+                    className={motorInputStyles.label}
+                    htmlFor="PhaseInput"
+                  >
                     Phase Control
                   </label>
                   <PhaseInput />

--- a/ui/src/containers/SampleViewContainer.jsx
+++ b/ui/src/containers/SampleViewContainer.jsx
@@ -115,13 +115,14 @@ class SampleViewContainer extends Component {
         <Row className="gx-3 mt-2 pt-1">
           <Col sm={2} xxl={1} className={styles.controllers}>
             <DefaultErrorBoundary>
-              <div className={motorInputStyles.container}>
-                <label className={motorInputStyles.label} htmlFor="PhaseInput">
-                  Phase Control
-                </label>
-                <PhaseInput />
-              </div>
-
+              {this.props.enablePhaseControl && (
+                <div className={motorInputStyles.container}>
+                  <label className={motorInputStyles.label} htmlFor="PhaseInput">
+                    Phase Control
+                  </label>
+                  <PhaseInput />
+                </div>
+              )}
               <div className={motorInputStyles.container}>
                 <label
                   className={motorInputStyles.label}
@@ -236,6 +237,7 @@ function mapStateToProps(state) {
     uiproperties: state.uiproperties,
     mode: state.general.mode,
     meshResultFormat: state.general.meshResultFormat,
+    enablePhaseControl: state.general.enablePhaseControl,
     sampleChangerContents: state.sampleChanger.contents,
     sampleChangerState: state.sampleChanger.state,
     global_state: state.sampleChangerMaintenance.global_state,

--- a/ui/src/reducers/general.js
+++ b/ui/src/reducers/general.js
@@ -44,6 +44,7 @@ function generalReducer(state = INITIAL_STATE, action = {}) {
         enable2DPoints: action.data.general.enable_2d_points,
         meshResultFormat: action.data.general.mesh_result_format,
         useNativeMesh: action.data.general.use_native_mesh,
+        enablePhaseControl: action.data.general.enable_phase_control,
       };
     }
     case 'APPLICATION_FETCHED': {


### PR DESCRIPTION
These changes make the "Phase control" optional, that is, you can remove the "Phase control" section from the frontend. This was requested by the beamline scientists (they don't use the button so they prefer not to display it at all).
<p align="center">
  <img src="https://github.com/user-attachments/assets/5e0aa2b2-0e32-4fc6-ba60-0357c78892b0" width="300"/>
  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
  <img src="https://github.com/user-attachments/assets/6914271d-131e-4a47-947f-7cfb85735560" width="300"/>
</p>

## HowTo
In order to disable the "Phase control" you have to edit the `beamline_config.yml` like this:
```diff
configuration:
  # Non-object attributes:
  advanced_methods:
    ...
  ...
  use_native_mesh: true
  enable_2d_points: true
+ enable_phase_control: false
 . ..
  ```

The `demo/beamline_config.yml` has been changed as well to provide a concrete example


> ⚠️ Make sure to merge the corresponding branch (see this PR https://github.com/mxcube/mxcubecore/pull/1291) in `mxcubecore` first. 

