### PR TITLE
Sync number of snapshots between HWR and frontend on startup

### DIFF
--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -280,6 +280,10 @@ class Queue(ComponentBase):
             "centringMethod": HWR.beamline.queue_manager.centring_method,
         }
 
+        self.app.queue.set_num_snapshots(
+            res.get("numSnapshots", self.app.DEFAULT_NUM_SNAPSHOTS)
+        )
+
         res.update(settings)
         return res
 


### PR DESCRIPTION
When not explicitly setting `num_snapshots` in `collect.yaml` file and loading this property in `MYCollect`(for [example](https://github.com/mxcube/mxcubecore/blob/develop/mxcubecore/HardwareObjects/ESRF/ESRFMultiCollect.py#L40)) hwo the `number_of_snapshots` on the frontend may be different than the one set on the backend due to the fact that we are keeping two sources of truth for the same data ( in the reducer store and in the HWO) and we are also keeping at least three aliases for the same thing, e.g., `take_snapshots`, `num_snapshots` and `number_of_snapshots`.

TBH, im not happy with this solution as it feels hacky, but i didn't felt comfortable with diving into `AbstractCollect` and `AbstractMultiCollect` objects and trying to unify these properties. Im willing to try it, though, just need some guidance (in particular with the data collection parameters which its use isn't clear for me).



