### PR TITLE
Fix the incorrect indentation of the helical section (in `beamline_config.yml`)

### DIFF
--- a/demo/beamline_config.yml
+++ b/demo/beamline_config.yml
@@ -103,9 +103,9 @@ configuration:
       disable_processing: false  # Not really needed (default is already false)
       # NB 'compression' not added as apparently never used
 
-      helical:
-        # Defaults for helical scan. Missing values are taken from default
-        number_of_images: 100
+    helical:
+      # Defaults for helical scan. Missing values are taken from default
+      number_of_images: 100
 
     characterisation:
       # Defaults for characterisation. Missing values are taken from default


### PR DESCRIPTION
While testing another PR, I noticed that the helical acquisition parameters weren’t being loaded from `beamline_config.yml`.

This PR fixes the indentation issue which was causing the problem.