### PR TITLE
handle case operator = None in Userlist

### DIFF
--- a/mxcubeweb/routes/ra.py
+++ b/mxcubeweb/routes/ra.py
@@ -133,11 +133,12 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.restrict
     def rasettings():
         """ """
+        operator = app.usermanager.get_operator()
         data = {
             "observers": [_u.todict() for _u in app.usermanager.get_observers()],
             "allowRemote": app.ALLOW_REMOTE,
             "timeoutGivesControl": app.TIMEOUT_GIVES_CONTROL,
-            "operator": app.usermanager.get_operator().todict(),
+            "operator": operator.todict() if operator else None,
         }
 
         return jsonify(data=data)

--- a/ui/src/components/RemoteAccess/UserList.jsx
+++ b/ui/src/components/RemoteAccess/UserList.jsx
@@ -29,22 +29,24 @@ function UserList() {
             </Col>
           )}
         </Row>
-        <Row key={operator.username} className="mt-3">
-          <Col sm={columnSize}>
-            <span style={{ lineHeight: '24px' }}>
-              <span style={{ fontWeight: 'bold' }}>In Control </span>
-              {user.inControl && (
-                <span style={{ fontWeight: 'bold', fontStyle: 'italic' }}>
-                  (You){' '}
-                </span>
-              )}
-              - {operator.nickname || <em>Not provided</em>}
-            </span>
-          </Col>
-          <Col sm={columnSize}>
-            <span style={{ lineHeight: '24px' }}>{operator.ip}</span>
-          </Col>
-        </Row>
+        {operator && (
+          <Row key={operator.username} className="mt-3">
+            <Col sm={columnSize}>
+              <span style={{ lineHeight: '24px' }}>
+                <span style={{ fontWeight: 'bold' }}>In Control </span>
+                {user.inControl && (
+                  <span style={{ fontWeight: 'bold', fontStyle: 'italic' }}>
+                    (You){' '}
+                  </span>
+                )}
+                - {operator.nickname || <em>Not provided</em>}
+              </span>
+            </Col>
+            <Col sm={columnSize}>
+              <span style={{ lineHeight: '24px' }}>{operator.ip}</span>
+            </Col>
+          </Row>
+        )}
         {observers.map((observer) => (
           <Row key={observer.username} className="mt-3">
             <Col sm={columnSize}>


### PR DESCRIPTION
This is a follow-up to #1741. It handles the case described in #1742, where the operator can be `None`, which would not have triggered a re-render of the userlist due to an error in the back-end. 

I will keep this as a draft until #1742 is merged and rebase on it later