### PR TITLE
Populate the TaskContextMenu based on the available tasks

### DIFF
--- a/ui/src/containers/SampleGridTableContainer.jsx
+++ b/ui/src/containers/SampleGridTableContainer.jsx
@@ -151,7 +151,10 @@ export default function SampleGridTableContainer(props) {
   );
   const viewMode = useSelector((state) => state.sampleGrid.viewMode);
   const workflows = useSelector((state) => state.workflow.workflows);
-
+  const defaultParameters = useSelector(
+    (state) => state.taskForm.defaultParameters,
+  );
+  const availableMethods = new Set(Object.keys(defaultParameters));
   const selectionRubberBand = document.querySelector('#selectionRubberBand');
 
   const {
@@ -854,12 +857,16 @@ export default function SampleGridTableContainer(props) {
         <Dropdown.Header>
           <i className="fas fa-plus" /> Add{' '}
         </Dropdown.Header>
-        <Dropdown.Item onClick={showDataCollectionForm}>
-          Data collection
-        </Dropdown.Item>
-        <Dropdown.Item onClick={showCharacterisationForm}>
-          Characterisation
-        </Dropdown.Item>
+        {availableMethods.has('datacollection') ? (
+          <Dropdown.Item onClick={showDataCollectionForm}>
+            Data collection
+          </Dropdown.Item>
+        ) : null}
+        {availableMethods.has('characterisation') ? (
+          <Dropdown.Item onClick={showCharacterisationForm}>
+            Characterisation
+          </Dropdown.Item>
+        ) : null}
         {getWorkflowMenuOptions(workflows, showWorkflowForm).samplegrid.map(
           (wf) => (
             <Dropdown.Item onClick={wf.handleAction} key={wf.key}>


### PR DESCRIPTION
This PR prevents to show not available tasks in the "TaskContextMenu" of the sample SampleGird view.
> This logic is already implemented in the `ContextMenu.js` used in the DataCollection view

## The Issue
In `beamline_config.yml` 
```diff
  ...
  available_methods:
    datacollection: true
+   characterisation: false
  ...
```
but in the menu...
![image](https://github.com/user-attachments/assets/5d872f3b-a2b1-4532-b7d6-7fbe26da7db4)
