### PR TITLE
[Fix] Frontend crashes on loading after login when the sample changer maintenance HWO is loaded and get_global_state raises an exception

### DIFF
--- a/mxcubeweb/core/components/samplechanger.py
+++ b/mxcubeweb/core/components/samplechanger.py
@@ -337,7 +337,12 @@ class SampleChanger(ComponentBase):
         try:
             return HWR.beamline.sample_changer_maintenance.get_global_state()
         except Exception:
-            return "OFFLINE", "OFFLINE", "OFFLINE"
+            logging.getLogger("MX3.HWR").exception("Could not get sc global state")
+            return (
+                {},
+                "SC maintenance controller doesn't response",
+                "Can't retrieve the global state",
+            )
 
     def get_initial_state(self):
         if HWR.beamline.sample_changer_maintenance is not None:


### PR DESCRIPTION
Details about this bug in this issue: https://github.com/mxcube/mxcubeweb/issues/1871