### PR TITLE
Add CSP 

### DIFF
--- a/demo/mxcube-web/server.yaml
+++ b/demo/mxcube-web/server.yaml
@@ -13,6 +13,38 @@ server:
   PORT: 8081
   USER_DB_PATH: /tmp/mxcube-user.db
 
+  CSP_ENABLED: true
+  CSP_POLICY:
+    default-src:
+      - "'self'"
+    script-src:
+      - "'self'"
+      - "'unsafe-inline'"
+      - "'unsafe-eval'"
+    style-src:
+      - "'self'"
+      - "'unsafe-inline'"
+    img-src:
+      - "'self'"
+      - "data:"
+      - "blob:"
+    font-src:
+      - "'self'"
+    connect-src:
+      - "'self'"
+      - "wss:"
+      - "ws:"
+    frame-src:
+      - "'self'"
+    object-src:
+      - "'none'"
+    base-uri:
+      - "'self'"
+    form-action:
+      - "'self'"
+  CSP_REPORT_ONLY: false
+  CSP_REPORT_URI: ""
+
 sso:
   USE_SSO: false
   ISSUER: https://websso.[site].[com]/realms/[site]/

--- a/demo/mxcube-web/server.yaml
+++ b/demo/mxcube-web/server.yaml
@@ -16,32 +16,32 @@ server:
   CSP_ENABLED: true
   CSP_POLICY:
     default-src:
-      - "'self'"
+      - "self"
     script-src:
-      - "'self'"
-      - "'unsafe-inline'"
-      - "'unsafe-eval'"
+      - "self"
+      - "unsafe-inline"
+      - "unsafe-eval"
     style-src:
-      - "'self'"
-      - "'unsafe-inline'"
+      - "self"
+      - "unsafe-inline"
     img-src:
-      - "'self'"
+      - "self"
       - "data:"
       - "blob:"
     font-src:
-      - "'self'"
+      - "self"
     connect-src:
-      - "'self'"
+      - "self"
       - "wss:"
       - "ws:"
     frame-src:
-      - "'self'"
+      - "self"
     object-src:
-      - "'none'"
+      - "none"
     base-uri:
-      - "'self'"
+      - "self"
     form-action:
-      - "'self'"
+      - "self"
   CSP_REPORT_ONLY: false
   CSP_REPORT_URI: "/mxcube/api/v0.1/csp/report"
 

--- a/demo/mxcube-web/server.yaml
+++ b/demo/mxcube-web/server.yaml
@@ -43,7 +43,7 @@ server:
     form-action:
       - "'self'"
   CSP_REPORT_ONLY: false
-  CSP_REPORT_URI: ""
+  CSP_REPORT_URI: "/mxcube/api/v0.1/csp/report"
 
 sso:
   USE_SSO: false

--- a/mxcubeweb/__init__.py
+++ b/mxcubeweb/__init__.py
@@ -79,6 +79,7 @@ def parse_args(argv):
             "user_logger",
             "queue_logger",
             "mx3_ui_logger",
+            "csp_logger",
         ],
     )
 

--- a/mxcubeweb/app.py
+++ b/mxcubeweb/app.py
@@ -249,6 +249,7 @@ class MXCUBEApplication:
             "user_logger": logging.getLogger("user_level_log"),
             "queue_logger": logging.getLogger("queue_exec"),
             "mx3_ui_logger": logging.getLogger("MX3.UI"),
+            "csp_logger": logging.getLogger("csp"),
         }
 
         stdout_log_handler = StreamHandler(sys.stdout)

--- a/mxcubeweb/core/models/configmodels.py
+++ b/mxcubeweb/core/models/configmodels.py
@@ -38,6 +38,30 @@ class FlaskConfigModel(BaseModel):
         description="One of the strings ['SIGNED', 'ADHOC', NONE]",
     )
 
