### PR TITLE
Removing `View results` and `View results in IPSYB`

### DIFF
--- a/mxcubeweb/routes/signals.py
+++ b/mxcubeweb/routes/signals.py
@@ -234,17 +234,6 @@ def get_task_state(entry):
     }
 
 
-def update_task_result(entry):
-    node_index = mxcube.queue.node_index(entry.get_data_model())
-
-    msg = {
-        "sample": node_index["sample"],
-        "taskIndex": node_index["idx"],
-    }
-
-    server.emit("update_task_lims_data", msg, namespace="/hwr")
-
-
 def queue_execution_entry_started(entry, message=None):
     handle_auto_mount_next(entry)
 

--- a/ui/src/actions/queue.js
+++ b/ui/src/actions/queue.js
@@ -409,10 +409,6 @@ export function addTaskResultAction(
   };
 }
 
-export function updateTaskLimsData(sampleID, taskIndex) {
-  return { type: 'UPDATE_TASK_LIMS_DATA', sampleID, taskIndex };
-}
-
 export function deleteSamplesFromQueue(sampleIDList) {
   return async (dispatch) => {
     dispatch(queueLoading(true));

--- a/ui/src/actions/queue.js
+++ b/ui/src/actions/queue.js
@@ -397,7 +397,6 @@ export function addTaskResultAction(
   taskIndex,
   state,
   progress,
-  limsResultData,
   queueID,
 ) {
   return {
@@ -406,13 +405,12 @@ export function addTaskResultAction(
     taskIndex,
     state,
     progress,
-    limsResultData,
     queueID,
   };
 }
 
-export function updateTaskLimsData(sampleID, taskIndex, limsResultData) {
-  return { type: 'UPDATE_TASK_LIMS_DATA', sampleID, taskIndex, limsResultData };
+export function updateTaskLimsData(sampleID, taskIndex) {
+  return { type: 'UPDATE_TASK_LIMS_DATA', sampleID, taskIndex };
 }
 
 export function deleteSamplesFromQueue(sampleIDList) {

--- a/ui/src/components/DataCollectionResult/DataCollectionResultDialog.css
+++ b/ui/src/components/DataCollectionResult/DataCollectionResultDialog.css
@@ -1,0 +1,3 @@
+.dc-result-dialog {
+  width: 40%;
+}

--- a/ui/src/components/DataCollectionResult/DataCollectionResultDialog.jsx
+++ b/ui/src/components/DataCollectionResult/DataCollectionResultDialog.jsx
@@ -1,12 +1,12 @@
 /* eslint-disable react/destructuring-assignment */
-import './LimsResultDialog.css';
+import './DataCollectionResultDialog.css';
 
 import React from 'react';
 import { Button, Modal } from 'react-bootstrap';
 
-import { LimsResultSummary } from './LimsResultSummary';
+import { DataCollectionResultSummary } from './DataCollectionResultSummary';
 
-export class LimsResultDialog extends React.Component {
+export class DataCollectionResultDialog extends React.Component {
   constructor(props) {
     super(props);
     this.onHide = this.onHide.bind(this);
@@ -19,7 +19,7 @@ export class LimsResultDialog extends React.Component {
   render() {
     return (
       <Modal
-        dialogClassName="lims-result-dialog"
+        dialogClassName="dc-result-dialog"
         show={this.props.show}
         onHide={this.onHide}
       >
@@ -28,7 +28,7 @@ export class LimsResultDialog extends React.Component {
         </Modal.Header>
         <Modal.Body>
           {this.props.taskData ? (
-            <LimsResultSummary taskData={this.props.taskData} />
+            <DataCollectionResultSummary taskData={this.props.taskData} />
           ) : null}
         </Modal.Body>
         <Modal.Footer>

--- a/ui/src/components/DataCollectionResult/DataCollectionResultSummary.jsx
+++ b/ui/src/components/DataCollectionResult/DataCollectionResultSummary.jsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 
-export class LimsResultSummary extends React.Component {
+export class DataCollectionResultSummary extends React.Component {
   taskSummary() {
     const task = this.props.taskData;
     const filePath = this.props.taskData.parameters.fullPath;

--- a/ui/src/components/Lims/LimsResultDialog.css
+++ b/ui/src/components/Lims/LimsResultDialog.css
@@ -1,3 +1,0 @@
-.lims-result-dialog {
-  width: 40%;
-}

--- a/ui/src/components/Lims/LimsResultDialog.jsx
+++ b/ui/src/components/Lims/LimsResultDialog.jsx
@@ -4,36 +4,16 @@ import './LimsResultDialog.css';
 import React from 'react';
 import { Button, Modal } from 'react-bootstrap';
 
-import { TASK_COLLECTED } from '../../constants';
 import { LimsResultSummary } from './LimsResultSummary';
 
 export class LimsResultDialog extends React.Component {
   constructor(props) {
     super(props);
     this.onHide = this.onHide.bind(this);
-    this.getResultLink = this.getResultLink.bind(this);
   }
 
   onHide() {
     this.props.onHide();
-  }
-
-  getResultLink() {
-    if (this.props.taskData.state !== TASK_COLLECTED) {
-      return <span />;
-    }
-
-    const link = this.props.taskData.limsResultData
-      ? this.props.taskData.limsResultData.limsTaskLink
-      : '';
-
-    return (
-      <div style={{ margin: '1em' }}>
-        <a href={link} target="_blank" rel="noreferrer">
-          View results in ISPyB
-        </a>
-      </div>
-    );
   }
 
   render() {
@@ -48,10 +28,7 @@ export class LimsResultDialog extends React.Component {
         </Modal.Header>
         <Modal.Body>
           {this.props.taskData ? (
-            <>
-              <LimsResultSummary taskData={this.props.taskData} />
-              {this.getResultLink()}
-            </>
+            <LimsResultSummary taskData={this.props.taskData} />
           ) : null}
         </Modal.Body>
         <Modal.Footer>

--- a/ui/src/components/Main.jsx
+++ b/ui/src/components/Main.jsx
@@ -18,7 +18,7 @@ import TaskContainer from '../containers/TaskContainer';
 import WorkflowParametersDialog from '../containers/WorkflowParametersDialog';
 import diagonalNoise from '../img/diagonal-noise.png';
 import ChatWidget from './ChatWidget';
-import { LimsResultDialog } from './Lims/LimsResultDialog';
+import { DataCollectionResultDialog } from './DataCollectionResult/DataCollectionResultDialog';
 import LoadingScreen from './LoadingScreen/LoadingScreen';
 import SelectProposal from './LoginForm/SelectProposal';
 import styles from './Main.module.css';
@@ -66,7 +66,7 @@ function Main() {
       <ConfirmCollectDialog />
       <WorkflowParametersDialog />
       <GphlWorkflowParametersDialog />
-      <LimsResultDialog
+      <DataCollectionResultDialog
         show={general.dialogType === 'LIMS_RESULT_DIALOG'}
         taskData={general.dialogData}
         onHide={() => dispatch(showDialog(false))}

--- a/ui/src/components/SampleGrid/TaskItem.jsx
+++ b/ui/src/components/SampleGrid/TaskItem.jsx
@@ -5,14 +5,12 @@ import React from 'react';
 import { Badge, OverlayTrigger, Popover } from 'react-bootstrap';
 
 import {
-  isUnCollected,
   TASK_COLLECT_FAILED,
   TASK_COLLECT_WARNING,
   TASK_COLLECTED,
   TASK_RUNNING,
   TASK_UNCOLLECTED,
 } from '../../constants';
-import loader from '../../img/busy-indicator.gif';
 import { LimsResultSummary } from '../Lims/LimsResultSummary';
 
 export class TaskItem extends React.Component {
@@ -30,7 +28,6 @@ export class TaskItem extends React.Component {
     this.summary = this.summary.bind(this);
     this.title = this.title.bind(this);
     this.stateClass = this.stateClass.bind(this);
-    this.result = this.result.bind(this);
   }
 
   tagName() {
@@ -100,108 +97,6 @@ export class TaskItem extends React.Component {
         </div>
       </div>
     );
-  }
-
-  result() {
-    const task = this.props.taskData;
-    let content = <div />;
-    let lImageUrl = '';
-    let fImageUrl = '';
-    let qIndUrl = '';
-
-    const r = task.limsResultData;
-
-    if (
-      !isUnCollected(task) &&
-      task.limsResultData &&
-      Object.keys(task.limsResultData).length > 0
-    ) {
-      if (task.limsResultData.firstImageId) {
-        fImageUrl = '/mxcube/api/v0.1/lims/dc/thumbnail/';
-        fImageUrl += task.limsResultData.firstImageId.toString();
-      }
-
-      if (task.limsResultData.lastImageId) {
-        lImageUrl = '/mxcube/api/v0.1/lims/dc/thumbnail/';
-        lImageUrl += task.limsResultData.lastImageId.toString();
-      }
-
-      if (task.limsResultData.dataCollectionId) {
-        qIndUrl = '/mxcube/api/v0.1/lims/quality_indicator_plot/';
-        qIndUrl += task.limsResultData.dataCollectionId.toString();
-      }
-
-      const sFlux = Number.parseInt(r.flux, 10) / 10 ** 9;
-      const eFlux = Number.parseInt(r.flux_end, 10) / 10 ** 9;
-
-      content = (
-        <div>
-          <div
-            className="row"
-            style={{
-              paddingLeft: '1em',
-              paddingTop: '1em',
-              paddingBottom: '0.2em',
-            }}
-          >
-            <b>Status: {r.runStatus}</b>
-          </div>
-
-          <div className="row">
-            <span className="col-sm-3">Resolution at collect</span>
-            <span className="col-sm-3">{`${r.resolution || '-'} Å`}</span>
-            <span className="col-sm-3">Resolution at corner:</span>
-            <span className="col-sm-3">{`${
-              r.resolutionAtCorner || '-'
-            } Å`}</span>
-          </div>
-
-          <div className="row">
-            <span className="col-sm-3">Wavelength</span>
-            <span className="col-sm-3">{`${r.wavelength || '-'} Å`}</span>
-            <span className="col-sm-3"> </span>
-            <span className="col-sm-3"> </span>
-          </div>
-
-          <div className="row" style={{ paddingTop: '1em' }}>
-            <span className="col-sm-2">Start time:</span>
-            <span className="col-sm-4">{r.startTime || '-'}</span>
-            <span className="col-sm-2">End time</span>
-            <span className="col-sm-4">{r.endTime || '-'}</span>
-          </div>
-
-          <div className="row">
-            <span className="col-sm-2">Flux at start:</span>
-            <span className="col-sm-4">{sFlux || '-'} ph/s</span>
-            <span className="col-sm-2">Flux at end</span>
-            <span className="col-sm-4">{eFlux || '-'} ph/s</span>
-          </div>
-
-          <div className="row" style={{ paddingTop: '0.5em' }}>
-            <span className="col-sm-4">
-              <b>Quality Indictor: </b>
-              <img alt="First" src={qIndUrl} width="90%" />
-            </span>
-            <span className="col-sm-4">
-              <b>First image: </b>
-              <img alt="First" src={fImageUrl} width="90%" />
-            </span>
-            <span className="col-sm-4">
-              <b>Last image: </b>
-              <img alt="Last" src={lImageUrl} width="90%" />
-            </span>
-          </div>
-        </div>
-      );
-    } else if (!isUnCollected(task)) {
-      content = (
-        <span>
-          <img src={loader} alt="" /> Fetching data, please wait
-        </span>
-      );
-    }
-
-    return content;
   }
 
   title() {

--- a/ui/src/components/SampleGrid/TaskItem.jsx
+++ b/ui/src/components/SampleGrid/TaskItem.jsx
@@ -11,7 +11,7 @@ import {
   TASK_RUNNING,
   TASK_UNCOLLECTED,
 } from '../../constants';
-import { LimsResultSummary } from '../Lims/LimsResultSummary';
+import { DataCollectionResultSummary } from '../DataCollectionResult/DataCollectionResultSummary';
 
 export class TaskItem extends React.Component {
   static defaultProps = {
@@ -167,7 +167,10 @@ export class TaskItem extends React.Component {
               id="taskSummaryPopover"
               title={<b>{this.title()}</b>}
             >
-              <LimsResultSummary taskData={this.props.taskData} scale="0.5" />
+              <DataCollectionResultSummary
+                taskData={this.props.taskData}
+                scale="0.5"
+              />
             </Popover>
           }
         >

--- a/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
+++ b/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { OverlayTrigger, Popover } from 'react-bootstrap';
 
-import { TASK_COLLECTED } from '../../constants';
 import styles from './Item.module.css';
 import TaskItemContainer from './TaskItemContainer';
 
@@ -20,26 +19,7 @@ export default class EnergyScanTaskItem extends Component {
   constructor(props) {
     super(props);
     this.showForm = this.showForm.bind(this);
-    this.getResult = this.getResult.bind(this);
     this.pointIDString = this.pointIDString.bind(this);
-  }
-
-  getResult(state) {
-    if (state !== TASK_COLLECTED) {
-      return <span />;
-    }
-    const link = this.props.data.limsResultData
-      ? this.props.data.limsResultData.limsTaskLink
-      : '';
-
-    return (
-      <div className={styles.resultBody}>
-        <a href={link} target="_blank" rel="noreferrer">
-          {' '}
-          View Results in ISPyB
-        </a>
-      </div>
-    );
   }
 
   showForm() {
@@ -134,7 +114,6 @@ export default class EnergyScanTaskItem extends Component {
                 <b>Edge:</b> {parameters.edge}
               </div>
             </div>
-            {this.getResult(state)}
           </div>
         </div>
       </TaskItemContainer>

--- a/ui/src/components/SampleQueue/TaskItem.jsx
+++ b/ui/src/components/SampleQueue/TaskItem.jsx
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { Button, Table } from 'react-bootstrap';
 
-import { TASK_COLLECTED } from '../../constants';
 import TooltipTrigger from '../TooltipTrigger';
 import styles from './Item.module.css';
 import TaskItemContainer from './TaskItemContainer';
@@ -21,36 +20,8 @@ export default class TaskItem extends Component {
   constructor(props) {
     super(props);
     this.showForm = this.showForm.bind(this);
-    this.getResult = this.getResult.bind(this);
     this.pointIDString = this.pointIDString.bind(this);
     this.wedgeParameters = this.wedgeParameters.bind(this);
-  }
-
-  getResult(state) {
-    if (state !== TASK_COLLECTED) {
-      return (
-        <div>
-          <span />
-        </div>
-      );
-    }
-    return (
-      <div className={styles.resultBody}>
-        <a
-          href="#"
-          onClick={() =>
-            this.props.showDialog(
-              true,
-              'LIMS_RESULT_DIALOG',
-              'Lims Results',
-              this.props.data,
-            )
-          }
-        >
-          View Results
-        </a>
-      </div>
-    );
   }
 
   showForm() {
@@ -243,7 +214,6 @@ export default class TaskItem extends Component {
                   </thead>
                   <tbody>{this.wedgeParameters(wedge)}</tbody>
                 </Table>
-                {this.getResult(state)}
               </div>
             );
           })}

--- a/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
+++ b/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { Button } from 'react-bootstrap';
 
-import { TASK_COLLECTED } from '../../constants';
 import TooltipTrigger from '../TooltipTrigger';
 import styles from './Item.module.css';
 import TaskItemContainer from './TaskItemContainer';
@@ -20,26 +19,7 @@ export default class WorkflowTaskItem extends Component {
   constructor(props) {
     super(props);
     this.showForm = this.showForm.bind(this);
-    this.getResult = this.getResult.bind(this);
     this.pointIDString = this.pointIDString.bind(this);
-  }
-
-  getResult(state) {
-    if (state !== TASK_COLLECTED) {
-      return <span />;
-    }
-    const link = this.props.data.limsResultData
-      ? this.props.data.limsResultData.limsTaskLink
-      : '';
-
-    return (
-      <div className={styles.resultBody}>
-        <a href={link} target="_blank" rel="noreferrer">
-          {' '}
-          View Results in ISPyB
-        </a>
-      </div>
-    );
   }
 
   showForm() {

--- a/ui/src/components/SampleQueue/XRFTaskItem.jsx
+++ b/ui/src/components/SampleQueue/XRFTaskItem.jsx
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { OverlayTrigger, Popover } from 'react-bootstrap';
 
-import { TASK_COLLECTED } from '../../constants';
 import styles from './Item.module.css';
 import TaskItemContainer from './TaskItemContainer';
 
@@ -20,26 +19,7 @@ export default class XRFTaskItem extends Component {
   constructor(props) {
     super(props);
     this.showForm = this.showForm.bind(this);
-    this.getResult = this.getResult.bind(this);
     this.pointIDString = this.pointIDString.bind(this);
-  }
-
-  getResult(state) {
-    if (state !== TASK_COLLECTED) {
-      return <span />;
-    }
-    const link = this.props.data.limsResultData
-      ? this.props.data.limsResultData.limsTaskLink
-      : '';
-
-    return (
-      <div className={styles.resultBody}>
-        <a href={link} target="_blank" rel="noreferrer">
-          {' '}
-          View Results in ISPyB
-        </a>
-      </div>
-    );
   }
 
   showForm() {
@@ -131,7 +111,6 @@ export default class XRFTaskItem extends Component {
                 <b>Count time:</b> {parameters.countTime}
               </div>
             </div>
-            {this.getResult(state)}
           </div>
         </div>
       </TaskItemContainer>

--- a/ui/src/reducers/sampleGrid.js
+++ b/ui/src/reducers/sampleGrid.js
@@ -132,7 +132,6 @@ function sampleGridReducer(state = INITIAL_STATE, action = {}) {
             {
               ...state.sampleList[action.sampleID].tasks[action.taskIndex],
               checked: false,
-              limsResultData: action.limsResultData,
               state: action.state,
             },
             ...state.sampleList[action.sampleID].tasks.slice(
@@ -154,10 +153,6 @@ function sampleGridReducer(state = INITIAL_STATE, action = {}) {
               0,
               action.taskIndex,
             ),
-            {
-              ...state.sampleList[action.sampleID].tasks[action.taskIndex],
-              limsResultData: action.limsResultData,
-            },
             ...state.sampleList[action.sampleID].tasks.slice(
               action.taskIndex + 1,
             ),

--- a/ui/src/reducers/sampleGrid.js
+++ b/ui/src/reducers/sampleGrid.js
@@ -143,25 +143,6 @@ function sampleGridReducer(state = INITIAL_STATE, action = {}) {
 
       return { ...state, sampleList };
     }
-    case 'UPDATE_TASK_LIMS_DATA': {
-      const sampleList = {
-        ...state.sampleList,
-        [action.sampleID]: {
-          ...state.sampleList[action.sampleID],
-          tasks: [
-            ...state.sampleList[action.sampleID].tasks.slice(
-              0,
-              action.taskIndex,
-            ),
-            ...state.sampleList[action.sampleID].tasks.slice(
-              action.taskIndex + 1,
-            ),
-          ],
-        },
-      };
-
-      return { ...state, sampleList };
-    }
     case 'ADD_TASKS': {
       const sampleList = { ...state.sampleList };
       action.tasks.forEach((t) => {

--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -174,13 +174,7 @@ class ServerIO {
     });
 
     this.hwrSocket.on('update_task_lims_data', (record) => {
-      dispatch(
-        updateTaskLimsData(
-          record.sample,
-          record.taskIndex,
-          record.limsResultData,
-        ),
-      );
+      dispatch(updateTaskLimsData(record.sample, record.taskIndex));
     });
 
     this.hwrSocket.on('task', (record, callback) => {
@@ -209,7 +203,6 @@ class ServerIO {
             record.taskIndex,
             record.state,
             record.progress,
-            record.limsResultData,
             record.queueID,
           ),
         );

--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -30,7 +30,6 @@ import {
   setSampleAttribute,
   setStatus,
   stopQueue,
-  updateTaskLimsData,
 } from './actions/queue';
 import { collapseItem, showResumeQueueDialog } from './actions/queueGUI';
 import { getRaState, incChatMessageCount } from './actions/remoteAccess';
@@ -171,10 +170,6 @@ class ServerIO {
 
     this.hwrSocket.on('energy_scan_result', (data) => {
       dispatch(setEnergyScanResult(data.pk, data.ip, data.rm));
-    });
-
-    this.hwrSocket.on('update_task_lims_data', (record) => {
-      dispatch(updateTaskLimsData(record.sample, record.taskIndex));
     });
 
     this.hwrSocket.on('task', (record, callback) => {


### PR DESCRIPTION
Accordingly to the discussion https://github.com/mxcube/mxcubeweb/issues/1773 `limsResultData` was removed from the backend signals' messages in https://github.com/mxcube/mxcubeweb/commit/6af4e5de242adc3affc62df2c43e79521671ac32

This PR removes it and related features from the frontend. `limsResultData` is not stored in global state, and there is no option of `View results` and `View results in ISPYB` any more

<img width="613" height="479" alt="Screenshot from 2025-07-17 15-00-23" src="https://github.com/user-attachments/assets/48ae8b63-1a62-42fc-9bfc-6644fb9d25b6" />
<img width="937" height="553" alt="Screenshot from 2025-07-17 15-00-35" src="https://github.com/user-attachments/assets/428bf1b6-e4f2-4e3c-bcf6-6455d828a2fe" />
. 