### PR TITLE
Fix regression in `SSXChipControl`

### DIFF
--- a/ui/src/components/SSXChip/SSXChipControl.jsx
+++ b/ui/src/components/SSXChip/SSXChipControl.jsx
@@ -39,7 +39,7 @@ export default class SSXChipControl extends React.Component {
   }
 
   handleAddGrid(data) {
-    this.props.sampleViewActions.addShape({ t: 'G', ...data });
+    this.props.addShape({ t: 'G', ...data });
   }
 
   renderChip() {

--- a/ui/src/containers/SampleViewContainer.jsx
+++ b/ui/src/containers/SampleViewContainer.jsx
@@ -9,6 +9,7 @@ import {
   logFrontEndTraceBack,
   setAttribute,
 } from '../actions/beamline';
+import { addShape } from '../actions/sampleview';
 import { showTaskForm } from '../actions/taskForm';
 import PlateManipulator from '../components/Equipment/PlateManipulator';
 import motorInputStyles from '../components/MotorInput/MotorInput.module.css';
@@ -116,7 +117,7 @@ class SampleViewContainer extends Component {
                   groupFolder={this.props.groupFolder}
                   hardwareObjects={this.props.hardwareObjects}
                   uiproperties={uiproperties.sample_view_motors}
-                  sampleViewActions={this.props.sampleViewActions}
+                  addShape={this.props.addShape}
                   grids={grids}
                   selectedGrids={selectedGrids}
                   setAttribute={this.props.setAttribute}
@@ -177,6 +178,7 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
+    addShape: bindActionCreators(addShape, dispatch),
     showForm: bindActionCreators(showTaskForm, dispatch),
     setAttribute: bindActionCreators(setAttribute, dispatch),
     sendExecuteCommand: bindActionCreators(executeCommand, dispatch),


### PR DESCRIPTION
I worked on #1900 first but ended up closing it since there's ongoing work on this part of the code.

As a result, in #1901, I forgot that `sampleViewActions` was also passed to `SSXChipControl`, for the `addShape` action. Sorry about that. Here's a quick fix.