### PR TITLE
remove prop from TaskItems

### DIFF
--- a/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
+++ b/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
@@ -125,7 +125,6 @@ export default class EnergyScanTaskItem extends Component {
         selected={selected}
         show={show}
         showContextMenu={showContextMenu}
-        specialTaskCSS="Characterisation"
         state={state}
         taskHeaderOnClickHandler={taskHeaderOnClickHandler}
         taskHeaderOnContextMenuHandler={taskHeaderOnContextMenuHandler}

--- a/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
+++ b/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
@@ -108,7 +108,6 @@ export default class WorkflowTaskItem extends Component {
         selected={selected}
         show={show}
         showContextMenu={showContextMenu}
-        specialTaskCSS="Characterisation"
         state={state}
         taskHeaderOnClickHandler={taskHeaderOnClickHandler}
         taskHeaderOnContextMenuHandler={taskHeaderOnContextMenuHandler}

--- a/ui/src/components/SampleQueue/XRFTaskItem.jsx
+++ b/ui/src/components/SampleQueue/XRFTaskItem.jsx
@@ -124,7 +124,6 @@ export default class XRFTaskItem extends Component {
         selected={selected}
         show={show}
         showContextMenu={showContextMenu}
-        specialTaskCSS="Characterisation"
         state={state}
         taskHeaderOnClickHandler={taskHeaderOnClickHandler}
         taskHeaderOnContextMenuHandler={taskHeaderOnContextMenuHandler}


### PR DESCRIPTION
The `specialTaskCSS` prop was wrongly passed by mistake in some TaskItems in #1753. It should only come from the `CharacterisationTaskItem`