### PR TITLE
Removed integrated MJPEG streamer - Part1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+`mxcubeweb` project change log. This file outlines significant and/or breaking changes that
+are important to be share between developers.
+
+## [4.521.0] - 2025-17-09 - PR1865
+
+This change was done in PR 1865: https://github.com/mxcube/mxcubeweb/pull/1865
+
+The internal MJPEG streamer was removed. Use the video-streamer project
+for handling video streams. See: https://github.com/mxcube/video-streamer
+
+### Removed
+
+- Internal MJPEG streamer
+- Option `USE_EXTERNAL_STREAMER` from `server.yaml`

--- a/demo.yaml/mxcube-web/server.yaml
+++ b/demo.yaml/mxcube-web/server.yaml
@@ -22,7 +22,6 @@ sso:
   CODE_CHALLANGE_METHOD: S256
 
 mxcube:
-  USE_EXTERNAL_STREAMER: true
   VIDEO_FORMAT: MPEG1
   VIDEO_STREAM_URL: ws://localhost:8000/ws
 

--- a/demo/mxcube-web/server.yaml
+++ b/demo/mxcube-web/server.yaml
@@ -59,7 +59,6 @@ sso:
   CODE_CHALLANGE_METHOD: S256
 
 mxcube:
-  USE_EXTERNAL_STREAMER: true
   VIDEO_FORMAT: MPEG1
   VIDEO_STREAM_URL: ws://localhost:8000/ws
 

--- a/docs/source/config/server.rst
+++ b/docs/source/config/server.rst
@@ -172,7 +172,6 @@ The section has the following syntax:
 
     mxcube:
       mode: <experiment mode>
-      USE_EXTERNAL_STREAMER: <boolean>
       VIDEO_FORMAT: <format name>
       VIDEO_STREAM_URL: <stream URL>
       VIDEO_STREAM_PORT: <stream port>
@@ -206,14 +205,7 @@ The following values are supported:
 
 Default mode is ``OSC``.
 
-``USE_EXTERNAL_STREAMER``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Use an external process to stream the sample view video.
-When enabled, MXCuBE will invoke an appropriate hook on the camera hardware object to start the streamer.
-It is assumed that the camera object supports the external streamer feature.
-
-Default value is ``False``.
 
 ``VIDEO_FORMAT``
 ~~~~~~~~~~~~~~~~
@@ -226,18 +218,12 @@ Default format is ``MPEG1``.
 
 ``VIDEO_STREAM_URL``
 ~~~~~~~~~~~~~~~~~~~~
-
-The URL that is used by the UI to fetch the sample view video.
-When set, it will override the default video stream URL.
-This configuration is primarily useful with external streams,
-that provide video stream from custom URLs.
+The URL from which the video stream is served. This URL is used by the front-end to
+connect to the video stream.
 
 ``VIDEO_STREAM_PORT``
 ~~~~~~~~~~~~~~~~~~~~~
-
-This configuration is used when ``USE_EXTERNAL_STREAMER`` flag is enabled.
-The specified value is passed on to the camera hardware object,
-when invoking the start stream hook.
+Port from which the video stream is served
 
 ``SESSION_REFRESH_INTERVAL``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mxcubeweb/app.py
+++ b/mxcubeweb/app.py
@@ -148,11 +148,10 @@ class MXCUBEApplication:
 
         MXCUBEApplication.mxcubecore.init()
 
-        if cfg.app.USE_EXTERNAL_STREAMER:
-            MXCUBEApplication.init_sample_video(
-                _format=cfg.app.VIDEO_FORMAT,
-                port=cfg.app.VIDEO_STREAM_PORT,
-            )
+        MXCUBEApplication.init_sample_video(
+            _format=cfg.app.VIDEO_FORMAT,
+            port=cfg.app.VIDEO_STREAM_PORT,
+        )
 
         MXCUBEApplication.init_logging(log_fpath, log_level, enabled_logger_list)
 

--- a/mxcubeweb/core/components/sampleview.py
+++ b/mxcubeweb/core/components/sampleview.py
@@ -1,9 +1,6 @@
 import logging
-from io import StringIO
 
 import gevent.event
-import PIL
-from flask import Response
 from mxcubecore import HardwareRepository as HWR
 from mxcubecore.queue_entry.base_queue_entry import CENTRING_METHOD
 
@@ -17,88 +14,12 @@ SNAPSHOT_RECEIVED = gevent.event.Event()
 SNAPSHOT = None
 
 
