### PR TITLE
OAV video: make `start_streaming()` hook optional

### DIFF
--- a/demo.yaml/mxcube-web/server.yaml
+++ b/demo.yaml/mxcube-web/server.yaml
@@ -27,6 +27,10 @@ mxcube:
 
   # At which port to stream from
   VIDEO_STREAM_PORT: 8000
+
+  # Start OAV stream from MXCuBE process
+  MXCUBE_STARTS_VIDEO_STREAM: true
+
   # Mode, SSX-CHIP, SSX-INJECTOR, OSC
   mode: OSC
 

--- a/demo/mxcube-web/server.yaml
+++ b/demo/mxcube-web/server.yaml
@@ -64,6 +64,10 @@ mxcube:
 
   # At which port to stream from
   VIDEO_STREAM_PORT: 8000
+
+  # Start OAV stream from MXCuBE process
+  MXCUBE_STARTS_VIDEO_STREAM: true
+
   # Mode, SSX-CHIP, SSX-INJECTOR, OSC
   mode: OSC
 

--- a/docs/source/config/server.rst
+++ b/docs/source/config/server.rst
@@ -175,6 +175,7 @@ The section has the following syntax:
       VIDEO_FORMAT: <format name>
       VIDEO_STREAM_URL: <stream URL>
       VIDEO_STREAM_PORT: <stream port>
+      MXCUBE_STARTS_VIDEO_STREAM: <boolean>
       SESSION_REFRESH_INTERVAL: <refresh interval>
       usermanager:
         class: <class name>
@@ -224,6 +225,14 @@ connect to the video stream.
 ``VIDEO_STREAM_PORT``
 ~~~~~~~~~~~~~~~~~~~~~
 Port from which the video stream is served
+
+``MXCUBE_STARTS_VIDEO_STREAM``
+~~~~~~~~~~~~~~~~~~~~~
+Controls if On-Axis-Video (OAV) stream is started by MXCuBE process.
+If set to ``True``, MXCuBE will call the ``start_streaming()`` method of the Camera hardware object during start-up.
+If set to ``False``, it is assumed that OAV stream is started outside of MXCuBE process.
+
+Default value is ``True``.
 
 ``SESSION_REFRESH_INTERVAL``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mxcubeweb/app.py
+++ b/mxcubeweb/app.py
@@ -143,10 +143,11 @@ class MXCUBEApplication:
 
         MXCUBEApplication.mxcubecore.init()
 
-        MXCUBEApplication.init_sample_video(
-            _format=cfg.app.VIDEO_FORMAT,
-            port=cfg.app.VIDEO_STREAM_PORT,
-        )
+        if cfg.app.MXCUBE_STARTS_VIDEO_STREAM:
+            MXCUBEApplication.init_sample_video(
+                _format=cfg.app.VIDEO_FORMAT,
+                port=cfg.app.VIDEO_STREAM_PORT,
+            )
 
         MXCUBEApplication.init_logging(log_fpath, log_level, enabled_logger_list)
 

--- a/mxcubeweb/core/models/configmodels.py
+++ b/mxcubeweb/core/models/configmodels.py
@@ -209,6 +209,13 @@ class MXCUBEAppConfigModel(BaseModel):
     # Port from which the video_stream process (https://github.com/mxcube/video-streamer)
     # streams video. The process runs in separate process (on localhost)
     VIDEO_STREAM_PORT: int = Field(8000, description="Video stream PORT")
+
+    # Should we call the `start_streaming()` method of Camera HWO
+    MXCUBE_STARTS_VIDEO_STREAM: bool = Field(
+        True,
+        description="Invoke 'start OAV stream' method on the Camera hardware object",
+    )
+
     USE_GET_SAMPLES_FROM_SC: bool = Field(
         True,
         description=(


### PR DESCRIPTION
Let's make `start_streaming()` method of the camera HWO optional.

We don't use at MAX IV. We start the video streaming process using external software (supervisitor). I suspect other facilities want to do it this way as well.