### PR TITLE
Make manual centring procedure name reflect configurable number of clicks

### DIFF
--- a/demo.yaml/mxcube-web/ui.yaml
+++ b/demo.yaml/mxcube-web/ui.yaml
@@ -93,7 +93,7 @@ sample_view_video_controls:
       show: true
       show_vspace: false
       show_hspace: true
-    - id: 3_click_centring
+    - id: click_centring
       show: true
     - id: focus
       show: true

--- a/demo/mxcube-web/ui.yaml
+++ b/demo/mxcube-web/ui.yaml
@@ -94,7 +94,7 @@ sample_view_video_controls:
       show: true
       show_vspace: false
       show_hspace: true
-    - id: 3_click_centring
+    - id: click_centring
       show: true
     - id: focus
       show: true

--- a/docs/source/config/ui.rst
+++ b/docs/source/config/ui.rst
@@ -154,7 +154,7 @@ The section has the following syntax:
           show: <show>
           show_hspace: <show_hspace>
           show_vspace: <show_vspace>
-        - id: 3_click_centring
+        - id: click_centring
           show: <show>
         - id: focus
           show: <show>

--- a/mxcubeweb/core/components/sampleview.py
+++ b/mxcubeweb/core/components/sampleview.py
@@ -374,7 +374,7 @@ class SampleView(ComponentBase):
 
     def start_manual_centring(self):
         """
-        Start 3 click centring procedure.
+        Start N-click centring procedure.
             :statuscode: 200: no error
             :statuscode: 409: error
         """
@@ -384,8 +384,10 @@ class SampleView(ComponentBase):
                     "Aborting current centring ..."
                 )
                 HWR.beamline.diffractometer.cancel_centring_method(reject=True)
-
-            logging.getLogger("user_level_log").info("Centring using 3-click centring")
+            msg = "Centring using %s-click centring"
+            logging.getLogger("user_level_log").info(
+                msg, HWR.beamline.config.click_centring_num_clicks
+            )
 
             HWR.beamline.diffractometer.start_centring_method(
                 HWR.beamline.diffractometer.MANUAL3CLICK_MODE

--- a/mxcubeweb/core/components/sampleview.py
+++ b/mxcubeweb/core/components/sampleview.py
@@ -374,7 +374,7 @@ class SampleView(ComponentBase):
 
     def start_manual_centring(self):
         """
-        Start N-click centring procedure.
+        Start Click centring procedure.
             :statuscode: 200: no error
             :statuscode: 409: error
         """
@@ -390,7 +390,7 @@ class SampleView(ComponentBase):
             )
 
             HWR.beamline.diffractometer.start_centring_method(
-                HWR.beamline.diffractometer.MANUAL3CLICK_MODE
+                HWR.beamline.diffractometer.CENTRING_METHOD_MANUAL
             )
 
             self.centring_reset_click_count()
@@ -424,7 +424,7 @@ class SampleView(ComponentBase):
                 HWR.beamline.diffractometer.cancel_centring_method()
 
                 HWR.beamline.diffractometer.start_centring_method(
-                    HWR.beamline.diffractometer.MANUAL3CLICK_MODE
+                    HWR.beamline.diffractometer.CENTRING_METHOD_MANUAL
                 )
 
         return {"clicksLeft": self.centring_clicks_left()}

--- a/mxcubeweb/core/models/generic.py
+++ b/mxcubeweb/core/models/generic.py
@@ -25,13 +25,16 @@ class AppSettingsModel(BaseModel):
             "be dis-activated to not clash with i.e workflow mesh,"
         ),
     )
-
     enable_2d_points: bool = Field(
         True,
         description=(
             " Enable features to work with points in the plane, called2D-points,"
             " (none centred positions)"
         ),
+    )
+    click_centring_num_clicks: int = Field(
+        3,
+        description="Number of clicks used for the manual click centring",
     )
 
     class Config:

--- a/mxcubeweb/routes/main.py
+++ b/mxcubeweb/routes/main.py
@@ -51,6 +51,7 @@ def init_route(app, server, url_prefix):
                 "use_native_mesh": _blc.use_native_mesh,
                 "enable_2d_points": _blc.enable_2d_points,
                 "use_get_samples_from_sc": app.CONFIG.app.USE_GET_SAMPLES_FROM_SC,
+                "click_centring_num_clicks": _blc.click_centring_num_clicks,
             }
         )
 

