### PR TITLE
[SampleGridTableItem ] Refactor to function comp

### DIFF
--- a/ui/src/components/SampleGrid/SampleGridTableItem.jsx
+++ b/ui/src/components/SampleGrid/SampleGridTableItem.jsx
@@ -16,7 +16,7 @@ import styles from './SampleGridTableItem.module.css';
 
 export default function SampleGridTableItem({
   sampleData = {},
-  queueOrder = [],
+  queueOrder = '',
   current = false,
   picked = false,
   pickButtonOnClickHandler,
@@ -156,13 +156,10 @@ export default function SampleGridTableItem({
               <Badge
                 href={limsLink}
                 target="_blank"
+                rel="noopener noreferrer"
                 bg="light"
                 text="primary"
                 className={`${styles.samplesGridTableItemNameProteinAcronym} ms-1 mt-2`}
-                data-type="text"
-                data-pk="1"
-                data-url="/post"
-                data-title="Enter protein acronym"
               >
                 {sampleName}
               </Badge>

--- a/ui/src/components/SampleGrid/SampleGridTableItem.jsx
+++ b/ui/src/components/SampleGrid/SampleGridTableItem.jsx
@@ -1,6 +1,4 @@
-/* eslint-disable react/destructuring-assignment */
 import cx from 'classnames';
-import React from 'react';
 import {
   Badge,
   Button,
@@ -16,32 +14,19 @@ import containerStyles from '../../containers/SampleGridTableContainer.module.cs
 import TooltipTrigger from '../TooltipTrigger';
 import styles from './SampleGridTableItem.module.css';
 
-export class SampleGridTableItem extends React.Component {
-  static defaultProps = {
-    itemKey: '',
-    sampleData: {},
-    queueOrder: [],
-    selected: false,
-    current: false,
-    picked: false,
-    allowedDirections: [],
-    pickButtonOnClickHandler: undefined,
-  };
-
-  constructor(props) {
-    super(props);
-    this.pickButtonOnClick = this.pickButtonOnClick.bind(this);
-    this.handleItemClick = this.handleItemClick.bind(this);
-    this.sampleInformation = this.sampleInformation.bind(this);
+export default function SampleGridTableItem({
+  sampleData = {},
+  queueOrder = [],
+  current = false,
+  picked = false,
+  pickButtonOnClickHandler,
+  children,
+}) {
+  function pickButtonOnClick(e) {
+    pickButtonOnClickHandler?.(e, sampleData.sampleID);
   }
 
-  pickButtonOnClick(e) {
-    if (this.props.pickButtonOnClickHandler) {
-      this.props.pickButtonOnClickHandler(e, this.props.sampleData.sampleID);
-    }
-  }
-
-  itemControls() {
+  function getItemControls() {
     return (
       <div className={styles.samplesItemControlsContainer}>
         <TooltipTrigger
@@ -51,14 +36,12 @@ export class SampleGridTableItem extends React.Component {
         >
           <Button
             variant="link"
-            disabled={this.props.current && this.props.picked}
+            disabled={current && picked}
             className={styles.samplesGridTableItemButton}
-            onClick={(e) => {
-              this.pickButtonOnClick(e);
-            }}
+            onClick={pickButtonOnClick}
           >
             <i>
-              {this.props.picked ? (
+              {picked ? (
                 <BsCheck2Square size="1em" />
               ) : (
                 <BsSquare size="0.9em" />
@@ -70,31 +53,30 @@ export class SampleGridTableItem extends React.Component {
     );
   }
 
-  seqId() {
-    const showId = this.props.picked ? '' : 'none';
+  function getsequenceId() {
+    const showId = picked ? '' : 'none';
     return (
       <div>
         <div style={{ display: showId }} className={styles.newQueueOrder}>
-          {this.props.queueOrder}
+          {queueOrder}
         </div>
       </div>
     );
   }
 
-  sampleDisplayName() {
-    let name = this.props.sampleData.proteinAcronym || '';
+  function getSampleName() {
+    let name = sampleData.proteinAcronym || '';
 
-    if (this.props.sampleData.sampleName && name) {
-      name += ` - ${this.props.sampleData.sampleName}`;
+    if (sampleData.sampleName && name) {
+      name += ` - ${sampleData.sampleName}`;
     } else {
-      name = this.props.sampleData.sampleName || '';
+      name = sampleData.sampleName || '';
     }
 
     return name;
   }
 
-  sampleInformation() {
-    const { sampleData } = this.props;
+  function getSampleInformation() {
     const limsData = (
       <div>
         <div className="row">
@@ -136,91 +118,71 @@ export class SampleGridTableItem extends React.Component {
     );
   }
 
-  handleItemClick(e) {
-    if (this.props.onClick) {
-      this.props.onClick(e, this.props.sampleData.sampleID);
-    }
-  }
+  const currentSampleText = current ? '(MOUNTED)' : '';
 
-  currentSampleText() {
-    return this.props.current ? '(MOUNTED)' : '';
-  }
+  const classes = cx(styles.samplesGridTableItem, {
+    [containerStyles.samplesGridTableItemToBeCollected]: picked,
+    [containerStyles.samplesGridTableItemCollected]: isCollected(sampleData),
+  });
 
-  render() {
-    const classes = cx(styles.samplesGridTableItem, {
-      [containerStyles.samplesGridTableItemToBeCollected]: this.props.picked,
-      [containerStyles.samplesGridTableItemCollected]: isCollected(
-        this.props.sampleData,
-      ),
-    });
+  const scLocationClasses = cx(styles.scLocation, 'label', 'label-default', {
+    [styles.labelCustomSuccess]: sampleData.loadable === true,
+  });
 
-    const scLocationClasses = cx(styles.scLocation, 'label', 'label-default', {
-      [styles.labelCustomSuccess]: this.props.sampleData.loadable === true,
-    });
+  const limsLink = sampleData.limsLink || '#';
+  const sampleName = getSampleName();
 
-    const limsLink = this.props.sampleData.limsLink || '#';
-    return (
-      <ListGroup
-        variant="flush"
-        id={this.props.sampleData.sampleID}
-        ref={(ref) => {
-          this.sampleItem = ref; // eslint-disable-line react/no-unused-class-component-methods
-        }}
-        onClick={this.handleItemClick}
-      >
-        <ListGroup.Item className={classes}>
-          <div className="d-flex">
-            {this.itemControls()}
-            <div>
-              <OverlayTrigger
-                placement="right"
-                overlay={
-                  <Popover id={this.sampleDisplayName()}>
-                    <Popover.Header className="d-flex">
-                      <div>
-                        <b className={styles.samplesGridTableItemNamePt}>
-                          {this.sampleDisplayName()}
-                        </b>
-                      </div>
-                    </Popover.Header>
-                    <Popover.Body>{this.sampleInformation()}</Popover.Body>
-                  </Popover>
-                }
+  return (
+    <ListGroup variant="flush" id={sampleData.sampleID}>
+      <ListGroup.Item className={classes}>
+        <div className="d-flex">
+          {getItemControls()}
+          <div>
+            <OverlayTrigger
+              placement="right"
+              overlay={
+                <Popover id={sampleName}>
+                  <Popover.Header className="d-flex">
+                    <div>
+                      <b className={styles.samplesGridTableItemNamePt}>
+                        {sampleName}
+                      </b>
+                    </div>
+                  </Popover.Header>
+                  <Popover.Body>{getSampleInformation()}</Popover.Body>
+                </Popover>
+              }
+            >
+              <Badge
+                href={limsLink}
+                target="_blank"
+                bg="light"
+                text="primary"
+                className={`${styles.samplesGridTableItemNameProteinAcronym} ms-1 mt-2`}
+                data-type="text"
+                data-pk="1"
+                data-url="/post"
+                data-title="Enter protein acronym"
               >
-                <Badge
-                  href={limsLink}
-                  target="_blank"
-                  bg="light"
-                  text="primary"
-                  ref={(ref) => {
-                    this.pacronym = ref; // eslint-disable-line react/no-unused-class-component-methods
-                  }}
-                  className={`${styles.samplesGridTableItemNameProteinAcronym} ms-1 mt-2`}
-                  data-type="text"
-                  data-pk="1"
-                  data-url="/post"
-                  data-title="Enter protein acronym"
-                >
-                  {this.sampleDisplayName()}
-                </Badge>
-              </OverlayTrigger>
-              <div
-                style={{ pointerEvents: 'none' }}
-                className={`ps-1 pe-1 ${scLocationClasses}`}
-              >
-                {this.props.sampleData.location} {this.currentSampleText()}
-              </div>
+                {sampleName}
+              </Badge>
+            </OverlayTrigger>
+            <div
+              style={{ pointerEvents: 'none' }}
+              className={`ps-1 pe-1 ${scLocationClasses}`}
+            >
+              {sampleData.location} {currentSampleText}
             </div>
-            <CopyToClipboard
-              text={this.sampleDisplayName()}
-              tittle="Sample Name"
-              id={`copy_${this.sampleDisplayName()}`}
-            />
-            {this.seqId()}
           </div>
-          {this.props.children}
-        </ListGroup.Item>
-      </ListGroup>
-    );
-  }
+          <CopyToClipboard
+            text={sampleName}
+            tittle="Sample Name"
+            id={`copy_${sampleName}`}
+          />
+          {getsequenceId()}
+        </div>
+        {children}
+      </ListGroup.Item>
+    </ListGroup>
+  );
 }

--- a/ui/src/containers/SampleGridTableContainer.jsx
+++ b/ui/src/containers/SampleGridTableContainer.jsx
@@ -30,7 +30,7 @@ import {
 import { showTaskForm } from '../actions/taskForm';
 import MXContextMenu from '../components/GenericContextMenu/MXContextMenu';
 import SampleCircleView from '../components/SampleGrid/SampleCircleView';
-import { SampleGridTableItem } from '../components/SampleGrid/SampleGridTableItem';
+import SampleGridTableItem from '../components/SampleGrid/SampleGridTableItem';
 import { TaskItem } from '../components/SampleGrid/TaskItem';
 import TooltipTrigger from '../components/TooltipTrigger';
 import { isCollected, QUEUE_RUNNING, QUEUE_STOPPED } from '../constants';
@@ -579,7 +579,6 @@ export default function SampleGridTableContainer(props) {
                 onClick={(e) => selectItemUnderCursor(e, key)}
               >
                 <SampleGridTableItem
-                  itemKey={key}
                   pickButtonOnClickHandler={sampleItemPickButtonOnClickHandler}
                   sampleData={sample}
                   queueOrder={
@@ -587,7 +586,6 @@ export default function SampleGridTableContainer(props) {
                       .filter((keys) => queue.queue.includes(keys))
                       .indexOf(key) + 1
                   }
-                  selected={selected[key]}
                   current={isCurrent}
                   picked={picked}
                 >


### PR DESCRIPTION
Converted SampleGridTableItem from a class component to  functional component and some minor cleanup

🚀 Changes Made
- Converted class component to functional component
- Streamlined prop handling with default values

Props Cleanup/ Removed:
itemKey (unused)
selected (unused)
allowedDirections (unused)
onClick (unused handler)
data-attributes (unused)

Renamed/Simplified method names for better readability:
seqId -> getsequenceId
sampleInformation - > getSampleInformation
sampleDisplayName - > getSampleName

export component as default. 