### PR TITLE
Made get_value as a ResourceHandler attribute instead of command

### DIFF
--- a/mxcubeweb/core/adapter/actuator_adapter.py
+++ b/mxcubeweb/core/adapter/actuator_adapter.py
@@ -12,7 +12,7 @@ from mxcubeweb.core.models.configmodels import ResourceHandlerConfigModel
 from mxcubeweb.core.util.networkutils import RateLimited
 
 resource_handler_config = ResourceHandlerConfigModel(
-    commands=["get_value", "set_value", "stop"], attributes=["data"]
+    commands=["set_value", "stop"], attributes=["data", "get_value"]
 )
 
 hwr_logger = logging.getLogger("MX3.HWR")

--- a/mxcubeweb/core/adapter/adapter_base.py
+++ b/mxcubeweb/core/adapter/adapter_base.py
@@ -24,9 +24,11 @@ from mxcubeweb.core.server.resource_handler import (
 default_resource_handler_config = ResourceHandlerConfigModel(
     commands=[
         "set_value",
+    ],
+    attributes=[
+        "data",
         "get_value",
     ],
-    attributes=["data"],
 )
 
 

--- a/mxcubeweb/core/adapter/energy_adapter.py
+++ b/mxcubeweb/core/adapter/energy_adapter.py
@@ -8,8 +8,8 @@ from mxcubeweb.core.adapter.wavelength_adapter import WavelengthAdapter
 from mxcubeweb.core.models.configmodels import ResourceHandlerConfigModel
 
 resource_handler_config = ResourceHandlerConfigModel(
-    commands=["get_value", "set_value", "stop", "get_resolution_limits_for_energy"],
-    attributes=["data"],
+    commands=["set_value", "stop", "get_resolution_limits_for_energy"],
+    attributes=["data", "get_value"],
 )
 
 

--- a/mxcubeweb/core/adapter/motor_adapter.py
+++ b/mxcubeweb/core/adapter/motor_adapter.py
@@ -11,8 +11,8 @@ from mxcubeweb.core.util.networkutils import RateLimited
 
 resource_handler_config = ResourceHandlerConfigModel(
     url_prefix="/mxcube/api/v0.1/motor_test",
-    commands=["set_value", "get_value", "stop"],
-    attributes=["data"],
+    commands=["set_value", "stop"],
+    attributes=["data", "get_value"],
 )
 
 

--- a/mxcubeweb/core/adapter/nstate_adapter.py
+++ b/mxcubeweb/core/adapter/nstate_adapter.py
@@ -16,7 +16,7 @@ from mxcubeweb.core.models.adaptermodels import (
 from mxcubeweb.core.models.configmodels import ResourceHandlerConfigModel
 
 resource_handler_config = ResourceHandlerConfigModel(
-    commands=["get_value", "set_value", "stop"], attributes=["data"]
+    commands=["set_value", "stop"], attributes=["data", "get_value"]
 )
 
 

--- a/ui/src/actions/beamlineActions.js
+++ b/ui/src/actions/beamlineActions.js
@@ -1,6 +1,6 @@
 import {
+  fetchAttribute,
   sendExecuteCommand,
-  sendGetAttribute,
   sendStop,
 } from '../api/hardware-object';
 import { RUNNING } from '../constants';
@@ -54,7 +54,7 @@ export function startBeamlineAction(cmdName, parameters, showOutput = true) {
 }
 
 export function fetchGetAllActions() {
-  return sendGetAttribute(
+  return fetchAttribute(
     'beamlineaction',
     'beamline_actions',
     'get_all_actions',

--- a/ui/src/api/hardware-object.js
+++ b/ui/src/api/hardware-object.js
@@ -8,7 +8,7 @@ export function sendExecuteCommand(objectType, objectId, command, value) {
     .safeJson();
 }
 
-export function sendGetAttribute(objectType, objectId, attributeName) {
+export function fetchAttribute(objectType, objectId, attributeName) {
   return endpoint.get(`/${objectType}/${objectId}/${attributeName}`).safeJson();
 }
 
@@ -16,8 +16,8 @@ export function sendSetValue(objectId, objectType, value) {
   return sendExecuteCommand(objectType, objectId, 'set_value', { value });
 }
 
-export function sendGetValue(objectId, objectType) {
-  return sendExecuteCommand(objectType, objectId, 'get_value', {});
+export function fetchValue(objectId, objectType) {
+  return fetchAttribute(objectType, objectId, 'get_value');
 }
 
 export function sendStop(objectId, objectType) {


### PR DESCRIPTION
The `ResourceHandler` prevents the use of `commands` for observer users. Retrieving an adapter value via `get_value` needs to be accessible to observers, thus made it a `ResourceHandler` attribute instead of command.

The method name `get_value` could simply be changed to `value` as well. I might do that change in a future PR. 

