### PR TITLE
Sample List  [ Part 1 ]

### DIFF
--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -26,7 +26,6 @@ import {
 import { showConfirmCollectDialog } from '../actions/queueGUI';
 import {
   filterAction,
-  getSamplesList,
   selectSamplesAction,
   setViewModeAction,
   showGenericContextMenu,
@@ -214,32 +213,12 @@ export default function SampleListViewContainer() {
     }
   }
 
-  async function getSamplesFromSC() {
-    const manualSamples = [];
-    Object.values(sampleList).forEach((sample) => {
-      if (sample.location === 'Manual') {
-        manualSamples.push(sample.sampleID);
-      }
-    });
-    // first need to remove manual sample from queue
-    // because they will be remove from sample List
-    await dispatch(setEnabledSample(manualSamples, false));
-
-    dispatch(getSamplesList());
-  }
-
   /**
    * Synchronises samples with LIMS
-   *
-   * @property {Object} loginData
+   * @param {string} lims - LIMS name to synchronise with
    */
-  async function handleSyncSamples(lims) {
-    if (Object.keys(sampleList).length === 0) {
-      await getSamplesFromSC();
-      dispatch(syncSamples(lims));
-    } else {
-      dispatch(syncSamples(lims));
-    }
+  function handleSyncSamples(lims) {
+    dispatch(syncSamples(lims));
     dispatch(filterAction({ limsSamples: true }));
   }
 

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -779,12 +779,17 @@ export default function SampleListViewContainer() {
               </TooltipTrigger>
               <span style={{ marginLeft: '1.5em' }} />
               <Dropdown>
-                <Dropdown.Toggle
-                  variant="outline-secondary"
-                  id="dropdown-basic"
+                <TooltipTrigger
+                  id="sync-samples-tooltip"
+                  tooltipContent="Change Samples List View Mode from Graphical to Table and vice versa"
                 >
-                  <MdGridView size="1em" /> {viewMode.mode}
-                </Dropdown.Toggle>
+                  <Dropdown.Toggle
+                    variant="outline-secondary"
+                    id="dropdown-basic"
+                  >
+                    <MdGridView size="1em" /> {viewMode.mode}
+                  </Dropdown.Toggle>
+                </TooltipTrigger>
                 <Dropdown.Menu>
                   {viewMode.options.map((option) => (
                     <Dropdown.Item

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -789,12 +789,12 @@ export default function SampleListViewContainer() {
                   className="nowrap-style"
                   variant="outline-secondary"
                   onClick={() => dispatch(showConfirmClearQueueDialog())}
-                  disabled={queue.queueStatus === QUEUE_RUNNING}
+                  disabled={
+                    queue.queueStatus === QUEUE_RUNNING ||
+                    Object.keys(sampleList).length === 0
+                  }
                 >
-                  <i
-                    className="fas fa-minus"
-                    style={{ marginRight: '0.5em' }}
-                  />
+                  <i className="fas fa-trash-alt me-1" />
                   Clear sample list
                 </Button>
               </TooltipTrigger>


### PR DESCRIPTION
While working on the previous PR related to the Sample List, I noticed a few small improvements that are worth addressing here first, before we proceed with implementing the main solution:

✅ Removed getSamplesFromSC call from handleSyncSamples
The backend already handles fetching samples from the Sample Changer, so the extra call is redundant.

✅ Temporarily removed getSamplesFromSC
Since it's currently unused, it was removed to satisfy the linter. We’ll reintroduce it later when we implement the use_get_all_samples option.

✅ Disable "Clear Samples" button when the sample list is empty
Prevents unnecessary actions and improves UI clarity.

✅ Added tooltip to the Sample List view mode selector

