### PR TITLE
Fix sample order not being set in some cases

### DIFF
--- a/ui/src/reducers/sampleGrid.js
+++ b/ui/src/reducers/sampleGrid.js
@@ -42,6 +42,7 @@ function sampleGridReducer(state = INITIAL_STATE, action = {}) {
       return {
         ...state,
         sampleList: { ...action.sampleList },
+        order: action.sampleOrder,
       };
     }
     // Set the list of samples (sampleList), clearing any existing list


### PR DESCRIPTION
There are two different ways the `/queue_state` response is handled in MXCuBE.
First one is on initial load of the application. The endpoint is being called, then both `sampleOrder` and `sampleList` are saved into redux store here:
https://github.com/mxcube/mxcubeweb/blob/da92c63661ab502512a5fa1707e9b95872cceaf8/ui/src/reducers/sampleGrid.js#L315-L319 The other way occurs when a signal is emitted from back-end (either 'queue' or 'update_queue')
These call `getQueue` action:
https://github.com/mxcube/mxcubeweb/blob/da92c63661ab502512a5fa1707e9b95872cceaf8/ui/src/actions/queue.js#L495-L504 which then invokes `SET_QUEUE` in `sampleGrid` reducer - it only saves the `sampleList` in the redux store, the information about `sampleOrder` is ignored.
It seems wrong and leads to a confusing bug when using session type login.
On session selection, `getQueue` after `update_queue` is emitted https://github.com/mxcube/mxcubeweb/blob/390d60a5493a137bec01eae3aefdb0d6b5bdcfd9/mxcubeweb/core/components/lims.py#L223 This leads to this issue:
1. User logs in
2. `sampleList` and `sampleOrder` are initialized with empty values
3. User selects a session
4. Only `sampleList` is set, `sampleOrder` is ignored.
5. Samples are displayed, but due to order being empty, nothing happens