### PR TITLE
remove call to removed `diffractometer_init_signals()` method

### DIFF
--- a/mxcubeweb/app.py
+++ b/mxcubeweb/app.py
@@ -211,7 +211,6 @@ class MXCUBEApplication:
 
         try:
             MXCUBEApplication.beamline.init_signals()
-            MXCUBEApplication.beamline.diffractometer_init_signals()
         except Exception:
             sys.excepthook(*sys.exc_info())
 


### PR DESCRIPTION
Right now, when running the "demo" beamline, you'll get this error message:


> Traceback (most recent call last):
>   File "/someplace/web/mxcubeweb/app.py", line 214, in init_signal_handlers
>     MXCUBEApplication.beamline.diffractometer_init_signals()
>     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 
> AttributeError: 'Beamline' object has no attribute 'diffractometer_init_signals'. Did you mean: 'diffractometer_get_info'?


In the commit 7fa89931db449962a02951df02ac21b5bdc69438 the` Beamline.diffractometer_init_signals()` method was removed.

I guess we should remove this call in `app.py` as well.
