### PR TITLE
Removed unnecessary `phaseChanged` signal handler from diffractometer

### DIFF
--- a/mxcubeweb/core/components/beamline.py
+++ b/mxcubeweb/core/components/beamline.py
@@ -32,16 +32,6 @@ class Beamline(ComponentBase):
                 signals.xrf_task_progress,
             )
 
-    def diffractometer_init_signals(self):
-        """
-        Connect all the relevant hwobj signals with the corresponding
-        callback method.
-        """
-        from mxcubeweb.routes import signals
-
-        diffractometer = HWR.beamline.diffractometer
-        diffractometer.connect("phaseChanged", signals.diffractometer_phase_changed)
-
     def get_aperture(self):
         """
         Returns list of apertures and the one currently used.

--- a/mxcubeweb/routes/signals.py
+++ b/mxcubeweb/routes/signals.py
@@ -91,14 +91,6 @@ def handle_auto_mount_next(entry):
             logging.getLogger("user_level_log").info(msg)
 
 
-def diffractometer_phase_changed(*args):
-    data = {"msg": "Diffractometer phase changed", "phase": args}
-    logging.getLogger("user_level_log").info(
-        "Diffractometer phase changed to %s" % args
-    )
-    server.emit("diff_phase_changed", data, namespace="/hwr")
-
-
 def harvester_state_changed(*args):
     new_state = args[0]
     state_str = HarvesterState.STATE_DESC.get(new_state, "Unknown").upper()


### PR DESCRIPTION
Removed unnecessary `phaseChanged` signal handler from diffractometer already handled by the Diffractometer adapter: https://github.com/mxcube/mxcubeweb/blob/768c784cb2a560ebf2e9466ba8a9ee6eb2b38687/mxcubeweb/core/adapter/diffractometer_adapter.py#L30