### PR TITLE
Custom manual centring method name

### DIFF
--- a/mxcubeweb/core/components/sampleview.py
+++ b/mxcubeweb/core/components/sampleview.py
@@ -384,11 +384,11 @@ class SampleView(ComponentBase):
                     "Aborting current centring ..."
                 )
                 HWR.beamline.diffractometer.cancel_centring_method(reject=True)
-
-            logging.getLogger("user_level_log").info(
+            msg = (
                 "Centring using %s centring"
                 % HWR.beamline.diffractometer.MANUAL3CLICK_MODE.lower()
             )
+            logging.getLogger("user_level_log").info(msg)
 
             HWR.beamline.diffractometer.start_centring_method(
                 HWR.beamline.diffractometer.MANUAL3CLICK_MODE

--- a/mxcubeweb/core/components/sampleview.py
+++ b/mxcubeweb/core/components/sampleview.py
@@ -386,7 +386,8 @@ class SampleView(ComponentBase):
                 HWR.beamline.diffractometer.cancel_centring_method(reject=True)
 
             logging.getLogger("user_level_log").info(
-                "Centring using %s centring" % HWR.beamline.diffractometer.MANUAL3CLICK_MODE.lower()
+                "Centring using %s centring"
+                % HWR.beamline.diffractometer.MANUAL3CLICK_MODE.lower()
             )
 
             HWR.beamline.diffractometer.start_centring_method(

--- a/mxcubeweb/core/components/sampleview.py
+++ b/mxcubeweb/core/components/sampleview.py
@@ -385,7 +385,9 @@ class SampleView(ComponentBase):
                 )
                 HWR.beamline.diffractometer.cancel_centring_method(reject=True)
 
-            logging.getLogger("user_level_log").info("Centring using 3-click centring")
+            logging.getLogger("user_level_log").info(
+                "Centring using %s centring" % HWR.beamline.diffractometer.MANUAL3CLICK_MODE.lower()
+            )
 
             HWR.beamline.diffractometer.start_centring_method(
                 HWR.beamline.diffractometer.MANUAL3CLICK_MODE

--- a/mxcubeweb/core/models/configmodels.py
+++ b/mxcubeweb/core/models/configmodels.py
@@ -83,6 +83,7 @@ class _UICameraConfigModel(BaseModel):
 class _UISampleViewVideoControlsModel(BaseModel):
     id: str
     show: bool
+    label: str | None
 
 
 class _UISampleViewVideoGridSettingsModel(BaseModel):

--- a/mxcubeweb/routes/samplecentring.py
+++ b/mxcubeweb/routes/samplecentring.py
@@ -252,7 +252,8 @@ def init_route(app, server, url_prefix):  # noqa: C901
             data = app.sample_view.start_manual_centring()
         except Exception:
             logging.getLogger("MX3.HWR").exception(
-                "Could not start %s centring" % HWR.beamline.diffractometer.MANUAL3CLICK_MODE.lower()
+                "Could not start %s centring"
+                % HWR.beamline.diffractometer.MANUAL3CLICK_MODE.lower()
             )
             resp = (
                 "Could not move motor",

--- a/mxcubeweb/routes/samplecentring.py
+++ b/mxcubeweb/routes/samplecentring.py
@@ -251,10 +251,8 @@ def init_route(app, server, url_prefix):  # noqa: C901
         try:
             data = app.sample_view.start_manual_centring()
         except Exception:
-            logging.getLogger("MX3.HWR").exception(
-                "Could not start %s centring"
-                % HWR.beamline.diffractometer.MANUAL3CLICK_MODE.lower()
-            )
+            err_msg = f"Could not start {HWR.beamline.diffractometer.MANUAL3CLICK_MODE.lower()} centring"
+            logging.getLogger("MX3.HWR").exception(err_msg)
             resp = (
                 "Could not move motor",
                 409,

--- a/mxcubeweb/routes/samplecentring.py
+++ b/mxcubeweb/routes/samplecentring.py
@@ -251,7 +251,9 @@ def init_route(app, server, url_prefix):  # noqa: C901
         try:
             data = app.sample_view.start_manual_centring()
         except Exception:
-            logging.getLogger("MX3.HWR").exception("Could not start 3 click centring")
+            logging.getLogger("MX3.HWR").exception(
+                "Could not start %s centring" % HWR.beamline.diffractometer.MANUAL3CLICK_MODE.lower()
+            )
             resp = (
                 "Could not move motor",
                 409,

--- a/mxcubeweb/routes/signals.py
+++ b/mxcubeweb/routes/signals.py
@@ -230,8 +230,10 @@ def centring_started(method, *args):
     if method in [HWR.beamline.diffractometer.C3D_MODE]:
         msg = {"method": qe.CENTRING_METHOD.LOOP}
     elif method in [HWR.beamline.diffractometer.MANUAL3CLICK_MODE]:
-        msg = {"method": qe.CENTRING_METHOD.MANUAL,
-               "method_name": HWR.beamline.diffractometer.MANUAL3CLICK_MODE.lower()}
+        msg = {
+            "method": qe.CENTRING_METHOD.MANUAL,
+            "method_name": HWR.beamline.diffractometer.MANUAL3CLICK_MODE.lower(),
+        }
 
     server.emit("sample_centring", msg, namespace="/hwr")
 

--- a/mxcubeweb/routes/signals.py
+++ b/mxcubeweb/routes/signals.py
@@ -227,10 +227,11 @@ def sc_maintenance_update(*args):
 def centring_started(method, *args):
     msg = {"method": method}
 
-    if method in ["Computer automatic"]:
+    if method in [HWR.beamline.diffractometer.C3D_MODE]:
         msg = {"method": qe.CENTRING_METHOD.LOOP}
-    elif method in ["Manual 3-click"]:
-        msg = {"method": qe.CENTRING_METHOD.MANUAL}
+    elif method in [HWR.beamline.diffractometer.MANUAL3CLICK_MODE]:
+        msg = {"method": qe.CENTRING_METHOD.MANUAL,
+               "method_name": HWR.beamline.diffractometer.MANUAL3CLICK_MODE.lower()}
 
     server.emit("sample_centring", msg, namespace="/hwr")
 

--- a/ui/src/actions/sampleview.js
+++ b/ui/src/actions/sampleview.js
@@ -189,13 +189,17 @@ export function rotateToShape(sid) {
 }
 
 export function recordCentringClick(x, y) {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
+    const { uiproperties } = getState();
+    const manualCentring = uiproperties.sample_view_video_controls.components.find((c) => c.id === '3_click_centring');
+    const manualCentringName = manualCentring?.label ?? '3-click';
+
     const json = await sendRecordCentringClick(x, y);
 
     const { clicksLeft } = json;
     dispatch(centringClicksLeft(clicksLeft));
 
-    let msg = '3-Click Centring: <br />';
+    let msg = `${manualCentringName} Centring: <br />`
     if (clicksLeft === 0) {
       msg += 'Save centring or clicking on screen to restart';
     } else if (clicksLeft === -1) {
@@ -302,7 +306,9 @@ export function toggleCentring() {
 
 export function startClickCentring() {
   return async (dispatch, getState) => {
-    const { queue, shapes } = getState();
+    const { queue, shapes, uiproperties } = getState();
+    const manualCentring = uiproperties.sample_view_video_controls.components.find((c) => c.id === '3_click_centring');
+    const manualCentringName = manualCentring?.label ?? '3-click';
 
     dispatch(clearSelectedShapes());
     dispatch(unselectShapes(shapes));
@@ -318,7 +324,7 @@ export function startClickCentring() {
     dispatch(startClickCentringAction());
     dispatch(centringClicksLeft(clicksLeft));
 
-    const msg = `3-Click Centring: <br />${
+    const msg = `${manualCentringName} Centring: <br />${
       clicksLeft === 0
         ? 'Save centring or clicking on screen to restart'
         : `Clicks left: ${clicksLeft}`

--- a/ui/src/actions/sampleview.js
+++ b/ui/src/actions/sampleview.js
@@ -191,7 +191,10 @@ export function rotateToShape(sid) {
 export function recordCentringClick(x, y) {
   return async (dispatch, getState) => {
     const { uiproperties } = getState();
-    const manualCentring = uiproperties.sample_view_video_controls.components.find((c) => c.id === '3_click_centring');
+    const manualCentring =
+      uiproperties.sample_view_video_controls.components.find(
+        (c) => c.id === '3_click_centring',
+      );
     const manualCentringName = manualCentring?.label ?? '3-click';
 
     const json = await sendRecordCentringClick(x, y);
@@ -199,7 +202,7 @@ export function recordCentringClick(x, y) {
     const { clicksLeft } = json;
     dispatch(centringClicksLeft(clicksLeft));
 
-    let msg = `${manualCentringName} Centring: <br />`
+    let msg = `${manualCentringName} Centring: <br />`;
     if (clicksLeft === 0) {
       msg += 'Save centring or clicking on screen to restart';
     } else if (clicksLeft === -1) {
@@ -307,7 +310,10 @@ export function toggleCentring() {
 export function startClickCentring() {
   return async (dispatch, getState) => {
     const { queue, shapes, uiproperties } = getState();
-    const manualCentring = uiproperties.sample_view_video_controls.components.find((c) => c.id === '3_click_centring');
+    const manualCentring =
+      uiproperties.sample_view_video_controls.components.find(
+        (c) => c.id === '3_click_centring',
+      );
     const manualCentringName = manualCentring?.label ?? '3-click';
 
     dispatch(clearSelectedShapes());

--- a/ui/src/components/SampleControls/CentringControl.jsx
+++ b/ui/src/components/SampleControls/CentringControl.jsx
@@ -5,7 +5,7 @@ import { toggleCentring } from '../../actions/sampleview';
 import styles from './SampleControls.module.css';
 
 function CentringControl(props) {
-  const { manualCentringName } = props
+  const { manualCentringName } = props;
   const dispatch = useDispatch();
   const isActive = useSelector((state) => state.sampleview.clickCentring);
 
@@ -18,7 +18,9 @@ function CentringControl(props) {
       onClick={() => dispatch(toggleCentring())}
     >
       <i className={`${styles.controlIcon} fas fa-circle-notch`} />
-      <span className={styles.controlLabel}>{`${manualCentringName} centring`}</span>
+      <span
+        className={styles.controlLabel}
+      >{`${manualCentringName} centring`}</span>
     </Button>
   );
 }

--- a/ui/src/components/SampleControls/CentringControl.jsx
+++ b/ui/src/components/SampleControls/CentringControl.jsx
@@ -4,7 +4,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import { toggleCentring } from '../../actions/sampleview';
 import styles from './SampleControls.module.css';
 
-function CentringControl() {
+function CentringControl(props) {
+  const { manualCentringName } = props
   const dispatch = useDispatch();
   const isActive = useSelector((state) => state.sampleview.clickCentring);
 
@@ -13,11 +14,11 @@ function CentringControl() {
       className={styles.controlBtn}
       data-default-styles
       active={isActive}
-      title={`${isActive ? 'Stop' : 'Start'} 3-click centring`}
+      title={`${isActive ? 'Stop' : 'Start'} ${manualCentringName} centring`}
       onClick={() => dispatch(toggleCentring())}
     >
       <i className={`${styles.controlIcon} fas fa-circle-notch`} />
-      <span className={styles.controlLabel}>3-click centring</span>
+      <span className={styles.controlLabel}>{`${manualCentringName} centring`}</span>
     </Button>
   );
 }

--- a/ui/src/components/SampleControls/SampleControls.jsx
+++ b/ui/src/components/SampleControls/SampleControls.jsx
@@ -9,13 +9,15 @@ import VideoSizeControl from './VideoSizeControl';
 import ZoomControl from './ZoomControl';
 
 function SampleControls(props) {
-  const { canvas } = props;
+  const { canvas, manualCentringName } = props;
 
   return (
     <div className={styles.controls}>
       {useShowControl('snapshot') && <SnapshotControl canvas={canvas} />}
       {useShowControl('draw_grid') && <GridControl />}
-      {useShowControl('3_click_centring') && <CentringControl />}
+      {useShowControl('3_click_centring') && (
+        <CentringControl manualCentringName={manualCentringName} />
+      )}
       {useShowControl('focus') && <FocusControl />}
       {useShowControl('zoom') && <ZoomControl />}
       {useShowControl('backlight') && (

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -928,8 +928,10 @@ export default class SampleImage extends React.Component {
   render() {
     this.configureGrid();
     this.updateGridResults();
-    const { components } = this.props.uiproperties.sample_view_video_controls;
-    const manualCentring = components.find((c) => c.id === '3_click_centring');
+    const manualCentring =
+      this.props.uiproperties.sample_view_video_controls.components.find(
+        (c) => c.id === '3_click_centring',
+      );
     const manualCentringName = manualCentring?.label ?? '3-click';
 
     return (
@@ -954,7 +956,10 @@ export default class SampleImage extends React.Component {
             />
             {this.createVideoPlayerContainer(this.props.videoFormat)}
 
-            <SampleControls canvas={this.canvas} manualCentringName={manualCentringName}/>
+            <SampleControls
+              canvas={this.canvas}
+              manualCentringName={manualCentringName}
+            />
             <div>{this.centringMessage()}</div>
 
             <canvas id="canvas" className="coveringCanvas" />

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -928,6 +928,9 @@ export default class SampleImage extends React.Component {
   render() {
     this.configureGrid();
     this.updateGridResults();
+    const { components } = this.props.uiproperties.sample_view_video_controls;
+    const manualCentring = components.find((c) => c.id === '3_click_centring');
+    const manualCentringName = manualCentring?.label ?? '3-click';
 
     return (
       <div>
@@ -951,7 +954,7 @@ export default class SampleImage extends React.Component {
             />
             {this.createVideoPlayerContainer(this.props.videoFormat)}
 
-            <SampleControls canvas={this.canvas} />
+            <SampleControls canvas={this.canvas} manualCentringName={manualCentringName}/>
             <div>{this.centringMessage()}</div>
 
             <canvas id="canvas" className="coveringCanvas" />

--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -304,8 +304,7 @@ class ServerIO {
     this.hwrSocket.on('sample_centring', (data) => {
       if (data.method === CLICK_CENTRING) {
         dispatch(startClickCentringAction());
-        const msg =
-          '3-Click Centring: <br /> Select centered position or center';
+        const msg = `${data.method_name} Centring: <br /> Select centered position or center`;
         dispatch(videoMessageOverlay(true, msg));
       } else {
         const msg = 'Auto loop centring: <br /> Save position or re-center';


### PR DESCRIPTION
These changes allow the name of the manual centering procedure to be customized.
One of the beamlines using MXCuBE has a custom `2-click` procedure, so it was necessary to make the name displayed in the UI configurable (see screenshots).

<p float="left">
  <img src="https://github.com/user-attachments/assets/dbdf8bde-3ad5-4ef0-841e-90b394c655d2" width="200"/>
  <img src="https://github.com/user-attachments/assets/a42d7e07-e9e9-4996-b6a0-9af83c34b7a7" width="200"/>
  <img src="https://github.com/user-attachments/assets/5424c4a8-e2bf-4a10-887c-f3b4a3f3c5db" width="200"/>
</p>



## HowTo
In order to change the name showed in the UI you have to edit the `mxcube-web/ui.yaml` like this:
```diff
sample_view_video_controls:
  id: sample_view_video_controls
  components:
    - id: snapshot
      ...
    ...
    - id: 3_click_centring
      show: true
+     label: 2-click
    ...
```
If the `label` key is not defined, the UI will show the `3-click` as default 