### PR TITLE
Cleanup TaskItems and collect similar container code

### DIFF
--- a/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
+++ b/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
@@ -1,21 +1,16 @@
 /* eslint-disable react/destructuring-assignment */
 /* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable react/no-unused-prop-types */
-/* eslint-disable react/no-unused-state */
 
 /* eslint-disable react/no-array-index-key */
 
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import { Button, Collapse, ProgressBar, Table } from 'react-bootstrap';
+import { Button, Table } from 'react-bootstrap';
 
-import {
-  TASK_COLLECT_FAILED,
-  TASK_COLLECTED,
-  TASK_RUNNING,
-  TASK_UNCOLLECTED,
-} from '../../constants';
+import { TASK_COLLECTED } from '../../constants';
 import TooltipTrigger from '../TooltipTrigger';
+import TaskItemContainer from './TaskItemContainer';
 
 export default class TaskItem extends Component {
   static propTypes = {
@@ -26,17 +21,9 @@ export default class TaskItem extends Component {
   constructor(props) {
     super(props);
     this.showForm = this.showForm.bind(this);
-    this.deleteTask = this.deleteTask.bind(this);
-    this.toggleChecked = this.toggleChecked.bind(this);
-    this.taskHeaderOnClick = this.taskHeaderOnClick.bind(this);
-    this.taskHeaderOnContextMenu = this.taskHeaderOnContextMenu.bind(this);
     this.getResult = this.getResult.bind(this);
     this.showDiffPlan = this.showDiffPlan.bind(this);
     this.pointIDString = this.pointIDString.bind(this);
-    this.state = {
-      overInput: false,
-      selected: false,
-    };
   }
 
   getResult(_state, data) {
@@ -110,38 +97,6 @@ export default class TaskItem extends Component {
         this.props.addTask([sampleId], pars, false);
       });
     }
-  }
-
-  toggleChecked() {
-    this.props.toggleChecked(this.props.sampleId, this.props.index);
-  }
-
-  taskHeaderOnClick(e) {
-    this.props.taskHeaderOnClickHandler(e, this.props.index);
-  }
-
-  taskHeaderOnContextMenu(e) {
-    this.props.taskHeaderOnContextMenuHandler(e, this.props.index);
-  }
-
-  deleteTask(e) {
-    e.stopPropagation();
-    this.props.deleteTask(this.props.sampleId, this.props.index);
-  }
-
-  // eslint-disable-next-line react/no-unused-class-component-methods
-  deleteButton() {
-    let content = (
-      <Button size="sm" onClick={this.deleteTask}>
-        Delete
-      </Button>
-    );
-
-    if (this.props.state !== TASK_UNCOLLECTED) {
-      content = <span> </span>;
-    }
-
-    return content;
   }
 
   showForm() {
@@ -233,184 +188,113 @@ export default class TaskItem extends Component {
     );
   }
 
-  progressBar() {
-    const { state } = this.props;
-    let pbarBsStyle = 'info';
-
-    switch (state) {
-      case TASK_RUNNING: {
-        pbarBsStyle = 'info';
-
-        break;
-      }
-      case TASK_COLLECTED: {
-        pbarBsStyle = 'success';
-
-        break;
-      }
-      case TASK_COLLECT_FAILED: {
-        pbarBsStyle = 'danger';
-
-        break;
-      }
-      // No default
-    }
-
-    return (
-      <span style={{ width: '150px', right: '60px', position: 'absolute' }}>
-        <ProgressBar
-          variant={pbarBsStyle}
-          striped
-          style={{ marginBottom: 0, height: '18px' }}
-          min={0}
-          max={1}
-          animated={this.props.progress < 1}
-          label={`${(this.props.progress * 100).toPrecision(3)} %`}
-          now={this.props.progress}
-        />
-      </span>
-    );
-  }
-
   render() {
-    const { state, data, show } = this.props;
+    const {
+      data,
+      deleteTask,
+      progress,
+      sampleId,
+      selected,
+      show,
+      showContextMenu,
+      state,
+      taskHeaderOnClickHandler,
+      taskHeaderOnContextMenuHandler,
+    } = this.props;
     const wedges =
       data.type === 'Interleaved' ? data.parameters.wedges : [data];
 
-    const delTaskCSS = {
-      display: 'flex',
-      marginLeft: 'auto',
-      alignItems: 'center',
-      paddingLeft: '10px',
-      paddingRight: '10px',
-      color: '#d9534f',
-      cursor: 'pointer',
-    };
-
-    let taskCSS = this.props.selected
-      ? 'task-head task-head-selected'
-      : 'task-head';
-
-    taskCSS += ' uncollected';
-
-    if (state === TASK_RUNNING) {
-      taskCSS += ' running';
-    } else if (state === TASK_COLLECTED && data.diffractionPlan.length > 0) {
-      taskCSS += ' success';
-    } else if (
-      state === TASK_COLLECTED &&
-      data.diffractionPlan.length === undefined
-    ) {
-      taskCSS += ' warning';
-    } else if (state === TASK_COLLECT_FAILED) {
-      taskCSS += ' error';
-    }
-
     return (
-      <div className="node node-sample">
-        <div
-          onContextMenu={(e) =>
-            this.props.showContextMenu(e, 'currentSampleQueueContextMenu')
-          }
-          id="currentSampleQueueContextMenu"
-        >
-          <div
-            onClick={this.taskHeaderOnClick}
-            onContextMenu={this.taskHeaderOnContextMenu}
-          >
-            <div className={taskCSS} style={{ display: 'flex' }}>
-              <b>
-                <span className="node-name" style={{ display: 'flex' }}>
-                  {this.pointIDString(wedges)} {data.label}
-                  {state === TASK_RUNNING && this.progressBar()}
-                </span>
-              </b>
-              {state === TASK_UNCOLLECTED && (
-                <i
-                  className="fas fa-times"
-                  onClick={this.deleteTask}
-                  style={delTaskCSS}
-                />
-              )}
-            </div>
-          </div>
-          <Collapse in={Boolean(show)}>
-            <div className="task-body">
-              {wedges.map((wedge, i) => {
-                const padding = i > 0 ? '1em' : '0em';
-                return (
-                  <div key={`wedge-${i}`}>
-                    <div
-                      style={{
-                        borderLeft: '1px solid #DDD',
-                        borderRight: '1px solid #DDD',
-                        paddingTop: padding,
+      <TaskItemContainer
+        dataLabel={data.label}
+        deleteTask={deleteTask}
+        diffractionPlanLength={data.diffractionPlan.length}
+        index={this.props.index}
+        pointIDString={this.pointIDString(wedges)}
+        progress={progress}
+        sampleId={sampleId}
+        selected={selected}
+        show={show}
+        showContextMenu={showContextMenu}
+        specialTaskCSS="Characterisation"
+        state={state}
+        taskHeaderOnClickHandler={taskHeaderOnClickHandler}
+        taskHeaderOnContextMenuHandler={taskHeaderOnContextMenuHandler}
+      >
+        <div className="task-body">
+          {wedges.map((wedge, i) => {
+            const padding = i > 0 ? '1em' : '0em';
+            return (
+              <div key={`wedge-${i}`}>
+                <div
+                  style={{
+                    borderLeft: '1px solid #DDD',
+                    borderRight: '1px solid #DDD',
+                    paddingTop: padding,
+                  }}
+                >
+                  <div
+                    style={{
+                      borderTop: '1px solid #DDD',
+                      padding: '0.5em',
+                      display: 'flex',
+                      justifyContent: 'space-around',
+                      alignItems: 'center',
+                    }}
+                  >
+                    <b>Path:</b>
+                    {this.wedgePath(wedge)}
+                    <Button
+                      variant="outline-secondary"
+                      style={{ width: '3em' }}
+                      title="Copy path"
+                      onClick={() => {
+                        navigator.clipboard.writeText(
+                          `${wedge.parameters.path}`,
+                        );
                       }}
                     >
-                      <div
-                        style={{
-                          borderTop: '1px solid #DDD',
-                          padding: '0.5em',
-                          display: 'flex',
-                          justifyContent: 'space-around',
-                          alignItems: 'center',
-                        }}
-                      >
-                        <b>Path:</b>
-                        {this.wedgePath(wedge)}
-                        <Button
-                          variant="outline-secondary"
-                          style={{ width: '3em' }}
-                          title="Copy path"
-                          onClick={() => {
-                            navigator.clipboard.writeText(
-                              `${wedge.parameters.path}`,
-                            );
-                          }}
-                        >
-                          <i
-                            style={{ marginLeft: 0 }}
-                            className="fa fa-copy"
-                            aria-hidden="true"
-                          />
-                        </Button>
-                      </div>
-                    </div>
-                    <Table
-                      striped
-                      bordered
-                      hover
-                      onClick={this.showForm}
-                      style={{ fontSize: 'smaller', marginBottom: 0 }}
-                      className="task-parameters-table"
-                    >
-                      <thead>
-                        <tr>
-                          <th>Start &deg; </th>
-                          <th>Osc. &deg; </th>
-                          <th>t (s)</th>
-                          <th># Img</th>
-                          <th>T (%)</th>
-                          <th>Res. (&Aring;)</th>
-                          <th>E (keV)</th>
-                          {wedge.parameters.kappa_phi !== null && (
-                            <th>&phi; &deg;</th>
-                          )}
-                          {wedge.parameters.kappa !== null && (
-                            <th>&kappa; &deg;</th>
-                          )}
-                        </tr>
-                      </thead>
-                      <tbody>{this.wedgeParameters(wedge)}</tbody>
-                    </Table>
-                    {this.getResult(state, data)}
+                      <i
+                        style={{ marginLeft: 0 }}
+                        className="fa fa-copy"
+                        aria-hidden="true"
+                      />
+                    </Button>
                   </div>
-                );
-              })}
-            </div>
-          </Collapse>
+                </div>
+                <Table
+                  striped
+                  bordered
+                  hover
+                  onClick={this.showForm}
+                  style={{ fontSize: 'smaller', marginBottom: 0 }}
+                  className="task-parameters-table"
+                >
+                  <thead>
+                    <tr>
+                      <th>Start &deg; </th>
+                      <th>Osc. &deg; </th>
+                      <th>t (s)</th>
+                      <th># Img</th>
+                      <th>T (%)</th>
+                      <th>Res. (&Aring;)</th>
+                      <th>E (keV)</th>
+                      {wedge.parameters.kappa_phi !== null && (
+                        <th>&phi; &deg;</th>
+                      )}
+                      {wedge.parameters.kappa !== null && (
+                        <th>&kappa; &deg;</th>
+                      )}
+                    </tr>
+                  </thead>
+                  <tbody>{this.wedgeParameters(wedge)}</tbody>
+                </Table>
+                {this.getResult(state, data)}
+              </div>
+            );
+          })}
         </div>
-      </div>
+      </TaskItemContainer>
     );
   }
 }

--- a/ui/src/components/SampleQueue/CurrentTree.jsx
+++ b/ui/src/components/SampleQueue/CurrentTree.jsx
@@ -157,7 +157,6 @@ export default class CurrentTree extends React.Component {
                     sampleId={sampleData.sampleID}
                     selected={displayData.selected}
                     checked={this.props.checked}
-                    toggleChecked={this.props.toggleCheckBox}
                     taskHeaderOnClickHandler={this.taskHeaderOnClickHandler}
                     taskHeaderOnContextMenuHandler={
                       this.taskHeaderOnContextMenuHandler
@@ -190,7 +189,6 @@ export default class CurrentTree extends React.Component {
                     sampleId={sampleData.sampleID}
                     selected={displayData.selected}
                     checked={this.props.checked}
-                    toggleChecked={this.props.toggleCheckBox}
                     taskHeaderOnClickHandler={this.taskHeaderOnClickHandler}
                     taskHeaderOnContextMenuHandler={
                       this.taskHeaderOnContextMenuHandler
@@ -221,7 +219,6 @@ export default class CurrentTree extends React.Component {
                     sampleId={sampleData.sampleID}
                     selected={displayData.selected}
                     checked={this.props.checked}
-                    toggleChecked={this.props.toggleCheckBox}
                     taskHeaderOnClickHandler={this.taskHeaderOnClickHandler}
                     taskHeaderOnContextMenuHandler={
                       this.taskHeaderOnContextMenuHandler
@@ -251,7 +248,6 @@ export default class CurrentTree extends React.Component {
                     sampleId={sampleData.sampleID}
                     selected={displayData.selected}
                     checked={this.props.checked}
-                    toggleChecked={this.props.toggleCheckBox}
                     taskHeaderOnClickHandler={this.taskHeaderOnClickHandler}
                     taskHeaderOnContextMenuHandler={
                       this.taskHeaderOnContextMenuHandler
@@ -282,7 +278,6 @@ export default class CurrentTree extends React.Component {
                     sampleId={sampleData.sampleID}
                     selected={displayData.selected}
                     checked={this.props.checked}
-                    toggleChecked={this.props.toggleCheckBox}
                     taskHeaderOnClickHandler={this.taskHeaderOnClickHandler}
                     taskHeaderOnContextMenuHandler={
                       this.taskHeaderOnContextMenuHandler

--- a/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
+++ b/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
@@ -2,24 +2,13 @@
 /* eslint-disable jsx-a11y/control-has-associated-label */
 /* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable react/no-unused-prop-types */
-/* eslint-disable react/no-unused-state */
 
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import {
-  Button,
-  Collapse,
-  OverlayTrigger,
-  Popover,
-  ProgressBar,
-} from 'react-bootstrap';
+import { OverlayTrigger, Popover } from 'react-bootstrap';
 
-import {
-  TASK_COLLECT_FAILED,
-  TASK_COLLECTED,
-  TASK_RUNNING,
-  TASK_UNCOLLECTED,
-} from '../../constants';
+import { TASK_COLLECTED } from '../../constants';
+import TaskItemContainer from './TaskItemContainer';
 
 export default class EnergyScanTaskItem extends Component {
   static propTypes = {
@@ -30,16 +19,8 @@ export default class EnergyScanTaskItem extends Component {
   constructor(props) {
     super(props);
     this.showForm = this.showForm.bind(this);
-    this.deleteTask = this.deleteTask.bind(this);
-    this.toggleChecked = this.toggleChecked.bind(this);
-    this.taskHeaderOnClick = this.taskHeaderOnClick.bind(this);
-    this.taskHeaderOnContextMenu = this.taskHeaderOnContextMenu.bind(this);
     this.getResult = this.getResult.bind(this);
     this.pointIDString = this.pointIDString.bind(this);
-    this.state = {
-      overInput: false,
-      selected: false,
-    };
   }
 
   getResult(state) {
@@ -65,38 +46,6 @@ export default class EnergyScanTaskItem extends Component {
         </a>
       </div>
     );
-  }
-
-  toggleChecked() {
-    this.props.toggleChecked(this.props.sampleId, this.props.index);
-  }
-
-  taskHeaderOnClick(e) {
-    this.props.taskHeaderOnClickHandler(e, this.props.index);
-  }
-
-  taskHeaderOnContextMenu(e) {
-    this.props.taskHeaderOnContextMenuHandler(e, this.props.index);
-  }
-
-  deleteTask(e) {
-    e.stopPropagation();
-    this.props.deleteTask(this.props.sampleId, this.props.index);
-  }
-
-  // eslint-disable-next-line react/no-unused-class-component-methods
-  deleteButton() {
-    let content = (
-      <Button size="sm" onClick={this.deleteTask}>
-        Delete
-      </Button>
-    );
-
-    if (this.props.state !== TASK_UNCOLLECTED) {
-      content = <span> </span>;
-    }
-
-    return content;
   }
 
   showForm() {
@@ -150,108 +99,52 @@ export default class EnergyScanTaskItem extends Component {
   }
 
   render() {
-    const { state, data, show } = this.props;
+    const {
+      data,
+      deleteTask,
+      progress,
+      sampleId,
+      selected,
+      show,
+      showContextMenu,
+      state,
+      taskHeaderOnClickHandler,
+      taskHeaderOnContextMenuHandler,
+    } = this.props;
 
     const { parameters } = data;
 
-    const delTaskCSS = {
-      display: 'flex',
-      marginLeft: 'auto',
-      alignItems: 'center',
-      paddingLeft: '10px',
-      paddingRight: '10px',
-      color: '#d9534f',
-      cursor: 'pointer',
-    };
-
-    const taskCSS = this.props.selected
-      ? 'task-head task-head-selected'
-      : 'task-head';
-
-    let pbarBsStyle = 'info';
-
-    switch (state) {
-      case TASK_RUNNING: {
-        pbarBsStyle = 'info';
-
-        break;
-      }
-      case TASK_COLLECTED: {
-        pbarBsStyle = 'success';
-
-        break;
-      }
-      case TASK_COLLECT_FAILED: {
-        pbarBsStyle = 'danger';
-
-        break;
-      }
-      // No default
-    }
-
     return (
-      <div className="node node-sample">
-        <div
-          onContextMenu={(e) =>
-            this.props.showContextMenu(e, 'currentSampleQueueContextMenu')
-          }
-          id="currentSampleQueueContextMenu"
-        >
-          <div
-            onClick={this.taskHeaderOnClick}
-            onContextMenu={this.taskHeaderOnContextMenu}
-          >
-            <div className={taskCSS} style={{ display: 'flex' }}>
-              <b>
-                <span className="node-name" style={{ display: 'flex' }}>
-                  {this.pointIDString(parameters)} {data.label}
-                  <span
-                    style={{
-                      width: '150px',
-                      right: '60px',
-                      position: 'absolute',
-                    }}
-                  >
-                    <ProgressBar
-                      variant={pbarBsStyle}
-                      striped
-                      style={{ marginBottom: 0, height: '18px' }}
-                      min={0}
-                      max={1}
-                      animated={this.props.progress < 1}
-                      label={`${(this.props.progress * 100).toPrecision(3)} %`}
-                      now={this.props.progress}
-                    />
-                  </span>
-                </span>
-              </b>
-              {state === TASK_UNCOLLECTED && (
-                <i
-                  className="fas fa-times"
-                  onClick={this.deleteTask}
-                  style={delTaskCSS}
-                />
-              )}
-            </div>
-          </div>
-          <Collapse in={Boolean(show)}>
-            <div className="task-body">
-              <div>
-                <div style={{ border: '1px solid #DDD' }}>
-                  <div style={{ padding: '0.5em' }} onClick={this.showForm}>
-                    <b>Path:</b> {this.path(parameters)}
-                    <br />
-                    <b>Element:</b> {parameters.element}
-                    <br />
-                    <b>Edge:</b> {parameters.edge}
-                  </div>
-                </div>
-                {this.getResult(state)}
+      <TaskItemContainer
+        dataLabel={data.label}
+        deleteTask={deleteTask}
+        index={this.props.index}
+        pointIDString={this.pointIDString(parameters)}
+        progress={progress}
+        sampleId={sampleId}
+        selected={selected}
+        show={show}
+        showContextMenu={showContextMenu}
+        specialTaskCSS="Characterisation"
+        state={state}
+        taskHeaderOnClickHandler={taskHeaderOnClickHandler}
+        taskHeaderOnContextMenuHandler={taskHeaderOnContextMenuHandler}
+      >
+        <div className="task-body">
+          <div>
+            <div style={{ border: '1px solid #DDD' }}>
+              <div style={{ padding: '0.5em' }} onClick={this.showForm}>
+                <b>Path:</b> {this.path(parameters)}
+                <br />
+                <b>Element:</b> {parameters.element}
+                <br />
+                <b>Edge:</b> {parameters.edge}
               </div>
             </div>
-          </Collapse>
+            {this.getResult(state)}
+          </div>
         </div>
-      </div>
+      </TaskItemContainer>
     );
   }
 }

--- a/ui/src/components/SampleQueue/TaskItem.jsx
+++ b/ui/src/components/SampleQueue/TaskItem.jsx
@@ -2,19 +2,14 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable react/no-array-index-key */
 /* eslint-disable react/no-unused-prop-types */
-/* eslint-disable react/no-unused-state */
 
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import { Button, Collapse, ProgressBar, Table } from 'react-bootstrap';
+import { Button, Table } from 'react-bootstrap';
 
-import {
-  TASK_COLLECT_FAILED,
-  TASK_COLLECTED,
-  TASK_RUNNING,
-  TASK_UNCOLLECTED,
-} from '../../constants';
+import { TASK_COLLECTED } from '../../constants';
 import TooltipTrigger from '../TooltipTrigger';
+import TaskItemContainer from './TaskItemContainer';
 
 export default class TaskItem extends Component {
   static propTypes = {
@@ -25,17 +20,9 @@ export default class TaskItem extends Component {
   constructor(props) {
     super(props);
     this.showForm = this.showForm.bind(this);
-    this.deleteTask = this.deleteTask.bind(this);
-    this.toggleChecked = this.toggleChecked.bind(this);
-    this.taskHeaderOnClick = this.taskHeaderOnClick.bind(this);
-    this.taskHeaderOnContextMenu = this.taskHeaderOnContextMenu.bind(this);
     this.getResult = this.getResult.bind(this);
     this.pointIDString = this.pointIDString.bind(this);
     this.wedgeParameters = this.wedgeParameters.bind(this);
-    this.state = {
-      overInput: false,
-      selected: false,
-    };
   }
 
   getResult(state) {
@@ -70,38 +57,6 @@ export default class TaskItem extends Component {
         </a>
       </div>
     );
-  }
-
-  toggleChecked() {
-    this.props.toggleChecked(this.props.sampleId, this.props.index);
-  }
-
-  taskHeaderOnClick(e) {
-    this.props.taskHeaderOnClickHandler(e, this.props.index);
-  }
-
-  taskHeaderOnContextMenu(e) {
-    this.props.taskHeaderOnContextMenuHandler(e, this.props.index);
-  }
-
-  deleteTask(e) {
-    e.stopPropagation();
-    this.props.deleteTask(this.props.sampleId, this.props.index);
-  }
-
-  // eslint-disable-next-line react/no-unused-class-component-methods
-  deleteButton() {
-    let content = (
-      <Button size="sm" onClick={this.deleteTask}>
-        Delete
-      </Button>
-    );
-
-    if (this.props.state !== TASK_UNCOLLECTED) {
-      content = <span> </span>;
-    }
-
-    return content;
   }
 
   showForm() {
@@ -208,192 +163,115 @@ export default class TaskItem extends Component {
     );
   }
 
-  progressBar() {
-    const { state } = this.props;
-    let pbarBsStyle = 'info';
-
-    switch (state) {
-      case TASK_RUNNING: {
-        pbarBsStyle = 'info';
-
-        break;
-      }
-      case TASK_COLLECTED: {
-        pbarBsStyle = 'success';
-
-        break;
-      }
-      case TASK_COLLECT_FAILED: {
-        pbarBsStyle = 'danger';
-
-        break;
-      }
-      // No default
-    }
-
-    return (
-      <span style={{ width: '150px', right: '60px', position: 'absolute' }}>
-        <ProgressBar
-          variant={pbarBsStyle}
-          striped
-          style={{ marginBottom: 0, height: '18px' }}
-          min={0}
-          max={1}
-          animated={this.props.progress < 1}
-          label={`${(this.props.progress * 100).toPrecision(3)} %`}
-          now={this.props.progress}
-        />
-      </span>
-    );
-  }
-
   render() {
-    const { state, data, show } = this.props;
+    const {
+      data,
+      deleteTask,
+      progress,
+      sampleId,
+      selected,
+      show,
+      showContextMenu,
+      state,
+      taskHeaderOnClickHandler,
+      taskHeaderOnContextMenuHandler,
+    } = this.props;
     const wedges =
       data.type === 'Interleaved' ? data.parameters.wedges : [data];
 
-    const delTaskCSS = {
-      display: 'flex',
-      marginLeft: 'auto',
-      alignItems: 'center',
-      paddingLeft: '10px',
-      paddingRight: '10px',
-      color: '#d9534f',
-      cursor: 'pointer',
-    };
-
-    let taskCSS = this.props.selected
-      ? 'task-head task-head-selected'
-      : 'task-head';
-
-    switch (state) {
-      case TASK_RUNNING: {
-        taskCSS += ' running';
-
-        break;
-      }
-      case TASK_COLLECTED: {
-        taskCSS += ' success';
-
-        break;
-      }
-      case TASK_COLLECT_FAILED: {
-        taskCSS += ' error';
-
-        break;
-      }
-      // No default
-    }
-
     return (
-      <div className="node node-sample">
-        <div
-          onContextMenu={(e) =>
-            this.props.showContextMenu(e, 'currentSampleQueueContextMenu')
-          }
-          id="currentSampleQueueContextMenu"
-        >
-          <div
-            onClick={this.taskHeaderOnClick}
-            onContextMenu={this.taskHeaderOnContextMenu}
-          >
-            <div className={taskCSS} style={{ display: 'flex' }}>
-              <b>
-                <span className="node-name" style={{ display: 'flex' }}>
-                  {this.pointIDString(wedges)} {data.label}
-                  {state === TASK_RUNNING && this.progressBar()}
-                </span>
-              </b>
-              {state === TASK_UNCOLLECTED && (
-                <i
-                  className="fas fa-times"
-                  onClick={this.deleteTask}
-                  style={delTaskCSS}
-                />
-              )}
-            </div>
-          </div>
-          <Collapse in={Boolean(show)}>
-            <div className="task-body">
-              {wedges.map((wedge, i) => {
-                const padding = i > 0 ? '1em' : '0em';
-                return (
-                  <div key={`wedge-${i}`}>
-                    <div
-                      style={{
-                        borderLeft: '1px solid #DDD',
-                        borderRight: '1px solid #DDD',
-                        paddingTop: padding,
+      <TaskItemContainer
+        dataLabel={data.label}
+        deleteTask={deleteTask}
+        index={this.props.index}
+        pointIDString={this.pointIDString(wedges)}
+        progress={progress}
+        sampleId={sampleId}
+        selected={selected}
+        show={show}
+        showContextMenu={showContextMenu}
+        state={state}
+        taskHeaderOnClickHandler={taskHeaderOnClickHandler}
+        taskHeaderOnContextMenuHandler={taskHeaderOnContextMenuHandler}
+      >
+        <div className="task-body">
+          {wedges.map((wedge, i) => {
+            const padding = i > 0 ? '1em' : '0em';
+            return (
+              <div key={`wedge-${i}`}>
+                <div
+                  style={{
+                    borderLeft: '1px solid #DDD',
+                    borderRight: '1px solid #DDD',
+                    paddingTop: padding,
+                  }}
+                >
+                  <div
+                    style={{
+                      borderTop: '1px solid #DDD',
+                      padding: '0.5em',
+                      display: 'flex',
+                      justifyContent: 'space-around',
+                      alignItems: 'center',
+                    }}
+                  >
+                    <b>Path:</b>
+                    {this.wedgePath(wedge)}
+                    <Button
+                      variant="outline-secondary"
+                      style={{ width: '3em' }}
+                      title="Copy path"
+                      onClick={() => {
+                        navigator.clipboard.writeText(
+                          `${wedge.parameters.path}`,
+                        );
                       }}
                     >
-                      <div
-                        style={{
-                          borderTop: '1px solid #DDD',
-                          padding: '0.5em',
-                          display: 'flex',
-                          justifyContent: 'space-around',
-                          alignItems: 'center',
-                        }}
-                      >
-                        <b>Path:</b>
-                        {this.wedgePath(wedge)}
-                        <Button
-                          variant="outline-secondary"
-                          style={{ width: '3em' }}
-                          title="Copy path"
-                          onClick={() => {
-                            navigator.clipboard.writeText(
-                              `${wedge.parameters.path}`,
-                            );
-                          }}
-                        >
-                          <i
-                            style={{ marginLeft: 0 }}
-                            className="fa fa-copy"
-                            aria-hidden="true"
-                          />
-                        </Button>
-                      </div>
-                    </div>
-                    <Table
-                      striped
-                      bordered
-                      hover
-                      onClick={this.showForm}
-                      style={{ fontSize: 'smaller', marginBottom: 0 }}
-                      className="task-parameters-table"
-                    >
-                      <thead>
-                        <tr>
-                          {wedge.parameters.osc_start !== null && (
-                            <th>Start &deg; </th>
-                          )}
-                          {wedge.parameters.osc_range !== null && (
-                            <th>Osc. &deg; </th>
-                          )}
-                          <th>t (s)</th>
-                          <th># Img</th>
-                          <th>T (%)</th>
-                          <th>Res. (&Aring;)</th>
-                          <th>E (keV)</th>
-                          {wedge.parameters.kappa_phi !== null && (
-                            <th>&phi; &deg;</th>
-                          )}
-                          {wedge.parameters.kappa !== null && (
-                            <th>&kappa; &deg;</th>
-                          )}
-                        </tr>
-                      </thead>
-                      <tbody>{this.wedgeParameters(wedge)}</tbody>
-                    </Table>
-                    {this.getResult(state)}
+                      <i
+                        style={{ marginLeft: 0 }}
+                        className="fa fa-copy"
+                        aria-hidden="true"
+                      />
+                    </Button>
                   </div>
-                );
-              })}
-            </div>
-          </Collapse>
+                </div>
+                <Table
+                  striped
+                  bordered
+                  hover
+                  onClick={this.showForm}
+                  style={{ fontSize: 'smaller', marginBottom: 0 }}
+                  className="task-parameters-table"
+                >
+                  <thead>
+                    <tr>
+                      {wedge.parameters.osc_start !== null && (
+                        <th>Start &deg; </th>
+                      )}
+                      {wedge.parameters.osc_range !== null && (
+                        <th>Osc. &deg; </th>
+                      )}
+                      <th>t (s)</th>
+                      <th># Img</th>
+                      <th>T (%)</th>
+                      <th>Res. (&Aring;)</th>
+                      <th>E (keV)</th>
+                      {wedge.parameters.kappa_phi !== null && (
+                        <th>&phi; &deg;</th>
+                      )}
+                      {wedge.parameters.kappa !== null && (
+                        <th>&kappa; &deg;</th>
+                      )}
+                    </tr>
+                  </thead>
+                  <tbody>{this.wedgeParameters(wedge)}</tbody>
+                </Table>
+                {this.getResult(state)}
+              </div>
+            );
+          })}
         </div>
-      </div>
+      </TaskItemContainer>
     );
   }
 }

--- a/ui/src/components/SampleQueue/TaskItemContainer.jsx
+++ b/ui/src/components/SampleQueue/TaskItemContainer.jsx
@@ -1,0 +1,140 @@
+import { Component } from 'react';
+import { Collapse, ProgressBar } from 'react-bootstrap';
+
+import {
+  TASK_COLLECT_FAILED,
+  TASK_COLLECTED,
+  TASK_RUNNING,
+  TASK_UNCOLLECTED,
+} from '../../constants';
+
+export default class TaskItemContainer extends Component {
+  constructor(props) {
+    super(props);
+    this.taskHeaderOnClick = this.taskHeaderOnClick.bind(this);
+    this.taskHeaderOnContextMenu = this.taskHeaderOnContextMenu.bind(this);
+    this.deleteTask = this.deleteTask.bind(this);
+  }
+
+  taskHeaderOnClick(e) {
+    const { index, taskHeaderOnClickHandler } = this.props;
+    taskHeaderOnClickHandler(e, index);
+  }
+
+  taskHeaderOnContextMenu(e) {
+    const { index, taskHeaderOnContextMenuHandler } = this.props;
+    taskHeaderOnContextMenuHandler(e, index);
+  }
+
+  deleteTask(e) {
+    e.stopPropagation();
+    const { deleteTask, sampleId, index } = this.props;
+    deleteTask(sampleId, index);
+  }
+
+  render() {
+    const {
+      children,
+      dataLabel,
+      diffractionPlanLength = undefined,
+      pointIDString,
+      progress,
+      selected,
+      show,
+      showContextMenu,
+      specialTaskCSS = '',
+      state,
+    } = this.props;
+
+    const delTaskCSS = {
+      display: 'flex',
+      marginLeft: 'auto',
+      alignItems: 'center',
+      paddingLeft: '10px',
+      paddingRight: '10px',
+      color: '#d9534f',
+      cursor: 'pointer',
+    };
+
+    let taskCSS = selected ? 'task-head task-head-selected' : 'task-head';
+    let pbarBsStyle = 'info';
+
+    switch (state) {
+      case TASK_RUNNING: {
+        taskCSS += ' running';
+        pbarBsStyle = 'info';
+        break;
+      }
+      case TASK_COLLECTED: {
+        pbarBsStyle = 'success';
+        if (
+          specialTaskCSS === 'Characterisation' &&
+          diffractionPlanLength === undefined
+        ) {
+          taskCSS += ' warning';
+          break;
+        }
+        taskCSS += ' success';
+        break;
+      }
+      case TASK_COLLECT_FAILED: {
+        taskCSS += ' error';
+        pbarBsStyle = 'danger';
+        break;
+      }
+      // No default
+    }
+
+    return (
+      <div className="node node-sample">
+        <div
+          onContextMenu={(e) =>
+            showContextMenu(e, 'currentSampleQueueContextMenu')
+          }
+          id="currentSampleQueueContextMenu"
+        >
+          <div
+            onClick={this.taskHeaderOnClick}
+            onContextMenu={this.taskHeaderOnContextMenu}
+          >
+            <div className={taskCSS} style={{ display: 'flex' }}>
+              <b>
+                <span className="node-name" style={{ display: 'flex' }}>
+                  {pointIDString} {dataLabel}
+                  {state === TASK_RUNNING && (
+                    <span
+                      style={{
+                        width: '150px',
+                        right: '60px',
+                        position: 'absolute',
+                      }}
+                    >
+                      <ProgressBar
+                        variant={pbarBsStyle}
+                        striped
+                        style={{ marginBottom: 0, height: '18px' }}
+                        min={0}
+                        max={1}
+                        animated={progress < 1}
+                        label={`${(progress * 100).toPrecision(3)} %`}
+                        now={progress}
+                      />
+                    </span>
+                  )}
+                </span>
+              </b>
+              {state === TASK_UNCOLLECTED && (
+                <i
+                  className="fas fa-times"
+                  onClick={this.deleteTask}
+                  style={delTaskCSS}
+                />
+              )}
+            </div>
+          </div>
+          <Collapse in={Boolean(show)}>{children}</Collapse>
+        </div>
+      </div>
+    );
+  }
+}

--- a/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
+++ b/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
@@ -1,19 +1,14 @@
 /* eslint-disable react/destructuring-assignment */
 /* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable react/no-unused-prop-types */
-/* eslint-disable react/no-unused-state */
 
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import { Button, Collapse, ProgressBar } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 
-import {
-  TASK_COLLECT_FAILED,
-  TASK_COLLECTED,
-  TASK_RUNNING,
-  TASK_UNCOLLECTED,
-} from '../../constants';
+import { TASK_COLLECTED } from '../../constants';
 import TooltipTrigger from '../TooltipTrigger';
+import TaskItemContainer from './TaskItemContainer';
 
 export default class WorkflowTaskItem extends Component {
   static propTypes = {
@@ -24,16 +19,8 @@ export default class WorkflowTaskItem extends Component {
   constructor(props) {
     super(props);
     this.showForm = this.showForm.bind(this);
-    this.deleteTask = this.deleteTask.bind(this);
-    this.toggleChecked = this.toggleChecked.bind(this);
-    this.taskHeaderOnClick = this.taskHeaderOnClick.bind(this);
-    this.taskHeaderOnContextMenu = this.taskHeaderOnContextMenu.bind(this);
     this.getResult = this.getResult.bind(this);
     this.pointIDString = this.pointIDString.bind(this);
-    this.state = {
-      overInput: false,
-      selected: false,
-    };
   }
 
   getResult(state) {
@@ -59,38 +46,6 @@ export default class WorkflowTaskItem extends Component {
         </a>
       </div>
     );
-  }
-
-  toggleChecked() {
-    this.props.toggleChecked(this.props.sampleId, this.props.index);
-  }
-
-  taskHeaderOnClick(e) {
-    this.props.taskHeaderOnClickHandler(e, this.props.index);
-  }
-
-  taskHeaderOnContextMenu(e) {
-    this.props.taskHeaderOnContextMenuHandler(e, this.props.index);
-  }
-
-  deleteTask(e) {
-    e.stopPropagation();
-    this.props.deleteTask(this.props.sampleId, this.props.index);
-  }
-
-  // eslint-disable-next-line react/no-unused-class-component-methods
-  deleteButton() {
-    let content = (
-      <Button size="sm" onClick={this.deleteTask}>
-        Delete
-      </Button>
-    );
-
-    if (this.props.state !== TASK_UNCOLLECTED) {
-      content = <span> </span>;
-    }
-
-    return content;
   }
 
   showForm() {
@@ -126,159 +81,82 @@ export default class WorkflowTaskItem extends Component {
     );
   }
 
-  progressBar() {
-    const { state } = this.props;
-    let pbarBsStyle = 'info';
-
-    switch (state) {
-      case TASK_RUNNING: {
-        pbarBsStyle = 'info';
-
-        break;
-      }
-      case TASK_COLLECTED: {
-        pbarBsStyle = 'success';
-
-        break;
-      }
-      case TASK_COLLECT_FAILED: {
-        pbarBsStyle = 'danger';
-
-        break;
-      }
-      // No default
-    }
-
-    return (
-      <span style={{ width: '150px', right: '60px', position: 'absolute' }}>
-        <ProgressBar
-          variant={pbarBsStyle}
-          striped
-          style={{ marginBottom: 0, height: '18px' }}
-          min={0}
-          max={1}
-          animated={this.props.progress < 1}
-          label={`${(this.props.progress * 100).toPrecision(3)} %`}
-          now={this.props.progress}
-        />
-      </span>
-    );
-  }
-
   render() {
-    const { state, data, show } = this.props;
+    const {
+      data,
+      deleteTask,
+      progress,
+      sampleId,
+      selected,
+      show,
+      showContextMenu,
+      state,
+      taskHeaderOnClickHandler,
+      taskHeaderOnContextMenuHandler,
+    } = this.props;
 
     const { parameters } = data;
 
-    const delTaskCSS = {
-      display: 'flex',
-      marginLeft: 'auto',
-      alignItems: 'center',
-      paddingLeft: '10px',
-      paddingRight: '10px',
-      color: '#d9534f',
-      cursor: 'pointer',
-    };
-
-    let taskCSS = this.props.selected
-      ? 'task-head task-head-selected'
-      : 'task-head';
-
-    switch (state) {
-      case TASK_RUNNING: {
-        taskCSS += ' running';
-
-        break;
-      }
-      case TASK_COLLECTED: {
-        taskCSS += ' success';
-
-        break;
-      }
-      case TASK_COLLECT_FAILED: {
-        taskCSS += ' error';
-
-        break;
-      }
-      // No default
-    }
-
     return (
-      <div className="node node-sample">
-        <div
-          onContextMenu={(e) =>
-            this.props.showContextMenu(e, 'currentSampleQueueContextMenu')
-          }
-          id="currentSampleQueueContextMenu"
-        >
-          <div
-            onClick={this.taskHeaderOnClick}
-            onContextMenu={this.taskHeaderOnContextMenu}
-          >
-            <div className={taskCSS} style={{ display: 'flex' }}>
-              <b>
-                <span className="node-name" style={{ display: 'flex' }}>
-                  {this.pointIDString(parameters)} {data.parameters.label}
-                  {state === TASK_RUNNING && this.progressBar()}
-                </span>
-              </b>
-              {state === TASK_UNCOLLECTED && (
-                <i
-                  key="delete_task"
-                  className="fa fa-times"
-                  onClick={this.deleteTask}
-                  style={delTaskCSS}
-                />
-              )}
+      <TaskItemContainer
+        dataLabel={data.parameters.label}
+        deleteTask={deleteTask}
+        index={this.props.index}
+        pointIDString={this.pointIDString(parameters)}
+        progress={progress}
+        sampleId={sampleId}
+        selected={selected}
+        show={show}
+        showContextMenu={showContextMenu}
+        specialTaskCSS="Characterisation"
+        state={state}
+        taskHeaderOnClickHandler={taskHeaderOnClickHandler}
+        taskHeaderOnContextMenuHandler={taskHeaderOnContextMenuHandler}
+      >
+        <div className="task-body">
+          <div>
+            <div style={{ border: '1px solid #DDD' }}>
+              <div
+                style={{
+                  borderTop: '1px solid #DDD',
+                  padding: '0.5em',
+                  display: 'flex',
+                  justifyContent: 'space-around',
+                  alignItems: 'center',
+                }}
+              >
+                <b>Path:</b>
+                {this.path(parameters)}
+                <Button
+                  variant="outline-secondary"
+                  style={{ width: '3em' }}
+                  title="Copy path"
+                  onClick={() => {
+                    navigator.clipboard.writeText(`${parameters.path}`);
+                  }}
+                >
+                  <i
+                    style={{ marginLeft: 0 }}
+                    className="fa fa-copy"
+                    aria-hidden="true"
+                  />
+                </Button>
+                <Button
+                  variant="outline-secondary"
+                  style={{ width: '3em' }}
+                  title="Open parameters dialog"
+                  onClick={() =>
+                    this.props.showWorkflowParametersDialog(null, true)
+                  }
+                >
+                  <i aria-hidden="true" className="fa fa-sliders-h" />
+                </Button>
+              </div>
+              {this.getResult(state)}
             </div>
           </div>
-          <Collapse in={Boolean(show)}>
-            <div className="task-body">
-              <div>
-                <div style={{ border: '1px solid #DDD' }}>
-                  <div
-                    style={{
-                      borderTop: '1px solid #DDD',
-                      padding: '0.5em',
-                      display: 'flex',
-                      justifyContent: 'space-around',
-                      alignItems: 'center',
-                    }}
-                  >
-                    <b>Path:</b>
-                    {this.path(parameters)}
-                    <Button
-                      variant="outline-secondary"
-                      style={{ width: '3em' }}
-                      title="Copy path"
-                      onClick={() => {
-                        navigator.clipboard.writeText(`${parameters.path}`);
-                      }}
-                    >
-                      <i
-                        style={{ marginLeft: 0 }}
-                        className="fa fa-copy"
-                        aria-hidden="true"
-                      />
-                    </Button>
-                    <Button
-                      variant="outline-secondary"
-                      style={{ width: '3em' }}
-                      title="Open parameters dialog"
-                      onClick={() =>
-                        this.props.showWorkflowParametersDialog(null, true)
-                      }
-                    >
-                      <i aria-hidden="true" className="fa fa-sliders-h" />
-                    </Button>
-                  </div>
-                  {this.getResult(state)}
-                </div>
-              </div>
-            </div>
-          </Collapse>
         </div>
-      </div>
+      </TaskItemContainer>
     );
   }
 }

--- a/ui/src/components/SampleQueue/XRFTaskItem.jsx
+++ b/ui/src/components/SampleQueue/XRFTaskItem.jsx
@@ -1,25 +1,14 @@
 /* eslint-disable react/destructuring-assignment */
 /* eslint-disable jsx-a11y/control-has-associated-label */
 /* eslint-disable jsx-a11y/anchor-is-valid */
-/* eslint-disable react/no-unused-state */
+/* eslint-disable react/no-unused-prop-types */
+
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import {
-  Button,
-  Collapse,
-  Modal,
-  OverlayTrigger,
-  Popover,
-  ProgressBar,
-} from 'react-bootstrap';
+import { OverlayTrigger, Popover } from 'react-bootstrap';
 
-import {
-  TASK_COLLECT_FAILED,
-  TASK_COLLECTED,
-  TASK_RUNNING,
-  TASK_UNCOLLECTED,
-} from '../../constants';
-import Plot1D from '../Plot1D';
+import { TASK_COLLECTED } from '../../constants';
+import TaskItemContainer from './TaskItemContainer';
 
 export default class XRFTaskItem extends Component {
   static propTypes = {
@@ -30,22 +19,8 @@ export default class XRFTaskItem extends Component {
   constructor(props) {
     super(props);
     this.showForm = this.showForm.bind(this);
-    this.deleteTask = this.deleteTask.bind(this);
-    this.toggleChecked = this.toggleChecked.bind(this);
-    this.taskHeaderOnClick = this.taskHeaderOnClick.bind(this);
-    this.taskHeaderOnContextMenu = this.taskHeaderOnContextMenu.bind(this);
     this.getResult = this.getResult.bind(this);
-    this.showXRFPlot = this.showXRFPlot.bind(this);
-    this.showPlotModal = this.showPlotModal.bind(this);
-    this.open = this.open.bind(this);
-    this.close = this.close.bind(this);
     this.pointIDString = this.pointIDString.bind(this);
-
-    this.state = {
-      overInput: false,
-      selected: false,
-      showModal: false,
-    };
   }
 
   getResult(state) {
@@ -71,97 +46,6 @@ export default class XRFTaskItem extends Component {
         </a>
       </div>
     );
-  }
-
-  // eslint-disable-next-line react/no-unused-class-component-methods
-  getIspybLink(state) {
-    if (state !== TASK_COLLECTED) {
-      return <span />;
-    }
-
-    return <a href={this.props.data.limstResultData}> ISPyB link</a>;
-  }
-
-  // eslint-disable-next-line react/no-unused-class-component-methods
-  getPlot(state) {
-    if (state === TASK_UNCOLLECTED) {
-      return <span />;
-    }
-
-    return (
-      <div className="float-end">
-        <a href="#" onClick={this.showXRFPlot}>
-          Plot available
-        </a>
-      </div>
-    );
-  }
-
-  showPlotModal() {
-    return (
-      <div>
-        <Modal show={this.state.showModal} onHide={this.close}>
-          <Modal.Header closeButton>
-            <Modal.Title>XRF Plot</Modal.Title>
-          </Modal.Header>
-          <Modal.Body>
-            <h4>Text in a modal</h4>
-          </Modal.Body>
-          <Plot1D
-            displayedPlotCallback={this.newPlotDisplayed}
-            plotId="this.plotIdByAction[currentActionName"
-            autoNext="True"
-          />
-          <Modal.Footer>
-            <Button onClick={this.close}>Close</Button>
-          </Modal.Footer>
-        </Modal>
-      </div>
-    );
-  }
-
-  close() {
-    this.setState({ showModal: false });
-  }
-
-  open() {
-    this.setState({ showModal: true });
-  }
-
-  showXRFPlot() {
-    this.open();
-  }
-
-  toggleChecked() {
-    this.props.toggleChecked(this.props.sampleId, this.props.index);
-  }
-
-  taskHeaderOnClick(e) {
-    this.props.taskHeaderOnClickHandler(e, this.props.index);
-  }
-
-  taskHeaderOnContextMenu(e) {
-    this.props.taskHeaderOnContextMenuHandler(e, this.props.index);
-  }
-
-  deleteTask(e) {
-    e.stopPropagation();
-    this.props.deleteTask(this.props.sampleId, this.props.index);
-  }
-
-  // eslint-disable-next-line react/no-unused-class-component-methods
-  deleteButton() {
-    let content = (
-      <Button size="sm" onClick={this.deleteTask}>
-        Delete
-      </Button>
-    );
-
-    if (this.props.state !== TASK_UNCOLLECTED) {
-      content = <span> </span>;
-    }
-
-    return content;
   }
 
   showForm() {
@@ -215,123 +99,49 @@ export default class XRFTaskItem extends Component {
   }
 
   render() {
-    const { state, data, show } = this.props;
-    const plotId = this.props.id;
+    const {
+      data,
+      deleteTask,
+      progress,
+      sampleId,
+      selected,
+      show,
+      showContextMenu,
+      state,
+      taskHeaderOnClickHandler,
+      taskHeaderOnContextMenuHandler,
+    } = this.props;
     const { parameters } = data;
 
-    const { result } = this.props.data;
-    const plotAlreadyStored = result !== null;
-
-    const delTaskCSS = {
-      display: 'flex',
-      marginLeft: 'auto',
-      alignItems: 'center',
-      paddingLeft: '10px',
-      paddingRight: '10px',
-      color: '#d9534f',
-      cursor: 'pointer',
-    };
-
-    const taskCSS = this.props.selected
-      ? 'task-head task-head-selected'
-      : 'task-head';
-
-    let pbarBsStyle = 'info';
-
-    switch (state) {
-      case TASK_RUNNING: {
-        pbarBsStyle = 'info';
-
-        break;
-      }
-      case TASK_COLLECTED: {
-        pbarBsStyle = 'success';
-
-        break;
-      }
-      case TASK_COLLECT_FAILED: {
-        pbarBsStyle = 'danger';
-
-        break;
-      }
-      // No default
-    }
-
     return (
-      <div className="node node-sample">
-        <div
-          onContextMenu={(e) =>
-            this.props.showContextMenu(e, 'currentSampleQueueContextMenu')
-          }
-          id="currentSampleQueueContextMenu"
-        >
-          <div
-            onClick={this.taskHeaderOnClick}
-            onContextMenu={this.taskHeaderOnContextMenu}
-          >
-            <div className={taskCSS} style={{ display: 'flex' }}>
-              <b>
-                <span className="node-name" style={{ display: 'flex' }}>
-                  {this.pointIDString(parameters)} {data.label}
-                  <span
-                    style={{
-                      width: '150px',
-                      right: '60px',
-                      position: 'absolute',
-                    }}
-                  >
-                    <ProgressBar
-                      variant={pbarBsStyle}
-                      striped
-                      style={{ marginBottom: 0, height: '18px' }}
-                      min={0}
-                      max={1}
-                      animated={this.props.progress < 1}
-                      label={`${(this.props.progress * 100).toPrecision(3)} %`}
-                      now={this.props.progress}
-                    />
-                  </span>
-                </span>
-              </b>
-              {state === TASK_UNCOLLECTED && (
-                <i
-                  className="fas fa-times"
-                  onClick={this.deleteTask}
-                  style={delTaskCSS}
-                />
-              )}
-            </div>
-          </div>
-          <Collapse in={Boolean(show)}>
-            <div className="task-body">
-              <div>
-                <div style={{ border: '1px solid #DDD' }}>
-                  <div style={{ padding: '0.5em' }} onClick={this.showForm}>
-                    <b>Path:</b> {this.path(parameters)}
-                    <br />
-                    <b>Count time:</b> {parameters.countTime}
-                  </div>
-                </div>
-                {this.getResult(state)}
-                <Modal show={this.state.showModal} onHide={this.close}>
-                  <Modal.Header closeButton>
-                    <Modal.Title>XRF Plot</Modal.Title>
-                  </Modal.Header>
-                  <Plot1D
-                    plotId={plotId}
-                    autoNext
-                    saved={plotAlreadyStored}
-                    data={result}
-                  />
-                  <Modal.Footer>
-                    <Button onClick={this.close}>Close</Button>
-                  </Modal.Footer>
-                </Modal>
+      <TaskItemContainer
+        dataLabel={data.label}
+        deleteTask={deleteTask}
+        index={this.props.index}
+        pointIDString={this.pointIDString(parameters)}
+        progress={progress}
+        sampleId={sampleId}
+        selected={selected}
+        show={show}
+        showContextMenu={showContextMenu}
+        specialTaskCSS="Characterisation"
+        state={state}
+        taskHeaderOnClickHandler={taskHeaderOnClickHandler}
+        taskHeaderOnContextMenuHandler={taskHeaderOnContextMenuHandler}
+      >
+        <div className="task-body">
+          <div>
+            <div style={{ border: '1px solid #DDD' }}>
+              <div style={{ padding: '0.5em' }} onClick={this.showForm}>
+                <b>Path:</b> {this.path(parameters)}
+                <br />
+                <b>Count time:</b> {parameters.countTime}
               </div>
             </div>
-          </Collapse>
+            {this.getResult(state)}
+          </div>
         </div>
-      </div>
+      </TaskItemContainer>
     );
   }
 }


### PR DESCRIPTION
This PR is a first (of probably many) PRs to try to clean up the different `TaskItems` components by doing two things essentially:

 - Introduce the `TaskItemContainer`: Every component had the exact same header rendering logic, so I created a single component to extract and centralise this code and make it easier to refacture/maintain. To make it easy to review, I did not make any changes to the code itself yet. (Will definitely in a later PR)
 - Remove dead code in `TaskItems`: 
   This includes:
    - Now unused imports
    - `deleteTask`, `headerOnClick` and headerOnContext` methods which were moved to `TaskItemContainer`
    - `deleteButton`, `toggleChecked` methods and internal `state`, which were present in every component but never used
    - logic related to showing 1D plots in the `XRFTaskItem`: it existed, but the Modal was never shown (always remained in `falsy` state) for now I removed it as part of a cleanup, but this could be added and/or fixed in a later PR

So while there are a lot changes in this PR, it is mainly one repetitive change in every file

Next steps are (not necessary in this order):
 - cleanup CSS 
 - remove unused `props`
 - remove logic from global state that could be handled in component states (collapse Item for example)
 - remove unused actions related to this section
 - fix 1D plotting (if necessary)
 - refactor components