### PR TITLE
refactor TaskItemContainer into functional component

### DIFF
--- a/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
+++ b/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
@@ -179,39 +179,15 @@ export default class TaskItem extends Component {
   }
 
   render() {
-    const {
-      data,
-      deleteTask,
-      progress,
-      sampleId,
-      selected,
-      show,
-      showContextMenu,
-      state,
-      taskHeaderOnClickHandler,
-      taskHeaderOnContextMenuHandler,
-    } = this.props;
+    const { data, state } = this.props;
     const wedges =
       data.type === 'Interleaved' ? data.parameters.wedges : [data];
 
     return (
       <TaskItemContainer
-        dataLabel={data.label}
-        deleteTask={deleteTask}
-        diffractionPlanLength={data.diffractionPlan.length}
         index={this.props.index}
+        data={data}
         pointIDString={this.pointIDString(wedges)}
-        progress={progress}
-        sampleId={sampleId}
-        selected={selected}
-        show={show}
-        showContextMenu={showContextMenu}
-        warningTaskCSS={
-          state === TASK_COLLECTED && data.diffractionPlan.length === undefined
-        } // this is a special prop for emitting a warning signal if the task is collected but has no diffraction plan
-        state={state}
-        taskHeaderOnClickHandler={taskHeaderOnClickHandler}
-        taskHeaderOnContextMenuHandler={taskHeaderOnContextMenuHandler}
       >
         <div className={styles.taskBody}>
           {wedges.map((wedge, i) => {

--- a/ui/src/components/SampleQueue/CurrentTree.jsx
+++ b/ui/src/components/SampleQueue/CurrentTree.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/destructuring-assignment */
-/* eslint-disable react/no-unused-state */
 import React from 'react';
-import { contextMenu, Item, Menu } from 'react-contexify';
+import { Item, Menu } from 'react-contexify';
 
 import CharacterisationTaskItem from './CharacterisationTaskItem';
 import EnergyScanTaskItem from './EnergyScanTaskItem';
@@ -13,14 +12,10 @@ import XRFTaskItem from './XRFTaskItem';
 export default class CurrentTree extends React.Component {
   constructor(props) {
     super(props);
-    this.taskHeaderOnClickHandler = this.taskHeaderOnClickHandler.bind(this);
-    this.taskHeaderOnContextMenuHandler =
-      this.taskHeaderOnContextMenuHandler.bind(this);
     this.showInterleavedDialog = this.showInterleavedDialog.bind(this);
     this.interleavedAvailable = this.interleavedAvailable.bind(this);
     this.selectedTasks = this.selectedTasks.bind(this);
     this.duplicateTask = this.duplicateTask.bind(this);
-    this.state = { showContextMenu: false, taskIndex: -1 };
   }
 
   selectedTasks() {
@@ -47,13 +42,6 @@ export default class CurrentTree extends React.Component {
     return selectedTasks;
   }
 
-  showContextMenu(event, id) {
-    contextMenu.show({
-      id,
-      event,
-    });
-  }
-
   interleavedAvailable() {
     let available = false;
     const selectedTasks = this.selectedTasks();
@@ -71,9 +59,8 @@ export default class CurrentTree extends React.Component {
     return available;
   }
 
-  duplicateTask() {
-    const task =
-      this.props.sampleList[this.props.mounted].tasks[this.state.taskIndex];
+  duplicateTask(taskIndex) {
+    const task = this.props.sampleList[this.props.mounted].tasks[taskIndex];
 
     if (task) {
       const tpars = {
@@ -83,19 +70,6 @@ export default class CurrentTree extends React.Component {
       };
       this.props.addTask([task.sampleID], tpars, false);
     }
-  }
-
-  taskHeaderOnClickHandler(e, index) {
-    const task = this.props.sampleList[this.props.mounted].tasks[index];
-    if (!e.ctrlKey) {
-      this.props.collapseItem(task.queueID);
-    } else {
-      this.props.selectItem(task.queueID);
-    }
-  }
-
-  taskHeaderOnContextMenuHandler(_e, index) {
-    this.setState({ showContextMenu: true, taskIndex: index });
   }
 
   showInterleavedDialog() {
@@ -141,7 +115,6 @@ export default class CurrentTree extends React.Component {
         <div style={{ top: '6%', height: '69%' }} className={styles.listBody}>
           {sampleTasks.map((taskData, i) => {
             let task = null;
-            const displayData = this.props.displayData[taskData.queueID] || {};
 
             switch (taskData.type) {
               case 'Workflow':
@@ -152,23 +125,14 @@ export default class CurrentTree extends React.Component {
                     index={i}
                     id={`${taskData.queueID}`}
                     data={taskData}
-                    deleteTask={this.props.deleteTask}
                     sampleId={sampleData.sampleID}
-                    selected={displayData.selected}
                     checked={this.props.checked}
-                    taskHeaderOnClickHandler={this.taskHeaderOnClickHandler}
-                    taskHeaderOnContextMenuHandler={
-                      this.taskHeaderOnContextMenuHandler
-                    }
                     state={
                       this.props.sampleList[taskData.sampleID].tasks[i].state
                     }
-                    show={displayData.collapsed}
-                    progress={displayData.progress}
                     showForm={this.props.showForm}
                     shapes={this.props.shapes}
                     showDialog={this.props.showDialog}
-                    showContextMenu={this.showContextMenu}
                     showWorkflowParametersDialog={
                       this.props.showWorkflowParametersDialog
                     }
@@ -184,24 +148,12 @@ export default class CurrentTree extends React.Component {
                     index={i}
                     id={`${taskData.queueID}`}
                     data={taskData}
-                    deleteTask={this.props.deleteTask}
                     sampleId={sampleData.sampleID}
-                    selected={displayData.selected}
                     checked={this.props.checked}
-                    taskHeaderOnClickHandler={this.taskHeaderOnClickHandler}
-                    taskHeaderOnContextMenuHandler={
-                      this.taskHeaderOnContextMenuHandler
-                    }
-                    state={
-                      this.props.sampleList[taskData.sampleID].tasks[i].state
-                    }
-                    show={displayData.collapsed}
-                    progress={displayData.progress}
                     showForm={this.props.showForm}
                     plotsData={this.props.plotsData}
                     plotsInfo={this.props.plotsInfo}
                     showDialog={this.props.showDialog}
-                    showContextMenu={this.showContextMenu}
                   />
                 );
 
@@ -214,23 +166,11 @@ export default class CurrentTree extends React.Component {
                     index={i}
                     id={`${taskData.queueID}`}
                     data={taskData}
-                    deleteTask={this.props.deleteTask}
                     sampleId={sampleData.sampleID}
-                    selected={displayData.selected}
                     checked={this.props.checked}
-                    taskHeaderOnClickHandler={this.taskHeaderOnClickHandler}
-                    taskHeaderOnContextMenuHandler={
-                      this.taskHeaderOnContextMenuHandler
-                    }
-                    state={
-                      this.props.sampleList[taskData.sampleID].tasks[i].state
-                    }
-                    show={displayData.collapsed}
-                    progress={displayData.progress}
                     showForm={this.props.showForm}
                     shapes={this.props.shapes}
                     showDialog={this.props.showDialog}
-                    showContextMenu={this.showContextMenu}
                   />
                 );
 
@@ -243,24 +183,15 @@ export default class CurrentTree extends React.Component {
                     index={i}
                     id={`${taskData.queueID}`}
                     data={taskData}
-                    deleteTask={this.props.deleteTask}
                     sampleId={sampleData.sampleID}
-                    selected={displayData.selected}
                     checked={this.props.checked}
-                    taskHeaderOnClickHandler={this.taskHeaderOnClickHandler}
-                    taskHeaderOnContextMenuHandler={
-                      this.taskHeaderOnContextMenuHandler
-                    }
                     state={
                       this.props.sampleList[taskData.sampleID].tasks[i].state
                     }
-                    show={displayData.collapsed}
-                    progress={displayData.progress}
                     showForm={this.props.showForm}
                     addTask={this.props.addTask}
                     shapes={this.props.shapes}
                     showDialog={this.props.showDialog}
-                    showContextMenu={this.showContextMenu}
                   />
                 );
 
@@ -273,23 +204,11 @@ export default class CurrentTree extends React.Component {
                     index={i}
                     id={`${taskData.queueID}`}
                     data={taskData}
-                    deleteTask={this.props.deleteTask}
                     sampleId={sampleData.sampleID}
-                    selected={displayData.selected}
                     checked={this.props.checked}
-                    taskHeaderOnClickHandler={this.taskHeaderOnClickHandler}
-                    taskHeaderOnContextMenuHandler={
-                      this.taskHeaderOnContextMenuHandler
-                    }
-                    state={
-                      this.props.sampleList[taskData.sampleID].tasks[i].state
-                    }
-                    show={displayData.collapsed}
-                    progress={displayData.progress}
                     showForm={this.props.showForm}
                     shapes={this.props.shapes}
                     showDialog={this.props.showDialog}
-                    showContextMenu={this.showContextMenu}
                   />
                 );
               }
@@ -305,7 +224,9 @@ export default class CurrentTree extends React.Component {
           >
             Create interleaved data collection
           </Item>
-          <Item onClick={this.duplicateTask}>Duplicate this item</Item>
+          <Item onClick={({ props }) => this.duplicateTask(props.taskIndex)}>
+            Duplicate this item
+          </Item>
         </Menu>
       </div>
     );

--- a/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
+++ b/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
@@ -73,35 +73,15 @@ export default class EnergyScanTaskItem extends Component {
   }
 
   render() {
-    const {
-      data,
-      deleteTask,
-      progress,
-      sampleId,
-      selected,
-      show,
-      showContextMenu,
-      state,
-      taskHeaderOnClickHandler,
-      taskHeaderOnContextMenuHandler,
-    } = this.props;
+    const { data } = this.props;
 
     const { parameters } = data;
 
     return (
       <TaskItemContainer
-        dataLabel={data.label}
-        deleteTask={deleteTask}
         index={this.props.index}
+        data={data}
         pointIDString={this.pointIDString(parameters)}
-        progress={progress}
-        sampleId={sampleId}
-        selected={selected}
-        show={show}
-        showContextMenu={showContextMenu}
-        state={state}
-        taskHeaderOnClickHandler={taskHeaderOnClickHandler}
-        taskHeaderOnContextMenuHandler={taskHeaderOnContextMenuHandler}
       >
         <div className={styles.taskBody}>
           <div>

--- a/ui/src/components/SampleQueue/TaskItem.jsx
+++ b/ui/src/components/SampleQueue/TaskItem.jsx
@@ -129,35 +129,15 @@ export default class TaskItem extends Component {
   }
 
   render() {
-    const {
-      data,
-      deleteTask,
-      progress,
-      sampleId,
-      selected,
-      show,
-      showContextMenu,
-      state,
-      taskHeaderOnClickHandler,
-      taskHeaderOnContextMenuHandler,
-    } = this.props;
+    const { data } = this.props;
     const wedges =
       data.type === 'Interleaved' ? data.parameters.wedges : [data];
 
     return (
       <TaskItemContainer
-        dataLabel={data.label}
-        deleteTask={deleteTask}
         index={this.props.index}
+        data={data}
         pointIDString={this.pointIDString(wedges)}
-        progress={progress}
-        sampleId={sampleId}
-        selected={selected}
-        show={show}
-        showContextMenu={showContextMenu}
-        state={state}
-        taskHeaderOnClickHandler={taskHeaderOnClickHandler}
-        taskHeaderOnContextMenuHandler={taskHeaderOnContextMenuHandler}
       >
         <div className={styles.taskBody}>
           {wedges.map((wedge, i) => {

--- a/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
+++ b/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
@@ -56,35 +56,15 @@ export default class WorkflowTaskItem extends Component {
   }
 
   render() {
-    const {
-      data,
-      deleteTask,
-      progress,
-      sampleId,
-      selected,
-      show,
-      showContextMenu,
-      state,
-      taskHeaderOnClickHandler,
-      taskHeaderOnContextMenuHandler,
-    } = this.props;
+    const { data, state } = this.props;
 
     const { parameters } = data;
 
     return (
       <TaskItemContainer
-        dataLabel={data.parameters.label}
-        deleteTask={deleteTask}
         index={this.props.index}
+        data={data}
         pointIDString={this.pointIDString(parameters)}
-        progress={progress}
-        sampleId={sampleId}
-        selected={selected}
-        show={show}
-        showContextMenu={showContextMenu}
-        state={state}
-        taskHeaderOnClickHandler={taskHeaderOnClickHandler}
-        taskHeaderOnContextMenuHandler={taskHeaderOnContextMenuHandler}
       >
         <div className={styles.taskBody}>
           <div>

--- a/ui/src/components/SampleQueue/XRFTaskItem.jsx
+++ b/ui/src/components/SampleQueue/XRFTaskItem.jsx
@@ -73,34 +73,14 @@ export default class XRFTaskItem extends Component {
   }
 
   render() {
-    const {
-      data,
-      deleteTask,
-      progress,
-      sampleId,
-      selected,
-      show,
-      showContextMenu,
-      state,
-      taskHeaderOnClickHandler,
-      taskHeaderOnContextMenuHandler,
-    } = this.props;
+    const { data } = this.props;
     const { parameters } = data;
 
     return (
       <TaskItemContainer
-        dataLabel={data.label}
-        deleteTask={deleteTask}
         index={this.props.index}
+        data={data}
         pointIDString={this.pointIDString(parameters)}
-        progress={progress}
-        sampleId={sampleId}
-        selected={selected}
-        show={show}
-        showContextMenu={showContextMenu}
-        state={state}
-        taskHeaderOnClickHandler={taskHeaderOnClickHandler}
-        taskHeaderOnContextMenuHandler={taskHeaderOnContextMenuHandler}
       >
         <div className={styles.taskBody}>
           <div>

--- a/ui/src/containers/SampleQueueContainer.jsx
+++ b/ui/src/containers/SampleQueueContainer.jsx
@@ -5,8 +5,8 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
 import { showDialog } from '../actions/general';
-import { addTask, deleteTask } from '../actions/queue';
-import { collapseItem, selectItem, showList } from '../actions/queueGUI';
+import { addTask } from '../actions/queue';
+import { showList } from '../actions/queueGUI';
 import { showTaskForm } from '../actions/taskForm';
 import { showWorkflowParametersDialog } from '../actions/workflow';
 import UserMessage from '../components/Notify/UserMessage';
@@ -102,10 +102,7 @@ class SampleQueueContainer extends React.Component {
             mounted={currentSampleID}
             sampleList={sampleList}
             checked={checked}
-            deleteTask={this.props.deleteTask}
             showForm={showForm}
-            collapseItem={this.props.collapseItem}
-            selectItem={this.props.selectItem}
             displayData={displayData}
             addTask={this.props.addTask}
             plotsData={this.props.plotsData}
@@ -156,7 +153,6 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
   return {
     // Queue actions
-    deleteTask: bindActionCreators(deleteTask, dispatch),
     addTask: bindActionCreators(addTask, dispatch),
 
     // Workflow action
@@ -165,9 +161,6 @@ function mapDispatchToProps(dispatch) {
       dispatch,
     ),
 
-    // Queue GUI actions
-    collapseItem: bindActionCreators(collapseItem, dispatch),
-    selectItem: bindActionCreators(selectItem, dispatch),
     showList: bindActionCreators(showList, dispatch),
 
     showForm: bindActionCreators(showTaskForm, dispatch),


### PR DESCRIPTION
This PR transforms the `TaskItemContainer` into a functional component while reducing prop drilling through multiple levels of components.

I also moved down functions that only affected `TaskItemContainer` from `CurrentTree` down to this component