### PR TITLE
Fix crash when field with ui schema has no group

### DIFF
--- a/ui/src/components/Tasks/CustomObjectFieldTemplate.jsx
+++ b/ui/src/components/Tasks/CustomObjectFieldTemplate.jsx
@@ -11,7 +11,7 @@ export default function CustomObjectFieldTemplate({
 }) {
   const groups = groupBy(
     properties,
-    (field) => uiSchema[field.name]?.['ui:options'].group,
+    (field) => uiSchema[field.name]?.['ui:options']?.group,
   );
 
   const { undefined: ungroupedFields = [], ...groupedFieldsMap } = groups;


### PR DESCRIPTION
Closes #1895
Currently code assumes that if field has an entry in uiSchema JSON, then it has an entry for group - due to a missing nullish coalescence.