### PR TITLE
[Sample State Part 2]  update Sample Grid Table Item to better display Sample information like State

### DIFF
--- a/ui/src/components/CopyToClipboard/CopyToClipboard.jsx
+++ b/ui/src/components/CopyToClipboard/CopyToClipboard.jsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { Button } from 'react-bootstrap';
 import { CopyToClipboard as TriggerCopyToClipboard } from 'react-copy-to-clipboard';
 import { MdContentCopy } from 'react-icons/md';
 
@@ -17,23 +16,21 @@ export default function CopyToClipboard(props) {
   }
 
   return (
-    <Button className={styles.btnContent} variant="unknown">
-      <TooltipTrigger
-        placement={copied ? 'auto' : 'right'}
-        rootClose={false}
-        id={id}
-        tooltipContent={
-          copied ? `${tittle} Copied` : `Copy ${tittle} to Clipboard`
-        }
+    <TooltipTrigger
+      placement={copied ? 'auto' : 'right'}
+      rootClose={false}
+      id={id}
+      tooltipContent={
+        copied ? `${tittle} Copied` : `Copy ${tittle} to Clipboard`
+      }
+    >
+      <TriggerCopyToClipboard
+        onCopy={onCopy}
+        className={styles.link}
+        text={text}
       >
-        <TriggerCopyToClipboard
-          onCopy={onCopy}
-          className={styles.link}
-          text={text}
-        >
-          <MdContentCopy color={iconColor} size="1em" />
-        </TriggerCopyToClipboard>
-      </TooltipTrigger>
-    </Button>
+        <MdContentCopy color={iconColor} size="1em" />
+      </TriggerCopyToClipboard>
+    </TooltipTrigger>
   );
 }

--- a/ui/src/components/CopyToClipboard/CopyToClipboard.module.css
+++ b/ui/src/components/CopyToClipboard/CopyToClipboard.module.css
@@ -1,7 +1,3 @@
-.btnContent {
-  border: 0 !important;
-}
-
 .link {
   opacity: 25%;
 }

--- a/ui/src/components/Equipment/Harvester.jsx
+++ b/ui/src/components/Equipment/Harvester.jsx
@@ -6,27 +6,8 @@ import { FcCollect, FcRefresh, FcUpload } from 'react-icons/fc';
 
 import CopyToClipboard from '../CopyToClipboard/CopyToClipboard.jsx';
 import ImageViewer from '../ImageViewer/ImageViewer.jsx';
+import { sampleStateBackground } from '../SampleGrid/util.js';
 import styles from './equipment.module.css';
