### PR TITLE
Removes unused props from `SampleViewContainer`

### DIFF
--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -937,7 +937,6 @@ export default class SampleImage extends React.Component {
               show={this.props.drawGrid}
               getGridOverlayOpacity={this.getGridOverlayOpacity}
               setGridOverlayOpacity={this.setGridOverlayOpacity}
-              cellSpacing={this.props.cellSpacing}
               setHCellSpacing={this.setHCellSpacing}
               setVCellSpacing={this.setVCellSpacing}
               gridList={this.props.grids}

--- a/ui/src/containers/SampleViewContainer.jsx
+++ b/ui/src/containers/SampleViewContainer.jsx
@@ -58,7 +58,6 @@ class SampleViewContainer extends Component {
     if (!('sample_view_motors' in uiproperties)) {
       return null;
     }
-
     const { sourceScale, imageRatio } = this.props.sampleViewState;
     const { currentSampleID } = this.props;
     const [points, lines, grids, twoDPoints] = [{}, {}, {}, {}];
@@ -207,7 +206,6 @@ class SampleViewContainer extends Component {
                 grids={grids}
                 selectedGrids={selectedGrids}
                 cellCounting={this.props.cellCounting}
-                cellSpacing={this.props.cellSpacing}
                 busy={this.props.queueState === QUEUE_RUNNING}
                 setAttribute={this.props.setAttribute}
                 displayImage={this.props.displayImage}
@@ -243,7 +241,6 @@ function mapStateToProps(state) {
     defaultParameters: state.taskForm.defaultParameters,
     shapes: state.shapes.shapes,
     cellCounting: state.taskForm.defaultParameters.mesh.cell_counting,
-    cellSpacing: state.taskForm.defaultParameters.mesh.cell_spacing,
     remoteAccess: state.remoteAccess,
     uiproperties: state.uiproperties,
     mode: state.general.mode,


### PR DESCRIPTION
The `cellSpacing` property is no longer used.
Cell spacing is now managed by the `drawGridPlugin` in the `gridData` property.