### PR TITLE
Improve Python docstrings

### DIFF
--- a/mxcubeweb/app.py
+++ b/mxcubeweb/app.py
@@ -1,6 +1,7 @@
-"""
-Module that contains application wide settings and state as well as functions
-for accessing and manipulating those.
+"""Application-wide settings and state.
+
+Module that contains application-wide settings and state
+as well as functions for accessing and manipulating them.
 """
 
 import logging
@@ -118,14 +119,11 @@ class MXCUBEApplication:
         enabled_logger_list,
         cfg,
     ):
-        """
-        Initializes application wide variables, sample video stream, and applies
+        """Initializes application wide variables, sample video stream, and applies.
 
-        :param hwr: HardwareRepository module
-        :param bool allow_remote: Allow remote usage, True else False
-        :param bool ra_timeout: Timeout gives control, True else False
-
-        :return None:
+        Params:
+            allow_remote(bool): Allow remote usage, ``True`` else ``False``.
+            ra_timeout(bool): Timeout gives control, ``True`` else ``False``.
         """
         # The routes created by the AdapterResourceHandler
         # via the factory are kept between calls to init as they
@@ -178,11 +176,8 @@ class MXCUBEApplication:
         logging.getLogger("MX3.HWR").info(msg)
 
     @staticmethod
-    def init_sample_video(_format, port):
-        """
-        Initializes video streaming
-        :return: None
-        """
+    def init_sample_video(_format, port) -> None:
+        """Initialize video streaming."""
         try:
             HWR.beamline.sample_view.camera.start_streaming(_format=_format, port=port)
         except Exception as ex:
@@ -192,9 +187,10 @@ class MXCUBEApplication:
 
     @staticmethod
     def init_signal_handlers():
-        """
-        Connects the signal handlers defined in routes/signals.py to the
-        corresponding signals/events
+        """Connect the signal handlers.
+
+        Connect the signal handlers defined in ``routes/signals.py``
+        to the corresponding signals/events.
         """
         MXCUBEApplication.queue.init_signals(HWR.beamline.queue_model)
         MXCUBEApplication.sample_view.init_signals()
@@ -219,11 +215,11 @@ class MXCUBEApplication:
         return None
 
     @staticmethod
-    def init_logging(log_file, log_level, enabled_logger_list):
-        """
-        :param str log_file: Path to log file
+    def init_logging(log_file: str, log_level, enabled_logger_list) -> None:
+        """Initialize logging.
 
-        :return: None
+        Params:
+            log_file: Path to log file.
         """
         removeLoggingHandlers()
 
@@ -295,7 +291,8 @@ class MXCUBEApplication:
 
     @staticmethod
     def init_state_storage():
-        """
+        """Set up of server side state storage.
+
         Set up of server side state storage, the UI state of the client is
         stored on the server
         """

--- a/mxcubeweb/core/adapter/actuator_adapter.py
+++ b/mxcubeweb/core/adapter/actuator_adapter.py
@@ -19,9 +19,9 @@ hwr_logger = logging.getLogger("MX3.HWR")
 
 
 class ActuatorAdapter(ActuatorAdapterBase):
-    """
-    Adapter for Energy Hardware Object, a web socket is used to communicate
-    information on longer running processes.
+    """Adapter for Energy Hardware Object.
+
+    A web socket is used to communicate information on longer running processes.
     """
 
     SUPPORTED_TYPES: ClassVar[list[object]] = [
@@ -29,8 +29,15 @@ class ActuatorAdapter(ActuatorAdapterBase):
         AbstractFlux.AbstractFlux,
     ]
 
-    def __init__(self, ho, role, app, resource_handler_config=resource_handler_config):
-        """
+    def __init__(  # noqa: D417
+        self,
+        ho,
+        role,
+        app,
+        resource_handler_config=resource_handler_config,
+    ):
+        """Initialize.
+
         Args:
             ho (object): Hardware object.
         """
@@ -54,12 +61,14 @@ class ActuatorAdapter(ActuatorAdapterBase):
         self._vc(*args, **kwargs)
 
     def set_value(self, value: HOActuatorValueChangeModel) -> str:
-        """
-        Execute the sequence to set the value.
+        """Execute the sequence to set the value.
+
         Args:
             value (float): Target energy [keV].
+
         Returns:
             (float as str): The actual value set.
+
         Raises:
             ValueError: Value not valid or attemp to set a non-tunable energy.
             RuntimeError: Timeout while setting the value.
@@ -69,10 +78,11 @@ class ActuatorAdapter(ActuatorAdapterBase):
         return self.get_value()
 
     def get_value(self) -> FloatValueModel:
-        """
-        Read the energy.
+        """Read the energy.
+
         Returns:
             (float as str): Energy [keV].
+
         Raises:
             ValueError: When value for any reason can't be retrieved.
         """
@@ -83,15 +93,13 @@ class ActuatorAdapter(ActuatorAdapterBase):
             raise ValueError(msg)
 
     def stop(self):
-        """
-        Stop the execution.
-        """
+        """Stop the execution."""
         self._ho.abort()
 
     def read_only(self):
-        """
-        Check if the energy is tunable or not.
-        Retuns:
+        """Check if the energy is tunable or not.
+
+        Returns:
             (bool): True if tunable, False if not.
         """
         return self._ho.read_only

--- a/mxcubeweb/core/adapter/adapter_base.py
+++ b/mxcubeweb/core/adapter/adapter_base.py
@@ -33,7 +33,7 @@ default_resource_handler_config = ResourceHandlerConfigModel(
 
 
 class AdapterBase:
-    """Hardware Object Adapter Base class"""
+    """Hardware Object Adapter Base class."""
 
     # List of supported HO base classes (or callable for more advanced matching)
     SUPPORTED_TYPES: ClassVar[list[object]] = []
@@ -45,8 +45,11 @@ class AdapterBase:
 
     ADAPTER_DICT = {}
 
-    def __init__(self, ho, role, app, resource_handler_config=None):
-        """
+    def __init__(  # noqa: D417
+        self, ho, role, app, resource_handler_config=None
+    ):
+        """Initialize.
+
         Args:
             ho (object): Hardware object to mediate for.
             (str): The name of the object
@@ -171,7 +174,8 @@ class AdapterBase:
 
     @property
     def adapter_type(self):
-        """
+        """Adapter type.
+
         Returns:
             (str): The data type of the value
         """
@@ -179,8 +183,8 @@ class AdapterBase:
 
     @property
     def ho(self):
-        """
-        Underlaying HardwareObject
+        """Underlaying HardwareObject.
+
         Returns:
             (object): HardwareObject
         """
@@ -188,9 +192,11 @@ class AdapterBase:
 
     # Abstract method
     def state(self):
-        """
+        """Retrieve the state of the underlying hardware object as a JavaScript string.
+
         Retrieves the state of the underlying hardware object and converts it to a str
         that can be used by the javascript front end.
+
         Returns:
             (str): The state
         """
@@ -198,25 +204,29 @@ class AdapterBase:
 
     # Abstract method
     def msg(self):
-        """
-        Returns a message describing the current state. should be used to communicate
-        details of the state to the user.
+        """Return a message describing the current state.
+
+        Should be used to communicate details of the state to the user.
+
         Returns:
             (str): The message string.
         """
         return self._msg
 
     def read_only(self):
-        """
-        Returns true if the hardware object is read only, set_value can not be called
+        """Return true if the hardware object is read only.
+
+        Return true if the hardware object is read only and
+        ``set_value`` can not be called.
+
         Returns:
             (bool): True if read enly.
         """
         return self._read_only
 
     def available(self):
-        """
-        Check if the hardware object is considered to be available/online/enabled
+        """Check if the hardware object is considered to be available/online/enabled.
+
         Returns:
             (bool): True if available.
         """
@@ -319,10 +329,7 @@ class AdapterBase:
         )
 
     def emit_ho_changed(self, state, **kwargs):
-        """
-        Signal handler to be used for sending the entire object to the client via
-        socketIO
-        """
+        """Signal handler to send entire object to the client via socketIO."""
         data = self.data().dict()
 
         if hasattr(state, "name"):
@@ -335,15 +342,12 @@ class AdapterBase:
         self.app.server.emit("hardware_object_changed", data, namespace="/hwr")
 
     def state_change(self, state, **kwargs):
-        """
-        Signal handler to be used for sending the state to the client via
-        socketIO
-        """
+        """Signal handler to send the state to the client via socketIO."""
         self.emit_ho_changed(state)
 
     def _dict_repr(self):
-        """
-        Dictionary representation of the hardware object.
+        """Dictionary representation of the hardware object.
+
         Returns:
             (dict): The dictionary.
         """
@@ -385,8 +389,11 @@ class AdapterBase:
 
 
 class ActuatorAdapterBase(AdapterBase):
-    def __init__(self, ho, role, app, resource_handler_config=None):
-        """
+    def __init__(  # noqa: D417
+        self, ho, role, app, resource_handler_config=None
+    ):
+        """Initialize.
+
         Args:
             (object): Hardware object to mediate for.
             (str): The name of the object.
@@ -402,34 +409,34 @@ class ActuatorAdapterBase(AdapterBase):
     # will share this method thus all methods will be effected if limit rated.
     # Rather LimitRate the function calling this one.
     def value_change(self, *args, **kwargs):
-        """
-        Signal handler to be used for sending values to the client via
-        socketIO.
-        """
+        """Signal handler to send values to the client via socketIO."""
         self.emit_ho_value_changed(args[0])
 
     # Abstract method
     def set_value(self, value) -> str:
-        """
-        Sets a value on underlying hardware object.
+        """Sets a value on underlying hardware object.
 
         Args:
             value(float): Value to be set.
+
         Returns:
             (str): The actual value set as str.
+
         Raises:
             ValueError: When conversion or treatment of value fails.
             StopIteration: When a value change was interrupted (abort/cancel).
+
         Emits:
             hardware_object_value_changed with values over websocket
         """
 
     # Abstract method
     def get_value(self):
-        """
-        Retrieve value from underlying hardware object.
+        """Retrieve value from underlying hardware object.
+
         Returns:
             (str): The value.
+
         Raises:
             ValueError: When value for any reason can't be retrieved.
         """
@@ -437,15 +444,14 @@ class ActuatorAdapterBase(AdapterBase):
 
     # Abstract method
     def stop(self):
-        """
-        Stop an action/movement.
-        """
+        """Stop an action/movement."""
 
     def limits(self):
-        """
-        Read the energy limits.
+        """Read the energy limits.
+
         Returns:
             (tuple): Two floats (min, max).
+
         Raises:
             ValueError: When limits for any reason can't be retrieved.
         """
@@ -459,6 +465,7 @@ class ActuatorAdapterBase(AdapterBase):
 
     def _dict_repr(self):
         """Dictionary representation of the hardware object.
+
         Returns:
             (dict): The dictionary.
         """

--- a/mxcubeweb/core/adapter/adapter_manager.py
+++ b/mxcubeweb/core/adapter/adapter_manager.py
@@ -16,9 +16,7 @@ class HardwareObjectAdapterManager:
         self.adapter_dict = {}
 
     def exit_with_error(self, msg: str) -> None:
-        """
-        Writes the traceback and msg to the log and exits the
-        application
+        """Write the traceback and msg to the log and exits the application.
 
         :param msg: Additional message to write to log
         """
@@ -33,8 +31,7 @@ class HardwareObjectAdapterManager:
         sys.exit(-1)
 
     def init(self) -> None:
-        """
-        Initializes the HardwareRepository with XML files read from hwdir.
+        """Initialize the HardwareRepository with XML files read from hwdir.
 
         The hwr module must be imported at the very beginning of the application
         start-up to function correctly.
@@ -73,19 +70,19 @@ class HardwareObjectAdapterManager:
         return self._get_object_from_id(_id)
 
     def find_best_adapter(self, ho):
-        """
-        Rank adapters by the depth of their SUPPORTED_TYPES in the
-        inheritance tree.
+        """Rank adapters by the depth of their SUPPORTED_TYPES in the inheritance tree.
 
-        Choose the adapter with the most specific match (deepest class
-        in the hierarchy).
+        Choose the adapter with the most specific match
+        (deepest class in the hierarchy).
 
         Args:
-            ho: HardwareObject to adapt
+            ho: HardwareObject to adapt.
+
         Returns:
-            The best adapter class for the hardware object
+            The best adapter class for the hardware object.
+
         Raises:
