### PR TITLE
Disable readonly HardwareObject-derived fields

### DIFF
--- a/ui/src/components/Tasks/Characterisation.jsx
+++ b/ui/src/components/Tasks/Characterisation.jsx
@@ -127,6 +127,9 @@ class Characterisation extends React.Component {
                 list={[1, 2, 4]}
               />
               <InputField
+                disabled={
+                  this.props.beamline.hardwareObjects.transmission.readonly
+                }
                 propName="transmission"
                 type="number"
                 label="Transmission"

--- a/ui/src/components/Tasks/DataCollection.jsx
+++ b/ui/src/components/Tasks/DataCollection.jsx
@@ -246,6 +246,9 @@ class DataCollection extends React.Component {
                 label="Exposure time (s)"
               />
               <InputField
+                disabled={
+                  this.props.beamline.hardwareObjects.transmission.readonly
+                }
                 propName="transmission"
                 type="number"
                 label="Transmission"

--- a/ui/src/components/Tasks/Helical.jsx
+++ b/ui/src/components/Tasks/Helical.jsx
@@ -142,6 +142,9 @@ class Helical extends React.Component {
                 label="Exposure time (s)"
               />
               <InputField
+                disabled={
+                  this.props.beamline.hardwareObjects.transmission.readonly
+                }
                 propName="transmission"
                 type="number"
                 label="Transmission"

--- a/ui/src/components/Tasks/Mesh.jsx
+++ b/ui/src/components/Tasks/Mesh.jsx
@@ -152,6 +152,9 @@ class Mesh extends React.Component {
                 label="Exposure time per image(s)"
               />
               <InputField
+                disabled={
+                  this.props.beamline.hardwareObjects.transmission.readonly
+                }
                 propName="transmission"
                 type="number"
                 label="Transmission"


### PR DESCRIPTION
In the Task forms (DataCollection, Mesh, etc.) if energy is set to read-only, then corresponding form controls are disabled. It makes it so that, the same behaviour is applied for transmission and energy.

For context: at MicroMAX we set transmission to read-only, so we don't want this field to be editable.