### PR TITLE
Add package initializer in `/test`

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -248,9 +248,6 @@ extend-ignore-names = ["HWR"] # To avoid "N814": Camelcase `HardwareRepository` 
     "ARG001",
     "N813",
 ]
-"test/*.py" = [
-    "INP001",
-]
 "test/conftest.py" = [
     "E402",
     "E501",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -16,7 +16,7 @@ import sys
 
 import psutil
 import pytest
-from input_parameters import (
+from .input_parameters import (
     test_sample_1,
     test_sample_5,
     test_task,

--- a/test/test_queue_routes.py
+++ b/test/test_queue_routes.py
@@ -2,7 +2,7 @@ import copy
 import json
 import time
 
-from input_parameters import (
+from .input_parameters import (
     default_char_acq_params,
     default_dc_params,
     default_mesh_params,


### PR DESCRIPTION
[Pytest recommends to arrange tests in importable packages](https://docs.pytest.org/en/stable/explanation/pythonpath.html#import-modes).