### PR TITLE
Processing fields are required if at least one of them is filled in

### DIFF
--- a/ui/src/components/Tasks/validate.js
+++ b/ui/src/components/Tasks/validate.js
@@ -109,6 +109,27 @@ function validate(values, props) {
     errors.num_images = 'Omega out of limits';
   }
 
+  // processing fields are required if at least one of them is filled in
+  const processingFields = {
+    space_group: values.space_group,
+    cellA: values.cellA,
+    cellB: values.cellB,
+    cellC: values.cellC,
+    cellAlpha: values.cellAlpha,
+    cellBeta: values.cellBeta,
+    cellGamma: values.cellGamma,
+  };
+  const processingFieldsRequired = Object.values(processingFields).some(
+    (field) => field !== undefined && field !== '',
+  );
+  if (processingFieldsRequired) {
+    Object.entries(processingFields).forEach(([key, value]) => {
+      if (value === undefined || value === '') {
+        errors[key] = emptyField;
+      }
+    });
+  }
+
   return errors;
 }
 


### PR DESCRIPTION
Max IV processing pipelines can't deal with partially filled up processing parameters. In our case such data needs to be reprocessed and that can even lead to lost beamtime.
If any site found this partial fill-up useful, we'll try to solve it another way.

Data Collection Processing parameters at current PR stage:

<img width="954" height="452" alt="image" src="https://github.com/user-attachments/assets/43bed616-649b-4650-923c-c030a50390f5" />

`Space group` as `SelectField` is not indicating the error value due to some bug, fixed here https://github.com/mxcube/mxcubeweb/pull/1885