### PR TITLE
Display error Messages on sample mount/unmount

### DIFF
--- a/mxcubeweb/routes/samplechanger.py
+++ b/mxcubeweb/routes/samplechanger.py
@@ -64,35 +64,20 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.restrict
     def unmount_current():
         try:
-            res = app.sample_changer.unmount_current()
+            return jsonify(app.sample_changer.unmount_current()), 200
         except Exception:
             logging.getLogger("MX3.HWR").exception("Cannot unload sample")
-            res = (
-                "Cannot unload sample",
-                409,
-                {
-                    "Content-Type": "application/json",
-                },
-            )
-        return jsonify(res)
+            return jsonify(message="Cannot unload sample"), 409
 
     @bp.route("/mount", methods=["POST"])
     @server.require_control
     @server.restrict
     def mount_sample():
         try:
-            resp = jsonify(app.sample_changer.mount_sample(request.get_json()))
+            return jsonify(app.sample_changer.mount_sample(request.get_json())), 200
         except Exception:
             logging.getLogger("MX3.HWR").exception("Cannot load sample")
-            resp = (
-                "Cannot load sample",
-                409,
-                {
-                    "Content-Type": "application/json",
-                },
-            )
-
-        return resp
+            return jsonify(message="Cannot load sample"), 409
 
     @bp.route("/capacity", methods=["GET"])
     @server.restrict

--- a/ui/src/actions/sampleChanger.js
+++ b/ui/src/actions/sampleChanger.js
@@ -93,7 +93,7 @@ export function mountSample(sampleData) {
     try {
       await sendMountSample(sampleData);
     } catch (error) {
-      dispatch(showErrorPanel(true, error.response.headers.get('message')));
+      dispatch(showErrorPanel(true, error.json.message));
       throw error;
     }
   };
@@ -105,7 +105,7 @@ export function unmountSample() {
       await sendUnmountCurrentSample();
       dispatch(clearCurrentSample());
     } catch (error) {
-      dispatch(showErrorPanel(true, error.response.headers.get('message')));
+      dispatch(showErrorPanel(true, error.json.message));
     }
   };
 }


### PR DESCRIPTION
This PR addresses two problems with the error message handling in the UI related to the `SampleChanger`:

- The Error Panel displayed never showed the error message. Fixed it to show the generic message that is returned upon error
       before: 
       ![Screenshot from 2025-06-24 15-46-48](https://github.com/user-attachments/assets/a8d0ac6d-e56b-469c-a592-e776030d185b)
       after: 
       ![Screenshot from 2025-06-24 15-45-08](https://github.com/user-attachments/assets/27dc7b18-e0f1-4012-b2e3-a16a54a3624b)


- On unmount error status code 200 was returned, changed it to be 409