### PR TITLE
Add in control user to userlist

### DIFF
--- a/mxcubeweb/routes/ra.py
+++ b/mxcubeweb/routes/ra.py
@@ -135,6 +135,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
             "observers": [_u.todict() for _u in app.usermanager.get_observers()],
             "allowRemote": app.ALLOW_REMOTE,
             "timeoutGivesControl": app.TIMEOUT_GIVES_CONTROL,
+            "operator": app.usermanager.get_operator().todict(),
         }
 
         return jsonify(data=data)

--- a/ui/src/components/RemoteAccess/UserList.jsx
+++ b/ui/src/components/RemoteAccess/UserList.jsx
@@ -8,34 +8,60 @@ function UserList() {
 
   const user = useSelector((state) => state.login.user);
   const observers = useSelector((state) => state.remoteAccess.observers);
+  const operator = useSelector((state) => state.remoteAccess.operator);
+
+  const columnSize = user.inControl ? 4 : 6;
 
   return (
     <Card className="mb-3">
       <Card.Header>Users</Card.Header>
       <Card.Body>
         <Row>
-          <Col sm={4}>
+          <Col sm={columnSize}>
             <b>Name</b>
           </Col>
-          <Col sm={4}>
+          <Col sm={columnSize}>
             <b>Host</b>
           </Col>
-          <Col sm={4}>
-            <span>&nbsp;</span>
+          {user.inControl && (
+            <Col sm={columnSize}>
+              <span>&nbsp;</span>
+            </Col>
+          )}
+        </Row>
+        <Row key={operator.username} className="mt-3">
+          <Col sm={columnSize}>
+            <span style={{ lineHeight: '24px' }}>
+              <span style={{ fontWeight: 'bold' }}>In Control </span>
+              {user.inControl && (
+                <span style={{ fontWeight: 'bold', fontStyle: 'italic' }}>
+                  (You){' '}
+                </span>
+              )}
+              - {operator.nickname || <em>Not provided</em>}
+            </span>
+          </Col>
+          <Col sm={columnSize}>
+            <span style={{ lineHeight: '24px' }}>{operator.ip}</span>
           </Col>
         </Row>
         {observers.map((observer) => (
           <Row key={observer.username} className="mt-3">
-            <Col sm={4}>
+            <Col sm={columnSize}>
               <span style={{ lineHeight: '24px' }}>
+                {user.nickname === observer.nickname && (
+                  <span style={{ fontWeight: 'bold', fontStyle: 'italic' }}>
+                    (You) -{' '}
+                  </span>
+                )}
                 {observer.nickname || <em>Not provided</em>}
               </span>
             </Col>
-            <Col sm={3}>
+            <Col sm={columnSize}>
               <span style={{ lineHeight: '24px' }}>{observer.ip}</span>
             </Col>
             {user.inControl && (
-              <Col sm={5}>
+              <Col sm={columnSize}>
                 <Button
                   size="sm"
                   variant="outline-secondary"

--- a/ui/src/containers/RemoteAccessContainer.jsx
+++ b/ui/src/containers/RemoteAccessContainer.jsx
@@ -14,18 +14,20 @@ function RemoteAccessContainer() {
   const remoteAccess = useSelector((state) => state.remoteAccess);
   const inControl = useSelector((state) => state.login.user.inControl);
 
+  const colSize = inControl ? 6 : 4;
+
   return (
     <Container fluid className="mt-4">
       <Row sm={12} className="d-flex">
         {!inControl && (
-          <Col sm={4} className="col-xs-4">
+          <Col sm={colSize} className="col-xs-4">
             <RequestControlForm />
           </Col>
         )}
-        <Col sm={4} className="mb-3">
+        <Col sm={colSize} className="mb-3">
           <UserList />
         </Col>
-        <Col sm={4}>
+        <Col sm={colSize}>
           <Card className="mb-3">
             <Card.Header>Options</Card.Header>
             <Card.Body>

--- a/ui/src/reducers/remoteAccess.js
+++ b/ui/src/reducers/remoteAccess.js
@@ -15,6 +15,7 @@ function remoteAccessReducer(state = INITIAL_STATE, action = {}) {
         observers: action.data.observers,
         allowRemote: action.data.allowRemote,
         timeoutGivesControl: action.data.timeoutGivesControl,
+        operator: action.data.operator,
       };
     }
     case 'SET_MASTER': {
@@ -45,6 +46,7 @@ function remoteAccessReducer(state = INITIAL_STATE, action = {}) {
         sid: action.data.remoteAccess.sid,
         allowRemote: action.data.remoteAccess.allowRemote,
         timeoutGivesControl: action.data.remoteAccess.timeoutGivesControl,
+        operator: action.data.remoteAccess.operator,
       };
     }
     default: {


### PR DESCRIPTION
The Userlist which was showed on the remote access tab was never complete as the user who was in control was not displayed, only observers.

This PR changes the way the User list is displayed, adding the in control user, and highlighting him and the current logged in User with different Tags (In Control and (You))

For this to work, the information of the user in control was added to the state under `remoteAccess`

Additionally, I made the Columns in the remote access page and Userlist more reactive to take up the space according to the number of columns (previously there was always some space left for elements that were only displayed to the user in control)