### PR TITLE
Make refresh session interval configurable

### DIFF
--- a/demo.yaml/mxcube-web/server.yaml
+++ b/demo.yaml/mxcube-web/server.yaml
@@ -31,6 +31,10 @@ mxcube:
   # Mode, SSX-CHIP, SSX-INJECTOR, OSC
   mode: OSC
 
+  # Interval with which request to refresh token is made
+  # by the client application.
+  SESSION_REFRESH_INTERVAL: 9000
+
   usermanager:
     class: UserManager
     inhouse_is_staff: true

--- a/demo/mxcube-web/server.yaml
+++ b/demo/mxcube-web/server.yaml
@@ -69,6 +69,10 @@ mxcube:
   # This is used to determine whether we can get samples from the sample changer
   # if false, Only LIMS samples will be availble to fetch for the sample list
 
+  # Interval with which request to refresh token is made
+  # by the client application.
+  SESSION_REFRESH_INTERVAL: 9000
+
   usermanager:
     class: UserManager
     inhouse_is_staff: true

--- a/docs/source/config/server.rst
+++ b/docs/source/config/server.rst
@@ -131,6 +131,7 @@ The section has the following syntax:
       VIDEO_FORMAT: <format name>
       VIDEO_STREAM_URL: <stream URL>
       VIDEO_STREAM_PORT: <stream port>
+      SESSION_REFRESH_INTERVAL: <refresh interval>
       usermanager:
         class: <class name>
         inhouse_is_staff: <boolean>
@@ -192,6 +193,13 @@ that provide video stream from custom URLs.
 This configuration is used when ``USE_EXTERNAL_STREAMER`` flag is enabled.
 The specified value is passed on to the camera hardware object,
 when invoking the start stream hook.
+
+``SESSION_REFRESH_INTERVAL``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The interval in milliseconds at which the front-end makes
+requests to refresh the session.
+
+Default interval is ``9000`` milliseconds.
 
 ``usermanager``
 ~~~~~~~~~~~~~~~

--- a/docs/source/dev/login.md
+++ b/docs/source/dev/login.md
@@ -49,7 +49,7 @@ For this purpose:
   right after successful authentication.
 
 - The front-end calls the `/mxcube/api/v0.1/login/refresh_session` endpoint
-  regularly (hardcoded value: 9000 milliseconds)
+  regularly (interval is specified in [`server.yaml`](../config/server.rst#session-refresh-interval), default to 9000 milliseconds )
   for as long as the browser tab is open.
 
 Every time the _refresh_ endpoint is called,

--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -390,6 +390,7 @@ class BaseUserManager(ComponentBase):
             "rootPath": HWR.beamline.session.get_base_image_directory(),
             "user": current_user.todict(),
             "useSSO": self.app.CONFIG.sso.USE_SSO,
+            "sessionRefreshInterval": self.app.CONFIG.app.SESSION_REFRESH_INTERVAL,
         }
 
         res["selectedProposal"] = "%s%s" % (

--- a/mxcubeweb/core/models/configmodels.py
+++ b/mxcubeweb/core/models/configmodels.py
@@ -201,6 +201,10 @@ class MXCUBEAppConfigModel(BaseModel):
         description="If the connected client's hostname ends with one of these domains"
         ", it will be considered 'local'",
     )
+    SESSION_REFRESH_INTERVAL: int = Field(
+        9000,
+        description="Session refresh interval in milliseconds",
+    )
     usermanager: UserManagerConfigModel
     ui_properties: dict[str, UIPropertiesModel] = {}
 

--- a/ui/src/components/App.jsx
+++ b/ui/src/components/App.jsx
@@ -20,8 +20,6 @@ import LoadingScreen from './LoadingScreen/LoadingScreen';
 import Main from './Main';
 import PrivateOutlet from './PrivateOutlet';
 
-const REFRESH_INTERVAL = 9000;
-
 const router = createBrowserRouter([
   {
     path: '/login',
@@ -71,6 +69,10 @@ function App() {
   const { showBoundary } = useErrorBoundary();
   const loggedIn = useSelector((state) => state.login.loggedIn);
 
+  const sessionRefreshInterval = useSelector(
+    (state) => state.login.sessionRefreshInterval,
+  );
+
   useEffect(() => {
     // Fetch login info on mount
     dispatch(getLoginInfo()).catch(showBoundary); // eslint-disable-line promise/prefer-await-to-then
@@ -79,7 +81,10 @@ function App() {
   useEffect(() => {
     if (loggedIn) {
       serverIO.listen();
-      const refreshInterval = setInterval(sendRefreshSession, REFRESH_INTERVAL);
+      const refreshInterval = setInterval(
+        sendRefreshSession,
+        sessionRefreshInterval,
+      );
 
       return () => {
         clearInterval(refreshInterval);
@@ -89,7 +94,7 @@ function App() {
 
     // no clean-up required, until we connect to serverIO
     return undefined;
-  }, [loggedIn]);
+  }, [loggedIn, sessionRefreshInterval]);
 
   if (loggedIn === null) {
     // Fetching login info

--- a/ui/src/reducers/login.js
+++ b/ui/src/reducers/login.js
@@ -7,6 +7,7 @@ const INITIAL_STATE = {
   user: {
     inControl: false,
   },
+  sessionRefreshInterval: 9000,
 };
 
 function loginReducer(state = INITIAL_STATE, action = {}) {
@@ -24,6 +25,7 @@ function loginReducer(state = INITIAL_STATE, action = {}) {
         rootPath,
         limsName,
         useSSO,
+        sessionRefreshInterval,
       } = action.loginInfo;
       return {
         ...state,
@@ -38,6 +40,7 @@ function loginReducer(state = INITIAL_STATE, action = {}) {
         rootPath,
         limsName,
         useSSO,
+        sessionRefreshInterval,
       };
     }
     case 'SHOW_PROPOSALS_FORM': {


### PR DESCRIPTION
`refreshSessionInterval` describes frequency with which frontend sends `refresh_token` requests. Currently it is hard-coded to be 9000 ms.

It's been added to server.yaml configuration file, because it is already home to other settings regarding managing user sessions.