+    CSP_ENABLED: bool = True
+    CSP_POLICY: dict[str, list[str]] = Field(
+        {
+            "default-src": ["'self'"],
+            "script-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
+            "style-src": ["'self'", "'unsafe-inline'"],
+            "img-src": ["'self'", "data:", "blob:"],
+            "font-src": ["'self'"],
+            "connect-src": ["'self'", "wss:", "ws:"],
+            "frame-src": ["'self'"],
+            "object-src": ["'none'"],
+            "base-uri": ["'self'"],
+            "form-action": ["'self'"],
+        },
+        description="Content Security Policy directives",
+    )
+    CSP_REPORT_ONLY: bool = Field(
+        False,
+        description="Set to True to enable report-only mode (won't block content)",
+    )
+    CSP_REPORT_URI: str = Field(
+        "", description="URI for CSP violation reports (empty to disable reporting)"
+    )
+
 
 class SSOConfigModel(BaseModel):
     USE_SSO: bool = Field(False, description="Set to True to use SSO")

--- a/mxcubeweb/core/models/configmodels.py
+++ b/mxcubeweb/core/models/configmodels.py
@@ -39,21 +39,7 @@ class FlaskConfigModel(BaseModel):
     )
 
     CSP_ENABLED: bool = True
-    CSP_POLICY: dict[str, list[str]] = Field(
-        {
-            "default-src": ["'self'"],
-            "script-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
-            "style-src": ["'self'", "'unsafe-inline'"],
-            "img-src": ["'self'", "data:", "blob:"],
-            "font-src": ["'self'"],
-            "connect-src": ["'self'", "wss:", "ws:"],
-            "frame-src": ["'self'"],
-            "object-src": ["'none'"],
-            "base-uri": ["'self'"],
-            "form-action": ["'self'"],
-        },
-        description="Content Security Policy directives",
-    )
+    CSP_POLICY: dict[str, list[str]] = {}
     CSP_REPORT_ONLY: bool = Field(
         False,
         description="Set to True to enable report-only mode (won't block content)",

--- a/mxcubeweb/core/server/csp.py
+++ b/mxcubeweb/core/server/csp.py
@@ -30,11 +30,29 @@ class CSPMiddleware:
         return self.app(environ, _start_response)
 
     def _build_policy_string(self) -> str:
-        parts = []
+        # CSP keywords that need to be quoted
+        csp_keywords = {
+            "self",
+            "unsafe-inline",
+            "unsafe-eval",
+            "none",
+            "strict-dynamic",
+            "unsafe-hashes",
+            "report-sample",
+            "wasm-unsafe-eval",
+            "script",
+        }
 
+        def quote_if_keyword(source):
+            if source in csp_keywords:
+                return f"'{source}'"
+            return source
+
+        parts = []
         for directive, sources in self.policy.items():
             if sources:
-                parts.append(f"{directive} {' '.join(sources)}")
+                quoted_sources = [quote_if_keyword(s) for s in sources]
+                parts.append(f"{directive} {' '.join(quoted_sources)}")
 
         if self.report_uri:
             parts.append(f"report-uri {self.report_uri}")

--- a/mxcubeweb/core/server/csp.py
+++ b/mxcubeweb/core/server/csp.py
@@ -1,0 +1,42 @@
+class CSPMiddleware:
+    """
+    Middleware to add Content Security Policy headers to responses.
+    """
+
+    def __init__(self, app, config):
+        self.app = app
+        self.config = config
+        self.enabled = config.get("CSP_ENABLED", True)
+        self.policy = config.get("CSP_POLICY", {})
+        self.report_only = config.get("CSP_REPORT_ONLY", False)
+        self.report_uri = config.get("CSP_REPORT_URI", "")
+
+    def __call__(self, environ, start_response):
+        if not self.enabled:
+            return self.app(environ, start_response)
+
+        def _start_response(status, headers, exc_info=None):
+            if self.enabled:
+                policy_str = self._build_policy_string()
+                header_name = (
+                    "Content-Security-Policy-Report-Only"
+                    if self.report_only
+                    else "Content-Security-Policy"
+                )
+                headers.append((header_name, policy_str))
+
+            return start_response(status, headers, exc_info)
+
+        return self.app(environ, _start_response)
+
+    def _build_policy_string(self) -> str:
+        parts = []
+
+        for directive, sources in self.policy.items():
+            if sources:
+                parts.append(f"{directive} {' '.join(sources)}")
+
+        if self.report_uri:
+            parts.append(f"report-uri {self.report_uri}")
+
+        return "; ".join(parts)

--- a/mxcubeweb/routes/csp_report.py
+++ b/mxcubeweb/routes/csp_report.py
@@ -11,13 +11,6 @@ def init_route(_mxcube_app, _server, url_prefix):
     bp = Blueprint("csp", __name__, url_prefix=url_prefix)
 
     csp_logger = logging.getLogger("csp")
-    if not csp_logger.handlers:
-        handler = logging.StreamHandler()
-        handler.setFormatter(
-            logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-        )
-        csp_logger.addHandler(handler)
-        csp_logger.setLevel(logging.WARNING)
 
     @bp.route("/report", methods=["POST"])
     def csp_report():

--- a/mxcubeweb/routes/csp_report.py
+++ b/mxcubeweb/routes/csp_report.py
@@ -1,0 +1,29 @@
+import logging
+
+from flask import Blueprint, jsonify, request
+
+
+def init_route(_mxcube_app, _server, url_prefix):
+    """
+    Initialize CSP report routes
+    url_prefix: URL prefix for the blueprint
+    """
+    bp = Blueprint("csp", __name__, url_prefix=url_prefix)
+
+    csp_logger = logging.getLogger("csp")
+    if not csp_logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+        )
+        csp_logger.addHandler(handler)
+        csp_logger.setLevel(logging.WARNING)
+
+    @bp.route("/report", methods=["POST"])
+    def csp_report():
+        """Endpoint to collect CSP violation reports"""
+        report = request.get_json()
+        csp_logger.warning("CSP Violation: %s", report.get("csp-report", {}))
+        return jsonify({"status": "report received"}), 204
+
+    return bp

