### PR TITLE
Unmount properly manually mounted sample.

### DIFF
--- a/mxcubeweb/core/components/samplechanger.py
+++ b/mxcubeweb/core/components/samplechanger.py
@@ -295,9 +295,12 @@ class SampleChanger(ComponentBase):
         return self.get_sc_contents()
 
     def unmount_current(self):
-        location = HWR.beamline.sample_changer.get_loaded_sample().get_address()
-        self.unmount_sample_clean_up({"location": location})
-
+        sc_sample = HWR.beamline.sample_changer.get_loaded_sample()
+        if sc_sample:
+            location = sc_sample.get_address()
+            self.unmount_sample_clean_up({"location": location})
+        else:
+            self.unmount_sample_clean_up({"location": "Manual"})
         return self.get_sc_contents()
 
     def get_loaded_sample(self):


### PR DESCRIPTION
Manually mounted sample does not appear in SC, thus `HWR.beamline.sample_changer.get_loaded_sample()` returns `None` causing unmounting to fail 
```
2025-09-11 09:57:49,248 |MX3.HWR|ERROR  | Cannot unload sample
Traceback (most recent call last):
  File "/opt/mxcube/web/mxcubeweb/routes/samplechanger.py", line 67, in unmount_current
    res = app.sample_changer.unmount_current()
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/mxcube/web/mxcubeweb/core/components/samplechanger.py", line 298, in unmount_current
    location = HWR.beamline.sample_changer.get_loaded_sample().get_address()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get_address
```
and ommiting `loadReady` signal being send.