### PR TITLE
Reworking on redux store: queue, sample order, sample list...

### DIFF
--- a/ui/src/actions/queue.js
+++ b/ui/src/actions/queue.js
@@ -20,7 +20,12 @@ import { sendSetCentringMethod } from '../api/sampleview';
 import { TASK_UNCOLLECTED } from '../constants';
 import { showErrorPanel } from './general';
 import { mountSample } from './sampleChanger';
-import { clearSampleGrid, selectSamplesAction } from './sampleGrid';
+import {
+  updateSampleList,
+  updateSampleListAndOrder,
+  clearSampleGrid,
+  selectSamplesAction
+} from './sampleGrid';
 import { abortCentring, updateShapes } from './sampleview';
 
 function queueLoading(loading) {
@@ -87,6 +92,7 @@ export function addSamplesToQueue(sampleDataList) {
     try {
       const json = await sendAddQueueItem(sampleDataList);
       dispatch(setQueue(json));
+      dispatch(updateSampleListAndOrder(json.sampleList, json.sampleOrder));
     } catch {
       dispatch(showErrorPanel(true, 'Server refused to add sample'));
     }
@@ -103,6 +109,7 @@ export function addSampleAndMount(sampleData) {
     try {
       const json = await sendAddQueueItem([sampleData]);
       dispatch(setQueue(json));
+      dispatch(updateSampleListAndOrder(json.sampleList, json.sampleOrder));
       dispatch(selectSamplesAction([sampleData.sampleID]));
     } catch {
       dispatch(showErrorPanel(true, 'Server refused to add sample'));
@@ -363,6 +370,7 @@ export function addTask(sampleIDs, parameters, runNow) {
     try {
       const json = await sendAddQueueItem(samples);
       dispatch(setQueue(json));
+      dispatch(updateSampleListAndOrder(json.sampleList, json.sampleOrder));
 
       if (runNow) {
         const sl = json.sampleList;
@@ -485,6 +493,7 @@ export function getQueue() {
     try {
       const json = await fetchQueueState();
       dispatch(setQueue(json.sampleList));
+      dispatch(updateSampleListAndOrder(json.sampleList, json.sampleOrder));
     } catch (error) {
       console.log(error); // eslint-disable-line no-console
     }

--- a/ui/src/actions/queue.js
+++ b/ui/src/actions/queue.js
@@ -92,7 +92,7 @@ export function addSamplesToQueue(sampleDataList) {
     try {
       const json = await sendAddQueueItem(sampleDataList);
       dispatch(setQueue(json));
-      dispatch(updateSampleListAndOrder(json.sampleList, json.sampleOrder));
+      dispatch(updateSampleList(json.sampleList));
     } catch {
       dispatch(showErrorPanel(true, 'Server refused to add sample'));
     }

--- a/ui/src/actions/sampleGrid.js
+++ b/ui/src/actions/sampleGrid.js
@@ -4,8 +4,12 @@ import { showErrorPanel } from './general';
 import { setQueue } from './queue';
 import { hideWaitDialog, showWaitDialog } from './waitDialog';
 
-function updateSampleList(sampleList, order) {
-  return { type: 'UPDATE_SAMPLE_LIST', sampleList, order };
+export function updateSampleList(sampleList) {
+  return { type: 'UPDATE_SAMPLE_LIST', sampleList };
+}
+
+export function updateSampleListAndOrder(sampleList, order) {
+  return { type: 'UPDATE_SAMPLE_LIST_AND_ORDER', sampleList, order };
 }
 
 export function clearSampleGrid() {
@@ -58,7 +62,7 @@ export function getSamplesList() {
     try {
       const json = await fetchSamplesList();
       const { sampleList, sampleOrder } = json;
-      dispatch(updateSampleList(sampleList, sampleOrder));
+      dispatch(updateSampleListAndOrder(sampleList, sampleOrder));
       dispatch(setQueue(json));
     } catch {
       dispatch(showErrorPanel(true, 'Could not get samples list'));
@@ -74,7 +78,7 @@ export function getLimsSamples(lims) {
 
     try {
       const json = await fetchLimsSamples(lims);
-      dispatch(updateSampleList(json.sampleList, json.sampleOrder));
+      dispatch(updateSampleListAndOrder(json.sampleList, json.sampleOrder));
       dispatch(setQueue(json));
     } catch (error) {
       dispatch(

--- a/ui/src/reducers/sampleGrid.js
+++ b/ui/src/reducers/sampleGrid.js
@@ -41,10 +41,12 @@ function sampleGridReducer(state = INITIAL_STATE, action = {}) {
         order: action.sampleOrder,
       };
     }
-    // Set the list of samples (sampleList), clearing any existing list
     case 'UPDATE_SAMPLE_LIST': {
+      const { sampleList } = action;
+      return { ...state, sampleList, selected: {} };
+    }
+    case 'UPDATE_SAMPLE_LIST_AND_ORDER': {
       const { sampleList, order } = action;
-
       return { ...state, sampleList, order, selected: {} };
     }
     case 'UPDATE_CRYSTAL_LIST': {

--- a/ui/src/reducers/sampleGrid.js
+++ b/ui/src/reducers/sampleGrid.js
@@ -34,13 +34,6 @@ const INITIAL_STATE = {
 // eslint-disable-next-line complexity
 function sampleGridReducer(state = INITIAL_STATE, action = {}) {
   switch (action.type) {
-    case 'SET_QUEUE': {
-      return {
-        ...state,
-        sampleList: { ...action.sampleList },
-        order: action.sampleOrder,
-      };
-    }
     case 'UPDATE_SAMPLE_LIST': {
       const { sampleList } = action;
       return { ...state, sampleList, selected: {} };


### PR DESCRIPTION
This PR is an outcome of: https://github.com/mxcube/mxcubeweb/issues/1943

Changes within this PR:
1. Uploading samples from LIMS / SC:
	* resets the **queue.queue** - which is not correct, it should be empty as nothing was added to the queue. It may be emptied by refreshing the page. WIP
	* resets **sampleGrid.order**
	* resets **sampleGrid.sampleList**

2. Adding **new** sample to queue (`QueueGUI` > `Create Sample` > `Queue`) :
	* appends **queue.queue** with this new sample, 
	
        <img width="1689" height="774" alt="Screenshot from 2025-10-24 16-40-04" src="https://github.com/user-attachments/assets/8c9fc721-f332-42a8-882b-bceb2ed93467" />


	* appends **sampleGrid.order**, what's important does not clear the previous content, which afaik may lead to the similar issues https://github.com/mxcube/mxcubeweb/pull/1814#issuecomment-3430846458
	
	<img width="1689" height="774" alt="Screenshot from 2025-10-24 16-42-21" src="https://github.com/user-attachments/assets/96f0837c-a0fa-41a2-9e24-7814b25d9f31" />

	* updates **sampleGrid.sampleList**, adds new sample at some (alphabetical) point, this new sample has property: ``queueID`` and this is important in order to have `Next Sample` button and be listed in `Queued Samples` of  `Queue GUI` (screenshot 4)

	<img width="1864" height="768" alt="Screenshot from 2025-10-24 16-43-56" src="https://github.com/user-attachments/assets/6336bd0a-27a7-4cb2-8d12-c52e8f6b2396" />


3. Adding **exisitng** sample to the queue (`Sample View` > `RMB` > `Add to Queue`):
	* appends **queue.queue** with this sample
	
	<img width="1864" height="768" alt="Screenshot from 2025-10-24 16-45-05" src="https://github.com/user-attachments/assets/30c3395a-27bd-477e-800a-4fae1a428923" />

	* **sampleGrid.order** remains as it was before
	
	<img width="1864" height="768" alt="Screenshot from 2025-10-24 16-45-24" src="https://github.com/user-attachments/assets/b22b9238-c526-40a8-b580-826bf6465807" />
	
	* updates **sampleGrid.sampleList**, enqueued sample has new property: queueID
	
	<img width="1864" height="768" alt="Screenshot from 2025-10-24 16-46-06" src="https://github.com/user-attachments/assets/41bf07b9-6edb-4650-ad6d-41529df185ff" />
