### PR TITLE
update img-responsive to img-fluid

### DIFF
--- a/ui/src/components/ImageViewer/ImageViewer.jsx
+++ b/ui/src/components/ImageViewer/ImageViewer.jsx
@@ -127,7 +127,7 @@ export default function ImageViewer(props) {
     <div>
       <div className={styles.gallery_card}>
         <GalleryImage
-          className={`${styles.gallery_thumbnail} img-responsive`}
+          className={`${styles.gallery_thumbnail} img-fluid`}
           src={props.imgUrl}
           alt={props.imgAlt}
         />

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -746,7 +746,7 @@ export default function SampleListViewContainer() {
         >
           <img
             src={loader}
-            className="img-centerd img-responsive"
+            className="img-centerd img-fluid"
             width="150"
             alt=""
           />

--- a/ui/src/containers/SampleQueueContainer.jsx
+++ b/ui/src/containers/SampleQueueContainer.jsx
@@ -94,7 +94,7 @@ class SampleQueueContainer extends React.Component {
           </Nav>
           {loading ? (
             <div className={styles.centerInBox} style={{ zIndex: '1000' }}>
-              <img src={loader} className="img-responsive" width="100" alt="" />
+              <img src={loader} className="img-fluid" width="100" alt="" />
             </div>
           ) : null}
           <CurrentTree


### PR DESCRIPTION
I saw this while working on #1786, but decided to make a separate PR since the scope for this is the whole repository. The utility class `img-responsive` is from [bootstrap v3](https://getbootstrap.com/docs/3.4/css/#images). In [bootstrapv5](https://getbootstrap.com/docs/5.3/content/images/) (which we use), `img-fluid` should be used.