--- a/mxcubeweb/routes/samplecentring.py
+++ b/mxcubeweb/routes/samplecentring.py
@@ -238,12 +238,12 @@ def init_route(app, server, url_prefix):  # noqa: C901
         app.sample_view.start_auto_centring()
         return Response(status=200)
 
-    @bp.route("/centring/start3click", methods=["PUT"])
+    @bp.route("/centring/start_click_centring", methods=["PUT"])
     @server.require_control
     @server.restrict
-    def centre_3_click():
+    def centre_click():
         """
-        Start N-click centring procedure.
+        Start Click centring procedure.
             :statuscode: 200: no error
             :statuscode: 409: error
         """
@@ -283,7 +283,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.restrict
     def click():
         """
-        The N-click method needs the input from the user, a running Nclick centring
+        The click method needs the input from the user, a running click centring
         procedure must be set before
 
         :request Content-type: application/json, integer positions of the clicks,

--- a/mxcubeweb/routes/samplecentring.py
+++ b/mxcubeweb/routes/samplecentring.py
@@ -243,7 +243,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.restrict
     def centre_3_click():
         """
-        Start 3 click centring procedure.
+        Start N-click centring procedure.
             :statuscode: 200: no error
             :statuscode: 409: error
         """
@@ -251,7 +251,10 @@ def init_route(app, server, url_prefix):  # noqa: C901
         try:
             data = app.sample_view.start_manual_centring()
         except Exception:
-            logging.getLogger("MX3.HWR").exception("Could not start 3 click centring")
+            msg = "Could not start %s click centring"
+            logging.getLogger("MX3.HWR").exception(
+                msg, HWR.beamline.config.click_centring_num_clicks
+            )
             resp = (
                 "Could not move motor",
                 409,
@@ -280,7 +283,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.restrict
     def click():
         """
-        The 3-click method needs the input from the user, a running 3click centring
+        The N-click method needs the input from the user, a running Nclick centring
         procedure must be set before
 
         :request Content-type: application/json, integer positions of the clicks,

--- a/mxcubeweb/routes/signals.py
+++ b/mxcubeweb/routes/signals.py
@@ -212,7 +212,7 @@ def centring_started(method, *args):
 
     if method in ["Computer automatic"]:
         msg = {"method": qe.CENTRING_METHOD.LOOP}
-    elif method in [HWR.beamline.diffractometer.MANUAL3CLICK_MODE]:
+    elif method in [HWR.beamline.diffractometer.CENTRING_METHOD_MANUAL]:
         msg = {"method": qe.CENTRING_METHOD.MANUAL}
 
     server.emit("sample_centring", msg, namespace="/hwr")

--- a/mxcubeweb/routes/signals.py
+++ b/mxcubeweb/routes/signals.py
@@ -212,7 +212,7 @@ def centring_started(method, *args):
 
     if method in ["Computer automatic"]:
         msg = {"method": qe.CENTRING_METHOD.LOOP}
-    elif method in ["Manual 3-click"]:
+    elif method in [HWR.beamline.diffractometer.MANUAL3CLICK_MODE]:
         msg = {"method": qe.CENTRING_METHOD.MANUAL}
 
     server.emit("sample_centring", msg, namespace="/hwr")