-
-function sampleStateBackground(key) {
-  switch (key) {
-    case 'ready_to_execute': {
-      return 'success';
-    }
-    case 'harvested': {
-      return 'info';
-    }
-    case 'needs_repositionning': {
-      return 'warning';
-    }
-    case 'failed': {
-      return 'danger';
-    }
-    default: {
-      return 'info';
-    }
-  }
-}
 
 export default function Harvester(props) {
   function showContextMenu(event, id) {

--- a/ui/src/components/SampleGrid/SampleGridTableItem.jsx
+++ b/ui/src/components/SampleGrid/SampleGridTableItem.jsx
@@ -14,6 +14,7 @@ import containerStyles from '../../containers/SampleGridTableContainer.module.cs
 import TooltipTrigger from '../TooltipTrigger';
 import styles from './SampleGridTableItem.module.css';
 import SampleInformation from './SampleInformation';
+import { getSampleName, sampleStateBackground } from './util';
 
 export default function SampleGridTableItem({
   sampleData = {},
@@ -65,17 +66,6 @@ export default function SampleGridTableItem({
     );
   }
 
-  function getSampleName() {
-    let name = sampleData.proteinAcronym || '';
-
-    if (sampleData.sampleName && name) {
-      name += ` - ${sampleData.sampleName}`;
-    } else {
-      name = sampleData.sampleName || '';
-    }
-
-    return name;
-  }
   const currentSampleText = current ? '(MOUNTED)' : '';
 
   const classes = cx(styles.samplesGridTableItem, {
@@ -88,7 +78,7 @@ export default function SampleGridTableItem({
   });
 
   const limsLink = sampleData.limsLink || '#';
-  const sampleName = getSampleName();
+  const sampleName = getSampleName(sampleData);
 
   return (
     <ListGroup variant="flush" id={sampleData.sampleID}>
@@ -122,6 +112,7 @@ export default function SampleGridTableItem({
                 className={`${styles.samplesGridTableItemNameProteinAcronym} ms-1 mt-2`}
               >
                 {sampleName}
+                <span className="ms-1">{sampleName}</span>
               </Badge>
             </OverlayTrigger>
             <div

--- a/ui/src/components/SampleGrid/SampleGridTableItem.jsx
+++ b/ui/src/components/SampleGrid/SampleGridTableItem.jsx
@@ -13,6 +13,7 @@ import { isCollected } from '../../constants';
 import containerStyles from '../../containers/SampleGridTableContainer.module.css';
 import TooltipTrigger from '../TooltipTrigger';
 import styles from './SampleGridTableItem.module.css';
+import SampleInformation from './SampleInformation';
 
 export default function SampleGridTableItem({
   sampleData = {},
@@ -75,49 +76,6 @@ export default function SampleGridTableItem({
 
     return name;
   }
-
-  function getSampleInformation() {
-    const limsData = (
-      <div>
-        <div className="row">
-          <span className="col-sm-6">Space group:</span>
-          <span className="col-sm-6">{sampleData.crystalSpaceGroup}</span>
-        </div>
-        <div className="row">
-          <span style={{ paddingTop: '0.5em' }} className="col-sm-12">
-            <b>Crystal unit cell:</b>
-          </span>
-          <span className="col-sm-1">A:</span>
-          <span className="col-sm-2">{sampleData.cellA}</span>
-          <span className="col-sm-1">B:</span>
-          <span className="col-sm-2">{sampleData.cellB}</span>
-          <span className="col-sm-1">C:</span>
-          <span className="col-sm-2">{sampleData.cellC}</span>
-        </div>
-        <div className="row">
-          <span className="col-sm-1">&alpha;:</span>
-          <span className="col-sm-2">{sampleData.cellAlpha}</span>
-          <span className="col-sm-1">&beta;:</span>
-          <span className="col-sm-2">{sampleData.cellBeta}</span>
-          <span className="col-sm-1">&gamma;:</span>
-          <span className="col-sm-2">{sampleData.cellGamma}</span>
-        </div>
-      </div>
-    );
-
-    return (
-      <div>
-        <div className="row">
-          <span className="col-sm-6">Location:</span>
-          <span className="col-sm-6">{sampleData.location}</span>
-          <span className="col-sm-6">Data matrix:</span>
-          <span className="col-sm-6">{sampleData.code}</span>
-        </div>
-        {sampleData.limsID ? limsData : ''}
-      </div>
-    );
-  }
-
   const currentSampleText = current ? '(MOUNTED)' : '';
 
   const classes = cx(styles.samplesGridTableItem, {
@@ -149,7 +107,9 @@ export default function SampleGridTableItem({
                       </b>
                     </div>
                   </Popover.Header>
-                  <Popover.Body>{getSampleInformation()}</Popover.Body>
+                  <Popover.Body>
+                    <SampleInformation sampleData={sampleData} />
+                  </Popover.Body>
                 </Popover>
               }
             >

--- a/ui/src/components/SampleGrid/SampleGridTableItem.jsx
+++ b/ui/src/components/SampleGrid/SampleGridTableItem.jsx
@@ -55,19 +55,6 @@ export default function SampleGridTableItem({
     );
   }
 
-  function getsequenceId() {
-    const showId = picked ? '' : 'none';
-    return (
-      <div>
-        <div style={{ display: showId }} className={styles.newQueueOrder}>
-          {queueOrder}
-        </div>
-      </div>
-    );
-  }
-
-  const currentSampleText = current ? '(MOUNTED)' : '';
-
   const classes = cx(styles.samplesGridTableItem, {
     [containerStyles.samplesGridTableItemToBeCollected]: picked,
     [containerStyles.samplesGridTableItemCollected]: isCollected(sampleData),
@@ -111,23 +98,38 @@ export default function SampleGridTableItem({
                 text="primary"
                 className={`${styles.samplesGridTableItemNameProteinAcronym} ms-1 mt-2`}
               >
-                {sampleName}
+                <CopyToClipboard
+                  text={sampleName}
+                  tittle="Sample Name"
+                  id={`copy_${sampleName}`}
+                />
                 <span className="ms-1">{sampleName}</span>
               </Badge>
             </OverlayTrigger>
-            <div
-              style={{ pointerEvents: 'none' }}
-              className={`ps-1 pe-1 ${scLocationClasses}`}
-            >
-              {sampleData.location} {currentSampleText}
+
+            <div className={`ps-1 pe-1 ${scLocationClasses}`}>
+              {sampleData.location}
+              {current ? (
+                ' (MOUNTED)'
+              ) : (
+                <div className={styles.sampleStateBadge}>
+                  <Badge
+                    bg={sampleStateBackground(
+                      sampleData?.container_info?.state,
+                    )}
+                  >
+                    {sampleData?.container_info?.state?.replaceAll('_', ' ')}
+                  </Badge>
+                </div>
+              )}
             </div>
           </div>
-          <CopyToClipboard
-            text={sampleName}
-            tittle="Sample Name"
-            id={`copy_${sampleName}`}
-          />
-          {getsequenceId()}
+          <div
+            style={{ display: picked ? '' : 'none' }}
+            className={styles.newQueueOrder}
+          >
+            {queueOrder}
+          </div>
         </div>
         {children}
       </ListGroup.Item>

--- a/ui/src/components/SampleGrid/SampleGridTableItem.jsx
+++ b/ui/src/components/SampleGrid/SampleGridTableItem.jsx
@@ -28,33 +28,6 @@ export default function SampleGridTableItem({
     pickButtonOnClickHandler?.(e, sampleData.sampleID);
   }
 
-  function getItemControls() {
-    return (
-      <div className={styles.samplesItemControlsContainer}>
-        <TooltipTrigger
-          id="pick-sample"
-          placement="auto"
-          tooltipContent="Pick/Unpick sample for collect"
-        >
-          <Button
-            variant="link"
-            disabled={current && picked}
-            className={styles.samplesGridTableItemButton}
-            onClick={pickButtonOnClick}
-          >
-            <i>
-              {picked ? (
-                <BsCheck2Square size="1em" />
-              ) : (
-                <BsSquare size="0.9em" />
-              )}
-            </i>
-          </Button>
-        </TooltipTrigger>
-      </div>
-    );
-  }
-
   const classes = cx(styles.samplesGridTableItem, {
     [containerStyles.samplesGridTableItemToBeCollected]: picked,
     [containerStyles.samplesGridTableItemCollected]: isCollected(sampleData),
@@ -71,7 +44,28 @@ export default function SampleGridTableItem({
     <ListGroup variant="flush" id={sampleData.sampleID}>
       <ListGroup.Item className={classes}>
         <div className="d-flex">
-          {getItemControls()}
+          <div className={styles.samplesItemControlsContainer}>
+            <TooltipTrigger
+              id="pick-sample"
+              placement="auto"
+              tooltipContent="Pick/Unpick sample for collect"
+            >
+              <Button
+                variant="link"
+                disabled={current && picked}
+                className={styles.samplesGridTableItemButton}
+                onClick={pickButtonOnClick}
+              >
+                <i>
+                  {picked ? (
+                    <BsCheck2Square size="1em" />
+                  ) : (
+                    <BsSquare size="0.9em" />
+                  )}
+                </i>
+              </Button>
+            </TooltipTrigger>
+          </div>
           <div>
             <OverlayTrigger
               placement="right"

--- a/ui/src/components/SampleGrid/SampleGridTableItem.module.css
+++ b/ui/src/components/SampleGrid/SampleGridTableItem.module.css
@@ -1,5 +1,8 @@
 .samplesGridTableItemButton {
   background: Transparent;
+  padding: 0%;
+  margin-left: 5px;
+  margin-top: 5px;
 }
 
 .samplesGridTableItem {
@@ -24,10 +27,11 @@
 }
 
 .samplesItemControlsContainer {
-  float: left;
+  margin-top: 2px;
 }
 
 .scLocation {
+  display: flex;
   font-size: 11px;
   float: right;
   pointer-events: none;
@@ -35,6 +39,11 @@
   margin: 2px;
   top: 0;
   right: 0;
+}
+
+.sampleStateBadge {
+  margin-left: 5px;
+  margin-bottom: 2px;
 }
 
 .newQueueOrder {

--- a/ui/src/components/SampleGrid/SampleInformation.jsx
+++ b/ui/src/components/SampleGrid/SampleInformation.jsx
@@ -1,0 +1,41 @@
+export default function SampleInformation({ sampleData = {} }) {
+  return (
+    <div>
+      <div className="row">
+        <span className="col-sm-6">Location:</span>
+        <span className="col-sm-6">{sampleData.location}</span>
+        <span className="col-sm-6">Data matrix / ID:</span>
+        <span className="col-sm-6">{sampleData.code}</span>
+        <span className="col-sm-6">State in Container:</span>
+        <span className="col-sm-6">{sampleData?.container_info?.state}</span>
+      </div>
+      {sampleData.limsID && (
+        <div>
+          <div className="row">
+            <span className="col-sm-6">Space group:</span>
+            <span className="col-sm-6">{sampleData.crystalSpaceGroup}</span>
+          </div>
+          <div className="row">
+            <span style={{ paddingTop: '0.5em' }} className="col-sm-12">
+              <b>Crystal unit cell:</b>
+            </span>
+            <span className="col-sm-1">A:</span>
+            <span className="col-sm-2">{sampleData.cellA}</span>
+            <span className="col-sm-1">B:</span>
+            <span className="col-sm-2">{sampleData.cellB}</span>
+            <span className="col-sm-1">C:</span>
+            <span className="col-sm-2">{sampleData.cellC}</span>
+          </div>
+          <div className="row">
+            <span className="col-sm-1">&alpha;:</span>
+            <span className="col-sm-2">{sampleData.cellAlpha}</span>
+            <span className="col-sm-1">&beta;:</span>
+            <span className="col-sm-2">{sampleData.cellBeta}</span>
+            <span className="col-sm-1">&gamma;:</span>
+            <span className="col-sm-2">{sampleData.cellGamma}</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/SampleGrid/util.js
+++ b/ui/src/components/SampleGrid/util.js
@@ -1,0 +1,30 @@
+export function sampleStateBackground(key) {
+  const map = {
+    ready_to_execute: 'success',
+    harvested: 'info',
+    needs_repositionning: 'warning',
+    in_puck: 'success',
+    on_gonio: 'info',
+    mounting: 'warning',
+    unmounting: 'warning',
+    recovery_puck: 'primary',
+    blacklisted: 'danger',
+    stuck_on_gripper: 'warning',
+    failed: 'danger',
+    unknown: 'secondary',
+  };
+
+  return map[key] || 'secondary';
+}
+
+export function getSampleName(sampleData) {
+  let name = sampleData?.proteinAcronym || '';
+
+  if (sampleData?.sampleName && name) {
+    name += ` - ${sampleData?.sampleName}`;
+  } else {
+    name = sampleData?.sampleName || '';
+  }
+
+  return name;
+}


### PR DESCRIPTION
This PR UPDATE SampleGridTableItem 

See Part 1 First  https://github.com/mxcube/mxcubeweb/pull/1951

Goal:  display Sample State  (from the Sample Changer)

What changed

- Extracted sample information rendering into its own component (improves readability & reuse).
- Moved sampleStateBackground and getSampleName helpers to utils.js.
- Inlined getSequenceId() & getItemControls() 
- Simplified the “Copy to Clipboard” component by removing the button node.
- Added a Sample State badge to each item.
- adjusted styles accordingly.

<img width="1891" height="897" alt="image" src="https://github.com/user-attachments/assets/92760eeb-4c85-49e3-8b8c-1626d1e8954d" />

 

Testing
- Verified that the Sample State badge reflects states returned by the Sample Changer.

The component need a little refactoring to adjust things properly.
Rather than opening 4 separate PRs, this is a single PR with clearly separated commits so each change can be reviewed in isolation.

Follow-ups
confirm  if the sample state change / sample_list is update when mount or unmounted sample
  