### PR TITLE
Clean up `main.css`

### DIFF
--- a/ui/src/components/SSXChip/ssxchipcontrol.css
+++ b/ui/src/components/SSXChip/ssxchipcontrol.css
@@ -1,3 +1,7 @@
+#test {
+  min-width: fit-content;
+}
+
 .chip-title {
   font-weight: bold;
   overflow: hidden;

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -561,7 +561,7 @@ export default function SampleListViewContainer() {
         >
           <Button
             variant="outline-secondary"
-            className="nowrap-style"
+            className={styles.actionBtn}
             onClick={() => handleGetLimsSamples(loginData.limsName[0].name)}
           >
             <i className="fas fa-sync-alt" style={{ marginRight: '0.5em' }} />
@@ -585,7 +585,7 @@ export default function SampleListViewContainer() {
               <Dropdown.Item
                 onClick={getSamplesFromSC}
                 variant="outline-secondary"
-                className="nowrap-style"
+                className={styles.actionBtn}
               >
                 Get samples from SC
               </Dropdown.Item>
@@ -777,7 +777,7 @@ export default function SampleListViewContainer() {
               {getSynchronizationDropDownList()}
               <span style={{ marginLeft: '1.5em' }} />
               <Button
-                className="nowrap-style"
+                className={styles.actionBtn}
                 variant="outline-secondary"
                 onClick={() => showAddSampleForm()}
               >
@@ -790,7 +790,7 @@ export default function SampleListViewContainer() {
                 tooltipContent="Remove all samples from sample list and queue"
               >
                 <Button
-                  className="nowrap-style"
+                  className={styles.actionBtn}
                   variant="outline-secondary"
                   onClick={() => dispatch(showConfirmClearQueueDialog())}
                   disabled={
@@ -858,7 +858,7 @@ export default function SampleListViewContainer() {
               <span style={{ marginLeft: '1.5em' }} />
               <Button
                 variant="outline-secondary"
-                className="nowrap-style"
+                className={styles.actionBtn}
                 title="Context Menu to Add DC or Workflow to all filtered Samples Options"
                 disabled={Object.keys(sampleList).length === 0}
                 onClick={(e) => {

--- a/ui/src/containers/SampleListViewContainer.module.css
+++ b/ui/src/containers/SampleListViewContainer.module.css
@@ -48,3 +48,7 @@
 .filterInputActive input:focus {
   box-shadow: none;
 }
+
+.actionBtn {
+  white-space: nowrap;
+}

--- a/ui/src/main.css
+++ b/ui/src/main.css
@@ -22,20 +22,6 @@ body {
   display: flex;
 }
 
-.popover {
-  width: auto !important;
-  z-index: 1040;
-}
-
-#test {
-  min-width: fit-content;
-}
-
-.device-status-container > div {
-  margin-right: 1em;
-  width: 12%;
-}
-
 button[disabled] {
   opacity: 0.2;
   pointer-events: none;
@@ -55,8 +41,7 @@ input[type='email']:focus,
 input[type='url']:focus,
 input[type='search']:focus,
 input[type='tel']:focus,
-input[type='color']:focus,
-.uneditable-input:focus {
+input[type='color']:focus {
   border-color: rgba(126, 161, 185, 0.8);
   box-shadow:
     0 1px 1px rgba(0, 0, 0, 0.075) inset,
@@ -78,6 +63,8 @@ input[type='color']:focus,
 
 .popover {
   max-width: 100%; /* Max Width of the popover (depending on the container!) */
+  width: auto !important;
+  z-index: 1040;
 }
 
 .btn-primary {
@@ -124,10 +111,6 @@ input[type='color']:focus,
   box-shadow: none !important;
   background: transparent;
   color: #000000;
-}
-
-.nowrap-style {
-  white-space: nowrap;
 }
 
 .btn-link:not([data-default-styles]) {


### PR DESCRIPTION
Part of #1906 

Most of the remaining "questionable" styles either override Bootstrap colours (which is fine), or are more complicated to get rid of as they affect Bootstrap components.

A while back I introduced a `data-default-styles` attribute to opt out of some of the most problematic styles when needed (`.modal-dialog`, `.btn` and `.dropdown-item`). I think it's a decent solution for the time being.