### PR TITLE
[PyDantic] - Dropped the use of `pydantic.v1` models

### DIFF
--- a/mxcubeweb/config.py
+++ b/mxcubeweb/config.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 import ruamel.yaml
-from pydantic.v1 import (
+from pydantic import (
     BaseModel,
     ValidationError,
 )

--- a/mxcubeweb/core/adapter/adapter_base.py
+++ b/mxcubeweb/core/adapter/adapter_base.py
@@ -6,7 +6,7 @@ import typing
 from typing import Any, ClassVar
 
 import gevent
-from pydantic.v1 import (
+from pydantic import (
     Field,
     ValidationError,
     create_model,
@@ -45,9 +45,7 @@ class AdapterBase:
 
     ADAPTER_DICT = {}
 
-    def __init__(  # noqa: D417
-        self, ho, role, app, resource_handler_config=None
-    ):
+    def __init__(self, ho, role, app, resource_handler_config=None):  # noqa: D417
         """Initialize.
 
         Args:
@@ -263,10 +261,12 @@ class AdapterBase:
 
     def _exported_methods(self):
         exported_methods = {}
-
         # Get exported attributes from underlaying HardwareObject
         # and only set display True for those methods that have
-        # been explicitly configured to be exported
+        # been explicitly configured to be exported. The method also
+        # needs to be defined as a command in the ResourceHandlerConfigModel
+        # to be exported.
+
         configured_exported = self._ho.exported_attributes.keys()
 
         rh = ResourceHandlerFactory.get_handler(self.__class__.__name__.lower())
@@ -394,9 +394,7 @@ class AdapterBase:
 
 
 class ActuatorAdapterBase(AdapterBase):
-    def __init__(  # noqa: D417
-        self, ho, role, app, resource_handler_config=None
-    ):
+    def __init__(self, ho, role, app, resource_handler_config=None):  # noqa: D417
         """Initialize.
 
         Args:

--- a/mxcubeweb/core/adapter/beamline_action_adapter.py
+++ b/mxcubeweb/core/adapter/beamline_action_adapter.py
@@ -4,7 +4,7 @@ from typing import ClassVar
 
 from mxcubecore.BaseHardwareObjects import HardwareObject
 from mxcubecore.HardwareObjects.BeamlineActions import BeamlineActions
-from pydantic.v1 import (
+from pydantic import (
     BaseModel,
 )
 

--- a/mxcubeweb/core/adapter/machine_info_adapter.py
+++ b/mxcubeweb/core/adapter/machine_info_adapter.py
@@ -13,9 +13,7 @@ class MachineInfoAdapter(ActuatorAdapterBase):
 
     SUPPORTED_TYPES: ClassVar[list[object]] = [AbstractMachineInfo.AbstractMachineInfo]
 
-    def __init__(  # noqa: D417
-        self, ho, *args
-    ):
+    def __init__(self, ho, *args):  # noqa: D417
         """Initialize.
 
         Args:
@@ -59,7 +57,7 @@ class MachineInfoAdapter(ActuatorAdapterBase):
         pass
 
     def state(self):
-        return HardwareObjectState.READY.value
+        return HardwareObjectState.READY.name
 
     def data(self) -> HOMachineInfoModel:
         return HOMachineInfoModel(**self._dict_repr())

--- a/mxcubeweb/core/models/adaptermodels.py
+++ b/mxcubeweb/core/models/adaptermodels.py
@@ -1,4 +1,4 @@
-from pydantic.v1 import (
+from pydantic import (
     BaseModel,
     Field,
 )
@@ -34,7 +34,10 @@ class NStateModel(HOActuatorModel):
     value: str = Field("", description="Value of nstate object")
 
 
-class HOMachineInfoModel(HOActuatorModel):
+class HOMachineInfoModel(HOModel):
+    limits: tuple[float | None, float | None] = Field(
+        (-1, -1), description="Limits (min max)"
+    )
     value: dict = Field(description="Value of machine info")
 
 
@@ -94,7 +97,7 @@ class SampleInputModel(BaseModel):
     sample_id: str = Field(default="", alias="sampleID")
 
     class Config:
-        allow_population_by_field_name = True
+        populate_by_name = True
 
 
 class ListOfShapesModel(BaseModel):

--- a/mxcubeweb/core/models/configmodels.py
+++ b/mxcubeweb/core/models/configmodels.py
@@ -5,7 +5,7 @@ from typing import (
     Literal,
 )
 
-from pydantic.v1 import BaseModel, Field, validator
+from pydantic import BaseModel, Field, validator
 
 
 class FlaskConfigModel(BaseModel):
@@ -71,25 +71,25 @@ class SSOConfigModel(BaseModel):
 class UIComponentModel(BaseModel):
     label: str
     attribute: str
-    role: str | None
-    step: float | None
-    precision: int | None
-    suffix: str | None
-    description: str | None
+    role: str | None = None
+    step: float | None = None
+    precision: int | None = None
+    suffix: str | None = None
+    description: str | None = None
     # Set internally not to be set through configuration
-    value_type: str | None
-    object_type: str | None
-    format: str | None
-    invert_color_semantics: bool | None
+    value_type: str | None = None
+    object_type: str | None = None
+    format: str | None = None
+    invert_color_semantics: bool | None = None
 
 
 class _UICameraConfigModel(BaseModel):
     label: str
     url: str
-    format: str | None
-    description: str | None
-    width: int | None
-    height: int | None
+    format: str | None = None
+    description: str | None = None
+    width: int | None = None
+    height: int | None = None
 
 
 class _UISampleViewVideoControlsModel(BaseModel):
@@ -165,12 +165,12 @@ class UISessionPickerModel(BaseModel):
 
 
 class UIPropertiesListModel(BaseModel):
-    sample_view: UIPropertiesModel | None
+    sample_view: UIPropertiesModel | None = None
     beamline_setup: UIPropertiesModel
-    camera_setup: UICameraConfigModel | None
+    camera_setup: UICameraConfigModel | None = None
     sample_view_motors: UISampleViewMotorsModel
     sample_list_view_modes: UISampleListViewModesModel = UISampleListViewModesModel()
-    sample_view_video_controls: UISampleViewVideoControlsModel | None
+    sample_view_video_controls: UISampleViewVideoControlsModel | None = None
     session_picker: UISessionPickerModel = UISessionPickerModel()
 
 
@@ -248,8 +248,8 @@ class BraggyConfigModel(BaseModel):
 class AppConfigModel(BaseModel):
     server: FlaskConfigModel
     mxcube: MXCUBEAppConfigModel
-    sso: SSOConfigModel | None
-    braggy: BraggyConfigModel | None
+    sso: SSOConfigModel | None = None
+    braggy: BraggyConfigModel | None = None
 
 
 class ResourceHandlerConfigModel(BaseModel):

--- a/mxcubeweb/core/models/generic.py
+++ b/mxcubeweb/core/models/generic.py
@@ -1,4 +1,4 @@
-from pydantic.v1 import (
+from pydantic import (
     BaseModel,
     Field,
 )

--- a/mxcubeweb/core/server/openapidoc.py
+++ b/mxcubeweb/core/server/openapidoc.py
@@ -1,7 +1,7 @@
 import re
 
 from flask import Blueprint, jsonify
-from pydantic.v1 import (
+from pydantic import (
     BaseModel,
 )
 

--- a/mxcubeweb/core/server/resource_handler.py
+++ b/mxcubeweb/core/server/resource_handler.py
@@ -6,7 +6,7 @@ from functools import reduce
 from typing import ClassVar
 
 from flask import Blueprint, Response, jsonify, request
-from pydantic.v1 import (
+from pydantic import (
     BaseModel,
     ValidationError,
 )

--- a/poetry.lock
+++ b/poetry.lock
@@ -1997,14 +1997,14 @@ uvicorn = ">=0.34.0,<0.35.0"
 
 [[package]]
 name = "mxcubecore"
-version = "1.391.0"
+version = "1.419.0"
 description = "Core libraries for the MXCuBE application"
 optional = false
 python-versions = "<3.12,>=3.10"
 groups = ["main"]
 files = [
-    {file = "mxcubecore-1.391.0-py3-none-any.whl", hash = "sha256:f0af343ef4cc432e33d1288c6a6a33d6072e2ee4bd4bf9d954277503d7f0a8d7"},
-    {file = "mxcubecore-1.391.0.tar.gz", hash = "sha256:59793ebc5cc9a2e9c323b5ea9a3ac52ca8899abab3ca0f76474971545ecb373a"},
+    {file = "mxcubecore-1.419.0-py3-none-any.whl", hash = "sha256:251996c1cb1b024cf12d79ae9fad3eed7d8815b1beb45804e0b89bb454fe589b"},
+    {file = "mxcubecore-1.419.0.tar.gz", hash = "sha256:e755727a055ed97f915119f26804e968a48792cb63d23bf8f6b32cb2308710cb"},
 ]
 
 [package.dependencies]
@@ -4039,4 +4039,4 @@ graylog = ["graypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "7e13d276c0715cb58f1209e2f0f72aa8b9713a2fd0d906f99b3741063ec7b257"
+content-hash = "b38f2c0c279765c12556aed09e90a269ab9fd82c0a20a12c3455cdef9d0f9b72"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ Flask-Security-Too = { version = "5.4.3", extras = ["common", "fsqla"] }
 Flask-SocketIO = "^5.3.6"
 gevent = "^23.9.1"
 markupsafe = "^2.1.5"
-mxcubecore =  ">=1.391.0"
+mxcubecore =  ">=1.419.0"
 pillow = "^10.4.0"
 pydantic = ">=2.8.2,<2.9.0"
 pytz = "^2022.6"


### PR DESCRIPTION
This PR drops the use of `pydantic.v1` models. PR, https://github.com/mxcube/mxcubecore/pull/1441 needs to be merged first