-            RuntimeError: If multiple adapters suit the hardware object
+            RuntimeError: If multiple adapters suit the hardware object.
         """
         if ho.__class__ in AdapterBase.SUPPORTED_TYPES_TO_ADAPTERS:
             return AdapterBase.SUPPORTED_TYPES_TO_ADAPTERS[ho.__class__]

--- a/mxcubeweb/core/adapter/beam_adapter.py
+++ b/mxcubeweb/core/adapter/beam_adapter.py
@@ -28,9 +28,7 @@ class BeamAdapter(ActuatorAdapterBase):
             ho.connect(ho, sig, self._beam_changed)
 
     def _beam_changed(self, *args, **kwargs):  # noqa: ARG002
-        """
-        Callback method for beam position and info changes.
-        """
+        """Callback method for beam position and info changes."""
         self.app.server.emit(
             "beam_changed", {"data": self.get_value().dict()["value"]}, namespace="/hwr"
         )
@@ -39,8 +37,7 @@ class BeamAdapter(ActuatorAdapterBase):
         return -1, -1
 
     def _get_aperture(self) -> tuple:
-        """
-        Returns list of apertures and the one currently used.
+        """Return list of apertures and the one currently used.
 
         :return: Tuple, (list of apertures, current aperture)
         :rtype: tuple

--- a/mxcubeweb/core/adapter/beamline_action_adapter.py
+++ b/mxcubeweb/core/adapter/beamline_action_adapter.py
@@ -57,16 +57,17 @@ class ActionsList(BaseModel):
 class BeamlineActionAdapter(AdapterBase):
     SUPPORTED_TYPES: ClassVar[list[object]] = [BeamlineActions]
 
-    def __init__(
+    def __init__(  # noqa: D417
         self,
         ho: HardwareObject,
         role: str,
         app,
         resource_handler_config: ResourceHandlerConfigModel = resource_handler_config,
     ):
-        """
+        """Initialize.
+
         Args:
-            (object): Hardware object.
+            ho: Hardware object.
         """
         super().__init__(ho, role, app, resource_handler_config)
         self._value_change_model = HOActuatorValueChangeModel
@@ -114,21 +115,21 @@ class BeamlineActionAdapter(AdapterBase):
         return ""
 
     def stop(self):
-        """
-        Stop the execution.
-        """
+        """Stop the execution."""
         for cmd in self._ho.get_commands():
             self._ho.abort_command(cmd.name())
 
     def _valid_action_input(self, value: dict | list) -> bool:
-        """
-        Validates that the the action input value structure is
-        flat and contains only valid types (str, int, float, bool).
+        """Validate the action input value.
+
+        Validates that the action input value structure is flat
+        and contains only valid types (``str``, ``int``, ``float``, ``bool``).
 
         Args:
-            value The structure to validate.
+            value: The structure to validate.
+
         Returns:
-            bool: True if valid, False otherwise.
+            ``True`` if valid, ``False`` otherwise.
         """
         allowed_types = (str, int, float, bool)
 
@@ -139,9 +140,7 @@ class BeamlineActionAdapter(AdapterBase):
         return False
 
     def run_action(self, value: BeamlineActionInputModel):
-        """
-        Starts beamline action
-        """
+        """Start beamline action."""
         # Beamline actions are retrieved from a finite list of commands
         # its either a simple command name or an annotated command
         # Getting the KeyError means that the command is not annotated

--- a/mxcubeweb/core/adapter/beamline_adapter.py
+++ b/mxcubeweb/core/adapter/beamline_adapter.py
@@ -15,9 +15,7 @@ resource_handler_config = ResourceHandlerConfigModel(
 
 
 class BeamlineAdapter(ActuatorAdapterBase):
-    """
-    Adapter between Beamline route and Beamline hardware object.
-    """
+    """Adapter between Beamline route and Beamline hardware object."""
 
     SUPPORTED_TYPES: ClassVar[list[object]] = [Beamline]
 
@@ -67,10 +65,10 @@ class BeamlineAdapter(ActuatorAdapterBase):
         return escan.get_elements() if escan else []
 
     def get_value(self) -> dict:
-        """
-        Build dictionary value-representation for each beamline attribute
-         Returns:
-           (dict): The dictionary.
+        """Build dictionary value-representation for each beamline attribute.
+
+        Returns:
+            The dictionary.
         """
         attributes = {}
 

--- a/mxcubeweb/core/adapter/data_publisher_adapter.py
+++ b/mxcubeweb/core/adapter/data_publisher_adapter.py
@@ -15,10 +15,13 @@ class DataPublisherAdapter(AdapterBase):
     ATTRIBUTES = ["current_data", "all_data", "current"]
     SUPPORTED_TYPES: ClassVar[list[object]] = [DataPublisher.DataPublisher]
 
-    def __init__(self, ho, *args):
-        """
+    def __init__(  # noqa: D417
+        self, ho, *args
+    ):
+        """Initialize.
+
         Args:
-            (object): Hardware object.
+            ho (object): Hardware object.
         """
         super().__init__(ho, *args)
         self._all_data_list = []

--- a/mxcubeweb/core/adapter/detector_adapter.py
+++ b/mxcubeweb/core/adapter/detector_adapter.py
@@ -15,18 +15,19 @@ resource_handler_config = ResourceHandlerConfigModel(
 class DetectorAdapter(AdapterBase):
     SUPPORTED_TYPES: ClassVar[list[object]] = [AbstractDetector.AbstractDetector]
 
-    def __init__(self, ho, role, app):
-        """
+    def __init__(  # noqa: D417
+        self, ho, role, app
+    ):
+        """Initialize.
+
         Args:
-            (object): Hardware object.
+            ho (object): Hardware object.
         """
         super().__init__(ho, role, app, resource_handler_config)
         ho.connect("stateChanged", self._state_change)
 
     def get_value(self) -> dict:
-        """
-        Get the file suffix of the data files.
-        """
+        """Get the file suffix of the data files."""
         return {"fileSuffix": HWR.beamline.detector.get_property("file_suffix", "?")}
 
     def _state_change(self, *args, **kwargs):
@@ -36,9 +37,7 @@ class DetectorAdapter(AdapterBase):
         return self._ho.get_state().name.upper()
 
     def display_image(self, path: str, img_num) -> dict:
-        """
-        Notify ADXV and/or Braggy of the image to display.
-        """
+        """Notify ADXV and/or Braggy of the image to display."""
         res = {"image_url": ""}
 
         if path:

--- a/mxcubeweb/core/adapter/diffractometer_adapter.py
+++ b/mxcubeweb/core/adapter/diffractometer_adapter.py
@@ -20,10 +20,13 @@ class DiffractometerAdapter(AdapterBase):
         GenericDiffractometer.GenericDiffractometer,
     ]
 
-    def __init__(self, ho, role, app):
-        """
+    def __init__(  # noqa: D417
+        self, ho, role, app
+    ):
+        """Initialize.
+
         Args:
-            (object): Hardware object.
+            ho (object): Hardware object.
         """
         super().__init__(ho, role, app, resource_handler_config)
         ho.connect("stateChanged", self._state_change)

--- a/mxcubeweb/core/adapter/energy_adapter.py
+++ b/mxcubeweb/core/adapter/energy_adapter.py
@@ -14,17 +14,20 @@ resource_handler_config = ResourceHandlerConfigModel(
 
 
 class EnergyAdapter(ActuatorAdapter):
-    """
-    Adapter for Energy Hardware Object, a web socket is used to communicate
-    information on longer running processes.
+    """Adapter for Energy Hardware Object.
+
+    A web socket is used to communicate information on longer running processes.
     """
 
     SUPPORTED_TYPES: ClassVar[list[object]] = [AbstractEnergy.AbstractEnergy]
 
-    def __init__(self, ho, role, app):
-        """
+    def __init__(  # noqa: D417
+        self, ho, role, app
+    ):
+        """Initialize.
+
         Args:
-            (object): Hardware object.
+            ho (object): Hardware object.
         """
         super().__init__(ho, role, app, resource_handler_config)
         self._add_adapter("wavelength", self._ho, WavelengthAdapter)

--- a/mxcubeweb/core/adapter/machine_info_adapter.py
+++ b/mxcubeweb/core/adapter/machine_info_adapter.py
@@ -9,12 +9,15 @@ from mxcubeweb.core.util.networkutils import RateLimited
 
 
 class MachineInfoAdapter(ActuatorAdapterBase):
-    """Adapter for MachineInfo like objects"""
+    """Adapter for MachineInfo like objects."""
 
     SUPPORTED_TYPES: ClassVar[list[object]] = [AbstractMachineInfo.AbstractMachineInfo]
 
-    def __init__(self, ho, *args):
-        """
+    def __init__(  # noqa: D417
+        self, ho, *args
+    ):
+        """Initialize.
+
         Args:
             (object): Hardware object.
         """
@@ -45,8 +48,10 @@ class MachineInfoAdapter(ActuatorAdapterBase):
         return value_dict
 
     def limits(self):
-        """
-        Returns: The detector distance limits.
+        """Get the detector distance limits.
+
+        Returns:
+            The detector distance limits.
         """
         return (-1, -1)
 

--- a/mxcubeweb/core/adapter/motor_adapter.py
+++ b/mxcubeweb/core/adapter/motor_adapter.py
@@ -19,8 +19,11 @@ resource_handler_config = ResourceHandlerConfigModel(
 class MotorAdapter(ActuatorAdapterBase):
     SUPPORTED_TYPES: ClassVar[list[object]] = [AbstractMotor.AbstractMotor]
 
-    def __init__(self, ho, role, app):
-        """
+    def __init__(  # noqa: D417
+        self, ho, role, app
+    ):
+        """Initialize.
+
         Args:
             ho (object): Hardware object.
         """
@@ -33,12 +36,14 @@ class MotorAdapter(ActuatorAdapterBase):
         self.value_change(*args, **kwargs)
 
     def set_value(self, value: float):
-        """
-        Set the detector distance.
+        """Set the detector distance.
+
         Args:
             value (float): Target distance [mm].
+
         Returns:
             (str): The actual value set.
+
         Raises:
             ValueError: Value not valid.
             RuntimeError: Timeout while setting the value.
@@ -48,10 +53,11 @@ class MotorAdapter(ActuatorAdapterBase):
         return self.get_value()
 
     def get_value(self) -> FloatValueModel:
-        """
-        Read the detector distance.
+        """Read the detector distance.
+
         Returns:
             (float as str): Detector distance [mm].
+
         Raises:
             ValueError: When value for any reason can't be retrieved.
         """
@@ -63,8 +69,8 @@ class MotorAdapter(ActuatorAdapterBase):
         return FloatValueModel(value=value)
 
     def state(self):
-        """
-        Get the state.
+        """Get the state.
+
         Returns:
             (str): The state.
         """
@@ -74,10 +80,11 @@ class MotorAdapter(ActuatorAdapterBase):
         self._ho.abort()
 
     def limits(self):
-        """
-        Read the detector distance limits.
+        """Read the detector distance limits.
+
         Returns:
             (tuple): Two floats (min, max).
+
         Raises:
             ValueError: When limits for any reason can't be retrieved.
         """

--- a/mxcubeweb/core/adapter/nstate_adapter.py
+++ b/mxcubeweb/core/adapter/nstate_adapter.py
@@ -26,10 +26,13 @@ class NStateAdapter(ActuatorAdapterBase):
         AbstractShutter.AbstractShutter,
     ]
 
-    def __init__(self, ho, role, app):
-        """
+    def __init__(  # noqa: D417
+        self, ho, role, app
+    ):
+        """Initialize.
+
         Args:
-            (object): Hardware object.
+            ho (object): Hardware object.
         """
         super().__init__(ho, role, app, resource_handler_config)
         self._value_change_model = HOActuatorValueChangeModel
@@ -59,13 +62,14 @@ class NStateAdapter(ActuatorAdapterBase):
         return self._get_valid_states()
 
     def set_value(self, value: HOActuatorValueChangeModel) -> str:
-        """
-        Sets value of the Nstate adapter.
+        """Set value of the N-state adapter.
 
         Args:
             value (Enum): value to be set containing name and value attributes.
+
         Returns:
             (str): The actual value set as a string.
+
         Raises:
             ValueError: Value not valid.
             RuntimeError: Timeout while setting the value.
@@ -78,9 +82,7 @@ class NStateAdapter(ActuatorAdapterBase):
         return StrValueModel(value=self._ho.get_value().name)
 
     def stop(self):
-        """
-        Stop the execution.
-        """
+        """Stop the execution."""
         self._ho.abort()
 
     def msg(self):

