### PR TITLE
Setting aperture via BeamAdapter instead of diffractometer route

### DIFF
--- a/mxcubeweb/core/adapter/beam_adapter.py
+++ b/mxcubeweb/core/adapter/beam_adapter.py
@@ -1,3 +1,4 @@
+import logging
 from typing import ClassVar
 
 from mxcubecore.HardwareObjects.abstract import AbstractBeam
@@ -51,6 +52,12 @@ class BeamAdapter(ActuatorAdapterBase):
 
         return aperture_list, current_aperture
 
+    def set_value(self, value: int) -> HOBeamModel:
+        self._ho.set_value(value)
+        msg = f"Changing beams size to: {value}"
+        logging.getLogger("MX3.HWR").info(msg)
+        return self.get_value()
+
     def get_value(self) -> HOBeamValueModel:
         beam_info_dict = {
             "position": [],
@@ -79,12 +86,6 @@ class BeamAdapter(ActuatorAdapterBase):
         )
 
         return HOBeamValueModel(value=beam_info_dict)
-
-    def get_size(self) -> HOBeamModel:
-        pass
-
-    def set_size(self, value: HOBeamModel) -> HOBeamModel:
-        pass
 
     def data(self) -> HOBeamModel:
         return HOBeamModel(**self._dict_repr())

--- a/mxcubeweb/core/components/beamline.py
+++ b/mxcubeweb/core/components/beamline.py
@@ -149,12 +149,6 @@ class Beamline(ComponentBase):
 
         HWR.beamline.diffractometer.set_phase(phase)
 
-    def set_aperture(self, pos):
-        beam = HWR.beamline.beam
-        msg = "Changing beam size to: %s" % pos
-        logging.getLogger("MX3.HWR").info(msg)
-        beam.set_value(pos)
-
     def diffractometer_get_info(self):
         ret = {}
 

--- a/mxcubeweb/routes/diffractometer.py
+++ b/mxcubeweb/routes/diffractometer.py
@@ -29,24 +29,6 @@ def init_route(app, server, url_prefix):
         app.beamline.diffractometer_set_phase(phase)
         return Response(status=200)
 
-    @bp.route("/aperture", methods=["PUT"])
-    @server.require_control
-    @server.restrict
-    def set_aperture():
-        """
-        Move the aperture motor.
-            :request Content-type: application/json, new position {'diameter': 50}.
-                Note: level specified as integer (not 'Diameter 50')
-            :statuscode: 200: no error
-            :statuscode: 409: error
-        """
-        params = request.data
-        params = json.loads(params)
-        new_pos = params["diameter"]
-        app.beamline.set_aperture(new_pos)
-
-        return Response(status=200)
-
     @bp.route("/info", methods=["GET"])
     @server.restrict
     def get_diffractometer_info():

--- a/test/test_diffractometer_routes.py
+++ b/test/test_diffractometer_routes.py
@@ -55,8 +55,8 @@ def test_set_aperture(client):
     assert ap != original_aperture
 
     resp = client.put(
-        "/mxcube/api/v0.1/diffractometer/aperture",
-        data=json.dumps({"diameter": ap}),
+        "/mxcube/api/v0.1/hwobj/beam/beam/set_value",
+        data=json.dumps({"value": ap}),
         content_type="application/json",
     )
 
@@ -70,8 +70,8 @@ def test_set_aperture(client):
     )
 
     resp = client.put(
-        "/mxcube/api/v0.1/diffractometer/aperture",
-        data=json.dumps({"diameter": original_aperture}),
+        "/mxcube/api/v0.1/hwobj/beam/beam/set_value",
+        data=json.dumps({"value": original_aperture}),
         content_type="application/json",
     )
     # wait until aperture changes the value

--- a/ui/src/actions/sampleview.js
+++ b/ui/src/actions/sampleview.js
@@ -1,7 +1,5 @@
-import {
-  sendUpdateAperture,
-  sendUpdateCurrentPhase,
-} from '../api/diffractometer';
+import { sendUpdateCurrentPhase } from '../api/diffractometer';
+import { sendSetValue } from '../api/hardware-object';
 import {
   sendAbortCentring,
   sendAcceptCentring,
@@ -350,7 +348,7 @@ export function moveToPoint(id) {
 
 export function changeAperture(size) {
   return async (dispatch) => {
-    await sendUpdateAperture(size);
+    await sendSetValue('beam', 'beam', size);
     dispatch(setAperture(size));
   };
 }

--- a/ui/src/api/diffractometer.js
+++ b/ui/src/api/diffractometer.js
@@ -9,7 +9,3 @@ export function fetchDiffractometerInfo() {
 export function sendUpdateCurrentPhase(phase) {
   return endpoint.put({ phase }, '/phase').res();
 }
-
-export function sendUpdateAperture(diameter) {
-  return endpoint.put({ diameter }, '/aperture').res();
-}


### PR DESCRIPTION
The change of "aperture" is done via the "Beam" `HardwareObject` but was handled in the diffractometer route. This PR moves the setting of beam size to the `BeamAdapter`. 

We are in reality dealing with beam size in general and not aperture size.

