### PR TITLE
Fixing `Rotate to` option of mesh grid with AbstractDiffractometer introduced

### DIFF
--- a/mxcubeweb/core/components/sampleview.py
+++ b/mxcubeweb/core/components/sampleview.py
@@ -350,7 +350,7 @@ class SampleView(ComponentBase):
             phi_value = round(float(cp.as_dict().get("phi", None)), 3)
             if phi_value:
                 try:
-                    HWR.beamline.diffractometer.centringPhi.set_value(phi_value)
+                    HWR.beamline.diffractometer.omega.set_value(phi_value)
                 except Exception:
                     raise
 


### PR DESCRIPTION
According to [discussion](https://github.com/mxcube/mxcubeweb/pull/1872#discussion_r2341048310) adjusted for mxcubecore containing AbstractDiffractometer. To be tested and merged after: https://github.com/mxcube/mxcubecore/pull/695
