### PR TITLE
Label was changed to currentAperture in a previous PR  #1646

### DIFF
--- a/ui/src/reducers/sampleview.js
+++ b/ui/src/reducers/sampleview.js
@@ -112,7 +112,7 @@ function sampleViewReducer(state = INITIAL_STATE, action = {}) {
         beamPosition: action.info.position,
         beamShape: action.info.shape,
         beamSize: { x: action.info.size_x, y: action.info.size_y },
-        currentAperture: action.info.label,
+        currentAperture: action.info.currentAperture,
       };
     }
     case 'SET_CURRENT_PHASE': {


### PR DESCRIPTION
Label was changed to currentAperture in a previous PR Added AdapterResourceHandler https://github.com/mxcube/mxcubeweb/pull/1646