### PR TITLE
Connect `SampleImage` to Redux store directly and bind sample view actions

### DIFF
--- a/ui/src/actions/sampleview.js
+++ b/ui/src/actions/sampleview.js
@@ -29,7 +29,7 @@ export function setOverlay(level) {
   return { type: 'SET_OVERLAY', level };
 }
 
-export function setAperture(size) {
+function setAperture(size) {
   return { type: 'SET_APERTURE', size };
 }
 
@@ -76,11 +76,11 @@ export function stopClickCentring() {
   return { type: 'STOP_CLICK_CENTRING' };
 }
 
-export function clearSelectedShapes() {
+function clearSelectedShapes() {
   return { type: 'CLEAR_SELECTED_SHAPES' };
 }
 
-export function addShapeAction(shape) {
+function addShapeAction(shape) {
   return { type: 'ADD_SHAPE', shape };
 }
 
@@ -88,7 +88,7 @@ export function updateShapesAction(shapes) {
   return { type: 'UPDATE_SHAPES', shapes };
 }
 
-export function deleteShapeAction(id) {
+function deleteShapeAction(id) {
   return { type: 'DELETE_SHAPE', id };
 }
 
@@ -147,7 +147,7 @@ export function toggleDrawGrid() {
   };
 }
 
-export function centringClicksLeft(clicksLeft) {
+function centringClicksLeft(clicksLeft) {
   return { type: 'CENTRING_CLICKS_LEFT', clicksLeft };
 }
 
@@ -238,7 +238,7 @@ export function deleteShape(id) {
   };
 }
 
-export function unselectShapes(shapes) {
+function unselectShapes(shapes) {
   return (dispatch, getState) => {
     const state = getState();
 
@@ -274,7 +274,7 @@ export function toggleCentring() {
   };
 }
 
-export function startClickCentring() {
+function startClickCentring() {
   return async (dispatch, getState) => {
     const { queue, shapes, general } = getState();
     dispatch(clearSelectedShapes());

--- a/ui/src/containers/SampleViewContainer.jsx
+++ b/ui/src/containers/SampleViewContainer.jsx
@@ -19,7 +19,6 @@ import {
   setPlate,
 } from '../actions/sampleChanger';
 import { syncWithCrims } from '../actions/sampleGrid';
-import * as sampleViewActions from '../actions/sampleview'; // eslint-disable-line import/no-namespace
 import { showTaskForm } from '../actions/taskForm';
 import PlateManipulator from '../components/Equipment/PlateManipulator';
 import motorInputStyles from '../components/MotorInput/MotorInput.module.css';
@@ -191,7 +190,6 @@ class SampleViewContainer extends Component {
                 getControlAvailability={this.getControlAvailability}
               />
               <SampleImage
-                sampleViewActions={this.props.sampleViewActions}
                 {...this.props.sampleViewState}
                 uiproperties={uiproperties}
                 hardwareObjects={this.props.hardwareObjects}
@@ -258,7 +256,6 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    sampleViewActions: bindActionCreators(sampleViewActions, dispatch),
     showForm: bindActionCreators(showTaskForm, dispatch),
     showErrorPanel: bindActionCreators(showErrorPanel, dispatch),
     setAttribute: bindActionCreators(setAttribute, dispatch),


### PR DESCRIPTION
As with #1900, I'm trying to simplify `SampleViewContainer` as much as possible so I can refactor it to a function component. (I've marked #1900 as draft for now as there is apparently incoming work on the SSX chip feature, so best not to risk conflicts at this stage.)

In this PR, I connect `SampleImage` to the Redux store directly so that I can move all the sample view actions bindings down one level.