### PR TITLE
Move sample-list related functionality to lims component

### DIFF
--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -1840,7 +1840,7 @@ class Queue(ComponentBase):
                 not len(current_queue[sid]["tasks"])
             ) and sid != self.app.lims.get_current_sample().get("sampleID", ""):
                 try:
-                    self.app.sample_changer.mount_sample_clean_up(current_queue[sid])
+                    self.app.sample_changer.mount_sample(current_queue[sid], wait=True)
                 except Exception:
                     HWR.beamline.queue_manager.emit("queue_execution_failed", (None,))
                 else:
@@ -1959,6 +1959,14 @@ class Queue(ComponentBase):
         HWR.beamline.queue_manager.connect(
             "energy_scan_finished", signals.energy_scan_finished
         )
+
+    def queue_toggle_sample(self, entry):
+        if isinstance(entry, qe.SampleQueueEntry):
+            msg = {
+                "Signal": "DisableSample",
+                "sampleID": entry.get_data_model().loc_str,
+            }
+            self.app.server.emit("queue", msg, namespace="/hwr")
 
     def enable_sample_entries(self, sample_id_list, flag):
         current_queue = self.queue_to_dict()

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -252,7 +252,7 @@ class Queue(ComponentBase):
         queue = self.queue_to_dict(include_lims_data=True)
         sample_order = queue.get("sample_order", [])
         try:
-            current = self.app.sample_changer.get_current_sample().get("sampleID", "")
+            current = self.app.lims.get_current_sample().get("sampleID", "")
         except Exception as ex:
             logging.getLogger("MX3.HWR").warning(
                 "Error retrieving current sample, {0}".format(ex.message)
@@ -1838,9 +1838,7 @@ class Queue(ComponentBase):
             # tasks, so in order function as expected; just mount the sample
             if (
                 not len(current_queue[sid]["tasks"])
-            ) and sid != self.app.sample_changer.get_current_sample().get(
-                "sampleID", ""
-            ):
+            ) and sid != self.app.lims.get_current_sample().get("sampleID", ""):
                 try:
                     self.app.sample_changer.mount_sample_clean_up(current_queue[sid])
                 except Exception:

--- a/mxcubeweb/core/components/sampleview.py
+++ b/mxcubeweb/core/components/sampleview.py
@@ -110,7 +110,7 @@ class SampleView(ComponentBase):
 
         # we do not send/save any centring data if there is no sample
         # to avoid the 2d centring when no sample is mounted
-        if self.app.sample_changer.get_current_sample().get("sampleID", "") == "":
+        if self.app.lims.get_current_sample().get("sampleID", "") == "":
             return
 
         # If centering is valid add the point, otherwise remove it

--- a/mxcubeweb/routes/samplechanger.py
+++ b/mxcubeweb/routes/samplechanger.py
@@ -17,8 +17,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @bp.route("/samples_list", methods=["GET"])
     @server.restrict
     def get_sample_list():
-        app.sample_changer.get_sample_list()
-        return jsonify(app.lims.sample_list_get())
+        return jsonify(app.lims.sample_list_get(retrieve_samples_from_sc=True))
 
     @bp.route("/sync_with_crims", methods=["GET"])
     @server.require_control

--- a/mxcubeweb/routes/signals.py
+++ b/mxcubeweb/routes/signals.py
@@ -155,13 +155,13 @@ def loaded_sample_changed(sample):
         sampleID = address
 
         if HWR.beamline.sample_changer.has_loaded_sample():
-            mxcube.sample_changer.set_current_sample(sampleID)
+            mxcube.lims.set_current_sample(sampleID)
         else:
             sample = HWR.beamline.sample_changer.get_loaded_sample()
 
             address = sample.get_address() if sample else None
 
-            mxcube.sample_changer.set_current_sample(address)
+            mxcube.lims.set_current_sample(address)
 
         server.emit(
             "loaded_sample_changed",
@@ -172,14 +172,6 @@ def loaded_sample_changed(sample):
         sc_load_ready(address)
     except Exception as msg:
         logging.getLogger("HWR").error("error setting loaded sample: %s" + str(msg))
-
-
-def set_current_sample(sample_id):
-    if not sample_id:
-        sample_id = ""
-
-    sample = {"sampleID": sample_id}
-    server.emit("set_current_sample", sample, namespace="/hwr")
 
 
 def sc_contents_update():


### PR DESCRIPTION
The aim of this PR is to facilitate; 

   - The move of the sample changer related routes to the `SampleChangerAdapter` object
   - In a second step clean up the sample-changer related signals in signals.py
   - In a third step cleanup the lims component and investigate how much of that logic that can be pushed pack to `mxcubecore`