### PR TITLE
display alert when user_level_log is critical

### DIFF
--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -14,7 +14,7 @@ import {
   plotEnd,
   setActionState,
 } from './actions/beamlineActions';
-import { showConnectionLostDialog } from './actions/general';
+import { showConnectionLostDialog, showErrorPanel } from './actions/general';
 import {
   setHarvesterState,
   updateHarvesterContents,
@@ -455,6 +455,9 @@ class ServerIO {
     this.loggingSocket.on('log_record', (record) => {
       if (record.severity !== 'DEBUG') {
         dispatch(addUserMessage(record));
+      }
+      if (record.severity === 'CRITICAL') {
+        dispatch(showErrorPanel(true, record.message));
       }
       dispatch(addLogRecord(record));
     });


### PR DESCRIPTION
- this adds a mechanism for mxcubecore objects to enforce
  an error message being displayed to the user
- showErrorPanel(msg) is called if 
     => logging.getLogger("user_level_log").**critical**(msg) is issued
- currently no user_level_log in the code is issuing messages on the critical level so this should be safe 👀
