### PR TITLE
Exporting `get_resolution_limits_for_energy` from `EnergyAdapter`

### DIFF
--- a/mxcubeweb/core/adapter/energy_adapter.py
+++ b/mxcubeweb/core/adapter/energy_adapter.py
@@ -8,7 +8,8 @@ from mxcubeweb.core.adapter.wavelength_adapter import WavelengthAdapter
 from mxcubeweb.core.models.configmodels import AdapterResourceHandlerConfigModel
 
 resource_handler_config = AdapterResourceHandlerConfigModel(
-    commands=["get_value", "set_value", "stop"], attributes=["data"]
+    commands=["get_value", "set_value", "stop", "get_resolution_limits_for_energy"],
+    attributes=["data"],
 )
 
 

--- a/ui/src/api/hardware-object.js
+++ b/ui/src/api/hardware-object.js
@@ -4,7 +4,7 @@ const endpoint = api.url('/hwobj');
 
 export function sendExecuteCommand(objectType, objectId, command, value) {
   return endpoint
-    .put({ value }, `/${objectType}/${objectId}/${command}`)
+    .put(value, `/${objectType}/${objectId}/${command}`)
     .safeJson();
 }
 
@@ -13,7 +13,7 @@ export function sendGetAttribute(objectType, objectId, attributeName) {
 }
 
 export function sendSetValue(objectId, objectType, value) {
-  return sendExecuteCommand(objectType, objectId, 'set_value', value);
+  return sendExecuteCommand(objectType, objectId, 'set_value', { value });
 }
 
 export function sendGetValue(objectId, objectType) {


### PR DESCRIPTION
The method `get_resolution_limits_for_energy` was previously exported from the Beamline route it was lost in the migration to `AdapterResourceHandler`. Exporting `get_resolution_limits_for_energy` via `EnergyAdapter`