### PR TITLE
Re-rise exception after unsuccessful login attempt

### DIFF
--- a/mxcubeweb/core/components/lims.py
+++ b/mxcubeweb/core/components/lims.py
@@ -1,7 +1,6 @@
 import logging
 import math
 import re
-import sys
 
 from flask_login import current_user
 from mxcubecore import HardwareRepository as HWR
@@ -189,18 +188,12 @@ class Lims(ComponentBase):
         # Selecting the active session in the LIMS object
         try:
             session = HWR.beamline.lims.set_active_session_by_id(session_id)
-            if session is None:
-                msg = "No session selected on LIMS"
-                raise NoSessionError(msg)
-        except BaseException as e:
-            import traceback
-
-            traceback.print_exc(file=sys.stdout)
-            logging.getLogger("MX3.HWR").info(
-                "No session candidate. Force signout. e=%s" % str(e)
+        except Exception as exc:
+            logging.getLogger("MX3.HWR").exception(
+                "No session candidate. Force signout."
             )
             self.app.usermanager.signout()
-            return False
+            raise NoSessionError from exc
 
         if (
             HWR.beamline.lims.is_user_login_type()


### PR DESCRIPTION
Re-rise exception after unsuccessful login attempt.
This causes to show up the error notification `Authentication failed` in UI, as mentioned in [documentation](https://github.com/mxcube/mxcubecore/blob/develop/docs/source/dev/user-based-login-details.md#multiple-users)

![Screenshot from 2025-07-03 14-44-11](https://github.com/user-attachments/assets/7b227f85-88c1-4382-bd10-1d7cdb966e0d)

Traceback:
```
2025-07-04 08:26:40,984 |MX3.HWR|ERROR  | No session candidate. Force signout.
mxcube-1              | Traceback (most recent call last):
mxcube-1              |   File "/app/web/mxcubeweb/core/components/lims.py", line 191, in select_session
mxcube-1              |     session = HWR.beamline.lims.set_active_session_by_id(session_id)
mxcube-1              |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
mxcube-1              |   File "/app/core/mxcubecore/HardwareObjects/MAXIV/ISPyBLims.py", line 217, in set_active_session_by_id
mxcube-1              |     raise Exception(f"no session with ID {session_id} found") 
mxcube-1              |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
mxcube-1              | Exception: no session with ID 87798 found
mxcube-1              | 2025-07-04 08:26:40,988 |MX3.HWR|ERROR  | [LOGIN] User extpawmoc could not login
mxcube-1              | Traceback (most recent call last):
mxcube-1              |   File "/app/web/mxcubeweb/core/components/lims.py", line 191, in select_session
mxcube-1              |     session = HWR.beamline.lims.set_active_session_by_id(session_id)
mxcube-1              |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
mxcube-1              |   File "/app/core/mxcubecore/HardwareObjects/MAXIV/ISPyBLims.py", line 217, in set_active_session_by_id
mxcube-1              |     raise Exception(f"no session with ID {session_id} found")
mxcube-1              |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
mxcube-1              | Exception: no session with ID 87798 found
mxcube-1              | 
mxcube-1              | The above exception was the direct cause of the following exception:
mxcube-1              | 
mxcube-1              | Traceback (most recent call last):
mxcube-1              |   File "/app/web/mxcubeweb/routes/login.py", line 44, in login
mxcube-1              |     app.usermanager.login(login_id, password)
mxcube-1              |   File "/app/web/mxcubeweb/core/components/user/usermanager.py", line 284, in login
mxcube-1              |     self.update_operator(new_login=True)
mxcube-1              |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
mxcube-1              |   File "/app/web/mxcubeweb/core/components/user/usermanager.py", line 201, in update_operator
mxcube-1              |     self.app.lims.select_session(_u.selected_proposal)
mxcube-1              |   File "/app/web/mxcubeweb/core/components/lims.py", line 197, in select_session
mxcube-1              |     raise NoSessionError from exc
```
Which is fine in ma opinion - it just shows up more precise information where exactly the problem with login comes from.
