### PR TITLE
Fix access component property

### DIFF
--- a/ui/src/components/DataCollectionResult/DataCollectionResultDialog.jsx
+++ b/ui/src/components/DataCollectionResult/DataCollectionResultDialog.jsx
@@ -34,7 +34,7 @@ export function DataCollectionResultDialog() {
         </Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        <DataCollectionResultSummary />
+        <DataCollectionResultSummary taskData={taskData} />
       </Modal.Body>
       <Modal.Footer>
         <Button onClick={handleHideDialog}>Close</Button>

--- a/ui/src/components/DataCollectionResult/DataCollectionResultSummary.jsx
+++ b/ui/src/components/DataCollectionResult/DataCollectionResultSummary.jsx
@@ -1,7 +1,5 @@
-import { useSelector } from 'react-redux';
-
-export function DataCollectionResultSummary() {
-  const taskData = useSelector((state) => state.general.dialogData);
+export function DataCollectionResultSummary(props) {
+  const { taskData } = props;
 
   if (!taskData?.parameters) {
     return <div>No data available</div>;


### PR DESCRIPTION
This fix a bug that was introduce in some prevous PR, see scree-short below.

Should not get props from useSelector
You'l get  "No data available" when the component is called from another comp with different state/props.

For now, to fix the "No data available" the taskData property is passed down from the parent component, since DataCollectionResultSummary is also used in TaskItem component.

https://github.com/mxcube/mxcubeweb/blob/28b03f9403e1ee7a8e98a795ad361dc6f2cb6cbf/ui/src/components/SampleGrid/TaskItem.jsx#L169


[Screencast from 2025-09-24 16-14-51.webm](https://github.com/user-attachments/assets/44592948-e75e-449e-936e-0c05251c7627)
