### PR TITLE
Return new shape from `addShape` and `add2DPoint` thunks to avoid callbacks

### DIFF
--- a/ui/src/actions/sampleview.js
+++ b/ui/src/actions/sampleview.js
@@ -192,24 +192,19 @@ export function moveToBeam(x, y) {
   return () => sendMoveToBeam(x, y);
 }
 
-export function add2DPoint(x, y, state, successCb) {
+export function add2DPoint(x, y, state) {
   return (dispatch) => {
-    return dispatch(
-      addShape({ t: '2DP', screenCoord: [x, y], state }, successCb),
-    );
+    return dispatch(addShape({ t: '2DP', screenCoord: [x, y], state }));
   };
 }
 
-export function addShape(shapeData = {}, successCb = null) {
+export function addShape(shapeData = {}) {
   return async (dispatch) => {
     try {
       const json = await sendAddOrUpdateShapes([shapeData]);
       const [shape] = json.shapes;
       dispatch(addShapeAction(shape));
-
-      if (successCb) {
-        successCb(shape);
-      }
+      return shape;
     } catch {
       throw new Error('Server refused to add shape');
     }

--- a/ui/src/components/SampleView/ContextMenu.jsx
+++ b/ui/src/components/SampleView/ContextMenu.jsx
@@ -492,19 +492,19 @@ export default function ContextMenu(props) {
     dispatch(toggleDrawGrid());
   }
 
-  function createPointAndShowModal(name, extraParams = {}) {
-    dispatch(
-      add2DPoint(sampleViewX, sampleViewY, 'SAVED', (shape2D) =>
-        showModal(name, extraParams, shape2D),
-      ),
+  async function createPointAndShowModal(name, extraParams = {}) {
+    const new2DPoint = await dispatch(
+      add2DPoint(sampleViewX, sampleViewY, 'SAVED'),
     );
+
+    showModal(name, extraParams, new2DPoint);
   }
 
   function createTwoDPoint() {
-    dispatch(add2DPoint(sampleViewX, sampleViewY, 'SAVED', null));
+    dispatch(add2DPoint(sampleViewX, sampleViewY, 'SAVED'));
   }
 
-  function createLine(modal, wf = {}) {
+  async function createLine(modal, wf = {}) {
     const sid = shape.id;
 
     const lines = sid.filter((x) => x.match(/L*/u)[0]);
@@ -515,11 +515,8 @@ export default function ContextMenu(props) {
       lines.map((x) => sid.splice(sid.indexOf(x), 1));
     }
 
-    dispatch(
-      addShape({ t: 'L', refs: shape.id }, (s) => {
-        showModal(modal, wf, s);
-      }),
-    );
+    const newLine = await dispatch(addShape({ t: 'L', refs: shape.id }));
+    showModal(modal, wf, newLine);
   }
 
   const options = menuOptions();


### PR DESCRIPTION
By returning the newly created shape from the thunk, we can just await it as the result of the `dispatch`.