### PR TITLE
Add log handler Graylog

### DIFF
--- a/demo/mxcube-web/server.yaml
+++ b/demo/mxcube-web/server.yaml
@@ -45,7 +45,7 @@ server:
   CSP_REPORT_ONLY: false
   CSP_REPORT_URI: "/mxcube/api/v0.1/csp/report"
 
-  GRAYLOG_HOST: null
+  GRAYLOG_HOST: None
   GRAYLOG_PORT: null
 
 sso:

--- a/demo/mxcube-web/server.yaml
+++ b/demo/mxcube-web/server.yaml
@@ -45,8 +45,8 @@ server:
   CSP_REPORT_ONLY: false
   CSP_REPORT_URI: "/mxcube/api/v0.1/csp/report"
 
-  GRAYLOG_HOST: "graylog-dau.esrf.fr"
-  GRAYLOG_PORT: 12210
+  GRAYLOG_HOST: null
+  GRAYLOG_PORT: null
 
 sso:
   USE_SSO: false

--- a/demo/mxcube-web/server.yaml
+++ b/demo/mxcube-web/server.yaml
@@ -46,7 +46,7 @@ server:
   CSP_REPORT_URI: "/mxcube/api/v0.1/csp/report"
 
   GRAYLOG_HOST: None
-  GRAYLOG_PORT: null
+  GRAYLOG_PORT: None
 
 sso:
   USE_SSO: false

--- a/demo/mxcube-web/server.yaml
+++ b/demo/mxcube-web/server.yaml
@@ -45,6 +45,9 @@ server:
   CSP_REPORT_ONLY: false
   CSP_REPORT_URI: "/mxcube/api/v0.1/csp/report"
 
+  GRAYLOG_HOST: "graylog-dau.esrf.fr"
+  GRAYLOG_PORT: 12210
+
 sso:
   USE_SSO: false
   ISSUER: https://websso.[site].[com]/realms/[site]/

--- a/docs/source/config/server.rst
+++ b/docs/source/config/server.rst
@@ -151,7 +151,7 @@ Default value is ``/mxcube/api/v0.1/csp/report``.
 Hostname or IP address of the Graylog server for logging.
 Set to ``null`` to disable Graylog logging.
 
-Default value is ``null``.
+Default value is ``None``.
 
 ``GRAYLOG_PORT``
 ~~~~~~~~~~~~~~~~

--- a/docs/source/config/server.rst
+++ b/docs/source/config/server.rst
@@ -159,7 +159,7 @@ Default value is ``None``.
 Port number of the Graylog server for logging.
 Set to ``null`` to disable Graylog logging.
 
-Default value is ``null``.
+Default value is ``None``.
 
 mxcube
 ------

--- a/docs/source/config/server.rst
+++ b/docs/source/config/server.rst
@@ -116,6 +116,51 @@ Path of the certificate file to use for SSL connections.
 
 Path of the private key file to use for SSL connections.
 
+``CSP_ENABLED``
+~~~~~~~~~~~~~~~
+
+Enable or disable Content Security Policy (CSP) headers for the server.
+When set to ``true``, CSP headers are sent with responses according to the policy defined in ``CSP_POLICY``.
+
+Default value is ``false``.
+
+``CSP_POLICY``
+~~~~~~~~~~~~~~
+
+Defines the Content Security Policy (CSP) rules applied by the server.
+This should be a mapping of CSP directives to lists of allowed sources.
+
+``CSP_REPORT_ONLY``
+~~~~~~~~~~~~~~~~~~~
+
+If set to ``true``, the CSP policy is only reported (not enforced).
+Violations are sent to the URI specified by ``CSP_REPORT_URI``.
+
+Default value is ``false``.
+
+``CSP_REPORT_URI``
+~~~~~~~~~~~~~~~~~~
+
+Specifies the URI where CSP violation reports are sent when ``CSP_REPORT_ONLY`` is enabled.
+
+Default value is ``/mxcube/api/v0.1/csp/report``.
+
+``GRAYLOG_HOST``
+~~~~~~~~~~~~~~~~
+
+Hostname or IP address of the Graylog server for logging.
+Set to ``null`` to disable Graylog logging.
+
+Default value is ``null``.
+
+``GRAYLOG_PORT``
+~~~~~~~~~~~~~~~~
+
+Port number of the Graylog server for logging.
+Set to ``null`` to disable Graylog logging.
+
+Default value is ``null``.
+
 mxcube
 ------
 

