### PR TITLE
Add NumericWithUnit and SmartText Widgets

### DIFF
--- a/ui/src/components/Tasks/CustomFieldTemplate.jsx
+++ b/ui/src/components/Tasks/CustomFieldTemplate.jsx
@@ -42,12 +42,15 @@ export default function CustomFieldTemplate(props) {
     );
   }
 
+  const unit = schema.unit ? ` [${schema.unit}]` : '';
+
   return (
     <div className={fieldClassNames}>
       <div className={styles.fieldTitle}>
         {label && (
           <label htmlFor={id} className={styles.fieldLabel}>
             {label}
+            <span className={styles.unitLabel}>{unit}</span>
             {required && <span className="text-danger">*</span>}
           </label>
         )}

--- a/ui/src/components/Tasks/CustomFieldTemplate.module.css
+++ b/ui/src/components/Tasks/CustomFieldTemplate.module.css
@@ -38,3 +38,10 @@
 .fieldHelp p {
   margin-bottom: 0;
 }
+
+.unitLabel {
+  /* font-weight is inherited from the label by default */
+  font-weight: normal;
+  font-family: monospace;
+  color: var(--bs-secondary);
+}


### PR DESCRIPTION
Closes #1897
This provides a way to display unit for numeric fields. By default RJSF renders the numeric fields with a built-in `TextWidget`. Thus it would be required for user to always specify in the `uiSchema` widget to be new `NumericWithUnitWidget`.
That wouldn't be convenient, so the `TextWidget` is being overriden with `SmartTextWidget`, which just renders `NumericWithUnitWidget` if the field is numeric.


This is how it looks
<img width="351" height="84" alt="image" src="https://github.com/user-attachments/assets/1f22af7e-60f0-420e-a6e6-a500ce1ce63b" />

It requires setting a `unit` field in the pydantic model, like so:
```python
class TestUserCollectionParameters(BaseModel):
    num_images: int = Field(0, description="")
    exp_time: float = Field(100e-6, gt=0, lt=1, unit="s", description="s")
```

Once it were to be merged, I'd add documentation section for it, along making documentation changes described in the #1894.

Note: feel free to propose alternative names for these widgets, the current names are not really that good... :D