### PR TITLE
[Fix] Prevents a crash when clicking the table inside a task item in the queue

### DIFF
--- a/ui/src/components/Tasks/Characterisation.jsx
+++ b/ui/src/components/Tasks/Characterisation.jsx
@@ -173,11 +173,11 @@ class Characterisation extends React.Component {
                 <InputField propName="kappa_phi" type="number" label="Phi" />
               </FieldsRow>
               <FieldsRow>
-                {this.props.initialValues.detector_mode_list.length > 0 && (
+                {this.props.detector_mode_list.length > 0 && (
                   <SelectField
                     propName="detector_roi_mode"
                     label="Detector mode"
-                    list={this.props.initialValues.detector_mode_list}
+                    list={this.props.detector_mode_list}
                   />
                 )}
                 <InputField propName="overlap" label="Overlap" />
@@ -496,7 +496,8 @@ export default connect((state) => {
   }
 
   const { type } = state.taskForm.taskData;
-  const { limits } = state.taskForm.defaultParameters[type.toLowerCase()];
+  const { limits, acq_parameters } =
+    state.taskForm.defaultParameters[type.toLowerCase()];
   const { parameters } = state.taskForm.taskData;
 
   // Set number of images to 1 for 2D points
@@ -523,6 +524,7 @@ export default connect((state) => {
     opt_sad: selector(state, 'opt_sad'),
     use_min_dose: selector(state, 'use_min_dose'),
     use_min_time: selector(state, 'use_min_time'),
+    detector_mode_list: acq_parameters.detector_mode_list,
     components: state.uiproperties.sample_view_motors.components,
     initialValues: {
       ...parameters,

--- a/ui/src/components/Tasks/DataCollection.jsx
+++ b/ui/src/components/Tasks/DataCollection.jsx
@@ -283,12 +283,12 @@ class DataCollection extends React.Component {
                 <InputField propName="kappa" type="number" label="Kappa" />
                 <InputField propName="kappa_phi" type="number" label="Phi" />
               </FieldsRow>
-              {this.props.initialValues.detector_mode_list.length > 0 && (
+              {this.props.detector_mode_list.length > 0 && (
                 <FieldsRow>
                   <SelectField
                     propName="detector_roi_mode"
                     label="Detector mode"
-                    list={this.props.initialValues.detector_mode_list}
+                    list={this.props.detector_mode_list}
                   />
                 </FieldsRow>
               )}
@@ -375,7 +375,8 @@ export default connect((state) => {
   }
 
   const { type } = state.taskForm.taskData;
-  const { limits } = state.taskForm.defaultParameters[type.toLowerCase()];
+  const { limits, acq_parameters } =
+    state.taskForm.defaultParameters[type.toLowerCase()];
   const { parameters } = state.taskForm.taskData;
 
   if (Number.parseFloat(parameters.osc_range) === 0) {
@@ -390,6 +391,7 @@ export default connect((state) => {
     filename: fname,
     acqParametersLimits: limits,
     beamline: state.beamline,
+    detector_mode_list: acq_parameters.detector_mode_list,
     components: state.uiproperties.sample_view_motors.components,
     initialValues: {
       ...parameters,

--- a/ui/src/components/Tasks/Helical.jsx
+++ b/ui/src/components/Tasks/Helical.jsx
@@ -174,11 +174,11 @@ class Helical extends React.Component {
                   label="Beam size"
                   list={this.props.apertureList}
                 />
-                {this.props.initialValues.detector_mode_list.length > 0 && (
+                {this.props.detector_mode_list.length > 0 && (
                   <SelectField
                     propName="detector_roi_mode"
                     label="Detector mode"
-                    list={this.props.initialValues.detector_mode_list}
+                    list={this.props.detector_mode_list}
                   />
                 )}
               </FieldsRow>
@@ -295,13 +295,15 @@ export default connect((state) => {
   }
 
   const { type } = state.taskForm.taskData;
-  const { limits } = state.taskForm.defaultParameters[type.toLowerCase()];
+  const { limits, acq_parameters } =
+    state.taskForm.defaultParameters[type.toLowerCase()];
 
   return {
     path: `${state.login.rootPath}/${subdir}`,
     filename: fname,
     acqParametersLimits: limits,
     beamline: state.beamline,
+    detector_mode_list: acq_parameters.detector_mode_list,
     components: state.uiproperties.sample_view_motors.components,
     initialValues: {
       ...state.taskForm.taskData.parameters,

--- a/ui/src/components/Tasks/Mesh.jsx
+++ b/ui/src/components/Tasks/Mesh.jsx
@@ -184,11 +184,11 @@ class Mesh extends React.Component {
                   label="Beam size"
                   list={this.props.apertureList}
                 />
-                {this.props.initialValues.detector_mode_list.length > 0 && (
+                {this.props.detector_mode_list.length > 0 && (
                   <SelectField
                     propName="detector_roi_mode"
                     label="Detector mode"
-                    list={this.props.initialValues.detector_mode_list}
+                    list={this.props.detector_mode_list}
                   />
                 )}
               </FieldsRow>
@@ -308,13 +308,15 @@ export default connect((state) => {
   }
 
   const { type } = state.taskForm.taskData;
-  const { limits } = state.taskForm.defaultParameters[type.toLowerCase()];
+  const { limits, acq_parameters } =
+    state.taskForm.defaultParameters[type.toLowerCase()];
 
   return {
     path: `${state.login.rootPath}/${subdir}`,
     filename: fname,
     acqParametersLimits: limits,
     beamline: state.beamline,
+    detector_mode_list: acq_parameters.detector_mode_list,
     components: state.uiproperties.sample_view_motors.components,
     initialValues: {
       ...state.taskForm.taskData.parameters,


### PR DESCRIPTION
Thanks to @walesch-yan for pointing out the issue suggested by the title. Here's a short video explaining it: [Screencast from 2025-07-28 17-29-10.webm](https://github.com/user-attachments/assets/6112581d-7153-4a8e-a26f-ac940d5aabd4)

This bug was introduced by me :sweat_smile:  with this PR #1723

I decided to use the `detector_mode_list` parameter directly from `acq_parameters`, instead of the one from `taskData`, since it's not really task data, at least it is not something that can be changed like the `detector_roi_mode`. 
This list is more like the `limits` of the range of the motors.