### PR TITLE
Calling SampleChangerAdapter instead of component

### DIFF
--- a/mxcubeweb/core/adapter/sample_changer_adapter.py
+++ b/mxcubeweb/core/adapter/sample_changer_adapter.py
@@ -160,7 +160,7 @@ class SampleChangerAdapter(AdapterBase):
             "queue", {"Signal": "update", "message": "all"}, namespace="/hwr"
         )
 
-    def _mount_sample(self, sample):
+    def _mount_sample(self, sample: SampleInputModel):
         sc = HWR.beamline.sample_changer
         res = False
 

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -16,6 +16,9 @@ from mxcubecore.model.queue_model_enumerables import CENTRING_METHOD
 from mxcubecore.queue_entry.base_queue_entry import QUEUE_ENTRY_STATUS
 
 from mxcubeweb.core.components.component_base import ComponentBase
+from mxcubeweb.core.models.adaptermodels import (
+    SampleInputModel,
+)
 from mxcubeweb.core.models.generic import SimpleNameValue
 from mxcubeweb.core.util.convertutils import (
     str_to_camel,
@@ -1821,8 +1824,11 @@ class Queue(ComponentBase):
                 not len(current_queue[sid]["tasks"])
             ) and sid != self.app.lims.get_current_sample().get("sampleID", ""):
                 try:
-                    self.app.sample_changer.mount_sample(current_queue[sid], wait=True)
+                    self.app.mxcubecore.get_adapter("sample_changer").mount_sample(
+                        SampleInputModel(**current_queue[sid]), wait=True
+                    )
                 except Exception:
+                    logging.getLogger("HWR").exception("")
                     HWR.beamline.queue_manager.emit("queue_execution_failed", (None,))
                 else:
                     HWR.beamline.queue_manager.emit("queue_stopped", (None,))


### PR DESCRIPTION
The sample changer component no longer exists the consequence of the current code is that no sample is mounted when calling `execute_entry_with_id`. 

Calling the  `SampleChangerAdapter` instead to maintain the current behavior, a future development would be to push back this behavior to the `mxcubecore` queue so that even an "empty" sample gets mounted.