### PR TITLE
Fix issue with running beamline actions

### DIFF
--- a/mxcubeweb/core/server/resource_handler.py
+++ b/mxcubeweb/core/server/resource_handler.py
@@ -346,7 +346,7 @@ class ResourceHandler:
                 # We only handle a single argument when using Pydantic models
                 # We handle complex structures by checking if param_data
                 # contains a value or a dictionary.
-                if isinstance(param_data[param_name], dict):
+                if isinstance(param_data.get(param_name), dict):
                     return param_type.parse_obj(param_data[param_name])
 
                 # If its a single value and Pydantic model, pass the entire


### PR DESCRIPTION
Right now if you run beamline action, the 'run_action' request fails with:

```
501 NOT IMPLEMENTED
{"error":"Server error"}
```

and the beamline action does not run.

These change fixes that issue.