### PR TITLE
Fix error when retrieving shapes list

### DIFF
--- a/mxcubeweb/core/adapter/sample_view_adapter.py
+++ b/mxcubeweb/core/adapter/sample_view_adapter.py
@@ -222,7 +222,7 @@ class SampleViewAdapter(AdapterBase):
         }
 
     def shapes(self) -> list:
-        return self._ho.get_shapes()
+        return {shape.id: to_camel(shape.as_dict()) for shape in self._ho.get_shapes()}
 
     def snapshot(self, overlay: Base64StrModel):
         """Take snapshot of the sample view.

--- a/ui/src/actions/login.js
+++ b/ui/src/actions/login.js
@@ -117,7 +117,7 @@ export function getInitialState() {
         .then((taskParameters) => ({ taskParameters }))
         .catch(notify),
       fetchShapes()
-        .then((json) => ({ shapes: json.shapes }))
+        .then((shapes) => ({ shapes }))
         .catch(notify),
       fetchValue('sample_changer', 'sample_changer')
         .then((json) => {


### PR DESCRIPTION
Currently when retrieving a `Grid` object from `shapes` attribute of the sample view adapter, there is a json-serialization error.

Bug reproduction:
1. Add some shapes
2. Refresh the page
3. There will be an error in the network tab for /shapes, the shapes won't appear in the canvas (nor the redux store)

It just makes sure that all shapes are properly serialized before sending them to the backend.