### PR TITLE
Remove Sonar check from fork

### DIFF
--- a/.github/workflows/bandit_sonar.yaml
+++ b/.github/workflows/bandit_sonar.yaml
@@ -47,6 +47,9 @@ jobs:
   sonarcloud:
     name: SonarCloud Scan
     runs-on: ubuntu-latest
+    if: >
+      github.event.pull_request.head.repo.full_name == github.repository ||
+      github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Java


### PR DESCRIPTION
As seen in PRs coming from forks, the Sonar token is not accessible, causing the check to always fail. Therefore, this PR:
-  Adds a conditional (`if`) statement to the `sonarcloud` job to ensure the scan only runs if the pull request originates from the same repository or if the event is not a pull request.