### PR TITLE
Map state to props in `SampleImage`

### DIFF
--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -577,7 +577,7 @@ class SampleImage extends React.Component {
   wheel(e) {
     e.preventDefault();
     e.stopPropagation();
-    const { hardwareObjects, uiproperties, setAttribute } = this.props;
+    const { hardwareObjects, uiproperties } = this.props;
     const { components } = uiproperties.sample_view_motors;
     const keyPressed = this._keyPressed;
 
@@ -591,22 +591,34 @@ class SampleImage extends React.Component {
 
     if (keyPressed === 'r' && omega.state === HW_STATE.READY) {
       if (e.deltaY > 0) {
-        setAttribute(omegaProps.attribute, omega.value + omegaProps.step);
+        this.props.setAttribute(
+          omegaProps.attribute,
+          omega.value + omegaProps.step,
+        );
       } else if (e.deltaY < 0) {
-        setAttribute(omegaProps.attribute, omega.value - omegaProps.step);
+        this.props.setAttribute(
+          omegaProps.attribute,
+          omega.value - omegaProps.step,
+        );
       }
     } else if (keyPressed === 'f' && focus.state === HW_STATE.READY) {
       if (e.deltaY > 0) {
-        setAttribute(focusProps.attribute, focus.value + focusProps.step);
+        this.props.setAttribute(
+          focusProps.attribute,
+          focus.value + focusProps.step,
+        );
       } else if (e.deltaY < 0) {
-        setAttribute(focusProps.attribute, focus.value - focusProps.step);
+        this.props.setAttribute(
+          focusProps.attribute,
+          focus.value - focusProps.step,
+        );
       }
     } else if (keyPressed === 'z' && zoom.state === HW_STATE.READY) {
       const index = zoom.commands.indexOf(zoom.value);
       if (e.deltaY > 0 && index < zoom.commands.length - 1) {
-        setAttribute(zoomProps.attribute, zoom.commands[index + 1]);
+        this.props.setAttribute(zoomProps.attribute, zoom.commands[index + 1]);
       } else if (e.deltaY < 0 && index > 0) {
-        setAttribute(zoomProps.attribute, zoom.commands[index - 1]);
+        this.props.setAttribute(zoomProps.attribute, zoom.commands[index - 1]);
       }
     }
   }
@@ -963,7 +975,24 @@ function mapStateToProps(state) {
     cellCounting: state.taskForm.defaultParameters.mesh.cell_counting,
     busy: state.queue.queueStatus === QUEUE_RUNNING,
     meshResultFormat: state.general.meshResultFormat,
-    imageRatio: state.sampleview.sourceScale * state.sampleview.imageRatio,
+    imageRatio: state.sampleview.sourceScale * state.sampleview.imageRatio, // <=== IMPORTANT!
+    clickCentring: state.sampleview.clickCentring,
+    clickCentringClicksLeft: state.sampleview.clickCentringClicksLeft,
+    measureDistance: state.sampleview.measureDistance,
+    distancePoints: state.sampleview.distancePoints,
+    width: state.sampleview.width,
+    height: state.sampleview.height,
+    sourceScale: state.sampleview.sourceScale,
+    drawGrid: state.sampleview.drawGrid,
+    selectedShapes: state.sampleview.selectedShapes,
+    pixelsPerMm: state.sampleview.pixelsPerMm,
+    beamPosition: state.sampleview.beamPosition,
+    beamShape: state.sampleview.beamShape,
+    beamSize: state.sampleview.beamSize,
+    videoMessageOverlay: state.sampleview.videoMessageOverlay,
+    videoURL: state.sampleview.videoURL,
+    videoHash: state.sampleview.videoHash,
+    videoFormat: state.sampleview.videoFormat,
   };
 }
 

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -6,6 +6,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
+import { setAttribute } from '../../actions/beamline.js';
+import { displayImage } from '../../actions/general.js';
 import {
   abortCentring,
   addDistancePoint,
@@ -20,7 +22,7 @@ import {
   toggleDrawGrid,
   updateShapes,
 } from '../../actions/sampleview.js';
-import { HW_STATE } from '../../constants';
+import { HW_STATE, QUEUE_RUNNING } from '../../constants';
 import SampleControls from '../SampleControls/SampleControls';
 import DrawGridPlugin from './DrawGridPlugin';
 import GridForm from './GridForm';
@@ -952,8 +954,23 @@ class SampleImage extends React.Component {
   }
 }
 
+function mapStateToProps(state) {
+  return {
+    uiproperties: state.uiproperties,
+    hardwareObjects: state.beamline.hardwareObjects,
+    contextMenuVisible: state.contextMenu.show,
+    shapes: state.shapes.shapes,
+    cellCounting: state.taskForm.defaultParameters.mesh.cell_counting,
+    busy: state.queue.queueStatus === QUEUE_RUNNING,
+    meshResultFormat: state.general.meshResultFormat,
+    imageRatio: state.sampleview.sourceScale * state.sampleview.imageRatio,
+  };
+}
+
 function mapDispatchToProps(dispatch) {
   return {
+    setAttribute: bindActionCreators(setAttribute, dispatch),
+    displayImage: bindActionCreators(displayImage, dispatch),
     setImageRatio: bindActionCreators(setImageRatio, dispatch),
     setOverlay: bindActionCreators(setOverlay, dispatch),
     showContextMenu: bindActionCreators(showContextMenu, dispatch),
@@ -969,4 +986,4 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export default connect(undefined, mapDispatchToProps)(SampleImage);
+export default connect(mapStateToProps, mapDispatchToProps)(SampleImage);

--- a/ui/src/containers/SampleViewContainer.jsx
+++ b/ui/src/containers/SampleViewContainer.jsx
@@ -9,7 +9,7 @@ import {
   logFrontEndTraceBack,
   setAttribute,
 } from '../actions/beamline';
-import { displayImage, showErrorPanel } from '../actions/general';
+import { showErrorPanel } from '../actions/general';
 import {
   mountSample,
   refresh,
@@ -28,7 +28,6 @@ import MotorControls from '../components/SampleView/MotorControls';
 import PhaseInput from '../components/SampleView/PhaseInput';
 import SampleImage from '../components/SampleView/SampleImage';
 import SSXChipControl from '../components/SSXChip/SSXChipControl';
-import { QUEUE_RUNNING } from '../constants';
 import BeamlineSetupContainer from './BeamlineSetupContainer';
 import DefaultErrorBoundary from './DefaultErrorBoundary';
 import SampleQueueContainer from './SampleQueueContainer';
@@ -189,7 +188,6 @@ class SampleViewContainer extends Component {
                 getControlAvailability={this.getControlAvailability}
               />
               <SampleImage
-                {...this.props.sampleViewState}
                 points={points}
                 twoDPoints={twoDPoints}
                 lines={lines}
@@ -219,7 +217,6 @@ function mapStateToProps(state) {
     sampleList: state.sampleGrid.sampleList,
     currentSampleID: state.queue.currentSampleID,
     groupFolder: state.queue.groupFolder,
-    sampleViewState: state.sampleview,
     hardwareObjects: state.beamline.hardwareObjects,
     defaultParameters: state.taskForm.defaultParameters,
     shapes: state.shapes.shapes,

--- a/ui/src/containers/SampleViewContainer.jsx
+++ b/ui/src/containers/SampleViewContainer.jsx
@@ -55,7 +55,6 @@ class SampleViewContainer extends Component {
     if (!('sample_view_motors' in uiproperties)) {
       return null;
     }
-    const { sourceScale, imageRatio } = this.props.sampleViewState;
     const { currentSampleID } = this.props;
     const [points, lines, grids, twoDPoints] = [{}, {}, {}, {}];
     const selectedGrids = [];
@@ -191,21 +190,11 @@ class SampleViewContainer extends Component {
               />
               <SampleImage
                 {...this.props.sampleViewState}
-                uiproperties={uiproperties}
-                hardwareObjects={this.props.hardwareObjects}
-                imageRatio={imageRatio * sourceScale}
-                contextMenuVisible={this.props.contextMenu.show}
-                shapes={this.props.shapes}
                 points={points}
                 twoDPoints={twoDPoints}
                 lines={lines}
                 grids={grids}
                 selectedGrids={selectedGrids}
-                cellCounting={this.props.cellCounting}
-                busy={this.props.queueState === QUEUE_RUNNING}
-                setAttribute={this.props.setAttribute}
-                displayImage={this.props.displayImage}
-                meshResultFormat={this.props.meshResultFormat}
               />
             </DefaultErrorBoundary>
           </Col>
@@ -230,17 +219,13 @@ function mapStateToProps(state) {
     sampleList: state.sampleGrid.sampleList,
     currentSampleID: state.queue.currentSampleID,
     groupFolder: state.queue.groupFolder,
-    queueState: state.queue.queueStatus,
     sampleViewState: state.sampleview,
-    contextMenu: state.contextMenu,
     hardwareObjects: state.beamline.hardwareObjects,
     defaultParameters: state.taskForm.defaultParameters,
     shapes: state.shapes.shapes,
-    cellCounting: state.taskForm.defaultParameters.mesh.cell_counting,
     remoteAccess: state.remoteAccess,
     uiproperties: state.uiproperties,
     mode: state.general.mode,
-    meshResultFormat: state.general.meshResultFormat,
     sampleChangerContents: state.sampleChanger.contents,
     sampleChangerState: state.sampleChanger.state,
     global_state: state.sampleChangerMaintenance.global_state,
@@ -259,7 +244,6 @@ function mapDispatchToProps(dispatch) {
     showForm: bindActionCreators(showTaskForm, dispatch),
     showErrorPanel: bindActionCreators(showErrorPanel, dispatch),
     setAttribute: bindActionCreators(setAttribute, dispatch),
-    displayImage: bindActionCreators(displayImage, dispatch),
     sendExecuteCommand: bindActionCreators(executeCommand, dispatch),
     logFrontEndTraceBack: bindActionCreators(logFrontEndTraceBack, dispatch),
 

--- a/ui/src/containers/SampleViewContainer.jsx
+++ b/ui/src/containers/SampleViewContainer.jsx
@@ -40,23 +40,21 @@ class SampleViewContainer extends Component {
   }
 
   getControlAvailability(name) {
-    const available =
-      this.props.uiproperties.sample_view_video_controls.components.find(
-        (component) => component.id === name && component.show === true,
-      );
+    const { uiproperties } = this.props;
+    const available = uiproperties.sample_view_video_controls.components.find(
+      (component) => component.id === name && component.show === true,
+    );
 
     return available?.show || false;
   }
 
   render() {
-    const { uiproperties } = this.props;
+    const { uiproperties, currentSampleID, shapes = {} } = this.props;
 
     if (!('sample_view_motors' in uiproperties)) {
       return null;
     }
-    const { currentSampleID } = this.props;
-    const [points, lines, grids, twoDPoints] = [{}, {}, {}, {}];
-    const selectedGrids = [];
+
     const phase_control = uiproperties.sample_view?.components?.find(
       (c) => c.attribute === 'phase_control',
     );
@@ -64,38 +62,19 @@ class SampleViewContainer extends Component {
       (c) => c.attribute === 'beam_size',
     );
 
-    if (this.props.shapes !== undefined) {
-      Object.keys(this.props.shapes).forEach((key) => {
-        const shape = this.props.shapes[key];
-        switch (shape.t) {
-          case 'P': {
-            points[shape.id] = shape;
-
-            break;
-          }
-          case '2DP': {
-            twoDPoints[shape.id] = shape;
-
-            break;
-          }
-          case 'L': {
-            lines[shape.id] = shape;
-
-            break;
-          }
-          case 'G': {
-            grids[shape.id] = shape;
-
-            if (shape.selected) {
-              selectedGrids.push(shape);
-            }
-
-            break;
-          }
-          // No default
-        }
-      });
-    }
+    const points = Object.fromEntries(
+      Object.entries(shapes).filter(([_, shape]) => shape.t === 'P'),
+    );
+    const twoDPoints = Object.fromEntries(
+      Object.entries(shapes).filter(([_, shape]) => shape.t === '2DP'),
+    );
+    const lines = Object.fromEntries(
+      Object.entries(shapes).filter(([_, shape]) => shape.t === 'L'),
+    );
+    const grids = Object.fromEntries(
+      Object.entries(shapes).filter(([_, shape]) => shape.t === 'G'),
+    );
+    const selectedGrids = Object.values(grids).filter((s) => s.selected);
 
     return (
       <Container fluid>


### PR DESCRIPTION
I've made two separate commits:

1. one to remove most of the explicit props passed down from `SampleViewContainer`,
2. and another to remove the spread of the `sampleview` state.

`<SampleImage {...this.props.sampleViewState} />` was a huge pain in the butt. Removing it will help refactor `SampleImage` in the future.