### PR TITLE
Added model `FrontEndStackTraceModel` for data passed to `log_frontend_traceback`

### DIFF
--- a/mxcubeweb/core/components/log.py
+++ b/mxcubeweb/core/components/log.py
@@ -3,6 +3,7 @@ import logging
 
 from mxcubeweb import logging_handler
 from mxcubeweb.core.components.component_base import ComponentBase
+from mxcubeweb.core.models.adaptermodels import FrontEndStackTraceModel
 from mxcubeweb.core.models.configmodels import (
     ResourceHandlerConfigModel,
 )
@@ -45,14 +46,14 @@ class Log(ComponentBase):
 
         return messages
 
-    def log_frontend_traceback(self, args):
+    def log_frontend_traceback(self, trace: FrontEndStackTraceModel) -> dict:
         """
         Logs a UI traceback to the UI logger
         """
         logging.getLogger("MX3.UI").error("------ Start of UI trace back ------")
-        logging.getLogger("MX3.UI").error("Traceback: %s", args["stack"])
+        logging.getLogger("MX3.UI").error("Traceback: %s", trace.stack)
         logging.getLogger("MX3.UI").error(
-            "State: %s", json.dumps(args["state"], indent=4)
+            "State: %s", json.dumps(trace.state, indent=4)
         )
         logging.getLogger("MX3.UI").error("------ End of UI trace back ------")
         return {}

--- a/mxcubeweb/core/models/adaptermodels.py
+++ b/mxcubeweb/core/models/adaptermodels.py
@@ -80,3 +80,8 @@ class StrValueModel(BaseModel):
 class BeamlineActionInputModel(BaseModel):
     cmd: str
     parameters: dict | list
+
+
+class FrontEndStackTraceModel(BaseModel):
+    stack: str
+    state: dict

--- a/ui/src/api/log.js
+++ b/ui/src/api/log.js
@@ -8,7 +8,7 @@ export function fetchLogMessages() {
 
 export function sendLogFrontEndTraceBack(stack, state) {
   const { logger, ...stateToLog } = state;
-  const body = { stack, state: stateToLog };
+  const trace = { stack, state: stateToLog };
 
-  return endpoint.post(body, '/log_frontend_traceback').res();
+  return endpoint.post({ trace }, '/log_frontend_traceback').res();
 }


### PR DESCRIPTION
The `ResourceHandler` does not allow passing of dicts that are not moddeled, so  added a model, `FrontEndStackTraceModel`, for data passed to `log_frontend_traceback`