### PR TITLE
cleanup styles of queue components Part 2

### DIFF
--- a/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
+++ b/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
@@ -32,18 +32,7 @@ export default class TaskItem extends Component {
       return <span />;
     }
 
-    return (
-      <div
-        style={{
-          borderLeft: '1px solid #DDD',
-          borderRight: '1px solid #DDD',
-          borderBottom: '1px solid #DDD',
-          padding: '0.5em',
-        }}
-      >
-        {this.getDiffPlan(data)}
-      </div>
-    );
+    return <div className={styles.resultBody}>{this.getDiffPlan(data)}</div>;
   }
 
   getDiffPlan(data) {
@@ -217,58 +206,42 @@ export default class TaskItem extends Component {
         selected={selected}
         show={show}
         showContextMenu={showContextMenu}
-        specialTaskCSS="Characterisation"
+        warningTaskCSS={
+          state === TASK_COLLECTED && data.diffractionPlan.length === undefined
+        } // this is a special prop for emitting a warning signal if the task is collected but has no diffraction plan
         state={state}
         taskHeaderOnClickHandler={taskHeaderOnClickHandler}
         taskHeaderOnContextMenuHandler={taskHeaderOnContextMenuHandler}
       >
         <div className={styles.taskBody}>
           {wedges.map((wedge, i) => {
-            const padding = i > 0 ? '1em' : '0em';
+            const padding = i > 0 ? '1.5em' : '0.5em';
             return (
               <div key={`wedge-${i}`}>
                 <div
+                  className={styles.dataPath}
                   style={{
-                    borderLeft: '1px solid #DDD',
-                    borderRight: '1px solid #DDD',
                     paddingTop: padding,
                   }}
                 >
-                  <div
-                    style={{
-                      borderTop: '1px solid #DDD',
-                      padding: '0.5em',
-                      display: 'flex',
-                      justifyContent: 'space-around',
-                      alignItems: 'center',
+                  <b>Path:</b>
+                  {this.wedgePath(wedge)}
+                  <Button
+                    variant="outline-secondary"
+                    style={{ width: '3em' }}
+                    title="Copy path"
+                    onClick={() => {
+                      navigator.clipboard.writeText(`${wedge.parameters.path}`);
                     }}
                   >
-                    <b>Path:</b>
-                    {this.wedgePath(wedge)}
-                    <Button
-                      variant="outline-secondary"
-                      style={{ width: '3em' }}
-                      title="Copy path"
-                      onClick={() => {
-                        navigator.clipboard.writeText(
-                          `${wedge.parameters.path}`,
-                        );
-                      }}
-                    >
-                      <i
-                        style={{ marginLeft: 0 }}
-                        className="fa fa-copy"
-                        aria-hidden="true"
-                      />
-                    </Button>
-                  </div>
+                    <i className="fa fa-copy" aria-hidden="true" />
+                  </Button>
                 </div>
                 <Table
                   striped
                   bordered
                   hover
                   onClick={this.showForm}
-                  style={{ fontSize: 'smaller', marginBottom: 0 }}
                   className={styles.taskParametersTable}
                 >
                   <thead>

--- a/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
+++ b/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
@@ -33,14 +33,7 @@ export default class EnergyScanTaskItem extends Component {
       : '';
 
     return (
-      <div
-        style={{
-          borderLeft: '1px solid #DDD',
-          borderRight: '1px solid #DDD',
-          borderBottom: '1px solid #DDD',
-          padding: '0.5em',
-        }}
-      >
+      <div className={styles.resultBody}>
         <a href={link} target="_blank" rel="noreferrer">
           {' '}
           View Results in ISPyB

--- a/ui/src/components/SampleQueue/Item.module.css
+++ b/ui/src/components/SampleQueue/Item.module.css
@@ -31,6 +31,7 @@
 .nodeName {
   margin-left: 4px;
   cursor: pointer;
+  display: flex;
 }
 
 .taskBody {
@@ -69,4 +70,38 @@
 .taskError {
   background: linear-gradient(to bottom, #ffffff 0%, rgba(255, 255, 255, 0) 5%);
   background-color: rgba(217, 83, 79, 0.56) !important;
+}
+
+.resultBody {
+  border-left: 1px solid #ddd;
+  border-right: 1px solid #ddd;
+  border-bottom: 1px solid #ddd;
+  padding: 0.5em;
+}
+
+.dataPath {
+  border-left: 1px solid #ddd;
+  border-right: 1px solid #ddd;
+  border-top: 1px solid #ddd;
+  padding: 0.5em;
+  display: flex;
+  justify-content: space-around;
+  align-items: 'center';
+}
+
+.delTask {
+  display: flex;
+  margin-left: auto;
+  align-items: center;
+  padding-left: 10px;
+  padding-right: 10px;
+  color: #d9534f;
+  cursor: pointer;
+}
+
+.progressBar {
+  height: 18px;
+  width: 150px;
+  right: 60px;
+  margin-left: 10px;
 }

--- a/ui/src/components/SampleQueue/TaskItem.jsx
+++ b/ui/src/components/SampleQueue/TaskItem.jsx
@@ -35,14 +35,7 @@ export default class TaskItem extends Component {
       );
     }
     return (
-      <div
-        style={{
-          borderLeft: '1px solid #DDD',
-          borderRight: '1px solid #DDD',
-          borderBottom: '1px solid #DDD',
-          padding: '0.5em',
-        }}
-      >
+      <div className={styles.resultBody}>
         <a
           href="#"
           onClick={() =>
@@ -197,51 +190,34 @@ export default class TaskItem extends Component {
       >
         <div className={styles.taskBody}>
           {wedges.map((wedge, i) => {
-            const padding = i > 0 ? '1em' : '0em';
+            const padding = i > 0 ? '1.5em' : '0.5em';
             return (
               <div key={`wedge-${i}`}>
                 <div
+                  className={styles.dataPath}
                   style={{
-                    borderLeft: '1px solid #DDD',
-                    borderRight: '1px solid #DDD',
                     paddingTop: padding,
                   }}
                 >
-                  <div
-                    style={{
-                      borderTop: '1px solid #DDD',
-                      padding: '0.5em',
-                      display: 'flex',
-                      justifyContent: 'space-around',
-                      alignItems: 'center',
+                  <b>Path:</b>
+                  {this.wedgePath(wedge)}
+                  <Button
+                    variant="outline-secondary"
+                    style={{ width: '3em' }}
+                    title="Copy path"
+                    onClick={() => {
+                      navigator.clipboard.writeText(`${wedge.parameters.path}`);
                     }}
                   >
-                    <b>Path:</b>
-                    {this.wedgePath(wedge)}
-                    <Button
-                      variant="outline-secondary"
-                      style={{ width: '3em' }}
-                      title="Copy path"
-                      onClick={() => {
-                        navigator.clipboard.writeText(
-                          `${wedge.parameters.path}`,
-                        );
-                      }}
-                    >
-                      <i
-                        style={{ marginLeft: 0 }}
-                        className="fa fa-copy"
-                        aria-hidden="true"
-                      />
-                    </Button>
-                  </div>
+                    <i className="fa fa-copy" aria-hidden="true" />
+                  </Button>
                 </div>
+
                 <Table
                   striped
                   bordered
                   hover
                   onClick={this.showForm}
-                  style={{ fontSize: 'smaller', marginBottom: 0 }}
                   className={styles.taskParametersTable}
                 >
                   <thead>

--- a/ui/src/components/SampleQueue/TaskItemContainer.jsx
+++ b/ui/src/components/SampleQueue/TaskItemContainer.jsx
@@ -9,6 +9,12 @@ import {
 } from '../../constants';
 import styles from './Item.module.css';
 
+const stateBasedStyles = {
+  [TASK_RUNNING]: styles.taskRunning,
+  [TASK_COLLECTED]: styles.taskSuccess,
+  [TASK_COLLECT_FAILED]: styles.taskError,
+};
+
 export default class TaskItemContainer extends Component {
   constructor(props) {
     super(props);
@@ -37,54 +43,19 @@ export default class TaskItemContainer extends Component {
     const {
       children,
       dataLabel,
-      diffractionPlanLength = undefined,
       pointIDString,
       progress,
       selected,
       show,
       showContextMenu,
-      specialTaskCSS = '',
+      warningTaskCSS = false,
       state,
     } = this.props;
 
-    const delTaskCSS = {
-      display: 'flex',
-      marginLeft: 'auto',
-      alignItems: 'center',
-      paddingLeft: '10px',
-      paddingRight: '10px',
-      color: '#d9534f',
-      cursor: 'pointer',
-    };
-
     let taskCSS = selected ? styles.taskHeadSelected : styles.taskHead;
-    let pbarBsStyle = 'info';
-
-    switch (state) {
-      case TASK_RUNNING: {
-        taskCSS += ` ${styles.taskRunning}`;
-        pbarBsStyle = 'info';
-        break;
-      }
-      case TASK_COLLECTED: {
-        pbarBsStyle = 'success';
-        if (
-          specialTaskCSS === 'Characterisation' &&
-          diffractionPlanLength === undefined
-        ) {
-          taskCSS += ` ${styles.taskWarning}`;
-          break;
-        }
-        taskCSS += ` ${styles.taskSuccess}`;
-        break;
-      }
-      case TASK_COLLECT_FAILED: {
-        taskCSS += ` ${styles.taskError}`;
-        pbarBsStyle = 'danger';
-        break;
-      }
-      // No default
-    }
+    taskCSS += ` ${
+      warningTaskCSS ? styles.taskWarning : stateBasedStyles[state] || ''
+    }`;
 
     return (
       <div className={styles.nodeSample}>
@@ -99,36 +70,26 @@ export default class TaskItemContainer extends Component {
             onContextMenu={this.taskHeaderOnContextMenu}
           >
             <div className={taskCSS} style={{ display: 'flex' }}>
-              <b>
-                <span className="node-name" style={{ display: 'flex' }}>
-                  {pointIDString} {dataLabel}
-                  {state === TASK_RUNNING && (
-                    <span
-                      style={{
-                        width: '150px',
-                        right: '60px',
-                        position: 'absolute',
-                      }}
-                    >
-                      <ProgressBar
-                        variant={pbarBsStyle}
-                        striped
-                        style={{ marginBottom: 0, height: '18px' }}
-                        min={0}
-                        max={1}
-                        animated={progress < 1}
-                        label={`${(progress * 100).toPrecision(3)} %`}
-                        now={progress}
-                      />
-                    </span>
-                  )}
-                </span>
-              </b>
+              <span className={styles.nodeName} style={{ fontWeight: 'bold' }}>
+                {pointIDString} {dataLabel}
+              </span>
+              {state === TASK_RUNNING && (
+                <ProgressBar
+                  variant="info"
+                  striped
+                  className={styles.progressBar}
+                  min={0}
+                  max={1}
+                  animated={progress < 1}
+                  label={`${(progress * 100).toPrecision(3)} %`}
+                  now={progress}
+                />
+              )}
+
               {state === TASK_UNCOLLECTED && (
                 <i
-                  className="fas fa-times"
+                  className={`fas fa-times ${styles.delTask}`}
                   onClick={this.deleteTask}
-                  style={delTaskCSS}
                 />
               )}
             </div>

--- a/ui/src/components/SampleQueue/TodoItem.jsx
+++ b/ui/src/components/SampleQueue/TodoItem.jsx
@@ -22,7 +22,7 @@ export default function TodoItem({ sampleData }) {
   return (
     <div className={styles.nodeSample}>
       <div className={styles.taskHead}>
-        <div className={`d-flex ${styles.nodeName}`}>
+        <div className={styles.nodeName}>
           <p className="pt-1 me-auto">
             <b>{`${sampleID} `}</b>
             {`${proteinAcronym} ${sampleName}`}

--- a/ui/src/components/SampleQueue/TodoTree.jsx
+++ b/ui/src/components/SampleQueue/TodoTree.jsx
@@ -30,7 +30,7 @@ export default function TodoTree(props) {
   return (
     <ListGroup variant="flush">
       <ListGroup.Item
-        className={`d-flex ${styles.listHead}`}
+        className={styles.listHead}
         style={{ borderBottom: 'none' }}
       >
         <Form className="me-auto">
@@ -53,7 +53,7 @@ export default function TodoTree(props) {
           </Button>
         </div>
       </ListGroup.Item>
-      <ListGroup.Item className={`d-flex ${styles.listBody}`}>
+      <ListGroup.Item className={styles.listBody}>
         {current_list.map((key) => {
           const sampleData = sampleList[key];
           return <TodoItem sampleData={sampleData} key={`Sample ${key}`} />;

--- a/ui/src/components/SampleQueue/Tree.module.css
+++ b/ui/src/components/SampleQueue/Tree.module.css
@@ -1,6 +1,7 @@
 .listHead {
   padding: 1rem 1rem;
   border: 0;
+  display: flex;
 }
 .listBody {
   padding: 0.5rem 1rem;

--- a/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
+++ b/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
@@ -33,14 +33,7 @@ export default class WorkflowTaskItem extends Component {
       : '';
 
     return (
-      <div
-        style={{
-          borderLeft: '1px solid #DDD',
-          borderRight: '1px solid #DDD',
-          borderBottom: '1px solid #DDD',
-          padding: '0.5em',
-        }}
-      >
+      <div className={styles.resultBody}>
         <a href={link} target="_blank" rel="noreferrer">
           {' '}
           View Results in ISPyB
@@ -115,45 +108,31 @@ export default class WorkflowTaskItem extends Component {
       >
         <div className={styles.taskBody}>
           <div>
-            <div style={{ border: '1px solid #DDD' }}>
-              <div
-                style={{
-                  borderTop: '1px solid #DDD',
-                  padding: '0.5em',
-                  display: 'flex',
-                  justifyContent: 'space-around',
-                  alignItems: 'center',
+            <div className={styles.dataPath}>
+              <b>Path:</b>
+              {this.path(parameters)}
+              <Button
+                variant="outline-secondary"
+                style={{ width: '3em' }}
+                title="Copy path"
+                onClick={() => {
+                  navigator.clipboard.writeText(`${parameters.path}`);
                 }}
               >
-                <b>Path:</b>
-                {this.path(parameters)}
-                <Button
-                  variant="outline-secondary"
-                  style={{ width: '3em' }}
-                  title="Copy path"
-                  onClick={() => {
-                    navigator.clipboard.writeText(`${parameters.path}`);
-                  }}
-                >
-                  <i
-                    style={{ marginLeft: 0 }}
-                    className="fa fa-copy"
-                    aria-hidden="true"
-                  />
-                </Button>
-                <Button
-                  variant="outline-secondary"
-                  style={{ width: '3em' }}
-                  title="Open parameters dialog"
-                  onClick={() =>
-                    this.props.showWorkflowParametersDialog(null, true)
-                  }
-                >
-                  <i aria-hidden="true" className="fa fa-sliders-h" />
-                </Button>
-              </div>
-              {this.getResult(state)}
+                <i className="fa fa-copy" aria-hidden="true" />
+              </Button>
+              <Button
+                variant="outline-secondary"
+                style={{ width: '3em' }}
+                title="Open parameters dialog"
+                onClick={() =>
+                  this.props.showWorkflowParametersDialog(null, true)
+                }
+              >
+                <i aria-hidden="true" className="fa fa-sliders-h" />
+              </Button>
             </div>
+            {this.getResult(state)}
           </div>
         </div>
       </TaskItemContainer>

--- a/ui/src/components/SampleQueue/XRFTaskItem.jsx
+++ b/ui/src/components/SampleQueue/XRFTaskItem.jsx
@@ -33,14 +33,7 @@ export default class XRFTaskItem extends Component {
       : '';
 
     return (
-      <div
-        style={{
-          borderLeft: '1px solid #DDD',
-          borderRight: '1px solid #DDD',
-          borderBottom: '1px solid #DDD',
-          padding: '0.5em',
-        }}
-      >
+      <div className={styles.resultBody}>
         <a href={link} target="_blank" rel="noreferrer">
           {' '}
           View Results in ISPyB


### PR DESCRIPTION
This PR is a follow-up to #1775. It includes the following changes concerning the CSS styles of the queue components:

- gathered duplicated styles applied in many files in the corresponding modules
- removed duplicated style parameters
- moved large style definitions to modules
- improved conditional styling in `TaskItemContainer`