### PR TITLE
Retrieving information about the beam from `beamadapter`

### DIFF
--- a/mxcubeweb/core/adapter/beam_adapter.py
+++ b/mxcubeweb/core/adapter/beam_adapter.py
@@ -85,7 +85,7 @@ class BeamAdapter(ActuatorAdapterBase):
             }
         )
 
-        return HOBeamValueModel(value=beam_info_dict)
+        return HOBeamModel(value={**beam_info_dict})
 
     def data(self) -> HOBeamModel:
         return HOBeamModel(**self._dict_repr())

--- a/mxcubeweb/core/components/beamline.py
+++ b/mxcubeweb/core/components/beamline.py
@@ -99,44 +99,6 @@ class Beamline(ComponentBase):
 
         return data
 
-    def get_beam_info(self):
-        """
-        Returns beam information retrieved by the beam_info hardware object,
-        containing position, size and shape.
-
-        :return: Beam info dictionary with keys: position, shape, size_x, size_y
-        :rtype: dict
-        """
-        beam = HWR.beamline.beam
-        beam_info_dict = {
-            "position": [],
-            "shape": "",
-            "size_x": 0,
-            "size_y": 0,
-        }
-        sx, sy, shape, _label = beam.get_value()
-
-        if beam is not None:
-            beam_info_dict.update(
-                {
-                    "position": beam.get_beam_position_on_screen(),
-                    "size_x": sx,
-                    "size_y": sy,
-                    "shape": shape.value,
-                }
-            )
-
-        aperture_list, current_aperture = self.get_aperture()
-
-        beam_info_dict.update(
-            {
-                "apertureList": aperture_list,
-                "currentAperture": current_aperture,
-            }
-        )
-
-        return beam_info_dict
-
     def prepare_beamline_for_sample(self):
         if hasattr(HWR.beamline.collect, "prepare_for_new_sample"):
             HWR.beamline.collect.prepare_for_new_sample()

--- a/mxcubeweb/core/models/adaptermodels.py
+++ b/mxcubeweb/core/models/adaptermodels.py
@@ -43,7 +43,7 @@ class HOActuatorValueChangeModel(BaseModel):
     value: str = Field("", description="New value of actuator (position)")
 
 
-class HOBeamRawValueModel(BaseModel):
+class HOBeamValueModel(BaseModel):
     apertureList: list[str] = Field([0], description="List of available apertures")
     currentAperture: str = Field(0, description="Current aperture label")
     position: tuple[float, float] = Field((0, 0), description="Beam position on OAV")
@@ -62,11 +62,7 @@ class HOBeamRawValueModel(BaseModel):
 
 
 class HOBeamModel(HOActuatorModel):
-    value: HOBeamRawValueModel
-
-
-class HOBeamValueModel(BaseModel):
-    value: HOBeamRawValueModel
+    value: HOBeamValueModel
 
 
 class FloatValueModel(BaseModel):

--- a/mxcubeweb/routes/beamline.py
+++ b/mxcubeweb/routes/beamline.py
@@ -16,15 +16,6 @@ def init_route(app, server, url_prefix):
     def beamline_get_all_attributes():
         return jsonify(app.beamline.beamline_get_all_attributes())
 
-    @bp.route("/beam/info", methods=["GET"])
-    @server.restrict
-    def get_beam_info():
-        """
-        Beam information: position, size, shape
-        return_data = {"position": , "shape": , "size_x": , "size_y": }
-        """
-        return jsonify(app.beamline.get_beam_info())
-
     @bp.route("/datapath", methods=["GET"])
     @server.restrict
     def beamline_get_data_path():

--- a/test/test_beamline_routes.py
+++ b/test/test_beamline_routes.py
@@ -128,10 +128,8 @@ def test_get_beam_info(client):
     Tests retrieval of information regarding the beam, and that the data is
     returned on the expected format
     """
-    resp = client.put(
+    resp = client.get(
         "/mxcube/api/v0.1/hwobj/beam/beam/get_value",
-        data="{}",
-        content_type="application/json",
     )
     data = json.loads(resp.data)["value"]
 

--- a/test/test_beamline_routes.py
+++ b/test/test_beamline_routes.py
@@ -128,13 +128,17 @@ def test_get_beam_info(client):
     Tests retrieval of information regarding the beam, and that the data is
     returned on the expected format
     """
-    resp = client.get("/mxcube/api/v0.1/beamline/beam/info")
-    data = json.loads(resp.data)
+    resp = client.put(
+        "/mxcube/api/v0.1/hwobj/beam/beam/get_value",
+        data="{}",
+        content_type="application/json",
+    )
+    data = json.loads(resp.data)["value"]
 
     assert isinstance(data["currentAperture"], str)
     assert len(data["apertureList"]) > 0
-    assert isinstance(data["position"][0], int)
-    assert isinstance(data["position"][1], int)
+    assert isinstance(data["position"][0], float)
+    assert isinstance(data["position"][1], float)
     assert isinstance(data["size_x"], float)
     assert isinstance(data["size_y"], float)
 

