### PR TITLE
Remove LIMS Filtering Functionality and return only LIMS samples 

### DIFF
--- a/mxcubeweb/routes/lims.py
+++ b/mxcubeweb/routes/lims.py
@@ -11,16 +11,16 @@ from flask import (
 def init_route(app, server, url_prefix):
     bp = Blueprint("lims", __name__, url_prefix=url_prefix)
 
-    @bp.route("/synch_samples", methods=["POST"])
+    @bp.route("/lims_samples", methods=["GET"])
     @server.restrict
-    def proposal_samples():
+    def get_proposal_samples():
         try:
-            lims_name = request.get_json().get("lims", None)
-            res = jsonify(app.lims.synch_with_lims(lims_name))
+            lims_name = request.args.get("lims")
+            res = jsonify(app.lims.get_lims_samples(lims_name))
         except Exception:
-            logging.getLogger("MX3.HWR").exception("Could not synchronize with Lims")
+            logging.getLogger("MX3.HWR").exception("Could not get Lims samples")
             res = (
-                "Could not synchronize with LIMS",
+                "Could not get Lims samples",
                 409,
                 {
                     "Content-Type": "application/json",

--- a/ui/src/actions/sampleGrid.js
+++ b/ui/src/actions/sampleGrid.js
@@ -80,7 +80,7 @@ export function getSamplesList() {
   };
 }
 
-export function syncSamples(lims) {
+export function getLimsSamples(lims) {
   return async (dispatch) => {
     dispatch(showWaitDialog('Please wait', 'Synchronizing with LIMS', true));
 
@@ -92,7 +92,7 @@ export function syncSamples(lims) {
       dispatch(
         showErrorPanel(
           true,
-          `Synchronization with LIMS failed ${error.response.headers.get(
+          `Error while getting LIMS samples ${error.response.headers.get(
             'message',
           )}`,
         ),

--- a/ui/src/api/lims.js
+++ b/ui/src/api/lims.js
@@ -3,7 +3,9 @@ import api from './api';
 const endpoint = api.url('/lims');
 
 export function fetchLimsSamples(lims) {
-  return endpoint.post({ lims }, '/synch_samples').safeJson();
+  return endpoint
+    .get(`/lims_samples?lims=${encodeURIComponent(lims)}`)
+    .safeJson();
 }
 
 export function fetchLimsResults(qid) {

--- a/ui/src/constants.js
+++ b/ui/src/constants.js
@@ -31,18 +31,6 @@ export function isUnCollected(task) {
   return task.state === TASK_UNCOLLECTED;
 }
 
-export function hasLimsData(sample) {
-  return sample.limsID !== undefined;
-}
-
-export function taskHasLimsData(task) {
-  return (
-    task.limsResultData &&
-    (task.limsResultData.dataCollectionId ||
-      task.limsResultData.dataCollectionGroupId)
-  );
-}
-
 export function twoStateActuatorIsActive(state) {
   return ['in', 'on', 'enabled'].includes(String(state).toLowerCase());
 }

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -33,7 +33,7 @@ import {
 } from '../actions/sampleGrid';
 import { showTaskForm } from '../actions/taskForm';
 import TooltipTrigger from '../components/TooltipTrigger';
-import { hasLimsData, isCollected, QUEUE_RUNNING } from '../constants';
+import { isCollected, QUEUE_RUNNING } from '../constants';
 import loader from '../img/loader.gif';
 import QueueSettings from './QueueSettings';
 import SampleGridTableContainer from './SampleGridTableContainer';
@@ -219,7 +219,6 @@ export default function SampleListViewContainer() {
    */
   function handleSyncSamples(lims) {
     dispatch(syncSamples(lims));
-    dispatch(filterAction({ limsSamples: true }));
   }
 
   /**
@@ -305,8 +304,6 @@ export default function SampleListViewContainer() {
         'notCollected',
         isCollected,
       );
-      // eslint-disable-next-line no-bitwise
-      fi &= mutualExclusiveFilterOption(sample, 'limsSamples', '', hasLimsData);
       if (cellFilter !== '') {
         // eslint-disable-next-line no-bitwise
         fi &= sample.cell_no === cellNo;
@@ -329,7 +326,6 @@ export default function SampleListViewContainer() {
       filterOptions.notInQueue ||
       filterOptions.collected ||
       filterOptions.notCollected ||
-      filterOptions.limsSamples ||
       filterOptions.text.length > 0 ||
       filterOptions.cellFilter !== '' ||
       filterOptions.puckFilter !== ''
@@ -366,7 +362,6 @@ export default function SampleListViewContainer() {
         notInQueue: false,
         collected: false,
         notCollected: false,
-        limsSamples: false,
         text: '',
         cellFilter: '',
         puckFilter: '',
@@ -693,21 +688,6 @@ export default function SampleListViewContainer() {
                 onChange={() => sampleGridFilter()}
                 label="Not Collected"
               />
-            </Col>
-          </Row>
-          <Row className="mb-2">
-            <Col xs={9}>
-              <Form.Check
-                type="checkbox"
-                inline
-                id="limsSamples"
-                checked={filterOptions.limsSamples}
-                onChange={sampleGridFilter}
-                label="LIMS Samples"
-              />
-            </Col>
-            <Col xs={3}>
-              <span />
             </Col>
           </Row>
           <Row className="mt-3">

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -26,10 +26,10 @@ import {
 import { showConfirmCollectDialog } from '../actions/queueGUI';
 import {
   filterAction,
+  getLimsSamples,
   selectSamplesAction,
   setViewModeAction,
   showGenericContextMenu,
-  syncSamples,
 } from '../actions/sampleGrid';
 import { showTaskForm } from '../actions/taskForm';
 import TooltipTrigger from '../components/TooltipTrigger';
@@ -217,8 +217,8 @@ export default function SampleListViewContainer() {
    * Synchronises samples with LIMS
    * @param {string} lims - LIMS name to synchronise with
    */
-  function handleSyncSamples(lims) {
-    dispatch(syncSamples(lims));
+  function handleGetLimsSamples(lims) {
+    dispatch(getLimsSamples(lims));
   }
 
   /**
@@ -530,7 +530,7 @@ export default function SampleListViewContainer() {
           <Button
             className="nowrap-style"
             variant="outline-secondary"
-            onClick={() => handleSyncSamples(loginData.limsName[0].name)}
+            onClick={() => handleGetLimsSamples(loginData.limsName[0].name)}
           >
             <i className="fas fa-sync-alt" style={{ marginRight: '0.5em' }} />
             Get Samples
@@ -552,7 +552,7 @@ export default function SampleListViewContainer() {
             >
               <Dropdown.Item
                 key={lims.name}
-                onClick={() => handleSyncSamples(lims.name)}
+                onClick={() => handleGetLimsSamples(lims.name)}
               >
                 {lims.name}
               </Dropdown.Item>

--- a/ui/src/reducers/sampleGrid.js
+++ b/ui/src/reducers/sampleGrid.js
@@ -32,7 +32,6 @@ const INITIAL_STATE = {
     notCollected: false,
     cellFilter: '',
     puckFilter: '',
-    limsSamples: false,
   },
 };
 


### PR DESCRIPTION
This PR removes the filter related to LIMS samples.

What Changes: 

✅ (Commit 1)
The LIMS filter option is removed from the UI.

USE Case
The user clicks “Get Samples”, or Chooses to Synchronize with LIMS/ISPyB
- The assumption is that only relevant samples (for the current user/session) will be returned directly from the backend
- As a result, an explicit filter for LIMS data is no longer necessary in the frontend.

✅ (Commit 2)
Only samples relevant to the user/session are returned .
Any required filtering is handled server-side.

[Screencast from 2025-06-26 16-12-44.webm](https://github.com/user-attachments/assets/bd85d87e-05de-4357-a649-8b9e60aea39f)
