### PR TITLE
Fixed casing of `imageClicked`, should be `image_clicked`

### DIFF
--- a/mxcubeweb/core/components/sampleview.py
+++ b/mxcubeweb/core/components/sampleview.py
@@ -412,7 +412,7 @@ class SampleView(ComponentBase):
     def centring_handle_click(self, x, y):
         if HWR.beamline.diffractometer.current_centring_procedure:
             try:
-                HWR.beamline.diffractometer.imageClicked(x, y, x, y)
+                HWR.beamline.diffractometer.image_clicked(x, y, x, y)
                 self.centring_click()
             except Exception:
                 return {"clicksLeft": -1}


### PR DESCRIPTION
An old "alias" of `image_clicked` was used in `sampleview.py`. I guess the camel cased method name have lingered in some site specific or mock code. It should be removed or change to `image_clicked`