### PR TITLE
Call to `get_beam_info` in `get_viewport_info` not needed anymore

### DIFF
--- a/mxcubeweb/core/components/beamline.py
+++ b/mxcubeweb/core/components/beamline.py
@@ -67,9 +67,7 @@ class Beamline(ComponentBase):
 
         pixelsPerMm = HWR.beamline.diffractometer.get_pixels_per_mm()
 
-        beam_info_dict = self.get_beam_info()
-
-        data = {
+        return {
             "pixelsPerMm": pixelsPerMm,
             "imageWidth": width,
             "imageHeight": height,
@@ -80,9 +78,6 @@ class Beamline(ComponentBase):
             "videoHash": HWR.beamline.sample_view.camera.stream_hash,
             "videoURL": self.app.CONFIG.app.VIDEO_STREAM_URL,
         }
-
-        data.update(beam_info_dict)
-        return data
 
     def beamline_get_all_attributes(self):
         ho = BeamlineAdapter(HWR.beamline)

--- a/ui/src/actions/login.js
+++ b/ui/src/actions/login.js
@@ -107,7 +107,7 @@ export function getInitialState() {
         .then((actionsList) => actionsList)
         .catch(notify),
       fetchImageData()
-        .then((Camera) => ({ Camera }))
+        .then((camera) => ({ camera }))
         .catch(notify),
       fetchDiffractometerInfo().catch(notify),
       fetchDetectorInfo()

--- a/ui/src/reducers/sampleview.js
+++ b/ui/src/reducers/sampleview.js
@@ -170,13 +170,13 @@ function sampleViewReducer(state = INITIAL_STATE, action = {}) {
     case 'SET_INITIAL_STATE': {
       return {
         ...state,
-        width: action.data.Camera.imageWidth,
-        height: action.data.Camera.imageHeight,
-        videoFormat: action.data.Camera.format,
-        videoSizes: action.data.Camera.videoSizes,
-        sourceIsScalable: action.data.Camera.sourceIsScalable,
-        videoHash: action.data.Camera.videoHash,
-        videoURL: action.data.Camera.videoURL,
+        width: action.data.camera.imageWidth,
+        height: action.data.camera.imageHeight,
+        videoFormat: action.data.camera.format,
+        videoSizes: action.data.camera.videoSizes,
+        sourceIsScalable: action.data.camera.sourceIsScalable,
+        videoHash: action.data.camera.videoHash,
+        videoURL: action.data.camera.videoURL,
         apertureList: action.data.beamInfo.apertureList,
         currentAperture: action.data.beamInfo.currentAperture,
         beamPosition: action.data.beamInfo.position,
@@ -187,8 +187,8 @@ function sampleViewReducer(state = INITIAL_STATE, action = {}) {
         },
         phaseList: action.data.phaseList,
         currentPhase: action.data.currentPhase,
-        pixelsPerMm: action.data.Camera.pixelsPerMm,
-        sourceScale: action.data.Camera.scale,
+        pixelsPerMm: action.data.camera.pixelsPerMm,
+        sourceScale: action.data.camera.scale,
       };
     }
     default: {


### PR DESCRIPTION
For some reason the route that retrieves information about the video stream also retrieves information about the beam. 

I assume it used to be the case that the beam information was not available via a separate call or that the relevant information was not available when it was needed (not yet fetched). The information about the beam does no longer need to be part of the camera route as we are, now, fetching all the relevant routes before initial render.

