### PR TITLE
Fix SampleImage mismatch on mount/navigating between tabs

### DIFF
--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -114,6 +114,7 @@ class SampleImage extends React.Component {
 
     globalThis.initJSMpeg = this.initJSMpeg;
     this.initJSMpeg();
+    this.renderSampleView();
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
Currently, there's brief mismatch between the video received and the sampleview rendered when navigating from `Data Collection` page to another tab e.g. `Samples` page and coming back.

https://github.com/user-attachments/assets/8c551575-64f2-4374-bbbe-fb663e807fe1

After a few seconds it seems to adjust itself ( perhaps between re-renders of the component). This change fixes the mismatch by rendering sampleview on mount as well, but it maintains the current behaviour of displaying a blank canvas while the video is being init.

https://github.com/user-attachments/assets/96d7f509-ae65-494d-92e4-474365607675



