### PR TITLE
Make sample_view_list_modes optional in ui.yaml

### DIFF
--- a/docs/source/config/ui.rst
+++ b/docs/source/config/ui.rst
@@ -61,6 +61,11 @@ Here is an example of ``sample_list_view_modes`` section:
         - id: graphical_view
           show: true
 
+.. note::
+
+    The ``sample_list_view_modes`` section is optional, if not specified, the default view modes are used.
+    The default view modes are: *table_view* and *graphical_view*.
+
 .. image:: view_modes.png
 
 sample_view

--- a/mxcubeweb/core/models/configmodels.py
+++ b/mxcubeweb/core/models/configmodels.py
@@ -124,8 +124,14 @@ class _UISampleListViewModesComponentModel(BaseModel):
 
 
 class UISampleListViewModesModel(BaseModel):
-    id: Literal["sample_list_view_modes"]
-    components: list[_UISampleListViewModesComponentModel]
+    id: Literal["sample_list_view_modes"] = "sample_list_view_modes"
+    components: list[_UISampleListViewModesComponentModel] = Field(
+        default_factory=lambda: [
+            _UISampleListViewModesComponentModel(id="table_view", show=True),
+            _UISampleListViewModesComponentModel(id="graphical_view", show=True),
+        ],
+        description="List of components for sample list view modes",
+    )
 
     @validator("components")
     @classmethod
@@ -165,7 +171,7 @@ class UIPropertiesListModel(BaseModel):
     beamline_setup: UIPropertiesModel
     camera_setup: UICameraConfigModel | None
     sample_view_motors: UISampleViewMotorsModel
-    sample_list_view_modes: UISampleListViewModesModel
+    sample_list_view_modes: UISampleListViewModesModel = UISampleListViewModesModel()
     sample_view_video_controls: UISampleViewVideoControlsModel | None
     session_picker: UISessionPickerModel = UISessionPickerModel()
 


### PR DESCRIPTION
Following the discussion in #1819 changed the `UISampleListViewModesModel` to have default values and make the `sample_list_view_modes` section optional in the `ui.yaml` file, thus enabling "backwards compatibility". 