### PR TITLE
split the TodoItem logic from the TodoTree component

### DIFF
--- a/ui/src/components/SampleQueue/Item.module.css
+++ b/ui/src/components/SampleQueue/Item.module.css
@@ -1,0 +1,24 @@
+.nodeSample {
+  font-size: 1em;
+  margin-bottom: 1rem;
+  background-color: white;
+}
+
+.taskHead {
+  padding: 0.5rem 1rem;
+  border: 1px solid #ddd;
+  background-color: #f9f9f9;
+}
+
+.taskHead p {
+  margin: 0;
+}
+
+.taskHead:hover {
+  background-color: #eaeaea;
+}
+
+.nodeName {
+  margin-left: 4px;
+  cursor: pointer;
+}

--- a/ui/src/components/SampleQueue/TodoItem.jsx
+++ b/ui/src/components/SampleQueue/TodoItem.jsx
@@ -1,0 +1,42 @@
+import { Button } from 'react-bootstrap';
+import { useDispatch } from 'react-redux';
+
+import { showList } from '../../actions/queueGUI';
+import { mountSample } from '../../actions/sampleChanger';
+import styles from './Item.module.css';
+
+export default function TodoItem({ sampleData }) {
+  const dispatch = useDispatch();
+
+  if (!sampleData) {
+    return null;
+  }
+
+  function mountAndSwitchTab() {
+    dispatch(mountSample(sampleData));
+    dispatch(showList('current'));
+  }
+
+  const { sampleID, sampleName = '', proteinAcronym = '' } = sampleData;
+
+  return (
+    <div className={styles.nodeSample}>
+      <div className={styles.taskHead}>
+        <div className={`d-flex ${styles.nodeName}`}>
+          <p className="pt-1 me-auto">
+            <b>{`${sampleID} `}</b>
+            {`${proteinAcronym} ${sampleName}`}
+          </p>
+
+          <Button
+            variant="outline-secondary"
+            size="sm"
+            onClick={mountAndSwitchTab}
+          >
+            Mount
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/SampleQueue/TodoTree.jsx
+++ b/ui/src/components/SampleQueue/TodoTree.jsx
@@ -1,18 +1,18 @@
 /* eslint-disable react/destructuring-assignment */
-/* eslint-disable react/no-array-index-key */
+
 import './app.css';
 
 import React from 'react';
 import { Button, Form, ListGroup } from 'react-bootstrap';
 
 import { QUEUE_RUNNING } from '../../constants';
+import TodoItem from './TodoItem';
 
 export default class TodoTree extends React.Component {
   constructor(props) {
     super(props);
     this.setSearchWord = this.setSearchWord.bind(this);
     this.showAddSampleForm = this.showAddSampleForm.bind(this);
-    this.mountAndSwitchTab = this.mountAndSwitchTab.bind(this);
     this.state = { searchWord: '' };
   }
 
@@ -23,11 +23,6 @@ export default class TodoTree extends React.Component {
   showAddSampleForm() {
     this.props.prepareBeamlineForNewSample();
     this.props.showForm('AddSample');
-  }
-
-  mountAndSwitchTab(sampleData) {
-    this.props.mount(sampleData);
-    this.props.showList('current');
   }
 
   filter(list, searchWord) {
@@ -69,33 +64,9 @@ export default class TodoTree extends React.Component {
           </div>
         </ListGroup.Item>
         <ListGroup.Item className="d-flex list-body">
-          {list.map((key, id) => {
+          {list.map((key) => {
             const sampleData = this.props.sampleList[key];
-            const sampleName = sampleData.sampleName || '';
-            const proteinAcronym = sampleData.proteinAcronym
-              ? `${sampleData.proteinAcronym} -`
-              : '';
-
-            return (
-              <div key={id} className="node node-sample">
-                <div className="task-head">
-                  <div className="d-flex node-name">
-                    <p className="pt-1 me-auto">
-                      <b>{`${sampleData.sampleID} `}</b>
-                      {`${proteinAcronym} ${sampleName}`}
-                    </p>
-
-                    <Button
-                      variant="outline-secondary"
-                      size="sm"
-                      onClick={() => this.mountAndSwitchTab(sampleData)}
-                    >
-                      Mount
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            );
+            return <TodoItem sampleData={sampleData} key={`Sample ${key}`} />;
           })}
         </ListGroup.Item>
       </ListGroup>

--- a/ui/src/containers/SampleQueueContainer.jsx
+++ b/ui/src/containers/SampleQueueContainer.jsx
@@ -14,7 +14,6 @@ import {
   toggleCheckBox,
 } from '../actions/queue';
 import { collapseItem, selectItem, showList } from '../actions/queueGUI';
-import { mountSample } from '../actions/sampleChanger';
 import { showTaskForm } from '../actions/taskForm';
 import { showWorkflowParametersDialog } from '../actions/workflow';
 import UserMessage from '../components/Notify/UserMessage';
@@ -131,10 +130,8 @@ class SampleQueueContainer extends React.Component {
             show={visibleList === 'todo'}
             list={todo}
             sampleList={sampleList}
-            mount={this.props.mountSample}
             showForm={showForm}
             queueStatus={queueStatus}
-            showList={this.props.showList}
             prepareBeamlineForNewSample={this.props.prepareBeamlineForNewSample}
           />
           <div className="queue-messages">
@@ -193,9 +190,6 @@ function mapDispatchToProps(dispatch) {
     collapseItem: bindActionCreators(collapseItem, dispatch),
     selectItem: bindActionCreators(selectItem, dispatch),
     showList: bindActionCreators(showList, dispatch),
-
-    // Sample changer actions
-    mountSample: bindActionCreators(mountSample, dispatch),
 
     showForm: bindActionCreators(showTaskForm, dispatch),
     showDialog: bindActionCreators(showDialog, dispatch),


### PR DESCRIPTION
This PR takes some of the logic from `TodoTree` and creates a new component for rendering the sample items in the todo list.

It also introduces a new CSS module `Item.module.css`. The plan would be to use this also for the different `TaskItem` components, as some styles are shared. As of now there is one CSS file that is imported everywhere in the `sampleQueue` and is in need of a clean-up.

It's a first part for refactoring this part, next will be the transformation of `Todotree` into a functional component.