--- a/ui/src/actions/sampleview.js
+++ b/ui/src/actions/sampleview.js
@@ -189,13 +189,14 @@ export function rotateToShape(sid) {
 }
 
 export function recordCentringClick(x, y) {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
+    const { general } = getState();
     const json = await sendRecordCentringClick(x, y);
 
     const { clicksLeft } = json;
     dispatch(centringClicksLeft(clicksLeft));
 
-    let msg = '3-Click Centring: <br />';
+    let msg = `${general.clickCentringNumClicks}-Click Centring: <br />`;
     if (clicksLeft === 0) {
       msg += 'Save centring or clicking on screen to restart';
     } else if (clicksLeft === -1) {
@@ -302,8 +303,7 @@ export function toggleCentring() {
 
 export function startClickCentring() {
   return async (dispatch, getState) => {
-    const { queue, shapes } = getState();
-
+    const { queue, shapes, general } = getState();
     dispatch(clearSelectedShapes());
     dispatch(unselectShapes(shapes));
 
@@ -318,7 +318,7 @@ export function startClickCentring() {
     dispatch(startClickCentringAction());
     dispatch(centringClicksLeft(clicksLeft));
 
-    const msg = `3-Click Centring: <br />${
+    const msg = `${general.clickCentringNumClicks}-Click Centring: <br />${
       clicksLeft === 0
         ? 'Save centring or clicking on screen to restart'
         : `Clicks left: ${clicksLeft}`

--- a/ui/src/api/sampleview.js
+++ b/ui/src/api/sampleview.js
@@ -31,7 +31,7 @@ export function sendSetCentringMethod(centringMethod) {
 }
 
 export function sendStartClickCentring() {
-  return endpoint.put(undefined, '/centring/start3click').safeJson();
+  return endpoint.put(undefined, '/centring/start_click_centring').safeJson();
 }
 
 export function sendRecordCentringClick(x, y) {

--- a/ui/src/components/SampleControls/CentringControl.jsx
+++ b/ui/src/components/SampleControls/CentringControl.jsx
@@ -7,17 +7,22 @@ import styles from './SampleControls.module.css';
 function CentringControl() {
   const dispatch = useDispatch();
   const isActive = useSelector((state) => state.sampleview.clickCentring);
+  const numClicks = useSelector(
+    (state) => state.general.clickCentringNumClicks,
+  );
 
   return (
     <Button
       className={styles.controlBtn}
       data-default-styles
       active={isActive}
-      title={`${isActive ? 'Stop' : 'Start'} 3-click centring`}
+      title={`${isActive ? 'Stop' : 'Start'} ${numClicks}-click centring`}
       onClick={() => dispatch(toggleCentring())}
     >
       <i className={`${styles.controlIcon} fas fa-circle-notch`} />
-      <span className={styles.controlLabel}>3-click centring</span>
+      <span
+        className={styles.controlLabel}
+      >{`${numClicks}-click centring`}</span>
     </Button>
   );
 }

--- a/ui/src/components/SampleControls/SampleControls.jsx
+++ b/ui/src/components/SampleControls/SampleControls.jsx
@@ -15,7 +15,7 @@ function SampleControls(props) {
     <div className={styles.controls}>
       {useShowControl('snapshot') && <SnapshotControl canvas={canvas} />}
       {useShowControl('draw_grid') && <GridControl />}
-      {useShowControl('3_click_centring') && <CentringControl />}
+      {useShowControl('click_centring') && <CentringControl />}
       {useShowControl('focus') && <FocusControl />}
       {useShowControl('zoom') && <ZoomControl />}
       {useShowControl('backlight') && (

--- a/ui/src/reducers/general.js
+++ b/ui/src/reducers/general.js
@@ -46,6 +46,7 @@ function generalReducer(state = INITIAL_STATE, action = {}) {
         enable2DPoints: action.data.general.enable_2d_points,
         meshResultFormat: action.data.general.mesh_result_format,
         useNativeMesh: action.data.general.use_native_mesh,
+        clickCentringNumClicks: action.data.general.click_centring_num_clicks,
       };
     }
     case 'APPLICATION_FETCHED': {

--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -290,10 +290,11 @@ class ServerIO {
     });
 
     this.hwrSocket.on('sample_centring', (data) => {
+      const numClicks = store.getState().general.clickCentringNumClicks;
+
       if (data.method === CLICK_CENTRING) {
         dispatch(startClickCentringAction());
-        const msg =
-          '3-Click Centring: <br /> Select centered position or center';
+        const msg = `${numClicks}-Click Centring: <br />Select centered position or center`;
         dispatch(videoMessageOverlay(true, msg));
       } else {
         const msg = 'Auto loop centring: <br /> Save position or re-center';


### PR DESCRIPTION
These changes allow the UI to reflect the number of clicks defined in the configuration file of the beamline.

### Reason
One of the beamlines using MXCuBE has a custom `2-click` procedure, so it was necessary to make the name displayed in the UI configurable (see screenshots).
<p float="left">
  <img src="https://github.com/user-attachments/assets/dbdf8bde-3ad5-4ef0-841e-90b394c655d2" width="200"/>
  <img src="https://github.com/user-attachments/assets/3ae9b4ec-10bd-4627-9d82-0e1fe15ccb20" width="180"/>
  <img src="https://github.com/user-attachments/assets/5424c4a8-e2bf-4a10-887c-f3b4a3f3c5db" width="320"/>
</p>

## HowTo
Edit the `beamline_config.yml` like this:
```diff
configuration:
  ...
  run_processing_parallel: true
  run_number: 1
+ click_centring_num_clicks: 2
    ...
```

This PR is a follow-up of this other PR https://github.com/mxcube/mxcubeweb/pull/1710