### PR TITLE
Remove the `--no-fix` option of the `ruff` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,10 +32,12 @@ repos:
 
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.6
+    rev: v0.9.10  # Keep in sync with `poetry.lock` and `pyproject.toml`
     hooks:
+      # For the `ruff` hook (which runs `ruff check`),
+      # we purposefully skip the `--fix` option,
+      # and recommend running a command like `poetry run ruff check --fix` instead.
       - id: ruff
-        args: [--fix]
       - id: ruff-format
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -286,13 +286,16 @@ def function_with_types_in_docstring(param1, param2):
 ```
 
 The Python code is to be formatted and checked for lint with
-[*ruff*](https://astral.sh/ruff).
-This repository uses [*pre-commit*](https://pre-commit.com/) hooks
+[*Ruff*](https://astral.sh/ruff).
+This repository uses [*Pre-commit*](https://pre-commit.com/) hooks
 to check the code quality automatically.
 These checks are done for each pull request on GitHub.
 It is also recommended to do these checks locally by enabling the git pre-commit hooks.
 For example with a one-time command like this: `pre-commit install`.
-
+One can also run the Ruff linter and Ruff formatter locally with commands like
+`poetry run ruff check` and `poetry run ruff format`.
+To get Ruff to automatically fix some of the issues it detects,
+one can run a command like this: `poetry run ruff check --fix`.
 
 
 ## Continuous integration (CI)

--- a/poetry.lock
+++ b/poetry.lock
@@ -3152,6 +3152,34 @@ files = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.9.10"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "ruff-0.9.10-py3-none-linux_armv6l.whl", hash = "sha256:eb4d25532cfd9fe461acc83498361ec2e2252795b4f40b17e80692814329e42d"},
+    {file = "ruff-0.9.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:188a6638dab1aa9bb6228a7302387b2c9954e455fb25d6b4470cb0641d16759d"},
+    {file = "ruff-0.9.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5284dcac6b9dbc2fcb71fdfc26a217b2ca4ede6ccd57476f52a587451ebe450d"},
+    {file = "ruff-0.9.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:47678f39fa2a3da62724851107f438c8229a3470f533894b5568a39b40029c0c"},
+    {file = "ruff-0.9.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:99713a6e2766b7a17147b309e8c915b32b07a25c9efd12ada79f217c9c778b3e"},
+    {file = "ruff-0.9.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:524ee184d92f7c7304aa568e2db20f50c32d1d0caa235d8ddf10497566ea1a12"},
+    {file = "ruff-0.9.10-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:df92aeac30af821f9acf819fc01b4afc3dfb829d2782884f8739fb52a8119a16"},
+    {file = "ruff-0.9.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de42e4edc296f520bb84954eb992a07a0ec5a02fecb834498415908469854a52"},
+    {file = "ruff-0.9.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d257f95b65806104b6b1ffca0ea53f4ef98454036df65b1eda3693534813ecd1"},
+    {file = "ruff-0.9.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b60dec7201c0b10d6d11be00e8f2dbb6f40ef1828ee75ed739923799513db24c"},
+    {file = "ruff-0.9.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d838b60007da7a39c046fcdd317293d10b845001f38bcb55ba766c3875b01e43"},
+    {file = "ruff-0.9.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ccaf903108b899beb8e09a63ffae5869057ab649c1e9231c05ae354ebc62066c"},
+    {file = "ruff-0.9.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f9567d135265d46e59d62dc60c0bfad10e9a6822e231f5b24032dba5a55be6b5"},
+    {file = "ruff-0.9.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5f202f0d93738c28a89f8ed9eaba01b7be339e5d8d642c994347eaa81c6d75b8"},
+    {file = "ruff-0.9.10-py3-none-win32.whl", hash = "sha256:bfb834e87c916521ce46b1788fbb8484966e5113c02df216680102e9eb960029"},
+    {file = "ruff-0.9.10-py3-none-win_amd64.whl", hash = "sha256:f2160eeef3031bf4b17df74e307d4c5fb689a6f3a26a2de3f7ef4044e3c484f1"},
+    {file = "ruff-0.9.10-py3-none-win_arm64.whl", hash = "sha256:5fd804c0327a5e5ea26615550e706942f348b197d5475ff34c19733aee4b2e69"},
+    {file = "ruff-0.9.10.tar.gz", hash = "sha256:9bacb735d7bada9cfb0f2c227d3658fc443d90a727b47f206fb33f52f3c0eac7"},
+]
+
+[[package]]
 name = "scandir"
 version = "1.10.0"
 description = "scandir, a better directory iterator and faster os.walk()"
@@ -4011,4 +4039,4 @@ graylog = ["graypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "8cdedc9dadfee981e42e766d8ffeb5ccf7afdb1db1df2246aa27f7d552455f70"
+content-hash = "e121a7705085aa19f2f08ae23adc914ab73a499523fa0f5418d33d2badb39fa9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ pre-commit = "^4.1.0"
 psutil = "^5.9.4"
 pytest = "^8.3.4"
 pytest-cov = "^6.0.0"
+ruff = "~=0.9.10"
 
 [tool.poetry.group.docs.dependencies]
 furo = "^2023.9.10"


### PR DESCRIPTION
When `ruff check --fix` makes modifications to files, it is not immediately clear where and why the files are modified. When running locally, one can see the changes with `git diff`, but it still does not clarify why (which Ruff rule was broken).

Without the `--fix` option, Ruff clearly shows where the violations are. Then the developer is free to decide how to fix the violations:
* The developer can choose to do the fixes manually.
* The developer can choose to run `poetry run ruff check --fix`.
* The developer can choose to add exceptions.
* The developer can choose to do a combination of the above.

GitHub: https://github.com/mxcube/mxcubecore/issues/1220
GitHub: https://github.com/mxcube/mxcubecore/pull/1243