### PR TITLE
Fix issues with adding tasks to the queue

### DIFF
--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -1150,9 +1150,7 @@ class Queue(ComponentBase):
         model.path_template.set_from_dict(params)
         model.path_template.base_prefix = params["prefix"]
         model.path_template.num_files = 0
-        model.path_template.precision = "0" + str(
-            HWR.beamline.session["file_info"].get_property("precision", 4)
-        )
+        model.path_template.precision = "0" + str(qmo.PathTemplate.precision)
 
         self.app.lims.apply_template(params, sample_model, model.path_template)
 
@@ -1253,9 +1251,7 @@ class Queue(ComponentBase):
 
         model.path_template.set_from_dict(params)
         model.path_template.suffix = ftype
-        model.path_template.precision = "0" + str(
-            HWR.beamline.session["file_info"].get_property("precision", 4)
-        )
+        model.path_template.precision = "0" + str(qmo.PathTemplate.precision)
 
         if params["prefix"]:
             model.path_template.base_prefix = params["prefix"]
@@ -1298,9 +1294,7 @@ class Queue(ComponentBase):
 
         model.path_template.set_from_dict(params)
         model.path_template.suffix = ftype
-        model.path_template.precision = "0" + str(
-            HWR.beamline.session["file_info"].get_property("precision", 4)
-        )
+        model.path_template.precision = "0" + str(qmo.PathTemplate.precision)
 
         if params["prefix"]:
             model.path_template.base_prefix = params["prefix"]
@@ -1547,9 +1541,7 @@ class Queue(ComponentBase):
         acq.path_template.start_num = params["first_image"]
         acq.path_template.num_files = params["num_images"]
         acq.path_template.suffix = ftype
-        acq.path_template.precision = "0" + str(
-            HWR.beamline.session["file_info"].get_property("precision", 4)
-        )
+        acq.path_template.precision = "0" + str(qmo.PathTemplate.precision)
 
         if params["prefix"]:
             acq.path_template.base_prefix = params["prefix"]

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -1081,9 +1081,9 @@ class Queue(ComponentBase):
                 grid.width,
                 grid.height,
             )
-            mesh_center = HWR.beamline.default_acquisition_parameters["mesh"].get(
-                "mesh_center", "top-left"
-            )
+            mesh_center = HWR.beamline.get_default_acquisition_parameters(
+                "mesh"
+            ).mesh_center
             if mesh_center == "top-left":
                 acq.acquisition_parameters.centred_position = (
                     grid.get_centred_positions()[0]


### PR DESCRIPTION
This fixes issues with adding mesh tasks and custom tasks to the queue.

- fixes accessing default parameters for mesh scans: https://github.com/mxcube/mxcubeweb/commit/fc685d0780e56b16dfed5ba71745da9d8ef74836
- fixes accessing precision parameter: https://github.com/mxcube/mxcubeweb/commit/b73e85c2782be6fc48f060e38cb7c8b3f45252d3

I guess these expressions become invalid during YAML config changes.
