### PR TITLE
Bring back  get samples from SC and make it Optional

### DIFF
--- a/demo/mxcube-web/server.yaml
+++ b/demo/mxcube-web/server.yaml
@@ -33,6 +33,10 @@ mxcube:
   # Mode, SSX-CHIP, SSX-INJECTOR, OSC
   mode: OSC
 
+  USE_GET_SAMPLES_FROM_SC: true
+  # This is used to determine whether we can get samples from the sample changer
+  # if false, Only LIMS samples will be availble to fetch for the sample list
+
   usermanager:
     class: UserManager
     inhouse_is_staff: true

--- a/mxcubeweb/core/models/configmodels.py
+++ b/mxcubeweb/core/models/configmodels.py
@@ -169,6 +169,12 @@ class MXCUBEAppConfigModel(BaseModel):
             "True to use video stream produced by external software, false otherwise"
         ),
     )
+    USE_GET_SAMPLES_FROM_SC: bool = Field(
+        True,
+        description=(
+            "True to acticvate or be able to get samples from the sample changer, false otherwise"
+        ),
+    )
     mode: ModeEnum = Field(
         ModeEnum.OSC, description="MXCuBE mode OSC, SSX-CHIP or SSX-INJECTOR"
     )

--- a/mxcubeweb/routes/main.py
+++ b/mxcubeweb/routes/main.py
@@ -50,6 +50,7 @@ def init_route(app, server, url_prefix):
                 "mesh_result_format": _blc.mesh_result_format,
                 "use_native_mesh": _blc.use_native_mesh,
                 "enable_2d_points": _blc.enable_2d_points,
+                "use_get_samples_from_sc": app.CONFIG.app.USE_GET_SAMPLES_FROM_SC,
             }
         )
 

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect } from 'react';
 import {
   Button,
+  ButtonGroup,
   Card,
   Col,
   Container,
@@ -27,6 +28,7 @@ import { showConfirmCollectDialog } from '../actions/queueGUI';
 import {
   filterAction,
   getLimsSamples,
+  getSamplesList,
   selectSamplesAction,
   setViewModeAction,
   showGenericContextMenu,
@@ -55,6 +57,10 @@ export default function SampleListViewContainer() {
   const sampleChanger = useSelector((state) => state.sampleChanger);
   const sampleChangerType = useSelector((state) =>
     state.sampleChanger.contents ? state.sampleChanger.contents.name : 'Mockup',
+  );
+
+  const showGetSamplesFromSC = useSelector(
+    (state) => state.general.useGetSamplesFromSC,
   );
 
   const handleSetViewMode = useCallback(
@@ -211,6 +217,13 @@ export default function SampleListViewContainer() {
         );
       }
     }
+  }
+
+  /**
+   * Fetches samples from the SampleChanger
+   */
+  function getSamplesFromSC() {
+    dispatch(getSamplesList());
   }
 
   /**
@@ -521,40 +534,54 @@ export default function SampleListViewContainer() {
   }
 
   function getSynchronizationDropDownList() {
-    if (loginData.limsName.length === 1) {
-      return (
+    return (
+      <Dropdown as={ButtonGroup}>
         <TooltipTrigger
           id="sync-samples-tooltip"
-          tooltipContent={`Synchronise sample list with ${loginData.limsName[0].name}`}
+          tooltipContent={`Synchronise sample list with ${loginData.limsName[0]?.name},
+          and apply filter to only show with LIMS samples`}
         >
           <Button
-            className="nowrap-style"
             variant="outline-secondary"
+            className="nowrap-style"
             onClick={() => handleGetLimsSamples(loginData.limsName[0].name)}
           >
             <i className="fas fa-sync-alt" style={{ marginRight: '0.5em' }} />
             Get Samples
           </Button>
         </TooltipTrigger>
-      );
-    }
-    return (
-      <Dropdown>
-        <Dropdown.Toggle variant="outline-secondary" id="dropdown-lims">
-          <i className="fas fa-sync-alt" style={{ marginRight: '0.5em' }} />{' '}
-          Synchronize with
-        </Dropdown.Toggle>
+        {/* Show the dropdown toggle only if there are multiple LIMS
+        or if the option to get samples from SC is enabled */}
+        {(loginData.limsName.length > 1 || showGetSamplesFromSC) && (
+          <Dropdown.Toggle
+            split
+            variant="outline-secondary"
+            id="dropdown-split-samples"
+            title="Other LIMS Options"
+          />
+        )}
+
         <Dropdown.Menu>
-          {loginData.limsName.map((lims) => (
+          {showGetSamplesFromSC && (
+            <TooltipTrigger tooltipContent="get samples from sample changer">
+              <Dropdown.Item
+                onClick={getSamplesFromSC}
+                variant="outline-secondary"
+                className="nowrap-style"
+              >
+                Get Samples from SC
+              </Dropdown.Item>
+            </TooltipTrigger>
+          )}
+          {/* Skip the first LIMS as it is already included in the button above */}
+          {loginData.limsName.slice(1).map((lims, _) => (
             <TooltipTrigger
-              key={lims.name}
+              key={`sync-samples-${lims.name}`}
+              id={`sync-samples-${lims.name}`}
               tooltipContent={`Synchronise sample list with ${lims.name}`}
             >
-              <Dropdown.Item
-                key={lims.name}
-                onClick={() => handleGetLimsSamples(lims.name)}
-              >
-                {lims.name}
+              <Dropdown.Item onClick={() => handleGetLimsSamples(lims.name)}>
+                Get Samples & Sync {lims.name}
               </Dropdown.Item>
             </TooltipTrigger>
           ))}

--- a/ui/src/reducers/general.js
+++ b/ui/src/reducers/general.js
@@ -8,6 +8,7 @@ const INITIAL_STATE = {
   showConnectionLostDialog: false,
   showConfirmClearQueueDialog: false,
   mode: 'OSC',
+  useGetSamplesFromSC: true,
   serverVersion: '3',
   applicationFetched: false,
 };
@@ -40,6 +41,7 @@ function generalReducer(state = INITIAL_STATE, action = {}) {
       return {
         ...state,
         mode: action.data.general.mode,
+        useGetSamplesFromSC: action.data.general.use_get_samples_from_sc,
         serverVersion: action.data.general.version,
         enable2DPoints: action.data.general.enable_2d_points,
         meshResultFormat: action.data.general.mesh_result_format,


### PR DESCRIPTION
This PR reintroduces the “Get Samples from SC” option, allowing users to retrieve the full list of samples from the sample changer, independent of LIMS/ISPyB.

🖱️ UI Behavior
The UI now provides two buttons:

1 : Get Samples  -> Default option to Synchronizes with LIMS/ISPyB and Returns only LIMS-tracked samples
see [PR](https://github.com/mxcube/mxcubeweb/pull/1717)

2 : Get Samples from SC (" Menu Inside split Button")
   it Fetches all samples currently in the sample changer
   Useful when samples are not registered in LIMS
   ⚙️ Configurable Option
   This feature is optional : You can disable the second button by setting:  "use_get_all_samples"  show : false
   
"use_get_all_samples"  show : false
![image](https://github.com/user-attachments/assets/5e58f5d9-64e2-4177-ba16-4d414f8e39fa)

"use_get_all_samples"  show : true
![image](https://github.com/user-attachments/assets/1b67e7ec-9f79-4f77-97ca-f3df02271b45)



