### PR TITLE
fix styling issues introduced during css split

### DIFF
--- a/ui/src/components/SampleGrid/SampleGridTableItem.jsx
+++ b/ui/src/components/SampleGrid/SampleGridTableItem.jsx
@@ -147,7 +147,7 @@ export class SampleGridTableItem extends React.Component {
   }
 
   render() {
-    const classes = cx(styles.SampleGridTableItem, {
+    const classes = cx(styles.samplesGridTableItem, {
       [containerStyles.samplesGridTableItemToBeCollected]: this.props.picked,
       [containerStyles.samplesGridTableItemCollected]: isCollected(
         this.props.sampleData,

--- a/ui/src/containers/SampleGridTableContainer.jsx
+++ b/ui/src/containers/SampleGridTableContainer.jsx
@@ -589,7 +589,7 @@ export default function SampleGridTableContainer(props) {
                   picked={picked}
                 >
                   <Slider
-                    className={styles.sampleGridTableItemTasks}
+                    className={styles.samplesGridTableItemTasks}
                     {...SETTINGS}
                   >
                     {sample.tasks.map((taskData, i) => (


### PR DESCRIPTION
This PR fixes styling issues introduced in #1874 and described in #1891. It comes from two typos that was introduced during the split of the main css file into modules.