### PR TITLE
Refactor QueueControl

### DIFF
--- a/ui/src/components/SampleQueue/QueueControl.jsx
+++ b/ui/src/components/SampleQueue/QueueControl.jsx
@@ -1,205 +1,37 @@
-/* eslint-disable react/destructuring-assignment */
 import './app.css';
 
-import React from 'react';
-import { Button, Nav, Navbar } from 'react-bootstrap';
+import { Nav, Navbar } from 'react-bootstrap';
+import { useSelector } from 'react-redux';
 
-import {
-  QUEUE_PAUSED,
-  QUEUE_RUNNING,
-  QUEUE_STARTED,
-  QUEUE_STOPPED,
-} from '../../constants';
+import { QUEUE_RUNNING } from '../../constants';
 import QueueSettings from '../../containers/QueueSettings';
 import loader from '../../img/busy-indicator.gif';
+import QueueControlOptions from './QueueControlOptions';
 
-export default class QueueControl extends React.Component {
-  constructor(props) {
-    super(props);
+export default function QueueControl() {
+  const queueStatus = useSelector((state) => state.queue.queueStatus);
 
-    this.nextSample = this.nextSample.bind(this);
+  const showBusyIndicator = queueStatus === QUEUE_RUNNING ? 'inline' : 'none';
 
-    this.state = {
-      options: {
-        [QUEUE_STARTED]: [
-          {
-            text: 'Stop',
-            class: 'btn-danger',
-            action: props.stopQueue,
-            key: 1,
-          },
-        ],
-        [QUEUE_RUNNING]: [
-          {
-            text: 'Stop',
-            class: 'btn-danger',
-            action: props.stopQueue,
-            key: 1,
-          },
-        ],
-        [QUEUE_STOPPED]: [
-          {
-            text: 'Run Queue',
-            class: 'btn-success',
-            action: props.startQueue,
-            key: 1,
-          },
-        ],
-        [QUEUE_PAUSED]: [
-          {
-            text: 'Stop',
-            class: 'btn-danger',
-            action: props.stopQueue,
-            key: 1,
-          },
-        ],
-      },
-    };
-
-    this.sampleState = {
-      options: {
-        [QUEUE_STARTED]: [
-          {
-            text: 'Pause',
-            class: 'btn-warning',
-            action: this.props.pauseQueue,
-            key: 2,
-          },
-        ],
-        [QUEUE_RUNNING]: [
-          {
-            text: 'Pause',
-            class: 'btn-warning',
-            action: this.props.pauseQueue,
-            key: 2,
-          },
-        ],
-        [QUEUE_STOPPED]: [],
-        [QUEUE_PAUSED]: [
-          {
-            text: 'Resume',
-            class: 'btn-success',
-            action: this.props.resumeQueue,
-            key: 2,
-          },
-        ],
-        NoSampleMounted: [
-          {
-            text: 'New Sample',
-            class: 'btn-primary',
-            action: this.showForm,
-            key: 1,
-          },
-        ],
-        LastSample: [
-          {
-            text: 'Unmount',
-            class: 'btn-primary',
-            action: this.nextSample,
-            key: 1,
-          },
-        ],
-      },
-    };
-  }
-
-  nextSample() {
-    const idx = this.props.queue.indexOf(this.props.mounted);
-
-    if (idx !== -1) {
-      // a sample is mounted but not in the queue.
-      this.props.setEnabledSample([this.props.queue[idx]], false);
-    }
-
-    if (this.props.queue[idx + 1]) {
-      this.props.runSample(this.props.queue[idx + 1]);
-    } else {
-      this.props.unmountSample();
-    }
-  }
-
-  renderOption(option) {
-    return (
-      <Button
-        className={option.class}
-        variant=""
-        size="sm"
-        onClick={option.action}
-        key={option.key}
+  return (
+    <Navbar className="m-tree" style={{ padding: '0.5em' }}>
+      <Nav
+        className="me-auto my-2 my-lg-0"
+        style={{ maxHeight: '100px' }}
+        navbarScroll
       >
-        {option.text}
-      </Button>
-    );
-  }
-
-  render() {
-    let nextSample = [];
-    let queueOptions = [];
-    let sampleQueueOptions = [];
-    if (this.props.queue) {
-      const idx = this.props.queue.indexOf(this.props.mounted);
-      if (this.props.queue[idx + 1]) {
-        const sampleData =
-          this.props.sampleList[this.props.queue[idx + 1]] || {};
-        const sampleName = sampleData.sampleName || '';
-        const proteinAcronym = sampleData.proteinAcronym
-          ? `${sampleData.proteinAcronym} - `
-          : '';
-
-        nextSample = [
-          {
-            text: `Next Sample (${proteinAcronym}${sampleName})`,
-            class: 'btn-outline-secondary',
-            action: this.nextSample,
-            key: 2,
-          },
-        ];
-      }
-
-      this.sampleState.options[QUEUE_STOPPED] = nextSample;
-
-      const sampleId = this.props.mounted;
-      queueOptions = this.state.options[this.props.queueStatus];
-      if (sampleId) {
-        if (
-          this.props.queue.length === idx + 1 &&
-          this.props.queueStatus === QUEUE_STOPPED
-        ) {
-          sampleQueueOptions = this.sampleState.options.LastSample;
-        } else {
-          sampleQueueOptions = this.sampleState.options[this.props.queueStatus];
-        }
-      }
-    }
-
-    const running = this.props.queueStatus === QUEUE_RUNNING;
-    const showBusyIndicator = running ? 'inline' : 'none';
-
-    return (
-      <Navbar className="m-tree" style={{ padding: '0.5em' }}>
-        <Nav
-          className="me-auto my-2 my-lg-0"
-          style={{ maxHeight: '100px' }}
-          navbarScroll
-        >
-          <Nav.Item>
-            <span style={{ marginRight: '0.6em' }}>
-              {queueOptions.map((option) => this.renderOption(option))}
-            </span>
-            <span>
-              {sampleQueueOptions.map((option) => this.renderOption(option))}
-            </span>
-          </Nav.Item>
-          <Nav.Item>
-            <img
-              src={loader}
-              style={{ display: showBusyIndicator, marginLeft: '25%' }}
-              alt=""
-            />
-          </Nav.Item>
-        </Nav>
-        <QueueSettings />
-      </Navbar>
-    );
-  }
+        <Nav.Item>
+          <QueueControlOptions />
+        </Nav.Item>
+        <Nav.Item>
+          <img
+            src={loader}
+            style={{ display: showBusyIndicator, marginLeft: '25%' }}
+            alt=""
+          />
+        </Nav.Item>
+      </Nav>
+      <QueueSettings />
+    </Navbar>
+  );
 }

--- a/ui/src/components/SampleQueue/QueueControlOptions.jsx
+++ b/ui/src/components/SampleQueue/QueueControlOptions.jsx
@@ -1,0 +1,117 @@
+import { Button } from 'react-bootstrap';
+import { useDispatch, useSelector } from 'react-redux';
+
+import {
+  pauseQueue,
+  resumeQueue,
+  runSample,
+  setEnabledSample,
+  stopQueue,
+} from '../../actions/queue';
+import { showConfirmCollectDialog } from '../../actions/queueGUI';
+import { unmountSample } from '../../actions/sampleChanger';
+import { QUEUE_PAUSED, QUEUE_RUNNING, QUEUE_STOPPED } from '../../constants';
+
+export default function QueueControlOptions() {
+  const dispatch = useDispatch();
+
+  const queueStatus = useSelector((state) => state.queue.queueStatus);
+  const queue = useSelector((state) => state.queue.queue);
+  const currentSampleID = useSelector((state) => state.queue.currentSampleID);
+  const sampleList = useSelector((state) => state.sampleGrid.sampleList);
+
+  if (!queue) {
+    return null;
+  }
+
+  function getNextSample() {
+    const idx = queue.indexOf(currentSampleID);
+
+    if (idx !== -1) {
+      // a sample is mounted but not in the queue.
+      dispatch(setEnabledSample([queue[idx]], false));
+    }
+
+    if (queue[idx + 1]) {
+      dispatch(runSample(queue[idx + 1]));
+    } else {
+      dispatch(unmountSample());
+    }
+  }
+
+  switch (queueStatus) {
+    case QUEUE_RUNNING: {
+      return (
+        <div>
+          <Button
+            variant="danger"
+            style={{ marginRight: '0.6em' }}
+            onClick={() => dispatch(stopQueue())}
+          >
+            Stop
+          </Button>
+          {currentSampleID && (
+            <Button variant="warning" onClick={() => dispatch(pauseQueue())}>
+              Pause
+            </Button>
+          )}
+        </div>
+      );
+    }
+    case QUEUE_STOPPED: {
+      let buttonText = 'Unmount';
+      let buttonStyle = 'primary';
+      // If there is a next sample in the queue, set the button text and style accordingly
+      if (currentSampleID) {
+        const idx = queue.indexOf(currentSampleID);
+        if (queue.length > idx + 1) {
+          const sampleData = sampleList[queue[idx + 1]] || {};
+          const sampleName = sampleData.sampleName || '';
+          const proteinAcronym = sampleData.proteinAcronym
+            ? `${sampleData.proteinAcronym} - `
+            : '';
+          buttonText = `Next Sample (${proteinAcronym}${sampleName})`;
+          buttonStyle = 'outline-secondary';
+        }
+      }
+
+      return (
+        <div>
+          <Button
+            variant="success"
+            style={{ marginRight: '0.6em' }}
+            onClick={() => dispatch(showConfirmCollectDialog())}
+          >
+            Run Queue
+          </Button>
+          {currentSampleID && (
+            <Button variant={buttonStyle} onClick={getNextSample}>
+              {buttonText}
+            </Button>
+          )}
+        </div>
+      );
+    }
+    case QUEUE_PAUSED: {
+      return (
+        <div>
+          <Button
+            variant="danger"
+            style={{ marginRight: '0.6em' }}
+            onClick={() => dispatch(stopQueue())}
+          >
+            Stop
+          </Button>
+          {currentSampleID && (
+            <Button variant="success" onClick={() => dispatch(resumeQueue())}>
+              Resume
+            </Button>
+          )}
+        </div>
+      );
+    }
+    default: {
+      return null;
+    }
+  }
+}

--- a/ui/src/constants.js
+++ b/ui/src/constants.js
@@ -3,7 +3,6 @@
 // are not used within the same file. So disable eslint for this
 // section
 
-export const QUEUE_STARTED = 'QueueStarted';
 export const QUEUE_RUNNING = 'QueueRunning';
 export const QUEUE_STOPPED = 'QueueStopped';
 export const QUEUE_PAUSED = 'QueuePaused';

--- a/ui/src/containers/SampleQueueContainer.jsx
+++ b/ui/src/containers/SampleQueueContainer.jsx
@@ -11,20 +11,10 @@ import {
   changeTaskOrderAction,
   deleteTask,
   moveTask,
-  pauseQueue,
-  resumeQueue,
-  runSample,
-  setEnabledSample,
-  stopQueue,
   toggleCheckBox,
 } from '../actions/queue';
-import {
-  collapseItem,
-  selectItem,
-  showConfirmCollectDialog,
-  showList,
-} from '../actions/queueGUI';
-import { mountSample, unmountSample } from '../actions/sampleChanger';
+import { collapseItem, selectItem, showList } from '../actions/queueGUI';
+import { mountSample } from '../actions/sampleChanger';
 import { showTaskForm } from '../actions/taskForm';
 import { showWorkflowParametersDialog } from '../actions/workflow';
 import UserMessage from '../components/Notify/UserMessage';
@@ -84,19 +74,7 @@ class SampleQueueContainer extends React.Component {
 
     return (
       <div style={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
-        <QueueControl
-          queue={queue}
-          setEnabledSample={this.props.setEnabledSample}
-          queueStatus={queueStatus}
-          startQueue={this.props.showConfirmCollectDialog}
-          stopQueue={this.props.stopQueue}
-          pauseQueue={this.props.pauseQueue}
-          resumeQueue={this.props.resumeQueue}
-          mounted={currentSampleID}
-          runSample={this.props.runSample}
-          sampleList={sampleList}
-          unmountSample={this.props.unmountSample}
-        />
+        <QueueControl />
         <div className="m-tree queue-body">
           <Nav
             variant="tabs"
@@ -200,15 +178,10 @@ function mapDispatchToProps(dispatch) {
   return {
     // Queue actions
     toggleCheckBox: bindActionCreators(toggleCheckBox, dispatch),
-    pauseQueue: bindActionCreators(pauseQueue, dispatch),
-    resumeQueue: bindActionCreators(resumeQueue, dispatch),
-    stopQueue: bindActionCreators(stopQueue, dispatch),
     changeTaskOrderAction: bindActionCreators(changeTaskOrderAction, dispatch),
     deleteTask: bindActionCreators(deleteTask, dispatch),
     addTask: bindActionCreators(addTask, dispatch),
     moveTask: bindActionCreators(moveTask, dispatch),
-    runSample: bindActionCreators(runSample, dispatch),
-    setEnabledSample: bindActionCreators(setEnabledSample, dispatch),
 
     // Workflow action
     showWorkflowParametersDialog: bindActionCreators(
@@ -218,16 +191,11 @@ function mapDispatchToProps(dispatch) {
 
     // Queue GUI actions
     collapseItem: bindActionCreators(collapseItem, dispatch),
-    showConfirmCollectDialog: bindActionCreators(
-      showConfirmCollectDialog,
-      dispatch,
-    ),
     selectItem: bindActionCreators(selectItem, dispatch),
     showList: bindActionCreators(showList, dispatch),
 
     // Sample changer actions
     mountSample: bindActionCreators(mountSample, dispatch),
-    unmountSample: bindActionCreators(unmountSample, dispatch),
 
     showForm: bindActionCreators(showTaskForm, dispatch),
     showDialog: bindActionCreators(showDialog, dispatch),


### PR DESCRIPTION
This PR refactors `QueueControl` component. As such, the following changes have been done:

- `QueueControl` has been rewritten as functional component
- The `QUEUE_STARTED` constant which was only used in the lookupTable here and never actually set by any signal in the code (Seems to be what `QUEUE_RUNNING` was called previously) has been removed
- Removed not anymore used props from parent component
- Instead of using two lookuptables, one per rendered button, they have been merged to one
- Removed unused states from lookuptables
- removed button render function
- simplified logic for rendering `Next Sample` button