### PR TITLE
remove call to getResult in WorkflowTaskItem

### DIFF
--- a/ui/src/components/SampleQueue/CurrentTree.jsx
+++ b/ui/src/components/SampleQueue/CurrentTree.jsx
@@ -127,9 +127,6 @@ export default class CurrentTree extends React.Component {
                     data={taskData}
                     sampleId={sampleData.sampleID}
                     checked={this.props.checked}
-                    state={
-                      this.props.sampleList[taskData.sampleID].tasks[i].state
-                    }
                     showForm={this.props.showForm}
                     shapes={this.props.shapes}
                     showDialog={this.props.showDialog}

--- a/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
+++ b/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
@@ -56,7 +56,7 @@ export default class WorkflowTaskItem extends Component {
   }
 
   render() {
-    const { data, state } = this.props;
+    const { data } = this.props;
 
     const { parameters } = data;
 
@@ -92,7 +92,6 @@ export default class WorkflowTaskItem extends Component {
                 <i aria-hidden="true" className="fa fa-sliders-h" />
               </Button>
             </div>
-            {this.getResult(state)}
           </div>
         </div>
       </TaskItemContainer>


### PR DESCRIPTION
As it was mentioned in mxcube/mxcubecore#1354, the `getResult` function does not exist on this component anymore (It was removed in #1790). 

This PR aims to remove the call to the non-existing function, while removing the now unnecessary props from the component. Thanks to @olofsvensson for pointing it out!