### PR TITLE
Removed unused diffractometer routes

### DIFF
--- a/mxcubeweb/routes/diffractometer.py
+++ b/mxcubeweb/routes/diffractometer.py
@@ -6,43 +6,10 @@ from flask import (
     jsonify,
     request,
 )
-from mxcubecore import HardwareRepository as HWR
 
 
 def init_route(app, server, url_prefix):
     bp = Blueprint("diffractometer", __name__, url_prefix=url_prefix)
-
-    @bp.route("/phase", methods=["GET"])
-    @server.restrict
-    def get_phase():
-        """
-        Retrieve the current phase in the diffractometer.
-            :response Content-type: application/json, example:
-                {'current_phase': 'Centring'},
-                available phases: [Centring, BeamLocation, DataCollection,
-                                Transfer]
-            :statuscode: 200: no error
-            :statuscode: 409: error
-        """
-        data = {"current_phase": HWR.beamline.diffractometer.get_current_phase()}
-        resp = jsonify(data)
-        resp.status_code = 200
-        return resp
-
-    @bp.route("/phaselist", methods=["GET"])
-    @server.restrict
-    def get_phase_list():
-        """
-        Retrieve the available phases in the diffractometer.
-            :response Content-type: application/json,
-                example: {'phase_list': [Centring, BeamLocation, DataCollection,
-                                        Transfer]}
-            :statuscode: 200: no error
-            :statuscode: 409: error
-        """
-        resp = jsonify({"current_phase": HWR.beamline.diffractometer.get_phase_list()})
-        resp.status_code = 200
-        return resp
 
     @bp.route("/phase", methods=["PUT"])
     @server.require_control
@@ -62,19 +29,6 @@ def init_route(app, server, url_prefix):
         app.beamline.diffractometer_set_phase(phase)
         return Response(status=200)
 
-    @bp.route("/platemode", methods=["GET"])
-    @server.restrict
-    def md_in_plate_mode():
-        """
-        md_in_plate_mode: check if diffractometer is in plate mode or not
-        data = {"md_in_plate_mode": } True /False
-        return_data: data plus error code 200/409
-        """
-        md_in_plate_mode = HWR.beamline.diffractometer.in_plate_mode()
-        resp = jsonify({"md_in_plate_mode": md_in_plate_mode})
-        resp.status_code = 200
-        return resp
-
     @bp.route("/aperture", methods=["PUT"])
     @server.require_control
     @server.restrict
@@ -92,24 +46,6 @@ def init_route(app, server, url_prefix):
         app.beamline.set_aperture(new_pos)
 
         return Response(status=200)
-
-    @bp.route("/aperture", methods=["GET"])
-    @server.restrict
-    def get_aperture():
-        ret = {}
-
-        aperture_list, current_aperture = app.beamline.get_aperture()
-
-        ret.update(
-            {
-                "apertureList": aperture_list,
-                "currentAperture": current_aperture,
-            }
-        )
-
-        resp = jsonify(ret)
-        resp.status_code = 200
-        return resp
 
     @bp.route("/info", methods=["GET"])
     @server.restrict


### PR DESCRIPTION
Removed a few unused routes from the `diffractometer` endpoint;
 - `diffractomter/phase (GET)`
 - `diffractomter/phaselist (GET)`
 - `diffractomter/platemode (GET)`
 - `diffractomter/aperture (GET)`

Some of these routes was also used in the tests which of-course is a bit inconsistent, so the tests was updated to reflect whats actually used.