--- a/test/test_diffractometer_routes.py
+++ b/test/test_diffractometer_routes.py
@@ -44,12 +44,16 @@ def test_set_aperture(client):
     original value also is the current
     """
 
-    resp = client.get("/mxcube/api/v0.1/beamline/beam/info")
+    resp = client.put(
+        "/mxcube/api/v0.1/hwobj/beam/beam/get_value",
+        data="{}",
+        content_type="application/json",
+    )
     data = json.loads(resp.data)
 
-    original_aperture = data["currentAperture"]
+    original_aperture = data["value"]["currentAperture"]
 
-    ap = data["apertureList"][0]
+    ap = data["value"]["apertureList"][0]
 
     # make sure we are testing a change of aperture
     assert ap != original_aperture
@@ -60,8 +64,12 @@ def test_set_aperture(client):
         content_type="application/json",
     )
 
-    resp = client.get("/mxcube/api/v0.1/beamline/beam/info")
-    actual_aperture = json.loads(resp.data)["currentAperture"]
+    resp = client.put(
+        "/mxcube/api/v0.1/hwobj/beam/beam/get_value",
+        data="{}",
+        content_type="application/json",
+    )
+    actual_aperture = json.loads(resp.data)["value"]["currentAperture"]
 
     aperture_value_changed = Event()
     # listen for 'valueChanged' signal
@@ -77,8 +85,12 @@ def test_set_aperture(client):
     # wait until aperture changes the value
     aperture_value_changed.wait()
 
-    resp = client.get("/mxcube/api/v0.1/beamline/beam/info")
-    actual_original_aperture = json.loads(resp.data)["currentAperture"]
+    resp = client.put(
+        "/mxcube/api/v0.1/hwobj/beam/beam/get_value",
+        data="{}",
+        content_type="application/json",
+    )
+    actual_original_aperture = json.loads(resp.data)["value"]["currentAperture"]
 
     assert ap == actual_aperture
     assert actual_original_aperture == original_aperture

--- a/test/test_diffractometer_routes.py
+++ b/test/test_diffractometer_routes.py
@@ -44,10 +44,8 @@ def test_set_aperture(client):
     original value also is the current
     """
 
-    resp = client.put(
+    resp = client.get(
         "/mxcube/api/v0.1/hwobj/beam/beam/get_value",
-        data="{}",
-        content_type="application/json",
     )
     data = json.loads(resp.data)
 
@@ -64,10 +62,8 @@ def test_set_aperture(client):
         content_type="application/json",
     )
 
-    resp = client.put(
+    resp = client.get(
         "/mxcube/api/v0.1/hwobj/beam/beam/get_value",
-        data="{}",
-        content_type="application/json",
     )
     actual_aperture = json.loads(resp.data)["value"]["currentAperture"]
 
@@ -85,10 +81,8 @@ def test_set_aperture(client):
     # wait until aperture changes the value
     aperture_value_changed.wait()
 
-    resp = client.put(
+    resp = client.get(
         "/mxcube/api/v0.1/hwobj/beam/beam/get_value",
-        data="{}",
-        content_type="application/json",
     )
     actual_original_aperture = json.loads(resp.data)["value"]["currentAperture"]
 

--- a/ui/src/actions/login.js
+++ b/ui/src/actions/login.js
@@ -1,7 +1,8 @@
 /* eslint-disable promise/prefer-await-to-then */
-import { fetchBeamInfo, fetchBeamlineSetup } from '../api/beamline';
+import { fetchBeamlineSetup } from '../api/beamline';
 import { fetchDetectorInfo } from '../api/detector';
 import { fetchDiffractometerInfo } from '../api/diffractometer';
+import { sendGetValue } from '../api/hardware-object';
 import { fetchHarvesterInitialState } from '../api/harvester';
 import { sendSelectProposal } from '../api/lims';
 import { fetchLogMessages } from '../api/log';
@@ -94,8 +95,8 @@ export function getInitialState() {
       fetchQueueState()
         .then((queue) => ({ queue }))
         .catch(notify),
-      fetchBeamInfo()
-        .then((beamInfo) => ({ beamInfo }))
+      sendGetValue('beam', 'beam')
+        .then((beamInfo) => ({ beamInfo: beamInfo.value }))
         .catch(notify),
       fetchBeamlineSetup()
         .then((beamlineSetup) => ({

--- a/ui/src/actions/login.js
+++ b/ui/src/actions/login.js
@@ -2,7 +2,7 @@
 import { fetchBeamlineSetup } from '../api/beamline';
 import { fetchDetectorInfo } from '../api/detector';
 import { fetchDiffractometerInfo } from '../api/diffractometer';
-import { sendGetValue } from '../api/hardware-object';
+import { fetchValue } from '../api/hardware-object';
 import { fetchHarvesterInitialState } from '../api/harvester';
 import { sendSelectProposal } from '../api/lims';
 import { fetchLogMessages } from '../api/log';
@@ -95,7 +95,7 @@ export function getInitialState() {
       fetchQueueState()
         .then((queue) => ({ queue }))
         .catch(notify),
-      sendGetValue('beam', 'beam')
+      fetchValue('beam', 'beam')
         .then((beamInfo) => ({ beamInfo: beamInfo.value }))
         .catch(notify),
       fetchBeamlineSetup()

--- a/ui/src/api/beamline.js
+++ b/ui/src/api/beamline.js
@@ -6,10 +6,6 @@ export function fetchBeamlineSetup() {
   return endpoint.get('/').safeJson();
 }
 
-export function fetchBeamInfo() {
-  return endpoint.get('/beam/info').safeJson();
-}
-
 export function sendPrepareBeamlineForNewSample() {
   return endpoint.put(undefined, '/prepare_beamline').res();
 }


### PR DESCRIPTION
Retrieving information about the beam from the `beamadapter` instead of using the beamline route.

Moved `get_beam_info` to `get_value` of the `BeamAdapter` object