### PR TITLE
Add missing returns to the set_value of adapters

### DIFF
--- a/mxcubeweb/core/adapter/actuator_adapter.py
+++ b/mxcubeweb/core/adapter/actuator_adapter.py
@@ -53,7 +53,7 @@ class ActuatorAdapter(ActuatorAdapterBase):
     def _value_change(self, *args, **kwargs):
         self._vc(*args, **kwargs)
 
-    def set_value(self, value: HOActuatorValueChangeModel):
+    def set_value(self, value: HOActuatorValueChangeModel) -> str:
         """
         Execute the sequence to set the value.
         Args:
@@ -66,6 +66,7 @@ class ActuatorAdapter(ActuatorAdapterBase):
             StopItteration: When a value change was interrupted (abort/cancel).
         """
         self._ho.set_value(float(value.value))
+        return self.get_value()
 
     def get_value(self) -> FloatValueModel:
         """

--- a/mxcubeweb/core/adapter/adapter_base.py
+++ b/mxcubeweb/core/adapter/adapter_base.py
@@ -406,12 +406,14 @@ class ActuatorAdapterBase(AdapterBase):
         self.emit_ho_value_changed(args[0])
 
     # Abstract method
-    def set_value(self, value) -> None:
+    def set_value(self, value) -> str:
         """
         Sets a value on underlying hardware object.
 
         Args:
             value(float): Value to be set.
+        Returns:
+            (str): The actual value set as str.
         Raises:
             ValueError: When conversion or treatment of value fails.
             StopIteration: When a value change was interrupted (abort/cancel).

--- a/mxcubeweb/core/adapter/nstate_adapter.py
+++ b/mxcubeweb/core/adapter/nstate_adapter.py
@@ -58,8 +58,21 @@ class NStateAdapter(ActuatorAdapterBase):
     def commands(self):
         return self._get_valid_states()
 
-    def set_value(self, value: HOActuatorValueChangeModel):
+    def set_value(self, value: HOActuatorValueChangeModel) -> str:
+        """
+        Sets value of the Nstate adapter.
+
+        Args:
+            value (Enum): value to be set containing name and value attributes.
+        Returns:
+            (str): The actual value set as a string.
+        Raises:
+            ValueError: Value not valid.
+            RuntimeError: Timeout while setting the value.
+            StopItteration: When a value change was interrupted (abort/cancel).
+        """
         self._ho.set_value(self._ho.VALUES[value.value])
+        return self.get_value()
 
     def get_value(self) -> StrValueModel:
         return StrValueModel(value=self._ho.get_value().name)


### PR DESCRIPTION
Missed return statement caused incomplete communication with front-end and error in a console:

> PUT http://localhost:8081/mxcube/api/v0.1/hwobj/nstate/diffractometer.backlightswitch/set_value 500 (INTERNAL SERVER ERROR)
> 
> (anonymous) @ resolver.js:22   
> (anonymous) @ safeJson.js:5   
> fne @ resolver.js:23
> 
> Uncaught (in promise) P8: {"error":"Return value of type '' is not serializable"}
> 
>    at http://localhost:8081/assets/index-C63EgBZ5.js:140:14928   
>    at async http://localhost:8081/assets/index-C63EgBZ5.js:141:12669   
> CAUSE: Error   
>    at fne (http://localhost:8081/assets/index-C63EgBZ5.js:140:14861)   
>    at Object.fetch (http://localhost:8081/assets/index-C63EgBZ5.js:141:2457)