--- a/mxcubeweb/app.py
+++ b/mxcubeweb/app.py
@@ -10,6 +10,7 @@ import time
 from logging import StreamHandler
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
+import graypy
 
 from mxcubecore import (
     ColorFormatter,
@@ -203,6 +204,22 @@ class MXCUBEApplication:
         MXCUBEApplication.harvester.init_signals()
 
     @staticmethod
+    def _get_graylog_handler(config, log_level):
+        server_cfg = getattr(config, "server", None)
+        graylog_host = getattr(server_cfg, "GRAYLOG_HOST", None)
+        graylog_port = getattr(server_cfg, "GRAYLOG_PORT", None)
+        if graylog_host and graylog_port:
+            try:
+                handler = graypy.GELFUDPHandler(graylog_host, graylog_port)
+                handler.setLevel(log_level)
+            except Exception as ex:
+                msg = "Graylog handler could not be initialized: " + str(ex)
+                logging.getLogger("HWR").info(msg)
+            else:
+                return handler
+        return None
+
+    @staticmethod
     def init_logging(log_file, log_level, enabled_logger_list):
         """
         :param str log_file: Path to log file
@@ -244,6 +261,9 @@ class MXCUBEApplication:
         custom_log_handler = MX3LoggingHandler(MXCUBEApplication.server)
         custom_log_handler.setLevel(log_level)
         custom_log_handler.setFormatter(file_formatter)
+        gelf_handler = MXCUBEApplication._get_graylog_handler(
+            MXCUBEApplication.CONFIG, log_level
+        )
 
         _loggers = {
             "hwr_logger": logging.getLogger("HWR"),
@@ -261,6 +281,8 @@ class MXCUBEApplication:
             if logger_name in enabled_logger_list:
                 logger.addHandler(custom_log_handler)
                 logger.addHandler(stdout_log_handler)
+                if gelf_handler:
+                    logger.addHandler(gelf_handler)
                 logger.setLevel(log_level)
 
                 if log_file and "mx3_ui" in logger_name:

--- a/mxcubeweb/app.py
+++ b/mxcubeweb/app.py
@@ -10,7 +10,11 @@ import time
 from logging import StreamHandler
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
-import graypy
+
+try:
+    import graypy
+except ImportError:
+    graypy = None
 
 from mxcubecore import (
     ColorFormatter,
@@ -205,17 +209,19 @@ class MXCUBEApplication:
 
     @staticmethod
     def _get_graylog_handler(config, log_level):
+        if graypy is None:
+            return None
         server_cfg = getattr(config, "server", None)
         graylog_host = getattr(server_cfg, "GRAYLOG_HOST", None)
         graylog_port = getattr(server_cfg, "GRAYLOG_PORT", None)
         if graylog_host and graylog_port:
             try:
                 handler = graypy.GELFUDPHandler(graylog_host, graylog_port)
-                handler.setLevel(log_level)
             except Exception as ex:
                 msg = "Graylog handler could not be initialized: " + str(ex)
                 logging.getLogger("HWR").info(msg)
             else:
+                handler.setLevel(log_level)
                 return handler
         return None
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1189,9 +1189,10 @@ test = ["cffi (>=1.12.2) ; platform_python_implementation == \"CPython\"", "cove
 name = "graypy"
 version = "2.1.0"
 description = "Python logging handlers that send messages in the Graylog Extended Log Format (GELF)."
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
+markers = "extra == \"graylog\""
 files = [
     {file = "graypy-2.1.0-py2.py3-none-any.whl", hash = "sha256:5df0102ed52fdaa24dd579bc1e4904480c2c9bbb98917a0b3241ecf510c94207"},
     {file = "graypy-2.1.0.tar.gz", hash = "sha256:fd8dc4a721de1278576d92db10ac015e99b4e480cf1b18892e79429fd9236e16"},
@@ -4004,7 +4005,10 @@ docs = ["Sphinx", "furo", "repoze.sphinx.autointerface"]
 test = ["coverage[toml]", "zope.event", "zope.testing"]
 testing = ["coverage[toml]", "zope.event", "zope.testing"]
 
+[extras]
+graylog = ["graypy"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "9d941fbce88fee5f6a1e41d364141337dcb560c7b83f00fbce86130d1693ebcc"
+content-hash = "8cdedc9dadfee981e42e766d8ffeb5ccf7afdb1db1df2246aa27f7d552455f70"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1186,6 +1186,22 @@ recommended = ["cffi (>=1.12.2) ; platform_python_implementation == \"CPython\""
 test = ["cffi (>=1.12.2) ; platform_python_implementation == \"CPython\"", "coverage (>=5.0) ; sys_platform != \"win32\"", "dnspython (>=1.16.0,<2.0) ; python_version < \"3.10\"", "idna ; python_version < \"3.10\"", "objgraph", "psutil (>=5.7.0) ; sys_platform != \"win32\" or platform_python_implementation == \"CPython\"", "requests", "setuptools"]
 
 [[package]]
+name = "graypy"
+version = "2.1.0"
+description = "Python logging handlers that send messages in the Graylog Extended Log Format (GELF)."
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "graypy-2.1.0-py2.py3-none-any.whl", hash = "sha256:5df0102ed52fdaa24dd579bc1e4904480c2c9bbb98917a0b3241ecf510c94207"},
+    {file = "graypy-2.1.0.tar.gz", hash = "sha256:fd8dc4a721de1278576d92db10ac015e99b4e480cf1b18892e79429fd9236e16"},
+]
+
+[package.extras]
+amqp = ["amqplib (==1.0.2)"]
+docs = ["sphinx (>=2.1.2,<3.0.0)", "sphinx-autodoc-typehints (>=1.6.0,<2.0.0)", "sphinx-rtd-theme (>=0.4.3,<1.0.0)"]
+
+[[package]]
 name = "greenlet"
 version = "3.1.1"
 description = "Lightweight in-process concurrent programming"
@@ -3991,4 +4007,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "0f0632f564b30c997f11b2d37b0fb2384b7a021247f1fe3f9c8885a3eff88244"
+content-hash = "9d941fbce88fee5f6a1e41d364141337dcb560c7b83f00fbce86130d1693ebcc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ dynamic = [
     "dependencies",
 ]
 
+[project.optional-dependencies]
+graylog = ["graypy>=2.1.0"]
+
 [tool.poetry]
 requires-poetry = "2.1.3"  # Keep in sync with `.pre-commit-config.yaml`
 
@@ -53,7 +56,6 @@ sqlalchemy = "^2.0.37"
 tomli = { version = "^2.2.1", python = "<=3.10" }
 tzlocal = "^4.2"
 werkzeug = "^3.0.3"
-graypy = "^2.1.0"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^4.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ sqlalchemy = "^2.0.37"
 tomli = { version = "^2.2.1", python = "<=3.10" }
 tzlocal = "^4.2"
 werkzeug = "^3.0.3"
+graypy = "^2.1.0"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^4.1.0"


### PR DESCRIPTION
This pull request introduces Graylog integration into the logging system of the `mxcubeweb` application. The most important changes include adding configuration parameters for Graylog, implementing a Graylog handler, and updating the logging setup to optionally include this handler.

### Graylog Integration:

* **Configuration Parameters**: Added `GRAYLOG_HOST` and `GRAYLOG_PORT` to the `server.yaml` configuration file to specify the Graylog server details. (`demo/mxcube-web/server.yaml`)
* **Dependency Addition**: Added the `graypy` library to the project dependencies in `pyproject.toml`. (`pyproject.toml`)
* **Graylog Handler Implementation**: Introduced the `_get_graylog_handler` method in `mxcubeweb/app.py` to create a Graylog handler using the `graypy.GELFUDPHandler`. This method checks for the presence of Graylog configuration and initializes the handler if valid. (`mxcubeweb/app.py`)