### PR TITLE
Fix toggling operators

### DIFF
--- a/mxcubeweb/routes/ra.py
+++ b/mxcubeweb/routes/ra.py
@@ -113,15 +113,17 @@ def init_route(app, server, url_prefix):  # noqa: C901
         oldop = app.usermanager.get_operator()
         newop = app.usermanager.set_operator(username)
 
-        oldop.requests_control = False
-        oldop.requests_control_msg = None
-        app.usermanager.update_user(oldop)
+        if oldop:
+            oldop.requests_control = False
+            oldop.requests_control_msg = None
+            app.usermanager.update_user(oldop)
 
         newop.requests_control = False
         newop.requests_control_msg = None
         app.usermanager.update_user(newop)
 
-        server.emit("userChanged", room=oldop.socketio_session_id, namespace="/hwr")
+        if oldop:
+            server.emit("userChanged", room=oldop.socketio_session_id, namespace="/hwr")
         server.emit(
             "userChanged", message, room=newop.socketio_session_id, namespace="/hwr"
         )


### PR DESCRIPTION
Addressing issue: https://github.com/mxcube/mxcubecore/issues/1214

Fix toggling operators when old operator logged out before new user pressed `Take control`

In such scenario `app.usermanager.get_operator()` was returning `None` value, back-end was raising an error while trying to assign values to `oldop.requests_control` and `oldop.requests_control_msg`, what finally caused in returning `501` response code to the frontend.