### PR TITLE
Hide the "Unknown" phase button.

### DIFF
--- a/ui/src/components/SampleView/PhaseInput.jsx
+++ b/ui/src/components/SampleView/PhaseInput.jsx
@@ -20,13 +20,19 @@ function PhaseInput() {
       value={value}
       data-busy={isBusy || undefined}
       onChange={(evt) => {
-        if (evt.target.value !== 'Unknown') {
-          dispatch(changeCurrentPhase(evt.target.value));
-        }
+        dispatch(changeCurrentPhase(evt.target.value));
       }}
     >
+      <option hidden key="Unknown">
+        Unknown
+      </option>
+
       {options.map((option) => (
-        <option key={option}>{option}</option>
+        // The "Unknown" option is hidden, so that it only appears as the selected value
+        // when the diffractometer hardware object sets it.
+        <option key={option} hidden={option === 'Unknown'}>
+          {option}
+        </option>
       ))}
     </Form.Select>
   );


### PR DESCRIPTION
Currently in the phase selection UI element, there is "Unknown" option, which just does not do anything (the ChangeEvent is ignored). It seems preferable to just have "Unknown" appear only as the current value (when set from the hardware object), as it currently is, but not as an option in the select.