### PR TITLE
Fix QueueSettings' labels behaviour

### DIFF
--- a/ui/src/containers/GroupFolderInput.jsx
+++ b/ui/src/containers/GroupFolderInput.jsx
@@ -29,25 +29,25 @@ function GroupFolderInput() {
   }
 
   return (
-    <Form as="div">
-      <Form.Label>Group path :</Form.Label>
-      <Form.Group className="d-flex">
-        <Form.Control
-          size="sm"
-          {...register('groupFolder')}
-          style={{
-            borderColor: isDirty ? '#ffc107' : undefined,
-            boxShadow: isDirty ? '0 0 0 0.2rem rgba(255,193,7,.25)' : undefined,
-          }}
-        />
-        <span style={{ marginRight: '0.5em' }} />
-        <Button
-          variant="outline-secondary"
-          size="sm"
-          onClick={handleSubmit(onSubmit)}
-        >
-          Set
-        </Button>
+    <Form onSubmit={handleSubmit(onSubmit)}>
+      <Form.Group className="d-flex flex-column" controlId="group-folder-input">
+        <Form.Label>Group path :</Form.Label>
+        <div className="d-flex">
+          <Form.Control
+            size="sm"
+            {...register('groupFolder')}
+            style={{
+              marginRight: '0.5rem',
+              borderColor: isDirty ? '#ffc107' : undefined,
+              boxShadow: isDirty
+                ? '0 0 0 0.2rem rgba(255,193,7,.25)'
+                : undefined,
+            }}
+          />
+          <Button variant="outline-secondary" size="sm" type="submit">
+            Set
+          </Button>
+        </div>
       </Form.Group>
     </Form>
   );

--- a/ui/src/containers/QueueSettings.jsx
+++ b/ui/src/containers/QueueSettings.jsx
@@ -24,7 +24,7 @@ export default function QueueSettings() {
         </span>
       </Dropdown.Toggle>
       <Dropdown.Menu className={styles.dropdownMenu}>
-        <Dropdown.Item>
+        <Dropdown.Item as="div">
           <Form.Check
             type="checkbox"
             name="autoMountNext"
@@ -34,7 +34,7 @@ export default function QueueSettings() {
             id="auto-mount-next"
           />
         </Dropdown.Item>
-        <Dropdown.Item>
+        <Dropdown.Item as="div">
           <Form.Check
             type="checkbox"
             onChange={(e) => {
@@ -50,7 +50,7 @@ export default function QueueSettings() {
             id="auto-loop-centring"
           />
         </Dropdown.Item>
-        <Dropdown.Item>
+        <Dropdown.Item as="div">
           <Form.Check
             type="checkbox"
             name="autoAddDiffPlan"
@@ -60,7 +60,7 @@ export default function QueueSettings() {
             id="auto-add-diff-plan"
           />
         </Dropdown.Item>
-        <Dropdown.Item>
+        <Dropdown.Item as="div">
           <Form.Check
             type="checkbox"
             name="rememberParametersBetweenSamples"
@@ -78,11 +78,11 @@ export default function QueueSettings() {
           />
         </Dropdown.Item>
         <Dropdown.Divider />
-        <Dropdown.Item>
+        <Dropdown.Item as="div">
           <NumSnapshotsDropDown align="end" />
         </Dropdown.Item>
         <Dropdown.Divider />
-        <Dropdown.Item>
+        <Dropdown.Item as="div">
           <GroupFolderInput />
         </Dropdown.Item>
       </Dropdown.Menu>


### PR DESCRIPTION
I am refactoring the `QueueSettings` dropdown menu and the `GroupFolderInput` form to fix the labels expected behaviour, right now the click on the labels don't check their boxes neither the tab navigation in the dropdown menu check the boxes on space click, so i basically turn the DropdownItems into divs so that they respect their childs standard behaviour. Also, refactored the `GroupFolderInput` form so that the label focus the input box and the enter key triggers the form submission along with the button click.

Quick demo:

https://github.com/user-attachments/assets/26e4e467-d352-4c49-a5ab-3d9461c03a4c

