### PR TITLE
Mimetype of reuqest is csp-report is not always json 

### DIFF
--- a/mxcubeweb/routes/csp_report.py
+++ b/mxcubeweb/routes/csp_report.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 from flask import Blueprint, jsonify, request
@@ -15,7 +16,9 @@ def init_route(_mxcube_app, _server, url_prefix):
     @bp.route("/report", methods=["POST"])
     def csp_report():
         """Endpoint to collect CSP violation reports"""
-        report = request.get_json()
+
+        report = json.loads(request.get_data())
+
         csp_logger.warning("CSP Violation: %s", report.get("csp-report", {}))
         return jsonify({"status": "report received"}), 204
 


### PR DESCRIPTION
It seems like some browsers use the csp-report mime type instead of json. Using `request.get_data()` instead of `request.get_json()` and then loading the data with `json.loads` fixes the issue. The data is still JSON but the mime-type changes.