### PR TITLE
remove hardcoded braggy-link

### DIFF
--- a/mxcubeweb/core/adapter/detector_adapter.py
+++ b/mxcubeweb/core/adapter/detector_adapter.py
@@ -39,13 +39,19 @@ class DetectorAdapter(AdapterBase):
         """
         Notify ADXV and/or Braggy of the image to display.
         """
-        res = {"path": "", "img": 0}
+        res = {"image_url": ""}
 
         if path:
             fpath, img = HWR.beamline.detector.get_actual_file_path(path, img_num)
             HWR.beamline.collect.adxv_notify(fpath, img)
             fpath = HWR.beamline.session.get_path_with_proposal_as_root(fpath)
 
-            res = {"path": fpath, "img_num": img_num}
+            if self.app.config.braggy.USE_BRAGGY:
+                res = {
+                    "image_url": (
+                        f"{self.app.config.braggy.BRAGGY_URL}/"
+                        f"?file={fpath}/image_${img_num}.h5.dataset"
+                    )
+                }
 
         return res

--- a/ui/src/actions/general.js
+++ b/ui/src/actions/general.js
@@ -44,9 +44,6 @@ export function displayImage(path, imgNum) {
       'display_image',
       { path, imgNum },
     );
-    window.open(
-      `https://braggy.mxcube3.esrf.fr/?file=${data.path}/image_${data.img_num}.h5.dataset`,
-      'braggy',
-    );
+    window.open(data.image_url, 'braggy');
   };
 }


### PR DESCRIPTION
A previous PR #1846 was made to replace the hard coded braggy link, with an entry in the config files. While the Entry was still there, it seems that #1849 ignored this change by mistake. Meaning the config entry etc still existed, but the code was still refering to the hardcoded link instead of using the one from the configuration.

This PR should fix this behaviour  