### PR TITLE
Remove `/mxcubeweb-server` script

### DIFF
--- a/mxcubeweb-server
+++ b/mxcubeweb-server
@@ -1,6 +1,0 @@
-#!/usr/bin/env python
-
-from mxcubeweb import main
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
It likely conflicts with the console script entry point of the same name that is defined in the packaging metadata.

GitHub: fix https://github.com/mxcube/mxcubeweb/issues/1937