### PR TITLE
Remove hardcoded braggy link

### DIFF
--- a/demo.yaml/mxcube-web/server.yaml
+++ b/demo.yaml/mxcube-web/server.yaml
@@ -41,3 +41,7 @@ mxcube:
     users:
       - username: opid291
         role: staff
+
+braggy:
+  BRAGGY_URL: ""
+  USE_BRAGGY: false

--- a/demo/mxcube-web/server.yaml
+++ b/demo/mxcube-web/server.yaml
@@ -82,3 +82,7 @@ mxcube:
     users:
       - username: opid291
         role: staff
+
+braggy:
+  BRAGGY_URL: ""
+  USE_BRAGGY: false

--- a/docs/source/config/server.rst
+++ b/docs/source/config/server.rst
@@ -265,6 +265,33 @@ The default value is ``True``.
 The content of this key is a list of username and role specifications.
 Currently, only the *staff* role can be specified.
 
+braggy
+------
+
+The ``braggy`` section allows you to configure the Braggy image viewer integration.
+It contains settings for the Braggy server URL and whether to use Braggy for displaying images.
+The section has the following syntax:
+
+.. code-block:: yaml
+
+    braggy:
+      BRAGGY_URL: <braggy server URL>
+      USE_BRAGGY: <boolean>
+
+The ``braggy`` section may contain keys as described below.
+
+``BRAGGY_URL``
+~~~~~~~~~~~~~~~
+The base URL for the Braggy server.
+This URL is used to construct the full image URL for displaying images in the UI.
+Default value is an empty string, which means that Braggy is not used.
+
+``USE_BRAGGY``
+~~~~~~~~~~~~~~~
+A boolean flag that indicates whether to use Braggy for displaying images.
+If set to `True`, the application will use the Braggy server to display images.
+Default value is `False`, meaning that Braggy is not used.
+
 .. _server_yaml_example:
 
 server.yaml example

--- a/mxcubeweb/config.py
+++ b/mxcubeweb/config.py
@@ -10,6 +10,7 @@ from pydantic.v1 import (
 
 from mxcubeweb.core.models.configmodels import (
     AppConfigModel,
+    BraggyConfigModel,
     FlaskConfigModel,
     MXCUBEAppConfigModel,
     SSOConfigModel,
@@ -38,6 +39,7 @@ class Config:
     flask: FlaskConfigModel
     app: MXCUBEAppConfigModel
     sso: SSOConfigModel
+    braggy: BraggyConfigModel
 
     def __init__(self, fpath):
         Config.CONFIG_ROOT_PATH = fpath
@@ -48,6 +50,7 @@ class Config:
         self.app = app_config.mxcube
         self.app.ui_properties = uiprop
         self.sso = app_config.sso
+        self.braggy = app_config.braggy
 
     def load_config(self, component_name, schema):
         fpath = os.path.join(Config.CONFIG_ROOT_PATH, f"{component_name}.yaml")

--- a/mxcubeweb/core/models/configmodels.py
+++ b/mxcubeweb/core/models/configmodels.py
@@ -239,10 +239,18 @@ class MXCUBEAppConfigModel(BaseModel):
     ui_properties: dict[str, UIPropertiesModel] = {}
 
 
+class BraggyConfigModel(BaseModel):
+    BRAGGY_URL: str = Field("", description="Base URL for braggy server")
+    USE_BRAGGY: bool = Field(
+        False, description="Set to True to use braggy for displaying images"
+    )
+
+
 class AppConfigModel(BaseModel):
     server: FlaskConfigModel
     mxcube: MXCUBEAppConfigModel
     sso: SSOConfigModel | None
+    braggy: BraggyConfigModel | None
 
 
 class ResourceHandlerConfigModel(BaseModel):

--- a/mxcubeweb/routes/detector.py
+++ b/mxcubeweb/routes/detector.py
@@ -26,11 +26,20 @@ def init_route(app, server, url_prefix):
     @bp.route("/display_image/", methods=["GET"])
     @server.restrict
     def display_image():
-        res = app.beamline.display_image(
+        data = app.beamline.display_image(
             request.args.get("path", None),
             request.args.get("img_num", None),
         )
 
+        if app.CONFIG.braggy.USE_BRAGGY:
+            res = {
+                "image_url": (
+                    f"{app.CONFIG.braggy.BRAGGY_URL}"
+                    f"?file=${data['path']}/image_${data['img_num']}.h5.dataset"
+                )
+            }
+        else:
+            res = {"image_url": ""}
         return jsonify(res)
 
     return bp

--- a/ui/src/actions/general.js
+++ b/ui/src/actions/general.js
@@ -55,9 +55,8 @@ export function showConfirmClearQueueDialog(show = true) {
 export function displayImage(path, imgNum) {
   return async () => {
     const data = await fetchDisplayImage(path, imgNum);
-    window.open(
-      `https://braggy.mxcube3.esrf.fr/?file=${data.path}/image_${data.img_num}.h5.dataset`,
-      'braggy',
-    );
+    if (data && data.image_url) {
+      window.open(data.image_url, 'braggy');
+    }
   };
 }


### PR DESCRIPTION
This PR removes a hard-coded **Braggy** link and makes it configurable through `server.yaml`. Big thanks to @walesch-yan for writing this code, I just made a last touch.
