### PR TITLE
remove unused uiproperties action

### DIFF
--- a/ui/src/actions/uiproperties.js
+++ b/ui/src/actions/uiproperties.js
@@ -1,3 +1,0 @@
-export function setUiProperties(data) {
-  return { type: 'SET_UI_PROPERTIES', data };
-}

--- a/ui/src/reducers/uiproperties.js
+++ b/ui/src/reducers/uiproperties.js
@@ -4,9 +4,6 @@ const INITIAL_STATE = {};
 
 function uiPropertiesReducer(state = INITIAL_STATE, action = {}) {
   switch (action.type) {
-    case 'SET_UI_PROPERTIES': {
-      return { ...state, ...action.data };
-    }
     /* `uiproperties` is a server state so it should ideally not be modified locally.
      * We make an exception here until motor steps can be updated on the server. */
     case 'SET_MOTOR_STEP': {


### PR DESCRIPTION
This PR removes the `SET_UI_PROPERTIES` action. `uiproperties` is only set once during the initial setup, this action here is never used