--- a/test/test_csp.py
+++ b/test/test_csp.py
@@ -1,0 +1,262 @@
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+from flask import Flask, jsonify
+
+from mxcubeweb.core.server.csp import CSPMiddleware
+from mxcubeweb.routes.csp_report import init_route
+
+
+class TestCSPMiddleware:
+    """Tests for the CSP middleware"""
+
+    def test_csp_middleware_enabled(self):
+        """Test that CSP middleware adds standard headers when enabled"""
+        config = {
+            "CSP_ENABLED": True,
+            "CSP_POLICY": {
+                "default-src": ["'self'"],
+                "script-src": ["'self'", "'unsafe-inline'"],
+            },
+            "CSP_REPORT_ONLY": False,
+            "CSP_REPORT_URI": "",
+        }
+
+        mock_start_response = Mock()
+        captured_headers = []
+
+        def mock_app(_environ, start_response):
+            status = "200 OK"
+            headers = [("Content-Type", "text/plain")]
+            start_response(status, headers)
+            mock_app.last_start_response = start_response
+            return [b"Response body"]
+
+        middleware = CSPMiddleware(mock_app, config)
+
+        def original_start_response(_status, headers, _exc_info=None):
+            captured_headers.extend(headers)
+            return mock_start_response
+
+        middleware({}, original_start_response)
+
+        csp_headers = [h for h in captured_headers if h[0] == "Content-Security-Policy"]
+        assert len(csp_headers) == 1
+        assert "default-src 'self'" in csp_headers[0][1]
+        assert "script-src 'self' 'unsafe-inline'" in csp_headers[0][1]
+
+    def test_csp_middleware_report_only(self):
+        """Test that CSP middleware sets Report-Only mode when configured"""
+        config = {
+            "CSP_ENABLED": True,
+            "CSP_POLICY": {"default-src": ["'self'"]},
+            "CSP_REPORT_ONLY": True,
+            "CSP_REPORT_URI": "",
+        }
+
+        mock_start_response = Mock()
+        captured_headers = []
+
+        def mock_app(_environ, start_response):
+            status = "200 OK"
+            headers = [("Content-Type", "text/plain")]
+            start_response(status, headers)
+            mock_app.last_start_response = start_response
+            return [b"Response body"]
+
+        middleware = CSPMiddleware(mock_app, config)
+
+        def original_start_response(_status, headers, _exc_info=None):
+            captured_headers.extend(headers)
+            return mock_start_response
+
+        middleware({}, original_start_response)
+
+        csp_headers = [
+            h for h in captured_headers if h[0] == "Content-Security-Policy-Report-Only"
+        ]
+        assert len(csp_headers) == 1
+
+    def test_csp_middleware_report_uri(self):
+        """Test that CSP middleware adds report-uri when configured"""
+        config = {
+            "CSP_ENABLED": True,
+            "CSP_POLICY": {"default-src": ["'self'"]},
+            "CSP_REPORT_ONLY": False,
+            "CSP_REPORT_URI": "/mxcube/api/v0.1/csp/report",
+        }
+
+        mock_start_response = Mock()
+        captured_headers = []
+
+        def mock_app(_environ, start_response):
+            status = "200 OK"
+            headers = [("Content-Type", "text/plain")]
+            start_response(status, headers)
+            mock_app.last_start_response = start_response
+            return [b"Response body"]
+
+        middleware = CSPMiddleware(mock_app, config)
+
+        def original_start_response(_status, headers, _exc_info=None):
+            captured_headers.extend(headers)
+            return mock_start_response
+
+        middleware({}, original_start_response)
+
+        csp_headers = [h for h in captured_headers if h[0] == "Content-Security-Policy"]
+        assert len(csp_headers) == 1
+        assert "report-uri /mxcube/api/v0.1/csp/report" in csp_headers[0][1]
+
+    def test_csp_middleware_disabled(self):
+        """Test that CSP middleware doesn't add any headers when disabled"""
+        config = {
+            "CSP_ENABLED": False,
+            "CSP_POLICY": {"default-src": ["'self'"]},
+        }
+
+        mock_start_response = Mock()
+        captured_headers = []
+
+        def mock_app(_environ, start_response):
+            status = "200 OK"
+            headers = [("Content-Type", "text/plain")]
+            start_response(status, headers)
+            return [b"Response body"]
+
+        middleware = CSPMiddleware(mock_app, config)
+
+        def original_start_response(_status, headers, _exc_info=None):
+            captured_headers.extend(headers)
+            return mock_start_response
+
+        middleware({}, original_start_response)
+
+        csp_headers = [
+            h for h in captured_headers if h[0].startswith("Content-Security-Policy")
+        ]
+        assert len(csp_headers) == 0
+
+    def test_build_policy_string(self):
+        """Test that CSP policy string is correctly built from dictionary"""
+        config = {
+            "CSP_ENABLED": True,
+            "CSP_POLICY": {
+                "default-src": ["'self'"],
+                "script-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
+                "img-src": ["'self'", "data:", "blob:"],
+            },
+            "CSP_REPORT_ONLY": False,
+            "CSP_REPORT_URI": "/report",
+        }
+
+        middleware = CSPMiddleware(Mock(), config)
+        captured_headers = []
+
+        def mock_app(_environ, start_response):
+            start_response("200 OK", [])
+            return [b""]
+
+        def capture_start_response(_status, headers, _exc_info=None):
+            captured_headers.extend(headers)
+
+        middleware.app = mock_app
+        middleware({}, capture_start_response)
+
+        csp_header = next(
+            (h[1] for h in captured_headers if h[0] == "Content-Security-Policy"), ""
+        )
+
+        assert "default-src 'self'" in csp_header
+        assert "script-src 'self' 'unsafe-inline' 'unsafe-eval'" in csp_header
+        assert "img-src 'self' data: blob:" in csp_header
+        assert "report-uri /report" in csp_header
+
+
+class TestCSPReportEndpoint:
+    """Tests for the CSP report endpoint"""
+
+    @pytest.fixture
+    def test_app(self):
+        """Create a test Flask app with the CSP report endpoint"""
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+
+        bp = init_route(None, None, "/csp")
+        app.register_blueprint(bp)
+
+        return app
+
+    @pytest.fixture
+    def client(self, test_app):
+        return test_app.test_client()
+
+    def test_csp_report_endpoint(self, client):
+        """Test that CSP violation reports are received and logged correctly"""
+        test_report = {
+            "csp-report": {
+                "document-uri": "http://localhost:8081/",
+                "referrer": "",
+                "violated-directive": "script-src-elem",
+                "effective-directive": "script-src-elem",
+                "original-policy": "default-src 'self'",
+                "disposition": "enforce",
+                "blocked-uri": "http://malicious-site.com/script.js",
+                "status-code": 0,
+            }
+        }
+
+        with patch("logging.Logger.warning") as mock_warning:
+            resp = client.post(
+                "/csp/report",
+                data=json.dumps(test_report),
+                content_type="application/json",
+            )
+
+            assert resp.status_code == 204
+            mock_warning.assert_called_once()
+            log_args = mock_warning.call_args[0]
+            assert "CSP Violation" in log_args[0]
+
+
+class TestCSPIntegration:
+    """Integration tests for CSP implementation"""
+
+    @pytest.fixture
+    def app_with_csp(self):
+        """Create a test Flask app with CSP middleware applied"""
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+
+        config = {
+            "CSP_ENABLED": True,
+            "CSP_POLICY": {
+                "default-src": ["'self'"],
+                "script-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
+            },
+            "CSP_REPORT_ONLY": False,
+            "CSP_REPORT_URI": "",
+        }
+
+        app.wsgi_app = CSPMiddleware(app.wsgi_app, config)
+
+        @app.route("/test")
+        def test_route():
+            return jsonify({"status": "ok"})
+
+        return app
+
+    @pytest.fixture
+    def client(self, app_with_csp):
+        return app_with_csp.test_client()
+
+    def test_csp_headers_in_response(self, client):
+        """Test that CSP headers are correctly included in actual HTTP responses"""
+        resp = client.get("/test")
+
+        assert "Content-Security-Policy" in resp.headers
+
+        policy = resp.headers["Content-Security-Policy"]
+        assert "default-src 'self'" in policy
+        assert "script-src 'self' 'unsafe-inline' 'unsafe-eval'" in policy


### PR DESCRIPTION
Introduces Content Security Policy (CSP). 
The changes include adding a middleware to enforce CSP headers, updating the configuration model to include CSP settings, and creating a route to handle CSP violation reports.

###Implementation:

* **Configuration Updates**:
  - Added new fields to the `FlaskConfigModel` for CSP settings, including `CSP_ENABLED`, `CSP_POLICY`, `CSP_REPORT_ONLY`, and `CSP_REPORT_URI`. These fields allow enabling/disabling CSP, defining the policy, enabling report-only mode, and specifying a URI for violation reports. 
  - (`mxcubeweb/core/models/configmodels.py`)

* **Middleware for CSP Enforcement**:
  - Introduced a `CSPMiddleware` class to add CSP headers to HTTP responses based on the specified configuration. The middleware dynamically constructs the CSP header string and supports both enforcement and report-only modes. 
  - (`mxcubeweb/core/server/csp.py`)

* **CSP Violation Reporting**:
  - Implemented a new route in `csp_report.py` to handle CSP violation reports. The route logs violations using a dedicated logger and returns a response indicating the report was received.
  -  (`mxcubeweb/routes/csp_report.py`)