--- a/mxcubeweb/core/adapter/sample_changer_adapter.py
+++ b/mxcubeweb/core/adapter/sample_changer_adapter.py
@@ -40,7 +40,7 @@ resource_handler_config = ResourceHandlerConfigModel(
 
 
 class SampleChangerAdapter(AdapterBase):
-    """Adapter for AbstractSampleChanger"""
+    """Adapter for AbstractSampleChanger."""
 
     SUPPORTED_TYPES: ClassVar[list[object]] = [SampleChanger]
 
@@ -371,10 +371,13 @@ class SampleChangerAdapter(AdapterBase):
             raise RuntimeError(msg) from _ex
 
     def sync_with_crims(self):
-        """
-        To be use mostly when Diffractometer is in plate mode
-        This retun a List of crystal dict available in Crims that have been Harvested
-        With this user can visualize easier where the crystal are in Plate GUI
+        """Synchronize with Crims.
+
+        To be used mostly when diffractometer is in plate mode.
+        This returns a list of crystal dicts available in Crims
+        that have been harvested.
+        With this, the user can visualize more easily
+        where the crystals are in the plate GUI.
         """
         xtal_list = []
         try:

--- a/mxcubeweb/core/adapter/wavelength_adapter.py
+++ b/mxcubeweb/core/adapter/wavelength_adapter.py
@@ -11,15 +11,18 @@ hwr_logger = logging.getLogger("MX3.HWR")
 
 
 class WavelengthAdapter(ActuatorAdapterBase):
-    """
-    Adapter for wavelength Hardware Object, a web socket is used communicate
-    information on longer running processes.
+    """Adapter for wavelength Hardware Object.
+
+    A web socket is used to communicate information on longer running processes.
     """
 
-    def __init__(self, ho, *args):
-        """
+    def __init__(  # noqa: D417
+        self, ho, *args
+    ):
+        """Initialize.
+
         Args:
-            (object): Hardware object.
+            ho (object): Hardware object.
         """
         super().__init__(ho, *args)
         self._type = "MOTOR"
@@ -36,12 +39,14 @@ class WavelengthAdapter(ActuatorAdapterBase):
         self.value_change(wl)
 
     def set_value(self, value: HOActuatorValueChangeModel):
-        """
-        Execute the sequence to set the value.
+        """Execute the sequence to set the value.
+
         Args:
             value (float): Target wavelength [Å].
+
         Returns:
             (float as str): The actual value set.
+
         Raises:
             ValueError: Value not valid or attemp to set read only value.
             RuntimeError: Timeout while setting the value.
@@ -55,10 +60,11 @@ class WavelengthAdapter(ActuatorAdapterBase):
             hwr_logger.exception(msg)
 
     def get_value(self) -> FloatValueModel:
-        """
-        Read the wavelength value.
+        """Read the wavelength value.
+
         Returns:
             (float as str): Wavelength [Å].
+
         Raises:
             ValueError: When value for any reason can't be retrieved.
         """
@@ -69,8 +75,8 @@ class WavelengthAdapter(ActuatorAdapterBase):
             raise ValueError(msg) from ex
 
     def state(self):
-        """
-        Get the state.
+        """Get the state.
+
         Returns:
             (str): The state
         """
@@ -78,16 +84,15 @@ class WavelengthAdapter(ActuatorAdapterBase):
         return self._ho.get_state().name
 
     def stop(self):
-        """
-        Stop the execution.
-        """
+        """Stop the execution."""
         self._ho.abort()
 
     def limits(self):
-        """
-        Read the wavelengt limits.
+        """Read the wavelengt limits.
+
         Returns:
             (tuple): Two floats (min, max) limits.
+
         Raises:
             ValueError: When limits for any reason can't be retrieved.
         """
@@ -98,9 +103,9 @@ class WavelengthAdapter(ActuatorAdapterBase):
             raise ValueError(msg) from ex
 
     def read_only(self):
-        """
-        Check if the wavelength is read only or not.
-        Retuns:
-            (bool): True if read only, False if not.
+        """Check if the wavelength is read only or not.
+
+        Returns:
+            (bool): ``True`` if read only, ``False`` if not.
         """
         return self._ho.read_only

--- a/mxcubeweb/core/components/harvester.py
+++ b/mxcubeweb/core/components/harvester.py
@@ -68,10 +68,10 @@ class Harvester(ComponentBase):
             return False
 
     def get_harvester_contents(self):
-        """Get the Harvester contents info
+        """Get the Harvester contents info.
 
-        Return (Dict): Dict content, object name etc..
-        crystal_list and number of available pins"
+        Returns:
+            dict: Dict containing name, crystal_list, number of available pins, etc.
         """
         if HWR.beamline.harvester:
             root_name = HWR.beamline.harvester.__TYPE__
@@ -97,10 +97,11 @@ class Harvester(ComponentBase):
         return contents
 
     def get_crystal_list(self):
-        """Get the Harvester Sample List info
+        """Get the Harvester Sample List info.
 
-        Return (List):  list of dict content
-        state , name etc.. of the current processing plan"
+        Returns:
+            list: List of dicts containing state, name, etc.
+                of the current processing plan.
         """
         crystal_list = []
 
@@ -145,9 +146,10 @@ class Harvester(ComponentBase):
             return "OFFLINE", "OFFLINE", "OFFLINE"
 
     def send_data_collection_info_to_crims(self) -> bool:
-        """Send Data collected to CRIMS
+        """Send Data collected to CRIMS.
 
-        Return (bool): Whether the request failed (false) or not (true)
+        Returns:
+            bool: Whether the request failed (``False``) or not (``True``).
         """
         dataCollectionGroupId = ""
         crystal_uuid = ""

--- a/mxcubeweb/core/components/lims.py
+++ b/mxcubeweb/core/components/lims.py
@@ -60,8 +60,7 @@ class Lims(ComponentBase):
         return self.sample_list_get(retrieve_samples_from_sc=True)
 
     def get_lims_samples(self, lims: str) -> dict:
-        """
-        Gets samples from LIMS and filters to include only LIMS-linked entries.
+        """Get samples from LIMS and filters to include only LIMS-linked entries.
 
         This method synchronizes the sample list with the specified LIMS,
         filters for entries that have a `limsID`, and sets the new sample list
@@ -89,8 +88,7 @@ class Lims(ComponentBase):
         return self.app.SAMPLE_LIST
 
     def set_proposal(self, proposal_number: str):
-        """
-        Set the selected proposal.
+        """Set the selected proposal.
 
         :param proposal_number: Proposal number
         """
@@ -100,9 +98,7 @@ class Lims(ComponentBase):
         return {}
 
     def get_proposal(self):
-        """
-        Return the currently selected proposal.
-        """
+        """Return the currently selected proposal."""
         return {"Proposal": self.get_proposal_info()}
 
     def new_sample_list(self):
@@ -325,9 +321,11 @@ class Lims(ComponentBase):
         params["prefix"] = self.strip_prefix(path_template, params["prefix"])
 
     def strip_prefix(self, pt, prefix):
-        """
-        Strips the reference, wedge and mad prefix from a given prefix. For example
-        removes ref- from the beginning and _w[n] and -pk, -ip, -ipp from the end.
+        """Strip the reference, wedge and mad prefix from a given prefix.
+
+        For example,
+        remove ``ref-`` from the beginning
+        and ``_w[n]`` and ``-pk``, ``-ip``, ``-ipp`` from the end.
 
         :param PathTemplate pt: path template used to create the prefix
         :param str prefix: prefix from the client
@@ -351,9 +349,10 @@ class Lims(ComponentBase):
         return HWR.beamline.lims.session_manager
 
     def is_rescheduled_session(self, session):
-        """
-        Returns true is the session is rescheduled. That means that either currently
-        is not the expected timeslot or because it is not in the expected beamline
+        """Return true is the session is rescheduled.
+
+        That means that either currently is not the expected timeslot
+        or because it is not in the expected beamline
         """
         return not (session.is_scheduled_beamline and session.is_scheduled_time)
 
@@ -361,9 +360,11 @@ class Lims(ComponentBase):
         HWR.beamline.lims.allow_session(session)
 
     def select_session(self, session_id: str) -> bool:
-        """
-        param session_id : this is a identifier that could be proposal name or
-        session_id depending of the type of LIMS login type
+        """Select session.
+
+        Params:
+            session_id: This is a identifier that could be proposal name or
+                ``session_id`` depending of the type of LIMS login type.
         """
         logging.getLogger("MX3.HWR").debug("select_session session_id=%s" % session_id)
 

--- a/mxcubeweb/core/components/log.py
+++ b/mxcubeweb/core/components/log.py
@@ -35,9 +35,7 @@ class Log(ComponentBase):
         )
 
     def log(self):
-        """
-        Retrieve log messages
-        """
+        """Retrieve log messages."""
         messages = []
 
         for handler in logging.getLogger("MX3.HWR").handlers:
@@ -47,9 +45,7 @@ class Log(ComponentBase):
         return messages
 
     def log_frontend_traceback(self, trace: FrontEndStackTraceModel) -> dict:
-        """
-        Logs a UI traceback to the UI logger
-        """
+        """Log a UI traceback to the UI logger."""
         logging.getLogger("MX3.UI").error("------ Start of UI trace back ------")
         logging.getLogger("MX3.UI").error("Traceback: %s", trace.stack)
         logging.getLogger("MX3.UI").error(

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -82,8 +82,7 @@ class Queue(ComponentBase):
         return pt.run_number
 
     def node_index(self, node):
-        """
-        Get the position (index) in the queue, sample and node id of node <node>.
+        """Get the position (index) in the queue, sample and node id of node <node>.
 
         :returns: dictionary on the form:
                 {'sample': sample, 'idx': index, 'queue_id': node_id}
@@ -123,8 +122,7 @@ class Queue(ComponentBase):
         }
 
     def load_queue_from_dict(self, queue_dict):
-        """
-        Loads the queue in queue_dict in to the current HWR.beamline.queue_model (HWR.beamline.queue_model)
+        """Load the queue in queue_dict in to the current HWR.beamline.queue_model (HWR.beamline.queue_model).
 
         :param dict queue_dict: Queue dictionary, on the same format as returned by
                                 queue_to_dict
@@ -138,8 +136,7 @@ class Queue(ComponentBase):
             self.queue_add_item(item_list)
 
     def queue_to_dict(self, node=None, include_lims_data=False):
-        """
-        Returns the dictionary representation of the queue
+        """Returns the dictionary representation of the queue.
 
         :param TaskNode node: list of Node objects to get representation for,
                             queue root used if nothing is passed.
@@ -172,8 +169,7 @@ class Queue(ComponentBase):
         )
 
     def queue_to_json(self, node=None, include_lims_data=False):
-        """
-        Returns the json representation of the queue
+        """Return the json representation of the queue.
 
         :param TaskNode node: list of Node objects to get representation for,
                             queue root used if nothing is passed.
@@ -208,8 +204,7 @@ class Queue(ComponentBase):
         return json.dumps(res, sort_keys=True, indent=4)
 
     def get_node_state(self, node_id):
-        """
-        Get the state of the given node.
+        """Get the state of the given node.
 
         :param TaskNode node: Node to get state for
 
@@ -239,8 +234,7 @@ class Queue(ComponentBase):
         return (enabled, state)
 
     def get_queue_state(self):
-        """
-        Return the dictionary representation of the current queue and its state
+        """Return the dictionary representation of the current queue and its state.
 
         :returns: dictionary on the form:
                 {
@@ -630,9 +624,7 @@ class Queue(ComponentBase):
         return {node.loc_str: sample}
 
     def queue_to_dict_rec(self, node, include_lims_data=False):
-        """
-        Parses node recursively and builds a representation of the queue based on
-        python dictionaries.
+        """Parse node recursively and builds a representation of the queue based on python dictionaries.
 
         :param TaskNode node: The node to parse
         :returns: A list on the form:
@@ -691,10 +683,10 @@ class Queue(ComponentBase):
         return result
 
     def queue_exec_state(self):
-        """
-        :returns: The queue execution state, one of QUEUE_STOPPED, QUEUE_PAUSED
-                or QUEUE_RUNNING
+        """Queue execution state.
 
+        :returns: The queue execution state, one of QUEUE_STOPPED, QUEUE_PAUSED
+        or QUEUE_RUNNING
         """
         state = QUEUE_STOPPED
 
@@ -706,8 +698,7 @@ class Queue(ComponentBase):
         return state
 
     def get_entry(self, _id):
-        """
-        Retrieves the model and the queue entry for the model node with id <id>
+        """Retrieve the model and the queue entry for the model node with id <id>.
 
         :param int _id: Node id of node to retrieve
         :returns: The tuple model, entry or the root node and QueueManger if _id is None
@@ -726,9 +717,7 @@ class Queue(ComponentBase):
         entry.set_enabled(enabled)
 
     def delete_entry(self, entry):
-        """
-        Helper function that deletes an entry and its model from the queue
-        """
+        """Helper function that deletes an entry and its model from the queue."""
         parent_entry = entry.get_container()
         parent_entry.dequeue(entry)
         model = entry.get_data_model()
@@ -757,10 +746,10 @@ class Queue(ComponentBase):
             self.delete_entry(entry)
 
     def enable_entry(self, id_or_qentry, flag):
-        """
-        Helper function that sets the enabled flag to <flag> for the entry
-        and associated model. Takes either the model node id or the QueueEntry
-        object.
+        """Helper function that sets the enabled flag for the entry and its model.
+
+        Helper function that sets the enabled flag to <flag> for the entry and associated model.
+        Takes either the model node id or the QueueEntry object.
 
         Sets enabled flag on both the entry and model.
 
@@ -776,9 +765,10 @@ class Queue(ComponentBase):
             model.set_enabled(flag)
 
     def swap_task_entry(self, sid, ti1, ti2):
-        """
+        """Swap order of two queue entries in the queue, with the same sample as parent.
+
         Swaps order of two queue entries in the queue, with the same sample <sid>
-        as parent
+        as parent.
 
         :param str sid: Sample id
         :param int ti1: Position of task1 (old position)
@@ -802,8 +792,9 @@ class Queue(ComponentBase):
         logging.getLogger("MX3.HWR").info("[QUEUE] is:\n%s " % self.queue_to_json())
 
     def queue_add_item(self, item_list):
-        """
-        Adds the queue items in item_list to the queue. The items in the list can
+        """Add queue items to the queue.
+
+        Add the queue items in item_list to the queue. The items in the list can
         be either samples and or tasks. Samples are only added if they are not
         already in the queue  and tasks are appended to the end of an
         (already existing) sample. A task is ignored if the sample is not already
@@ -853,7 +844,8 @@ class Queue(ComponentBase):
         return self.queue_to_dict()
 
     def _queue_add_item_rec(self, item_list, sample_node_id=None):
-        """
+        """Add the queue items in item_list to the queue.
+
         Adds the queue items in item_list to the queue. The items in the list can
         be either samples and or tasks. Samples are only added if they are not
         already in the queue  and tasks are appended to the end of an
@@ -911,8 +903,7 @@ class Queue(ComponentBase):
                 self.add_queue_entry(sample_node_id, item, item_t)
 
     def add_sample(self, sample_id, item):
-        """
-        Adds a sample with sample id <sample_id> the queue.
+        """Add a sample with sample id <sample_id> the queue.
 
         :param str sample_id: Sample id (often sample changer location)
         :returns: SampleQueueEntry
@@ -965,8 +956,7 @@ class Queue(ComponentBase):
         return tag
 
     def set_dc_params(self, model, entry, task_data, sample_model):
-        """
-        Helper method that sets the data collection parameters for a DataCollection.
+        """Helper method that sets the data collection parameters for a DataCollection.
 
         :param DataCollectionQueueModel: The model to set parameters of
         :param DataCollectionQueueEntry: The queue entry of the model
@@ -1095,8 +1085,7 @@ class Queue(ComponentBase):
         entry.set_enabled(task_data["checked"])
 
     def set_gphl_wf_params(self, model, entry, task_data, sample_model):
-        """
-        Helper method that sets the parameters for a GPhL workflow task.
+        """Helper method that sets the parameters for a GPhL workflow task.
 
         :param queue_model_objectsGphlWorkflow: The model to set parameters of
         :param GphlWorkflowQueueEntry: The queue entry of the model
@@ -1120,8 +1109,7 @@ class Queue(ComponentBase):
         entry.set_enabled(task_data["checked"])
 
     def set_wf_params(self, model, entry, task_data, sample_model):
-        """
-        Helper method that sets the parameters for a workflow task.
+        """Helper method that sets the parameters for a workflow task.
 
         :param WorkflowQueueModel: The model to set parameters of
         :param GenericWorkflowQueueEntry: The queue entry of the model
@@ -1185,9 +1173,9 @@ class Queue(ComponentBase):
         entry.set_enabled(task_data["checked"])
 
     def set_char_params(self, model, entry, task_data, sample_model):
-        """
-        Helper method that sets the characterisation parameters for a
-        Characterisation.
+        """Helper method that sets the characterisation parameters.
+
+        Helper method that sets the characterisation parameters for a Characterisation.
 
         :param CharacterisationQueueModel: The mode to set parameters of
         :param CharacterisationQueueEntry: The queue entry of the model
@@ -1220,8 +1208,7 @@ class Queue(ComponentBase):
         entry.set_enabled(task_data["checked"])
 
     def set_xrf_params(self, model, entry, task_data, sample_model):
-        """
-        Helper method that sets the xrf scan parameters for a XRF spectrum Scan.
+        """Helper method that sets the xrf scan parameters for a XRF spectrum Scan.
 
         :param XRFSpectrum QueueModel: The model to set parameters of
         :param XrfSpectrumQueueEntry: The queue entry of the model
@@ -1263,8 +1250,7 @@ class Queue(ComponentBase):
         entry.set_enabled(task_data["checked"])
 
     def set_energy_scan_params(self, model, entry, task_data, sample_model):
-        """
-        Helper method that sets the xrf scan parameters for a XRF spectrum Scan.
+        """Helper method that sets the xrf scan parameters for a XRF spectrum Scan.
 
         :param EnergyScan QueueModel: The model to set parameters of
         :param EnergyScanQueueEntry: The queue entry of the model
@@ -1307,7 +1293,8 @@ class Queue(ComponentBase):
         entry.set_enabled(task_data["checked"])
 
     def _create_dc(self):
-        """
+        """Create a data collection model and its corresponding queue entry.
+
         Creates a data collection model and its corresponding queue entry from
         a dict with collection parameters.
 
@@ -1326,8 +1313,10 @@ class Queue(ComponentBase):
 
         return dc_model, dc_entry
 
-    def _create_queue_entry(self, task, task_name):
-        """Creates a queue entry and its corresponding data model
+    def _create_queue_entry(  # noqa: D417
+        self, task, task_name
+    ):
+        """Create a queue entry and its corresponding data model.
 
         Args:
             task (dict): Collection parameters
@@ -1356,8 +1345,7 @@ class Queue(ComponentBase):
         return model, entry
 
     def _create_wf(self):
-        """
-        Creates a workflow model.
+        """Create a workflow model.
 
         :returns: The tuple (model, entry)
         :rtype: Tuple
@@ -1369,8 +1357,7 @@ class Queue(ComponentBase):
         return dc_model, dc_entry
 
     def _create_gphl_wf(self):
-        """
-        Creates a gphl workflow model.
+        """Create a gphl workflow model.
 
         :returns: The tuple (model, entry)
         :rtype: Tuple
@@ -1386,8 +1373,7 @@ class Queue(ComponentBase):
         return dc_model, dc_entry
 
     def _create_xrf(self, sample_model):
-        """
-        Creates a XRFSpectrum model.
+        """Create a XRFSpectrum model.
 
         :param dict task: Collection parameters
         :returns: The tuple (model, entry)
@@ -1400,8 +1386,9 @@ class Queue(ComponentBase):
         return xrf_model, xrf_entry
 
     def _create_energy_scan(self, sample_model):
-        """
-        Creates a energy scan model and its corresponding queue entry from
+        """Create an energy scan model and its corresponding queue entry.
+
+        Create an energy scan model and its corresponding queue entry from
         a dict with collection parameters.
 
         :param dict task: Collection parameters
@@ -1415,8 +1402,7 @@ class Queue(ComponentBase):
         return escan_model, escan_entry
 
     def add_characterisation(self, node_id, task):
-        """
-        Adds a data characterisation task to the sample with id: <id>
+        """Add a data characterisation task to the sample with id: <id>.
 
         :param int id: id of the sample to which the task belongs
         :param dict task: Task data (parameters)
@@ -1464,8 +1450,7 @@ class Queue(ComponentBase):
         return char_model._node_id
 
     def add_data_collection(self, node_id, task):
-        """
-        Adds a data collection task to the sample with id: <id>
+        """Add a data collection task to the sample with id: <id>.
 
         :param int id: id of the sample to which the task belongs
         :param dict task: task data
@@ -1491,7 +1476,7 @@ class Queue(ComponentBase):
         return dc_model._node_id
 
     def add_queue_entry(self, node_id, task, task_name):
-        """Adds a queue entry to the sample with id <node_id>
+        """Add a queue entry to the sample with id <node_id>.
 
         Args:
             node_id (int): id of the sample to which the task belongs
@@ -1560,8 +1545,7 @@ class Queue(ComponentBase):
         return model._node_id
 
     def add_workflow(self, node_id, task):
-        """
-        Adds a worklfow task to the parent node with id: <id>
+        """Add a worklfow task to the parent node with id: <id>.
 
         For adding GPhL Auto workflow, call with node_id==parent_node_id
         and all required parameters in task["parameters"]
@@ -1602,8 +1586,7 @@ class Queue(ComponentBase):
         return wf_model._node_id
 
     def add_interleaved(self, node_id, task):
-        """
-        Adds a interleaved data collection task to the sample with id: <id>
+        """Add a interleaved data collection task to the sample with id: <id>.
 
         :param int node_id: id of the sample to which the task belongs
         :param dict task: task data
@@ -1642,8 +1625,7 @@ class Queue(ComponentBase):
         return group_model._node_id
 
     def add_xrf_scan(self, node_id, task):
-        """
-        Adds a XRF Scan task to the sample with id: <id>
+        """Add a XRF Scan task to the sample with id: <id>.
 
         :param int id: id of the sample to which the task belongs
         :param dict task: task data
@@ -1669,8 +1651,7 @@ class Queue(ComponentBase):
         return xrf_model._node_id
 
     def add_energy_scan(self, node_id, task):
-        """
-        Adds a energy scan task to the sample with id: <id>
+        """Add a energy scan task to the sample with id: <id>.
 
         :param int id: id of the sample to which the task belongs
         :param dict task: task data
@@ -1696,8 +1677,8 @@ class Queue(ComponentBase):
         return escan_model._node_id
 
     def clear_queue(self):
-        """
-        Creates a new queue
+        """Create a new queue.
+
         :returns: MxCuBE QueueModel Object
         """
         from mxcubecore import HardwareRepository as HWR
@@ -1711,8 +1692,8 @@ class Queue(ComponentBase):
         HWR.beamline.queue_model.select_model("ispyb")
 
     def queue_model_child_added(self, parent, child):
-        """
-        Listen to the addition of elements to the queue model ('child_added').
+        """Listen to the addition of elements to the queue model ('child_added').
+
         Add the corresponding entries to the queue if they are not already
         added. Handles for instance the addition of reference collections for
         characterisations and workflows.
@@ -1800,7 +1781,8 @@ class Queue(ComponentBase):
         self.app.server.emit("add_diff_plan", {"tasks": cols}, namespace="/hwr")
 
     def set_auto_add_diffplan(self, autoadd):
-        """
+        """Set auto add diffraction plan flag.
+
         Sets auto add diffraction plan flag, automatically add to the queue
         (True) or wait for user (False)
 
@@ -1822,8 +1804,7 @@ class Queue(ComponentBase):
                     entry.auto_add_diff_plan = autoadd
 
     def execute_entry_with_id(self, sid, tindex=None):
-        """
-        Execute the entry at position (sampleID, task index) in queue
+        """Execute the entry at position (sampleID, task index) in queue.
 
         :param str sid: sampleID
         :param int tindex: task index of task within sample with id sampleID
@@ -1872,9 +1853,7 @@ class Queue(ComponentBase):
                 HWR.beamline.queue_manager.emit("queue_execution_failed", (None,))
 
     def init_signals(self, queue):
-        """
-        Initialize queue hwobj related signals.
-        """
+        """Initialize queue hwobj related signals."""
         from mxcubeweb.routes import signals
 
         HWR.beamline.collect.connect(
@@ -1976,7 +1955,8 @@ class Queue(ComponentBase):
             self.enable_entry(sample_data["queueID"], flag)
 
     def set_auto_mount_sample(self, automount):
-        """
+        """Set auto mount next flag.
+
         Sets auto mount next flag, automatically mount next sample in queue
         (True) or wait for user (False)
 
@@ -1985,7 +1965,8 @@ class Queue(ComponentBase):
         self.app.AUTO_MOUNT_SAMPLE = automount
 
     def get_auto_mount_sample(self):
-        """
+        """Get auto-mount sample.
+
         :returns: Returns auto mount flag
         :rtype: bool
         """
@@ -2043,8 +2024,7 @@ class Queue(ComponentBase):
         )
 
     def queue_start(self, sid):