-class HttpStreamer:
-    """
-    Implements 'MJPEG' streaming from the sample view camera.
-
-    Provides get_response() method, that creates a Response object,
-    that will stream JPEG images from the sample view camera,
-    in 'multipart' HTTP response format.
-    """
-
-    def __init__(self):
-        self._new_frame = gevent.event.Event()
-        self._sample_image = None
-        self._clients = 0
-
-    def _client_connected(self):
-        if self._clients == 0:
-            # first client connected,
-            # start listening to frames from sample camera
-            HWR.beamline.sample_view.camera.connect(
-                "imageReceived", self._new_frame_received
-            )
-
-        self._clients += 1
-
-    def _client_disconnected(self):
-        self._clients -= 1
-        if self._clients == 0:
-            # last client disconnected,
-            # disconnect from the sample camera
-            HWR.beamline.sample_view.camera.disconnect(
-                "imageReceived", self._new_frame_received
-            )
-
-    def _new_frame_received(self, img, width, height, *args, **kwargs):
-        if not isinstance(img, str | bytes):
-            rawdata = img.bits().asstring(img.numBytes())
-            strbuf = StringIO()
-            image = PIL.Image.frombytes("RGBA", (width, height), rawdata)
-            (r, g, b, a) = image.split()
-            image = PIL.Image.merge("RGB", (b, g, r))
-            image.save(strbuf, "JPEG")
-            img = strbuf.get_value()
-
-        self._sample_image = img
-
-        # signal clients that there is a new frame available
-        self._new_frame.set()
-        self._new_frame.clear()
-
-    def get_response(self) -> Response:
-        """
-        build new Response object, that will send frames to the client
-        """
-
-        def frames():
-            while True:
-                self._new_frame.wait()
-                yield (
-                    b"--frame\r\n--!>\nContent-type: image/jpeg\n\n"
-                    + self._sample_image
-                    + b"\r\n"
-                )
-
-        self._client_connected()
-
-        response = Response(
-            frames(),
-            mimetype='multipart/x-mixed-replace; boundary="!>"',
-        )
-        # keep track of when client stops reading the stream
-        response.call_on_close(self._client_disconnected)
-
-        return response
-
-
 class SampleView(ComponentBase):
     def __init__(self, app, config):
         super().__init__(app, config)
         self._click_count = 0
         self._click_limit = 3
         self._centring_point_id = None
-        self.http_streamer = HttpStreamer()
 
         HWR.beamline.sample_view.connect("shapesChanged", self._emit_shapes_updated)
 

--- a/mxcubeweb/core/models/configmodels.py
+++ b/mxcubeweb/core/models/configmodels.py
@@ -211,12 +211,6 @@ class MXCUBEAppConfigModel(BaseModel):
     # Port from which the video_stream process (https://github.com/mxcube/video-streamer)
     # streams video. The process runs in separate process (on localhost)
     VIDEO_STREAM_PORT: int = Field(8000, description="Video stream PORT")
-    USE_EXTERNAL_STREAMER: bool = Field(
-        False,
-        description=(
-            "True to use video stream produced by external software, false otherwise"
-        ),
-    )
     USE_GET_SAMPLES_FROM_SC: bool = Field(
         True,
         description=(

--- a/mxcubeweb/routes/samplecentring.py
+++ b/mxcubeweb/routes/samplecentring.py
@@ -16,31 +16,6 @@ from mxcubecore import HardwareRepository as HWR
 def init_route(app, server, url_prefix):  # noqa: C901
     bp = Blueprint("sampleview", __name__, url_prefix=url_prefix)
 
-    @bp.route("/camera/subscribe", methods=["GET"])
-    @server.restrict
-    def subscribe_to_camera():
-        """
-        Subscribe to the camera streaming
-            :response: image as html Content-type
-        """
-        if app.CONFIG.app.VIDEO_FORMAT == "MPEG1":
-            result = Response(status=200)
-        else:
-            result = app.sample_view.http_streamer.get_response()
-
-        return result
-
-    @bp.route("/camera/unsubscribe", methods=["PUT"])
-    @server.restrict
-    def unsubscribe_to_camera():
-        """
-        SampleCentring: unsubscribe from the camera streaming
-            :statuscode: 200: no error
-            :statuscode: 409: error
-        """
-        HWR.beamline.sample_view.camera.streaming_greenlet.kill()
-        return Response(status=200)
-
     @bp.route("/camera/snapshot", methods=["POST"])
     @server.restrict
     def snapshot():


### PR DESCRIPTION
This PR removes the integrated MJPEG streamer and the option `USE_EXTERNAL_STREAMER`. The later permitted to specify whether the internal streamer or an external streamer (most likely the mxcube [video-streamer](https://github.com/mxcube/video-streamer)) was to be used.

With this PR its thus no longer possible to use the internal streamer and one has to rely on i.e [video-streamer](https://github.com/mxcube/video-streamer)

As far as we know everybody is today already using the `video-streamer` mentioned above. 

In **Part-1** we focus on removing the backend bits, we will follow up with a **Part-2** for the front end and possibly a **Part-3** with some general improvements.