### PR TITLE
Add CheckboxWidget

### DIFF
--- a/ui/src/components/Tasks/CustomFieldTemplate.jsx
+++ b/ui/src/components/Tasks/CustomFieldTemplate.jsx
@@ -1,7 +1,5 @@
-import { BsInfoCircleFill } from 'react-icons/bs';
-
-import TooltipTrigger from '../TooltipTrigger';
 import styles from './CustomFieldTemplate.module.css';
+import { FieldDescriptionTooltip } from './Widgets/FieldDescriptionTooltip/FieldDescriptionTooltip';
 
 /**
  * CustomFieldTemplate is a custom field template for React JSON Schema Form (RJSF).
@@ -29,9 +27,23 @@ export default function CustomFieldTemplate(props) {
 
   const span = Number(uiSchema['ui:options']?.col) || 6;
   const gridClass = `col-${span}`;
+  const fieldClassNames = `${gridClass} ${classNames}`.trim();
+
+  if (schema.type === 'boolean') {
+    return (
+      <div className={fieldClassNames}>
+        {/*
+         * RJSF renders the checkbox with label and description by default
+         * These will be provided be custom CheckboxWidget
+         * In the same line as the checkbox input.
+         */}
+        {children}
+      </div>
+    );
+  }
 
   return (
-    <div className={`${gridClass} ${classNames}`.trim()}>
+    <div className={fieldClassNames}>
       <div className={styles.fieldTitle}>
         {label && (
           <label htmlFor={id} className={styles.fieldLabel}>
@@ -40,15 +52,7 @@ export default function CustomFieldTemplate(props) {
           </label>
         )}
         {rawDescription && (
-          <TooltipTrigger
-            tooltipContent={rawDescription}
-            id={`${id}_tooltip`}
-            inModal
-          >
-            <span>
-              <BsInfoCircleFill />
-            </span>
-          </TooltipTrigger>
+          <FieldDescriptionTooltip description={rawDescription} />
         )}
       </div>
       <div className={styles.fieldInput}>

--- a/ui/src/components/Tasks/CustomFieldTemplate.module.css
+++ b/ui/src/components/Tasks/CustomFieldTemplate.module.css
@@ -1,14 +1,13 @@
 .fieldTitle {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 0.5rem;
 }
+
 .fieldTitle .fieldLabel {
   font-weight: bold;
   font-size: 1rem;
-  line-height: 1.2;
   margin-bottom: 0;
-  margin-top: 0.5rem;
 }
 
 .fieldInput {

--- a/ui/src/components/Tasks/GenericTaskForm.jsx
+++ b/ui/src/components/Tasks/GenericTaskForm.jsx
@@ -22,6 +22,7 @@ import {
 } from './fields';
 import validate from './validate';
 import warn from './warning';
+import CheckboxWidget from './Widgets/CheckboxWidget/CheckboxWidget';
 
 class GenericTaskForm extends React.Component {
   constructor(props) {
@@ -312,6 +313,9 @@ class GenericTaskForm extends React.Component {
                 ObjectFieldTemplate: CustomObjectFieldTemplate,
                 FieldTemplate: CustomFieldTemplate,
                 FieldErrorTemplate: CustomFieldErrorTemplate,
+              }}
+              widgets={{
+                CheckboxWidget,
               }}
             />
           </div>

--- a/ui/src/components/Tasks/Widgets/CheckboxWidget/CheckboxWidget.jsx
+++ b/ui/src/components/Tasks/Widgets/CheckboxWidget/CheckboxWidget.jsx
@@ -1,0 +1,42 @@
+import { Form } from 'react-bootstrap';
+
+import { FieldDescriptionTooltip } from '../FieldDescriptionTooltip/FieldDescriptionTooltip';
+import styles from './CheckboxWidget.module.css';
+/**
+ * Checkbox widget for RJSF forms.
+ *
+ * It is used to display checkboxes with the description as a tooltip.
+ * @param {import('@rjsf/utils').WidgetProps} props
+ */
+export default function CheckboxWidget({
+  id,
+  value,
+  disabled,
+  schema,
+  label,
+  required,
+  readonly,
+  onChange,
+  onBlur,
+  onFocus,
+}) {
+  const { description } = schema;
+
+  return (
+    <div className={styles.wrapper}>
+      <Form.Check
+        id={id}
+        checked={Boolean(value)}
+        disabled={disabled || readonly}
+        onChange={(e) => onChange(e.target.checked)}
+        onBlur={(e) => onBlur(id, e.target.checked)}
+        onFocus={(e) => onFocus(id, e.target.checked)}
+      />
+      <label htmlFor={id} className={styles.label}>
+        {label}
+        {required && <span className="text-danger">*</span>}
+      </label>
+      {description && <FieldDescriptionTooltip description={description} />}
+    </div>
+  );
+}

--- a/ui/src/components/Tasks/Widgets/CheckboxWidget/CheckboxWidget.module.css
+++ b/ui/src/components/Tasks/Widgets/CheckboxWidget/CheckboxWidget.module.css
@@ -1,0 +1,31 @@
+.wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/*
+ * Changing default bootstrap-provided styles for checkboxes,
+ * to make it more obvious that a checkbox is disabled.
+ */
+
+.wrapper input[type='checkbox'] {
+  background-color: white;
+  border-color: black;
+  cursor: pointer;
+}
+.wrapper input[type='checkbox']:checked {
+  background-color: var(--bs-primary);
+  border-color: var(--bs-primary);
+}
+
+.wrapper input[type='checkbox']:disabled {
+  background-color: #f0f0f0; /* Light gray */
+  border-color: #ccc;
+}
+
+.label {
+  font-weight: bold;
+  font-size: 1rem;
+  margin-bottom: 0;
+}

--- a/ui/src/components/Tasks/Widgets/FieldDescriptionTooltip/FieldDescriptionTooltip.jsx
+++ b/ui/src/components/Tasks/Widgets/FieldDescriptionTooltip/FieldDescriptionTooltip.jsx
@@ -1,0 +1,28 @@
+import { BsInfoCircleFill } from 'react-icons/bs';
+
+import TooltipTrigger from '../../../TooltipTrigger';
+
+/**
+ * @typedef
+ * {Object} FieldDescriptionTooltipProps
+ * @property {string} description - The description text to display in the tooltip.
+ */
+
+/**
+ * FieldDescriptionTooltip is a component that displays a tooltip
+ * with a description when hovering over an info icon.
+ * @param {FieldDescriptionTooltipProps} props
+ */
+export function FieldDescriptionTooltip({ description }) {
+  return (
+    <TooltipTrigger
+      tooltipContent={description}
+      id={`${description}_tooltip`}
+      inModal
+    >
+      <span>
+        <BsInfoCircleFill />
+      </span>
+    </TooltipTrigger>
+  );
+}


### PR DESCRIPTION
Closes #1896
The custom checkbox widget is used to provide the description tooltip for the description fields.
By default RJSF renders the checkbox with the description and label provided next to the checkbox, as text paragraph.
To make it more consistent, and reduce visual clutter, the description will be rendered in a tooltip, as in other fields.

There is also a small CSS change, which makes the label title vertically aligned with the description tooltip icon - it's also rendered directly after the label.

Result (for a `bool`-valued field) 
<img width="689" height="194" alt="image" src="https://github.com/user-attachments/assets/f2b6caa3-b2a7-415a-b59a-a8f72ed7c295" />
