### PR TITLE
cleanup remoteAccess actions

### DIFF
--- a/ui/src/actions/remoteAccess.js
+++ b/ui/src/actions/remoteAccess.js
@@ -55,7 +55,7 @@ export function requestControl(message) {
   };
 }
 
-export function cancelControlRequest() {
+function cancelControlRequest() {
   return async (dispatch) => {
     await sendCancelControlRequest();
     dispatch(getLoginInfo());
@@ -106,10 +106,6 @@ export function updateTimeoutGivesControl(timeoutGivesControl) {
     await sendUpdateTimeoutGivesControl(timeoutGivesControl);
     dispatch({ type: 'SET_TIMEOUT_GIVES_CONTROL', timeoutGivesControl });
   };
-}
-
-export function setObservers(observers) {
-  return { type: 'SET_OBSERVERS', observers };
 }
 
 export function resetChatMessageCount() {

--- a/ui/src/reducers/remoteAccess.js
+++ b/ui/src/reducers/remoteAccess.js
@@ -21,9 +21,6 @@ function remoteAccessReducer(state = INITIAL_STATE, action = {}) {
     case 'SET_MASTER': {
       return { ...state, sid: action.sid };
     }
-    case 'SET_OBSERVERS': {
-      return { ...state, observers: action.observers };
-    }
     case 'SET_ALLOW_REMOTE': {
       return { ...state, allowRemote: action.allow };
     }


### PR DESCRIPTION
This is a straightforward cleanup, mainly the `setObservers` action is not used anymore, instead the `observers` state variable is updated during `SET_RA_STATE`, which is called every few seconds