### PR TITLE
[sample order] Remove unused code

### DIFF
--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -819,29 +819,6 @@ class Queue(ComponentBase):
 
         logging.getLogger("MX3.HWR").info("[QUEUE] is:\n%s " % self.queue_to_json())
 
-    def set_sample_order(self, order):
-        """
-        Set the sample order of the queue
-        :param list sample_order: List of sample ids
-        """
-        current_queue = self.queue_to_dict()
-        sid_list = [sid for sid in order if current_queue.get(sid, False)]
-
-        if sid_list:
-            queue_id_list = [current_queue[sid]["queueID"] for sid in sid_list]
-            model_entry_list = [self.get_entry(qid) for qid in queue_id_list]
-            model_list = [model_entry[0] for model_entry in model_entry_list]
-            entry_list = [model_entry[1] for model_entry in model_entry_list]
-
-            # Set the order in the queue model
-            HWR.beamline.queue_model.get_model_root()._children = model_list
-            # Set queue entry order
-            HWR.beamline.queue_manager._queue_entry_list = entry_list
-
-        self.app.lims.sample_list_set_order(order)
-
-        logging.getLogger("MX3.HWR").info("[QUEUE] is:\n%s " % self.queue_to_json())
-
     def queue_add_item(self, item_list):
         """
         Adds the queue items in item_list to the queue. The items in the list can

--- a/mxcubeweb/routes/queue.py
+++ b/mxcubeweb/routes/queue.py
@@ -249,18 +249,6 @@ def init_route(app, server, url_prefix):  # noqa: C901
 
         return Response(status=200)
 
-    @bp.route("/sample-order", methods=["POST"])
-    @server.require_control
-    @server.restrict
-    def queue_set_sample_order():
-        sample_order = request.get_json().get("sampleOrder", [])
-        app.queue.set_sample_order(sample_order)
-        server.emit(
-            "queue", {"Signal": "update", "message": "observers"}, namespace="/hwr"
-        )
-
-        return Response(status=200)
-
     @bp.route("/<sample_id>", methods=["PUT"])
     @server.require_control
     @server.restrict

--- a/test/input_parameters.py
+++ b/test/input_parameters.py
@@ -20,17 +20,6 @@ test_sample_5 = {
     "type": "Sample",
 }
 
-test_sample_6 = {
-    "code": "matr1_6",
-    "checked": True,
-    "sampleName": "Sample-106",
-    "sampleID": "1:06",
-    "tasks": [],
-    "location": "1:6",
-    "defaultPrefix": "local-user",
-    "type": "Sample",
-}
-
 test_task = {
     "checked": True,
     "code": "matr1_5",

--- a/test/test_queue_routes.py
+++ b/test/test_queue_routes.py
@@ -8,7 +8,6 @@ from input_parameters import (
     default_mesh_params,
     default_xrf_parameters,
     test_edit_task,
-    test_sample_6,
     test_task,
 )
 
@@ -321,29 +320,6 @@ def test_queue_move_task_item_fail(client):
 
     assert resp.status_code == 200
     assert json.loads(resp.data).get("1:05")["tasks"][2]["parameters"]["kappa"] == 180
-
-
-def test_queue_set_sample_order(client):
-    """Test if we can set the sample order in the queue."""
-    sample_to_add = test_sample_6
-    resp = client.post(
-        "/mxcube/api/v0.1/queue/",
-        data=json.dumps([sample_to_add]),
-        content_type="application/json",
-    )
-    assert resp.status_code == 200
-
-    new_sample_order = {"sampleOrder": ["1:01", "1:06", "1:05"]}
-    resp = client.post(
-        "/mxcube/api/v0.1/queue/sample-order",
-        data=json.dumps(new_sample_order),
-        content_type="application/json",
-    )
-    assert resp.status_code == 200
-
-    resp = client.get("/mxcube/api/v0.1/queue/")
-    assert resp.status_code == 200
-    assert json.loads(resp.data).get("sample_order")[1] == "1:06"
 
 
 def assert_and_remove_keys_with_random_value(parameters):


### PR DESCRIPTION
The sample list is now pre-filtered by puck and cell and presented in a fixed order.

Since drag-and-drop reordering is no longer supported in the UI and the logic to set sample order has been removed.

The corresponding API functionality has also been cleaned up for consistency.