### PR TITLE
Drop version number from the start-up log message

### DIFF
--- a/mxcubeweb/app.py
+++ b/mxcubeweb/app.py
@@ -177,7 +177,7 @@ class MXCUBEApplication:
         # Install server-side UI state storage
         MXCUBEApplication.init_state_storage()
 
-        msg = "MXCuBE 3 initialized, it took %.1f seconds" % (
+        msg = "MXCuBE initialized, it took %.1f seconds" % (
             time.time() - MXCUBEApplication.t0
         )
         logging.getLogger("MX3.HWR").info(msg)


### PR DESCRIPTION
The logged version is outdated. Let's skip including version number in the start-up log message.