### PR TITLE
Connect `SSXChipControl` to Redux store

### DIFF
--- a/ui/src/components/SSXChip/SSXChipControl.jsx
+++ b/ui/src/components/SSXChip/SSXChipControl.jsx
@@ -4,10 +4,17 @@ import './ssxchipcontrol.css';
 
 import React from 'react';
 import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 
+import { executeCommand, setAttribute } from '../../actions/beamline.js';
+import { addShape } from '../../actions/sampleview.js';
+import { showTaskForm } from '../../actions/taskForm.js';
 import SSXChip from './SSXChip.jsx';
 
-export default class SSXChipControl extends React.Component {
+const SID = -1;
+
+class SSXChipControl extends React.Component {
   constructor(props) {
     super(props);
     this.handleAddTask = this.handleAddTask.bind(this);
@@ -15,10 +22,12 @@ export default class SSXChipControl extends React.Component {
   }
 
   handleAddTask(triggerEvent) {
-    const { currentSampleID, sampleData, defaultParameters } = this.props;
-    const sid = -1;
+    const { currentSampleID, sampleList, defaultParameters, groupFolder } =
+      this.props;
 
-    this.props.showForm(
+    const sampleData = sampleList[currentSampleID];
+
+    this.props.showTaskForm(
       'Generic',
       [currentSampleID],
       {
@@ -26,7 +35,7 @@ export default class SSXChipControl extends React.Component {
           ...defaultParameters.ssx_chip_collection.acq_parameters,
           name: 'SSX Collection',
           prefix: sampleData.defaultPrefix,
-          subdir: `${this.props.groupFolder}${sampleData.defaultSubDir}`,
+          subdir: `${groupFolder}${sampleData.defaultSubDir}`,
           cell_count: 0,
           numRows: 0,
           numCols: 0,
@@ -34,26 +43,27 @@ export default class SSXChipControl extends React.Component {
         },
         type: 'ssx_chip_collection',
       },
-      sid,
+      SID,
     );
   }
 
   handleAddGrid(data) {
-    this.props.sampleViewActions.addShape({ t: 'G', ...data });
+    this.props.addShape({ t: 'G', ...data });
   }
 
   renderChip() {
+    const { grids, hardwareObjects, uiproperties } = this.props;
+
     const headConfiguration =
-      this.props.hardwareObjects.diffractometer.attributes.head_configuration ??
-      {};
+      hardwareObjects.diffractometer.attributes.head_configuration ?? {};
 
     const chipLayoutList = headConfiguration.available;
 
-    const sampleVerticalUiProp = this.props.uiproperties.components.find(
+    const sampleVerticalUiProp = uiproperties.components.find(
       (el) => el.role === 'sample_vertical',
     );
 
-    const sampleHorizontalUiProp = this.props.uiproperties.components.find(
+    const sampleHorizontalUiProp = uiproperties.components.find(
       (el) => el.role === 'sample_horizontal',
     );
 
@@ -70,11 +80,11 @@ export default class SSXChipControl extends React.Component {
             availableChipLayoutList={Object.keys(headConfiguration.available)}
             onAddTask={this.handleAddTask}
             onAddGrid={this.handleAddGrid}
-            gridList={Object.values(this.props.grids)}
+            gridList={Object.values(grids)}
             sampleMotorVerticalName={sampleVerticalUiProp.attribute}
             sampleMotorHorizontalName={sampleHorizontalUiProp.attribute}
             setAttribute={this.props.setAttribute}
-            sendExecuteCommand={this.props.sendExecuteCommand}
+            sendExecuteCommand={this.props.executeCommand}
           />
         </Popover.Body>
       </Popover>
@@ -99,3 +109,25 @@ export default class SSXChipControl extends React.Component {
     );
   }
 }
+
+function mapStateToProps(state) {
+  return {
+    sampleList: state.sampleGrid.sampleList,
+    currentSampleID: state.queue.currentSampleID,
+    defaultParameters: state.taskForm.defaultParameters,
+    groupFolder: state.queue.groupFolder,
+    hardwareObjects: state.beamline.hardwareObjects,
+    uiproperties: state.uiproperties.sample_view_motors,
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    addShape: bindActionCreators(addShape, dispatch),
+    showTaskForm: bindActionCreators(showTaskForm, dispatch),
+    setAttribute: bindActionCreators(setAttribute, dispatch),
+    executeCommand: bindActionCreators(executeCommand, dispatch),
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(SSXChipControl);

--- a/ui/src/containers/SampleViewContainer.jsx
+++ b/ui/src/containers/SampleViewContainer.jsx
@@ -4,11 +4,7 @@ import { Col, Container, Row } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
-import {
-  executeCommand,
-  logFrontEndTraceBack,
-  setAttribute,
-} from '../actions/beamline';
+import { logFrontEndTraceBack, setAttribute } from '../actions/beamline';
 import { displayImage, showErrorPanel } from '../actions/general';
 import {
   mountSample,
@@ -20,7 +16,6 @@ import {
 } from '../actions/sampleChanger';
 import { syncWithCrims } from '../actions/sampleGrid';
 import * as sampleViewActions from '../actions/sampleview'; // eslint-disable-line import/no-namespace
-import { showTaskForm } from '../actions/taskForm';
 import PlateManipulator from '../components/Equipment/PlateManipulator';
 import motorInputStyles from '../components/MotorInput/MotorInput.module.css';
 import ApertureInput from '../components/SampleView/ApertureInput';
@@ -57,7 +52,6 @@ class SampleViewContainer extends Component {
       return null;
     }
     const { sourceScale, imageRatio } = this.props.sampleViewState;
-    const { currentSampleID } = this.props;
     const [points, lines, grids, twoDPoints] = [{}, {}, {}, {}];
     const selectedGrids = [];
     const phase_control = uiproperties.sample_view?.components?.find(
@@ -142,20 +136,7 @@ class SampleViewContainer extends Component {
               )}
 
               {this.props.mode === 'SSX-CHIP' && (
-                <SSXChipControl
-                  showForm={this.props.showForm}
-                  currentSampleID={currentSampleID}
-                  sampleData={this.props.sampleList[currentSampleID]}
-                  defaultParameters={this.props.defaultParameters}
-                  groupFolder={this.props.groupFolder}
-                  hardwareObjects={this.props.hardwareObjects}
-                  uiproperties={uiproperties.sample_view_motors}
-                  sampleViewActions={this.props.sampleViewActions}
-                  grids={grids}
-                  selectedGrids={selectedGrids}
-                  setAttribute={this.props.setAttribute}
-                  sendExecuteCommand={this.props.sendExecuteCommand}
-                />
+                <SSXChipControl grids={grids} />
               )}
               {this.props.sampleChangerContents.name === 'PlateManipulator' && (
                 <PlateManipulator
@@ -229,17 +210,12 @@ class SampleViewContainer extends Component {
 
 function mapStateToProps(state) {
   return {
-    sampleList: state.sampleGrid.sampleList,
-    currentSampleID: state.queue.currentSampleID,
-    groupFolder: state.queue.groupFolder,
     queueState: state.queue.queueStatus,
     sampleViewState: state.sampleview,
     contextMenu: state.contextMenu,
     hardwareObjects: state.beamline.hardwareObjects,
-    defaultParameters: state.taskForm.defaultParameters,
     shapes: state.shapes.shapes,
     cellCounting: state.taskForm.defaultParameters.mesh.cell_counting,
-    remoteAccess: state.remoteAccess,
     uiproperties: state.uiproperties,
     mode: state.general.mode,
     meshResultFormat: state.general.meshResultFormat,
@@ -259,11 +235,9 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
   return {
     sampleViewActions: bindActionCreators(sampleViewActions, dispatch),
-    showForm: bindActionCreators(showTaskForm, dispatch),
     showErrorPanel: bindActionCreators(showErrorPanel, dispatch),
     setAttribute: bindActionCreators(setAttribute, dispatch),
     displayImage: bindActionCreators(displayImage, dispatch),
-    sendExecuteCommand: bindActionCreators(executeCommand, dispatch),
     logFrontEndTraceBack: bindActionCreators(logFrontEndTraceBack, dispatch),
 
     mountSample: (address) => dispatch(mountSample(address)),


### PR DESCRIPTION
I'm trying to simplify `SampleViewContainer` as much as possible to make it easier to refactor it to a function component.

In this PR, I start by connecting `SSXChipControl` to the Redux store directly so that I can remove a lot of props. I'll do the same with the other components in separate PRs.

---

FYI, I'm considering to refactor `SSXChipControl` further but it seems to be broken at the moment in the demo. Maybe I'm missing some configuration?  :shrug: 

**EDIT**: there's apparently ongoing work on this feature, so I'll wait until it's done