### PR TITLE
remove unecessary exports for harvester and login actions

### DIFF
--- a/ui/src/actions/harvester.js
+++ b/ui/src/actions/harvester.js
@@ -10,7 +10,7 @@ import {
 } from '../api/harvester';
 import { showErrorPanel } from './general';
 
-export function setContents(contents) {
+function setContents(contents) {
   return {
     type: 'SET_HARVESTER_CONTENTS',
     data: { harvesterContents: contents },
@@ -25,7 +25,7 @@ export function updateHarvesterContents(data) {
   return { type: 'UPDATE_HARVESTER_CONTENTS', data };
 }
 
-export function setHarvesterCommandResponse(response) {
+function setHarvesterCommandResponse(response) {
   return { type: 'SET_HARVESTER_RESPONSE', response };
 }
 

--- a/ui/src/actions/login.js
+++ b/ui/src/actions/login.js
@@ -14,7 +14,7 @@ import { fetchAvailableWorkflows } from '../api/workflow';
 import { fetchGetAllActions } from './beamlineActions';
 import { applicationFetched, showErrorPanel } from './general';
 
-export function setLoginInfo(loginInfo) {
+function setLoginInfo(loginInfo) {
   return {
     type: 'SET_LOGIN_INFO',
     loginInfo,
@@ -33,7 +33,7 @@ export function hideProposalsForm() {
   };
 }
 
-export function setInitialState(data) {
+function setInitialState(data) {
   return { type: 'SET_INITIAL_STATE', data };
 }
 


### PR DESCRIPTION
This PR removes the `export` of actions in `login` and `harvester`, that are not used outside of the corresponding files