### PR TITLE
fix slick styles

### DIFF
--- a/ui/src/containers/SampleGridTableContainer.module.css
+++ b/ui/src/containers/SampleGridTableContainer.module.css
@@ -81,18 +81,7 @@
   margin-left: 0 !important;
 }
 
-.samplesGridTableItemTasks > .slick-next::before,
-.samplesGridTableItemTasks > .slick-prev:before {
-  color: #9e9c9c;
-  opacity: 100%;
-}
-
-.samplesGridTableItemTasks > .slick-prev.slick-disabled:before,
-.samplesGridTableItemTasks > .slick-next.slick-disabled:before {
-  opacity: 25%;
-}
-
-.samplesGridTableItemTasks > .slick-prev {
+.samplesGridTableItemTasks :global(.slick-prev) {
   left: 1px;
 }
 


### PR DESCRIPTION
Currently there is a visual bug, where the left arrow of the slider for Sample list items is not visible:
<img width="402" height="77" alt="Screenshot from 2025-10-20 17-35-47" src="https://github.com/user-attachments/assets/df353174-68a3-4681-ad83-823145dc569f" />
This is caused by a css style, that is not applied to slick elements. This PR adds a `:global` field to make sure that the style is used. The result:
<img width="402" height="77" alt="Screenshot from 2025-10-20 17-35-33" src="https://github.com/user-attachments/assets/8ac231fc-9067-436e-af32-e40b4bc37979" />