-        """
-        Start execution of the queue.
+        """Start execution of the queue.
 
         :returns: Respons object, status code set to:
                 200: On success
@@ -2075,9 +2055,7 @@ class Queue(ComponentBase):
         HWR.beamline.queue_manager.stop()
 
     def queue_pause(self):
-        """
-        Pause the execution of the queue
-        """
+        """Pause the execution of the queue."""
         HWR.beamline.queue_manager.pause(True)
 
         msg = {
@@ -2091,8 +2069,7 @@ class Queue(ComponentBase):
         return msg
 
     def queue_unpause(self):
-        """
-        Unpause execution of the queue
+        """Unpause execution of the queue.
 
         :returns: Response object, status code set to:
                 200: On success
@@ -2320,10 +2297,10 @@ class Queue(ComponentBase):
         root_path = HWR.beamline.session.get_base_image_directory()
         return {"path": path, "rootPath": root_path}
 
-    def set_setting(self, name_value: SimpleNameValue) -> tuple:
-        """
-        Sets the setting (on the MXCUBEApplication object)
-        with name to value
+    def set_setting(  # noqa: D417
+        self, name_value: SimpleNameValue
+    ) -> tuple:
+        """Set the setting (on the MXCUBEApplication object) with name to value.
 
         Args:
            name: The name of the setting
@@ -2344,7 +2321,8 @@ class Queue(ComponentBase):
         return result
 
     def set_num_snapshots(self, num_snapshots: int):
-        """Sets the number of snapshots to take during data collection
+        """Set the number of snapshots to take during data collection.
+
         Args:
             num_snapshots (int): number of snapshots to be taken
         """

--- a/mxcubeweb/core/components/sampleview.py
+++ b/mxcubeweb/core/components/sampleview.py
@@ -98,11 +98,10 @@ class SampleView(ComponentBase):
         self._emit_shapes_updated()
 
     def wait_for_centring_finishes(self, *args, **kwargs):
-        """
-        Executed when a centring is finished. It updates the temporary
-        centred point.
-        """
+        """Executed when a centring is finished.
 
+        It updates the temporary centred point.
+        """
         try:
             centring_status = args[1]
         except IndexError:
@@ -130,9 +129,9 @@ class SampleView(ComponentBase):
                 HWR.beamline.diffractometer.accept_centring()
 
     def init_signals(self):
-        """
-        Connect all the relevant hwobj signals with the corresponding
-        callback method.
+        """Connect relevant hardware object signals to callbacks.
+
+        Connect all the relevant hwobj signals with the corresponding callback method.
         """
         from mxcubeweb.routes import signals
 
@@ -276,10 +275,10 @@ class SampleView(ComponentBase):
                     raise
 
     def start_auto_centring(self):
-        """
-        Start automatic (lucid) centring procedure.
-            :statuscode: 200: no error
-            :statuscode: 409: error
+        """Start automatic (lucid) centring procedure.
+
+        :statuscode: 200: no error
+        :statuscode: 409: error
         """
         if not HWR.beamline.diffractometer.current_centring_procedure:
             msg = "Starting automatic centring"
@@ -293,10 +292,10 @@ class SampleView(ComponentBase):
             logging.getLogger("user_level_log").info(msg)
 
     def start_manual_centring(self):
-        """
-        Start Click centring procedure.
-            :statuscode: 200: no error
-            :statuscode: 409: error
+        """Start Click centring procedure.
+
+        :statuscode: 200: no error
+        :statuscode: 409: error
         """
         if HWR.beamline.diffractometer.is_ready():
             if HWR.beamline.diffractometer.current_centring_procedure:
@@ -370,7 +369,8 @@ class SampleView(ComponentBase):
         logging.getLogger("user_level_log").info(msg)
 
     def get_viewport_info(self):
-        """
+        """Get information about current "view port".
+
         Get information about current "view port" video dimension, beam position,
         pixels per mm, returns a dictionary with the format:
 

--- a/mxcubeweb/core/components/user/database.py
+++ b/mxcubeweb/core/components/user/database.py
@@ -23,10 +23,12 @@ def init_db(path):
 
 
 class UserDatastore(SQLAlchemySessionUserDatastore):
-    """A UserDatastore implementation that assumes the
-    use of
+    """User datastore for Flask-SQLAlchemy datastore transactions.
+
+    A UserDatastore implementation that assumes the use of
     `Flask-SQLAlchemy <https://pypi.python.org/pypi/flask-sqlalchemy/>`_
     for datastore transactions.
+
     :param db:
     :param user_model: See :ref:`Models <models_topic>`.
     :param role_model: See :ref:`Models <models_topic>`.

--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -22,7 +22,7 @@ HTTP_REQUESTS_TIMEOUT = 10  # Generic timeout for HTTP requests in seconds
 
 
 class BaseUserManager(ComponentBase):
-    """Base class for managing user-related operations
+    """Base class for managing user-related operations.
 
     Operation it manages are: authentication, session management, and Single Sign-On
     (SSO) integration. It provides methods to handle user login, logout, session

--- a/mxcubeweb/core/models/configmodels.py
+++ b/mxcubeweb/core/models/configmodels.py
@@ -138,9 +138,7 @@ class UISampleListViewModesModel(BaseModel):
     def check_at_least_one_component_shown(
         cls, components: list[_UISampleListViewModesComponentModel]
     ) -> list[_UISampleListViewModesComponentModel]:
-        """
-        Validates that at least one component in the list has 'show' set to True.
-        """
+        """Validate that at least one component in the list has 'show' set to True."""
         if not any(component.show for component in components):
             msg = "At least one component must have 'show' set to True."
             raise ValueError(msg)
@@ -248,7 +246,8 @@ class AppConfigModel(BaseModel):
 
 
 class ResourceHandlerConfigModel(BaseModel):
-    """
+    """Configuration modle for resource handler.
+
     Used to define  which adapter properties and methods that are
     exported over HTTP. An endpoint for each method and/or property
     is created by the AdapterResourceHandler and attached to the server.
@@ -257,10 +256,11 @@ class ResourceHandlerConfigModel(BaseModel):
     the HTTP verb to use and the decorators to apply to the view
     function,
 
-    The format is:
-    [
-        {"attr": "get_value", "method": "PUT", "decorators":[]}
-    ]
+    The format is::
+
+        [
+            {"attr": "get_value", "method": "PUT", "decorators": []},
+        ]
 
     Where "attr" is the method or property of the adapter, "method"
     is the http verb i.e GET, PUT, POST. and decoratoes are a list
@@ -271,14 +271,14 @@ class ResourceHandlerConfigModel(BaseModel):
     commands and attributes.
 
     Commands is list of functions/methods to export.
-    A dictionary like the one above:
+    A dictionary like the one above::
 
-        ({"attr": "get_value", "method": "PUT", "decorators":[]})
+        ({"attr": "get_value", "method": "PUT", "decorators": []})
 
     Will be generated from the commands list. With the values "method" and
     decorators set to defualt values, PUT and [restrict, require_control]
 
-    Example:
+    Example::
 
         commands = ["set_value", "get_value"]
 
@@ -286,7 +286,7 @@ class ResourceHandlerConfigModel(BaseModel):
 
     In the same way:
 
-    Example:
+    Example::
 
         attributes = ["data"]
 

--- a/mxcubeweb/core/server/csp.py
+++ b/mxcubeweb/core/server/csp.py
@@ -1,7 +1,5 @@
 class CSPMiddleware:
-    """
-    Middleware to add Content Security Policy headers to responses.
-    """
+    """Middleware to add Content Security Policy headers to responses."""
 
     def __init__(self, app, config):
         self.app = app

--- a/mxcubeweb/core/server/limiter.py
+++ b/mxcubeweb/core/server/limiter.py
@@ -6,7 +6,7 @@ from flask_limiter.util import get_remote_address
 
 
 def rate_limit_error_handler(_):
-    """Handler for rate limit errors"""
+    """Handler for rate limit errors."""
     logging.warning("Rate limit exceeded")
     return jsonify(
         {
@@ -17,7 +17,7 @@ def rate_limit_error_handler(_):
 
 
 def init_limiter(app):
-    """Initialize the rate limiter"""
+    """Initialize the rate limiter."""
     limiter = Limiter(
         app=app,
         key_func=get_remote_address,

--- a/mxcubeweb/core/server/openapidoc.py
+++ b/mxcubeweb/core/server/openapidoc.py
@@ -14,8 +14,7 @@ DEFAULT_RESPONSES = {
 
 
 def to_openapi_path(route: str) -> str:
-    """
-    Adds the "{" "}" to the route arguments that OpenAPI requires
+    """Add the "{" "}" to the route arguments that OpenAPI requires.
 
     Args:
         route(str): The route
@@ -87,7 +86,6 @@ class OpenAPISpec:
         self, prefix: str, route: str, http_method: str, model: type[BaseModel]
     ):
         """Adds Pydantic model definitions to OpenAPI schema."""
-
         open_api_path = to_openapi_path(prefix + route)
         schema_name = model.__name__
 
@@ -112,7 +110,6 @@ class OpenAPISpec:
         self, prefix: str, route: str, http_method: str, model: type[BaseModel]
     ):
         """Adds response schema to OpenAPI documentation."""
-
         open_api_path = to_openapi_path(prefix + route)
         schema_name = model.__name__ if isinstance(model, BaseModel) else None
 

--- a/mxcubeweb/core/server/resource_handler.py
+++ b/mxcubeweb/core/server/resource_handler.py
@@ -27,9 +27,7 @@ def valid_object_id(object_id: str) -> bool:
 
 
 def validate_input_str(input_string: str) -> bool:
-    """
-    Validates that the input string contains only alphanumeric characters
-    and/or dot (.).
+    """Validate that input string contains only alphanumeric characters and/or dot (.).
 
     Args:
         input_string (str): The string to validate.
@@ -42,8 +40,10 @@ def validate_input_str(input_string: str) -> bool:
 
 
 def assert_valid_type_arguments(func):
-    """Make sure that all the arguments of func are typehinted as pydantic model,
-    float, int, str or bool
+    """Make sure that all the arguments of the function are typehinted correctly.
+
+    Make sure that all the arguments of the function are typehinted as
+    pydantic model, float, int, str or bool
     """
     annotations = func.__annotations__
 
@@ -77,8 +77,10 @@ class ResourceHandlerFactory:
         attributes: list[str],
         handler_type="adapter",
     ) -> object:
-        """
-        Return existing handler if it exists, otherwise create and register a new one.
+        """Return or create handler.
+
+        Returns:
+            Existing handler if it exists, otherwise create and register a new one.
         """
         if name in cls._handlers:
             return cls._handlers[name]
@@ -133,8 +135,7 @@ class ResourceHandler:
         commands: list[str],
         attributes: list[str],
     ) -> None:
-        """
-        Initialize the AdapterResourceHandler.
+        """Initialize the AdapterResourceHandler.
 
         Args:
             name: Name of the blueprint.
@@ -169,9 +170,7 @@ class ResourceHandler:
         return [export for export in self._exports if export["method"] == "GET"]
 
     def _create_routes_for_exports(self) -> None:
-        """
-        Creates Flask routes dynamically for each exported command or attribute.
-        """
+        """Create Flask routes dynamically for each exported command or attribute."""
         for export in self._exports:
             route = self._get_handler_object_route(export)
             # For the time being we enforce the usage of pydantic models, int, float or
@@ -204,8 +203,7 @@ class ResourceHandler:
     def _apply_decorators(
         self, view_func: Callable, decorators: list[Callable]
     ) -> Callable:
-        """
-        Applies a list of decorators to a view function.
+        """Applies a list of decorators to a view function.
 
         Args:
             view_func (Callable): The view function.
@@ -217,8 +215,7 @@ class ResourceHandler:
         return reduce(lambda f, decorator: decorator(f), decorators, view_func)
 
     def _create_view_func(self, export: dict[str, str]) -> Callable:
-        """
-        Creates a Flask view function for handling requests dynamically.
+        """Creates a Flask view function for handling requests dynamically.
 
         Args:
             route (str): URL route.
@@ -233,15 +230,15 @@ class ResourceHandler:
         export: dict[str, str],
         handler_obj: object,
     ) -> dict | Response:
-        """
-        Validates parameters from the request and calls the handler function.
+        """Validates parameters from the request and calls the handler function.
+
         Args:
             export: Export definition with method, attr, and decorators.
             handler_obj: The handler object to call.
+
         Returns:
             The result of the handler function call or an error response.
         """
-
         # Get the method and its annotations
         handler_func = getattr(handler_obj, export["attr"])
         annotations = handler_func.__annotations__
@@ -281,16 +278,12 @@ class ResourceHandler:
             return self._handle_view_result(result)
 
     def _assert_valid_type_arguments(self, export):
-        """
-        Ensures the method referenced in the export uses Pydantic arguments.
-        """
+        """Ensure the method referenced in the export uses Pydantic arguments."""
         obj = next(iter(self._handler_dict.values()))
         assert_valid_type_arguments(getattr(obj, export["attr"]))
 
     def _create_openapi_doc_for_view(self, route, export):
-        """
-        Adds OpenAPI documentation for a route.
-        """
+        """Add OpenAPI documentation for a route."""
         # Get the first adapter object, the signature are all the same (same class) so
         # any will do for documentation purpose
         http_method = export["method"]
@@ -318,8 +311,7 @@ class ResourceHandler:
                 )
 
     def _extract_param_data(self, http_method) -> dict:
-        """
-        Extracts parameter data from request (JSON, query params, or form).
+        """Extract parameter data from request (JSON, query params, or form).
 
         Returns:
             Extracted data
@@ -334,8 +326,7 @@ class ResourceHandler:
     def _validate_param_data(
         self, param_name: str, param_type: type, param_data: any
     ) -> dict | int | float | bool | str:
-        """
-        Validates a single parameter based on its expected type.
+        """Validate a single parameter based on its expected type.
 
         Raises:
             ValueError: If validation fails or type is unsupported.
@@ -382,9 +373,10 @@ class ResourceHandler:
         raise TypeError(msg)
 
     def _handle_view_result(self, result: object) -> dict | Response:
-        """
-        Handles the result of a view function, ensuring that it is serializable and
-        properly formatted.
+        """Handle the result of a view function.
+
+        Handle the result of a view function,
+        ensuring that it is serializable and properly formatted.
 
         Returns:
             Flask Response: JSON response.
@@ -435,8 +427,7 @@ class ResourceHandler:
             )
 
     def _add_exports(self, items: list[str], http_method: str) -> None:
-        """
-        Add export definitions to the EXPORTS list.
+        """Add export definitions to the EXPORTS list.
 
         Args:
             items: The list of commands or properties to add
@@ -461,7 +452,8 @@ class ResourceHandler:
             self._exports.append(export)
 
     def is_unique_export(self, new_export):
-        """
+        """Check if an export is unique.
+
         Check if an export with the same 'attr' and 'method' already exists in the
         EXPORTS list.
 
@@ -488,11 +480,10 @@ class ResourceHandler:
         self._add_exports(attribute_list, "GET")
 
     def register_blueprint(self, parent_bp) -> None:
-        """
-        Registers the blueprint on the Flask server (server.flask). This allows the
-        routes defined in the blueprint to be accessible on the server.
-        """
+        """Register the blueprint on the Flask server (server.flask).
 
+        This allows the routes defined in the blueprint to be accessible on the server.
+        """
         self._create_routes_for_exports()
         parent_bp.register_blueprint(self._bp)
 
@@ -507,7 +498,8 @@ class ResourceHandler:
 
 
 class ComponentResourceHandler(ResourceHandler):
-    """
+    """Flask resource handler that dynamically creates routes for hardware objects.
+
     AdapterResourceHandler is a Flask resource handler that dynamically creates routes
     for hardware objects based on their attributes and methods.
     It supports GET and PUT requests for attributes and commands respectively.
@@ -528,14 +520,11 @@ class ComponentResourceHandler(ResourceHandler):
         )
 
     def _get_handler_object_route(self, export) -> str:
-        """
-        Returns the base route for the resource handler.
-        """
+        """Return the base route for the resource handler."""
         return f"{export['url']}"
 
     def _create_view_func(self, export: dict[str, str]) -> Callable:
-        """
-        Creates a Flask view function for handling requests dynamically.
+        """Create a Flask view function for handling requests dynamically.
 
         Args:
             route (str): URL route.
@@ -571,7 +560,8 @@ class ComponentResourceHandler(ResourceHandler):
 
 
 class AdapterResourceHandler(ResourceHandler):
-    """
+    """Flask resource handler that dynamically creates routes for hardware objects.
+
     AdapterResourceHandler is a Flask resource handler that dynamically creates routes
     for hardware objects based on their attributes and methods.
     It supports GET and PUT requests for attributes and commands respectively.
@@ -592,16 +582,13 @@ class AdapterResourceHandler(ResourceHandler):
         )
 
     def _get_handler_object_route(self, export) -> str:
-        """
-        Returns the base route for the resource handler.
-        """
+        """Return the base route for the resource handler."""
         # Dynamic route for handler object with id object_id, i.e:
         # /<object_id>/set_value
         return f"/<string:object_id>/{export['attr']}"
 
     def _create_view_func(self, export: dict[str, str]) -> Callable:
-        """
-        Creates a Flask view function for handling requests dynamically.
+        """Create a Flask view function for handling requests dynamically.
 
         Args:
             route (str): URL route.

--- a/mxcubeweb/core/util/networkutils.py
+++ b/mxcubeweb/core/util/networkutils.py
@@ -47,8 +47,7 @@ def remote_addr():
 
 
 def is_local_network(ip: str, local_domains: list):
-    """
-    Determines whether a given IP address belongs to the local network.
+    """Determine whether a given IP address belongs to the local network.
 
     The function compares the first two octets of the given IP address with the
     local host's IP address. It also checks if the reverse-resolved hostname of
@@ -80,8 +79,7 @@ def is_local_network(ip: str, local_domains: list):
 
 
 def is_local_host(local_domains: list):
-    """
-    Determines whether the remote client making the request is a "local host".
+    """Determine whether the remote client making the request is a "local host".
 
     A client is considered a "local host" if it runs on the same host as the
     mxcube-server, or if it belongs to the local network. The local network can

--- a/mxcubeweb/routes/csp_report.py
+++ b/mxcubeweb/routes/csp_report.py
@@ -5,9 +5,10 @@ from flask import Blueprint, jsonify, request
 
 
 def init_route(_mxcube_app, _server, url_prefix):
-    """
-    Initialize CSP report routes
-    url_prefix: URL prefix for the blueprint
+    """Initialize CSP report routes.
+
+    Params:
+        url_prefix: URL prefix for the blueprint
     """
     bp = Blueprint("csp", __name__, url_prefix=url_prefix)
 
@@ -15,8 +16,7 @@ def init_route(_mxcube_app, _server, url_prefix):
 
     @bp.route("/report", methods=["POST"])
     def csp_report():
-        """Endpoint to collect CSP violation reports"""
-
+        """Endpoint to collect CSP violation reports."""
         report = json.loads(request.get_data())
 
         csp_logger.warning("CSP Violation: %s", report.get("csp-report", {}))

--- a/mxcubeweb/routes/login.py
+++ b/mxcubeweb/routes/login.py
@@ -19,8 +19,7 @@ def init_route(app, server, url_prefix):
 
     @bp.route("/", methods=["POST"])
     def login():
-        """
-        Login into mxcube application.
+        """Login into mxcube application.
 
         :returns: Response Object, Content-Type: application/json, an object
         containing following info:
@@ -77,28 +76,25 @@ def init_route(app, server, url_prefix):
     @bp.route("/signout")
     @server.restrict
     def signout():
-        """
-        Signout from MXCuBE Web and reset the session
-        """
+        """Signout from MXCuBE Web and reset the session."""
         app.usermanager.signout()
         return make_response(jsonify(""), 200)
 
     @bp.route("/login_info", methods=["GET"])
     def login_info():
-        """
-        Retrieve session/login info
+        """Retrieve session/login info.
 
         :returns: Response Object, Content-Type: application/json, an object
-                containing:
+                containing::
 
-        {'synchrotron_name': synchrotron_name,
-        'beamline_name': beamline_name,
-        'loginType': loginType,
-        'loggedIn': True,
-        'Proposal': proposal, 'session': todays_session,
-        'local_contact': local_contact,
-        'person': someone,
-        'laboratory': a_laboratory']}}
+            {'synchrotron_name': synchrotron_name,
+            'beamline_name': beamline_name,
+            'loginType': loginType,
+            'loggedIn': True,
+            'Proposal': proposal, 'session': todays_session,
+            'local_contact': local_contact,
+            'person': someone,
+            'laboratory': a_laboratory']}}
 
         Status code set to:
         200: On success

--- a/mxcubeweb/routes/queue.py
+++ b/mxcubeweb/routes/queue.py
@@ -19,8 +19,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.require_control
     @server.restrict
     def queue_start():
-        """
-        Start execution of the queue.
+        """Start execution of the queue.
 
         :returns: Respons object, status code set to:
                 200: On success
@@ -35,8 +34,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.require_control
     @server.restrict
     def queue_stop():
-        """
-        Stop execution of the queue.
+        """Stop execution of the queue.
 
         :returns: Response object status code set to:
                 200: On success
@@ -49,8 +47,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.require_control
     @server.restrict
     def queue_abort():
-        """
-        Abort execution of the queue.
+        """Abort execution of the queue.
 
         :returns: Response object, status code set to:
                 200 On success
@@ -63,8 +60,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.require_control
     @server.restrict
     def queue_pause():
-        """
-        Pause the execution of the queue
+        """Pause the execution of the queue.
 
         :returns: Response object, status code set to:
                 200: On success
@@ -78,8 +74,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.require_control
     @server.restrict
     def queue_unpause():
-        """
-        Unpause execution of the queue
+        """Unpause execution of the queue.
 
         :returns: Response object, status code set to:
                 200: On success
@@ -93,8 +88,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.require_control
     @server.restrict
     def queue_clear():
-        """
-        Clear the queue.
+        """Clear the queue.
 
         :returns: Response object, status code set to:
                 200: On success
@@ -106,8 +100,8 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @bp.route("/", methods=["GET"])
     @server.restrict
     def queue_get():
-        """
-        Get the queue
+        """Get the queue.
+
         :returns: Response object response Content-Type: application/json, json
                 object containing the queue on the format returned by
                 queue_to_dict. The status code is set to:
@@ -122,8 +116,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @bp.route("/queue_state", methods=["GET"])
     @server.restrict
     def queue_get_state():
-        """
-        Get the queue.
+        """Get the queue.
 
         :returns: Response object response Content-Type: application/json, json
                 object containing the queue state. The status code is set to:
@@ -139,8 +132,8 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.require_control
     @server.restrict
     def execute_entry_with_id(sid, tindex):
-        """
-        Execute the entry at position (sampleID, task index) in queue
+        """Execute the entry at position (sampleID, task index) in queue.
+
         :param str sid: sampleID
         :param int tindex: task index of task within sample with id sampleID
 
@@ -243,16 +236,16 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.require_control
     @server.restrict
     def update_sample(sample_id):
-        """
-        Update a sample info
-            :parameter node_id: entry identifier, integer. It can be a sample
-                or a task within a sample
-            :request Content-Type: application/json, object containing the
-                parameter(s) to be updated, any parameter not sent will
-                not be modified.
-            :statuscode: 200: no error
-            :statuscode: 409: sample info could not be updated, possibly because
-                the given sample does not exist in the queue
+        """Update a sample info.
+
+        :parameter node_id: entry identifier, integer. It can be a sample
+            or a task within a sample
+        :request Content-Type: application/json, object containing the
+            parameter(s) to be updated, any parameter not sent will
+            not be modified.
+        :statuscode: 200: no error
+        :statuscode: 409: sample info could not be updated, possibly because
+            the given sample does not exist in the queue
         """
         params = json.loads(request.data)
         node_id = int(sample_id)
@@ -268,9 +261,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @bp.route("/available_tasks", methods=["GET"])
     @server.restrict
     def get_avilable_tasks():
-        """
-        Returns a list of all available tasks
-        """
+        """Return a list of all available tasks."""
         resp = jsonify(app.queue.get_available_tasks())
 
         resp.status_code = 200
@@ -279,9 +270,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @bp.route("/update_dependent_field", methods=["POST"])
     @server.restrict
     def update_dependent_field():
-        """
-        Updates the dependent fields of the given task
-        """
+        """Update the dependent fields of the given task."""
         args = request.get_json()
         resp = jsonify(
             app.queue.update_dependent_field(args["task_name"], args["field_data"])

--- a/mxcubeweb/routes/ra.py
+++ b/mxcubeweb/routes/ra.py
@@ -19,8 +19,6 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @bp.route("/request_control", methods=["POST"])
     @server.restrict
     def request_control():
-        """ """
-
         @copy_current_request_context
         def handle_timeout_gives_control(sid, timeout=30):
             gevent.sleep(timeout)
@@ -56,7 +54,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @bp.route("/cancel_request", methods=["POST"])
     @server.restrict
     def cancel_request():
-        """Cancel request for control"""
+        """Cancel request for control."""
         current_user.requests_control = False
         current_user.requests_control_msg = None
         app.usermanager.update_user(current_user)
@@ -68,7 +66,6 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @bp.route("/take_control", methods=["POST"])
     @server.restrict
     def take_control():
-        """ """
         # Already master do nothing
         if app.usermanager.is_operator():
             return make_response("", 200)
@@ -80,7 +77,6 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @bp.route("/give_control", methods=["POST"])
     @server.restrict
     def give_control():
-        """ """
         username = request.get_json().get("username")
         toggle_operator(username, "You were given control")
 
@@ -89,7 +85,6 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @bp.route("/update_user_nickname", methods=["POST"])
     @server.restrict
     def update_user_nickname():
-        """ """
         name = request.get_json().get("name")
         current_user.nickname = name
         app.usermanager.update_user(current_user)
@@ -104,7 +99,6 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @bp.route("/logout_user", methods=["POST"])
     @server.restrict
     def logout_user():
-        """ """
         username = request.get_json().get("username")
         app.usermanager.force_signout_user(username)
         return make_response("", 200)
@@ -132,7 +126,6 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @bp.route("/", methods=["GET"])
     @server.restrict
     def rasettings():
-        """ """
         operator = app.usermanager.get_operator()
         data = {
             "observers": [_u.todict() for _u in app.usermanager.get_observers()],
@@ -146,7 +139,6 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @bp.route("/allow_remote", methods=["POST"])
     @server.restrict
     def allow_remote():
-        """ """
         allow = request.get_json().get("allow")
 
         if app.ALLOW_REMOTE and not allow:
@@ -159,7 +151,6 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @bp.route("/timeout_gives_control", methods=["POST"])
     @server.restrict
     def timeout_gives_control():
-        """ """
         control = request.get_json().get("timeoutGivesControl")
         app.TIMEOUT_GIVES_CONTROL = control
 
@@ -177,7 +168,6 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @bp.route("/request_control_response", methods=["POST"])
     @server.restrict
     def request_control_response():
-        """ """
         data = request.get_json()
         new_op = observer_requesting_control()
 

--- a/mxcubeweb/routes/samplecentring.py
+++ b/mxcubeweb/routes/samplecentring.py
@@ -19,11 +19,15 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @bp.route("/camera/snapshot", methods=["POST"])
     @server.restrict
     def snapshot():
-        """
-        Take snapshot of the sample view
-        data = {"overlay": overlay_data} overlay is the image data to overlay on sample image,
+        """Take snapshot of the sample view.
+
+        ``data = {"overlay": overlay_data}``
+        ``overlay`` is the image data to overlay on sample image,
         it should normally contain the data of shapes drawn on canvas.
-        Return: Overlayed image uri, if successful, statuscode 500 otherwise.
+
+        Returns:
+            Overlayed image URI, if successful.
+            Status code ``500`` otherwise.
         """
         try:
             overlay = json.loads(request.data).get("overlay")
@@ -55,14 +59,17 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @bp.route("/camera", methods=["GET"])
     @server.restrict
     def get_image_data():
-        """
-        Get size of the image of the diffractometer
-            :response Content-type:application/json, example:
-            {  "imageHeight": 576, "imageWidth": 768,
-            "pixelsPerMm": [1661.1295681063123, 1661.1295681063123]
+        """Get size of the image of the diffractometer.
+
+        :response Content-type:application/json, example::
+            {
+                "imageHeight": 576,
+                "imageWidth": 768,
+                "pixelsPerMm": [1661.1295681063123, 1661.1295681063123],
             }
-            :statuscode: 200: no error
-            :statuscode: 409: error
+
+        :statuscode: 200: no error
+        :statuscode: 409: error
         """
         data = app.sample_view.get_viewport_info()
 
@@ -73,7 +80,6 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @bp.route("/camera", methods=["POST"])
     @server.restrict
     def set_image_size():
-        """ """
         params = request.get_json()
 
         res = app.sample_view.set_image_size(
@@ -88,11 +94,11 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.require_control
     @server.restrict
     def move_to_centred_position(point_id):
-        """
-        Move to the given centred position.
-            :parameter id: centred position identifier, integer
-            :statuscode: 200: no error
-            :statuscode: 409: error
+        """Move to the given centred position.
+
+        :parameter id: centred position identifier, integer
+        :statuscode: 200: no error
+        :statuscode: 409: error
         """
         point = app.sample_view.move_to_centred_position(point_id)
 
@@ -103,11 +109,11 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @bp.route("/shapes", methods=["GET"])
     @server.restrict
     def get_shapes():
-        """
-        Retrieve all the stored centred positions.
-            :response Content-type: application/json, the stored centred positions.
-            :statuscode: 200: no error
-            :statuscode: 409: error
+        """Retrieve all the stored centred positions.
+
+        :response Content-type: application/json, the stored centred positions.
+        :statuscode: 200: no error
+        :statuscode: 409: error
         """
         shapes = app.sample_view.get_shapes()
 
@@ -119,12 +125,12 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.require_control
     @server.restrict
     def update_shapes():
-        """
-        Update shape information.
-            :parameter shape_data: dict with shape information (id, type, ...)
-            :response Content-type: application/json, the stored centred positions.
-            :statuscode: 200: no error
-            :statuscode: 409: error
+        """Update shape information.
+
+        :parameter shape_data: dict with shape information (id, type, ...)
+        :response Content-type: application/json, the stored centred positions.
+        :statuscode: 200: no error
+        :statuscode: 409: error
         """
         shapes = request.get_json().get("shapes", [])
 
@@ -137,11 +143,11 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.require_control
     @server.restrict
     def delete_shape(sid):
-        """
-        Retrieve all the stored centred positions.
-            :response Content-type: application/json, the stored centred positions.
-            :statuscode: 200: no error
-            :statuscode: 409: error
+        """Retrieve all the stored centred positions.
+
+        :response Content-type: application/json, the stored centred positions.
+        :statuscode: 200: no error
+        :statuscode: 409: error
         """
         HWR.beamline.sample_view.delete_shape(sid)
         return Response(status=200)
@@ -150,13 +156,12 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.require_control
     @server.restrict
     def rotate_to():
-        """
-        Rotate Phi to the position where the given shape was defined
+        """Rotate Phi to the position where the given shape was defined.
 
-            :parameter sid: The shape id
-            :response Content-type: application/json, the stored centred positions.
-            :statuscode: 200: no error
-            :statuscode: 409: error
+        :parameter sid: The shape id
+        :response Content-type: application/json, the stored centred positions.
+        :statuscode: 200: no error
+        :statuscode: 409: error
         """
         sid = request.get_json().get("sid", -1)
 
@@ -173,12 +178,11 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.require_control
     @server.restrict
     def centre_click():
-        """
-        Start Click centring procedure.
-            :statuscode: 200: no error
-            :statuscode: 409: error
-        """
+        """Start Click centring procedure.
 
+        :statuscode: 200: no error
+        :statuscode: 409: error
+        """
         try:
             data = app.sample_view.start_manual_centring()
         except Exception:
@@ -201,10 +205,10 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.require_control
     @server.restrict
     def abort_centring():
-        """
-        Abort centring procedure.
-            :statuscode: 200: no error
-            :statuscode: 409: error
+        """Abort centring procedure.
+
+        :statuscode: 200: no error
+        :statuscode: 409: error
         """
         app.sample_view.abort_centring()
         return Response(status=200)
@@ -213,9 +217,9 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.require_control
     @server.restrict
     def click():
-        """
-        The click method needs the input from the user, a running click centring
-        procedure must be set before
+        """The click method needs the input from the user.
+
+        A running click centring procedure must be set before.
 
         :request Content-type: application/json, integer positions of the clicks,
                             {clickPos={"x": 123,"y": 456}}
@@ -236,9 +240,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.require_control
     @server.restrict
     def accept_centring():
-        """
-        Accept the centring position.
-        """
+        """Accept the centring position."""
         HWR.beamline.diffractometer.accept_centring()
         return Response(status=200)
 
@@ -257,13 +259,10 @@ def init_route(app, server, url_prefix):  # noqa: C901
     @server.require_control
     @server.restrict
     def set_centring_method():
-        """
-        Set MXCuBE to use automatic (lucid) centring procedure when
-        mounting samples
+        """Set automatic (lucid) centring procedure when mounting samples.
 
         :statuscode: 200: no error
         :statuscode: 409: error
-
         """
         method = json.loads(request.data).get("centringMethod", None)
         app.sample_view.set_centring_method(method)

--- a/ruff.toml
+++ b/ruff.toml
@@ -2,13 +2,14 @@ target-version = "py310"
 
 
 [format]
+docstring-code-format = true
 
 
 [lint]
 ignore = [
     "ANN",  # flake8-annotations: ignored, too many hits (1322)
     "COM812",  # Ruff recommends to ignore this linter rule when using its formatter
-    "D",  # pydocstyle: ignored, too many hits (958)
+    "D1",  # Allow missing docstrings
     "PLR2004",  # magic-value-comparison: ignored, too many hits
 ]
 select = [

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,4 @@
-"""Helper functions for pytest"""
+"""Helper functions and fixtures for pytest."""
 
 from gevent import monkey
 
@@ -139,7 +139,10 @@ def client():
 
 @pytest.fixture
 def add_sample(client):
-    """Fixture to add a sample to the queue, since it is required for alot of test cases."""
+    """Fixture to add a sample to the queue.
+
+    A sample in the queue is required for a lot of test cases.
+    """
     resp = client.post(
         "/mxcube/api/v0.1/queue",
         data=json.dumps([test_sample_1]),
@@ -160,7 +163,10 @@ def add_sample(client):
 
 @pytest.fixture
 def add_task(client):
-    """Fixture to add a task to the sample in the queue queue, since it is required for alot of test cases."""
+    """Fixture to add a task to the sample in the queue.
+
+    A task on the sample in the queue is required for a lot of test cases.
+    """
     resp = client.get("/mxcube/api/v0.1/queue")
 
     assert resp.status_code == 200

--- a/test/test_authn.py
+++ b/test/test_authn.py
@@ -1,6 +1,3 @@
-#
-
-
 """Authentication tests."""
 
 import contextlib
@@ -117,7 +114,6 @@ def test_authn_same_proposal(make_client):
     If a user signs in for the same proposal as another user already signed in,
     this user should not be "in control".
     """
-
     client_0 = make_client()
     resp = client_0.post(URL_SIGNIN, json=CREDENTIALS_0)
 
@@ -153,12 +149,11 @@ def test_authn_same_proposal(make_client):
 
 
 def test_authn_session_timeout(client):
-    """Test the session timeout
+    """Test the session timeout.
 
     The session can be refreshed, and can expire.
     It should be possible to sign in again after a valid session expired.
     """
-
     # Sign in and --as a side effect-- create a session
     client.post(URL_SIGNIN, json=CREDENTIALS_0)
     resp = client.get(URL_INFO)

--- a/test/test_beamline_routes.py
+++ b/test/test_beamline_routes.py
@@ -2,7 +2,8 @@ import json
 
 
 def test_beamline_get_all_attribute(client):
-    """
+    """Test getting all beamline attributes.
+
     Checks that the data returned has the right structure and if "all"
     beamline attributes are at least present
     """
@@ -56,7 +57,8 @@ def test_beamline_get_all_attribute(client):
 
 
 def test_beamline_get_attribute(client):
-    """
+    """Test retrieval of all the beamline attributes (one by one).
+
     Tests retrieval of all the beamline attributes (one by one), checks that
     the data returned at-least contain a minimal set of keys that make up a
     'beamline attribute'
@@ -90,8 +92,7 @@ def test_beamline_get_attribute(client):
 
 
 def test_beamline_set_attribute(client):
-    """
-    Tests set on the writable attributes
+    """Test set on the writable attributes.
 
     Basically only tests that the set command executes without unexpected
     errors. Reads the attributes current value and sets it to the same, so
@@ -127,7 +128,8 @@ def test_beamline_set_attribute(client):
 
 
 def test_get_beam_info(client):
-    """
+    """Test retrieval of information regarding the beam.
+
     Tests retrieval of information regarding the beam, and that the data is
     returned on the expected format
     """

--- a/test/test_csp.py
+++ b/test/test_csp.py
@@ -9,10 +9,10 @@ from mxcubeweb.routes.csp_report import init_route
 
 
 class TestCSPMiddleware:
-    """Tests for the CSP middleware"""
+    """Tests for the CSP middleware."""
 
     def test_csp_middleware_enabled(self):
-        """Test that CSP middleware adds standard headers when enabled"""
+        """Test that CSP middleware adds standard headers when enabled."""
         config = {
             "CSP_ENABLED": True,
             "CSP_POLICY": {
@@ -47,7 +47,7 @@ class TestCSPMiddleware:
         assert "script-src 'self' 'unsafe-inline'" in csp_headers[0][1]
 
     def test_csp_middleware_report_only(self):
-        """Test that CSP middleware sets Report-Only mode when configured"""
+        """Test that CSP middleware sets Report-Only mode when configured."""
         config = {
             "CSP_ENABLED": True,
             "CSP_POLICY": {"default-src": ["'self'"]},
@@ -79,7 +79,7 @@ class TestCSPMiddleware:
         assert len(csp_headers) == 1
 
     def test_csp_middleware_report_uri(self):
-        """Test that CSP middleware adds report-uri when configured"""
+        """Test that CSP middleware adds report-uri when configured."""
         config = {
             "CSP_ENABLED": True,
             "CSP_POLICY": {"default-src": ["'self'"]},
@@ -110,7 +110,7 @@ class TestCSPMiddleware:
         assert "report-uri /mxcube/api/v0.1/csp/report" in csp_headers[0][1]
 
     def test_csp_middleware_disabled(self):
-        """Test that CSP middleware doesn't add any headers when disabled"""
+        """Test that CSP middleware doesn't add any headers when disabled."""
         config = {
             "CSP_ENABLED": False,
             "CSP_POLICY": {"default-src": ["'self'"]},
@@ -139,7 +139,7 @@ class TestCSPMiddleware:
         assert len(csp_headers) == 0
 
     def test_build_policy_string(self):
-        """Test that CSP policy string is correctly built from dictionary"""
+        """Test that CSP policy string is correctly built from dictionary."""
         config = {
             "CSP_ENABLED": True,
             "CSP_POLICY": {
@@ -175,11 +175,11 @@ class TestCSPMiddleware:
 
 
 class TestCSPReportEndpoint:
-    """Tests for the CSP report endpoint"""
+    """Tests for the CSP report endpoint."""
 
     @pytest.fixture
     def test_app(self):
-        """Create a test Flask app with the CSP report endpoint"""
+        """Create a test Flask app with the CSP report endpoint."""
         app = Flask(__name__)
         app.config["TESTING"] = True
 
@@ -193,7 +193,7 @@ class TestCSPReportEndpoint:
         return test_app.test_client()
 
     def test_csp_report_endpoint(self, client):
-        """Test that CSP violation reports are received and logged correctly"""
+        """Test that CSP violation reports are received and logged correctly."""
         test_report = {
             "csp-report": {
                 "document-uri": "http://localhost:8081/",
@@ -221,11 +221,11 @@ class TestCSPReportEndpoint:
 
 
 class TestCSPIntegration:
-    """Integration tests for CSP implementation"""
+    """Integration tests for CSP implementation."""
 
     @pytest.fixture
     def app_with_csp(self):
-        """Create a test Flask app with CSP middleware applied"""
+        """Create a test Flask app with CSP middleware applied."""
         app = Flask(__name__)
         app.config["TESTING"] = True
 
@@ -252,7 +252,7 @@ class TestCSPIntegration:
         return app_with_csp.test_client()
 
     def test_csp_headers_in_response(self, client):
-        """Test that CSP headers are correctly included in actual HTTP responses"""
+        """Test that CSP headers are correctly included in actual HTTP responses."""
         resp = client.get("/test")
 
         assert "Content-Security-Policy" in resp.headers

--- a/test/test_diffractometer_routes.py
+++ b/test/test_diffractometer_routes.py
@@ -6,7 +6,8 @@ from mxcubecore import HardwareRepository as HWR
 
 
 def test_set_phase(client):
-    """
+    """Check the "set phase" operation.
+
     Sets phase to a phase P (any phase in the phase list), checks if the
     actual phase after set_phase is P.
 
@@ -36,14 +37,14 @@ def test_set_phase(client):
 
 
 def test_set_aperture(client):
-    """
+    """Check the "set aperture" operation.
+
     Sets the aperture to an aperture AP belonging to the list of valid
     apertures and verifies that the aperture actually changed to AP.
 
     Moves the aperture back to its original value and verifies that the
     original value also is the current
     """
-
     resp = client.get(
         "/mxcube/api/v0.1/hwobj/beam/beam/get_value",
     )

--- a/test/test_queue_routes.py
+++ b/test/test_queue_routes.py
@@ -58,8 +58,8 @@ def test_add_and_edit_task(client):
 
 
 def test_queue_start(client):
-    """
-    Test if we can start the queue.
+    """Test if we can start the queue.
+
     The queue requires a sample and a task to start which are added by fixtures.
     It also requires a 3d point to be saved before it move from paused state to running.
     Unpause is called to mimick that.
@@ -87,7 +87,6 @@ def test_queue_start(client):
 
 def test_queue_stop(client):
     """Test if we can stop the queue. The queue is started and then stopped."""
-
     resp = client.put(
         "/mxcube/api/v0.1/queue/start",
         data=json.dumps({"sid": "1:05"}),
@@ -136,7 +135,10 @@ def test_queue_abort(client):
 
 
 def test_queue_clear(client):
-    """Test if we can clear the queue. A sample and a task are added by fixtures and then cleared."""
+    """Test if we can clear the queue.
+
+    A sample and a task are added by fixtures and then cleared.
+    """
     resp = client.put("/mxcube/api/v0.1/queue/clear")
     assert resp.status_code == 200
 
@@ -189,7 +191,10 @@ def test_queue_enable_item(client):
 
 
 def test_queue_swap_task_item(client):
-    """Test if we can swap tasks in a sample in queue. Two tasks are added with a different param and then swaped and tested"""
+    """Test if we can swap tasks in a sample in queue.
+
+    Two tasks are added with a different param and then swaped and tested.
+    """
     resp = client.get("/mxcube/api/v0.1/queue/")
     assert resp.status_code == 200
     assert len(json.loads(resp.data).get("1:05")["tasks"]) == 1
@@ -238,7 +243,6 @@ def assert_and_remove_keys_with_random_value(parameters):
 
 def test_get_default_dc_params(client):
     """Test if we get the right default data collection params."""
-
     resp = client.get("/mxcube/api/v0.1/queue/available_tasks")
     actual = json.loads(resp.data)["datacollection"]
 
@@ -265,7 +269,6 @@ def test_get_default_char_acq_params(client):
 
 def test_get_default_xrf_parameters(client):
     """Test if we get the right default xrf params."""
-
     resp = client.get("/mxcube/api/v0.1/queue/available_tasks")
     actual = json.loads(resp.data)["xrf_spectrum"]
 
@@ -279,7 +282,6 @@ def test_get_default_xrf_parameters(client):
 
 def test_get_default_mesh_params(client):
     """Test if we get the right default mesh params."""
-
     resp = client.get("/mxcube/api/v0.1/queue/available_tasks")
     actual = json.loads(resp.data)["mesh"]
 
@@ -293,7 +295,6 @@ def test_get_default_mesh_params(client):
 
 def test_set_automount(client):
     """Test if we can set automount for samples."""
-
     resp = client.post(
         "/mxcube/api/v0.1/queue/automount",
         data=json.dumps({"automount": True}),
@@ -305,7 +306,6 @@ def test_set_automount(client):
 
 def test_set_num_snapshots(client):
     """Test if we can set num of snapshots for acq."""
-
     resp = client.put(
         "/mxcube/api/v0.1/queue/num_snapshots",
         data=json.dumps({"numSnapshots": 2}),

--- a/test/test_rate_limiter.py
+++ b/test/test_rate_limiter.py
@@ -8,7 +8,7 @@ from mxcubeweb.core.server.limiter import init_limiter, rate_limit_error_handler
 
 @pytest.fixture
 def limiter_app():
-    """Create a fresh Flask app with limiter for testing"""
+    """Create a fresh Flask app with limiter for testing."""
     app = Flask("limiter_test")
     app.config["RATELIMIT_DEFAULT"] = "3 per minute"
     app.config["RATELIMIT_STORAGE_URI"] = "memory://"
@@ -24,7 +24,7 @@ def limiter_app():
 
 
 def test_rate_limiter_initialization():
-    """Test that the limiter initializes correctly with various configurations"""
+    """Test that the limiter initializes correctly with various configurations."""
     app = Flask("limiter_test")
 
     app.config["RATELIMIT_DEFAULT"] = "100 per day;10 per hour"
@@ -39,7 +39,7 @@ def test_rate_limiter_initialization():
 
 
 def test_rate_limit_error_handler(limiter_app):
-    """Test the rate limit error handler directly"""
+    """Test the rate limit error handler directly."""
     with limiter_app.app_context():
         response, status_code = rate_limit_error_handler(Exception())
         data = json.loads(response.data)
@@ -50,7 +50,7 @@ def test_rate_limit_error_handler(limiter_app):
 
 
 def test_rate_limiter_enforcement(limiter_app):
-    """Test that the rate limiter enforces limits"""
+    """Test that the rate limiter enforces limits."""
     client = limiter_app.test_client()
 
     for _ in range(3):

--- a/test/test_samplechanger_routes.py
+++ b/test/test_samplechanger_routes.py
@@ -2,9 +2,7 @@ import json
 
 
 def test_get_sample_list(client):
-    """
-    Checks retrieval of the samples list from lims
-    """
+    """Check retrieval of the samples list from lims."""
     resp = client.get("/mxcube/api/v0.1/lims/samples_list")
     data = json.loads(resp.data)
 
@@ -13,9 +11,7 @@ def test_get_sample_list(client):
 
 
 def test_get_loaded_sample(client):
-    """
-    Checks retrieval of the sample changer loaded sample
-    """
+    """Check retrieval of the sample changer loaded sample."""
     resp = client.get(
         "/mxcube/api/v0.1/hwobj/sample_changer/sample_changer/loaded_sample"
     )
@@ -26,9 +22,7 @@ def test_get_loaded_sample(client):
 
 
 def test_get_sc_contents_view(client):
-    """
-    Checks retrieval of the sample changer contents
-    """
+    """Check retrieval of the sample changer contents."""
     resp = client.get(
         "/mxcube/api/v0.1/hwobj/sample_changer/sample_changer/get_contents"
     )
@@ -38,9 +32,7 @@ def test_get_sc_contents_view(client):
 
 
 def test_get_initial_state(client):
-    """
-    Checks retrieval of the sample changer initial state
-    """
+    """Check retrieval of the sample changer initial state."""
     resp = client.get("/mxcube/api/v0.1/hwobj/sample_changer/sample_changer/get_value")
     data = json.loads(resp.data)
 


### PR DESCRIPTION
The intention of this commit is to improve the Python docstrings so that tools like Sphinx can generate a more useful output.

For this purpose, the Ruff `D` rules are enabled except `D1`, which means all the rules from the `pydocstyle` group except the rules about missing docstrings.

This does not attempt to unify type hints between docstrings and annotations. This does not attempt to add missing docstrings, or fix incomplete or incorrect docstrings.

Most of this was done automatically by Ruff with `ruff check --fix`. Then some manual editing was done to fix remaining issues:

* Some light rephrasing, in particular to extract a title line.
* Some formatting of code embedded in docstrings.
* Some typo fixes here and there.

Still, a lot of docstrings do not follow the Google style, although that is our chosen style according to our style guidelines.