### PR TITLE
Fixes UI crash on data collection

### DIFF
--- a/ui/src/components/Tasks/fields.jsx
+++ b/ui/src/components/Tasks/fields.jsx
@@ -91,6 +91,9 @@ export function toFixed(state, hoName, parameterName = null) {
   let precision = null;
 
   for (const group of Object.values(state.uiproperties)) {
+    if (!group.components) {
+      continue;
+    }
     for (const component of group.components) {
       if (component.attribute === hoName) {
         precision = component.precision;


### PR DESCRIPTION
The `toFixed` method assumed that each of the sections in the `ui.yaml` config file has `components` key in it.

`session_picker` section added in
https://github.com/mxcube/mxcubeweb/commit/c60285b7fea044d976dc505d2027a1af76fd03dd did not follow this format.

Related Issue: https://github.com/mxcube/mxcubeweb/issues/1712


Edit: I've checked that it works by opening dialog for each task and by code inspection targeting references to `.components` references in the codebase.