### PR TITLE
Update h11 to fix malformed Chunked-Encoding bodies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1248,14 +1248,14 @@ test = ["objgraph", "psutil"]
 
 [[package]]
 name = "h11"
-version = "0.14.0"
+version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
-    {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
+    {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
+    {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
 ]
 
 [[package]]


### PR DESCRIPTION
Updating h11 to newer version because of a vulnerability. 
The problem is that h11 used to accept some incorrectly formatted chunked HTTP messages, which could let attackers trick a proxy and the server into interpreting requests differently.

https://github.com/python-hyper/h11/security/advisories/GHSA-vqfr-h8mv-ghfj