### PR TITLE
Fixing take snapshot

### DIFF
--- a/mxcubeweb/core/adapter/sample_view_adapter.py
+++ b/mxcubeweb/core/adapter/sample_view_adapter.py
@@ -251,10 +251,12 @@ class SampleViewAdapter(AdapterBase):
 
         try:
             image = self._ho.take_snapshot(overlay_data=overlay_data)
-            b = io.BytesIO()
-            image.save(b, "JPEG")
+            data = io.BytesIO()
+            image.save(data, "JPEG")
+            data.seek(0)
+
             return send_file(
-                b,
+                data,
                 mimetype="image/jpeg",
                 as_attachment=True,
                 download_name="snapshot.jpeg",

--- a/ui/src/api/hardware-object.js
+++ b/ui/src/api/hardware-object.js
@@ -8,6 +8,10 @@ export function sendExecuteCommand(objectType, objectId, command, value) {
     .safeJson();
 }
 
+export function sendExecuteCommandRaw(objectType, objectId, command, value) {
+  return endpoint.put(value, `/${objectType}/${objectId}/${command}`);
+}
+
 export function fetchAttribute(objectType, objectId, attributeName) {
   return endpoint.get(`/${objectType}/${objectId}/${attributeName}`).safeJson();
 }

--- a/ui/src/api/sampleview.js
+++ b/ui/src/api/sampleview.js
@@ -1,4 +1,8 @@
-import { fetchAttribute, sendExecuteCommand } from './hardware-object';
+import {
+  fetchAttribute,
+  sendExecuteCommand,
+  sendExecuteCommandRaw,
+} from './hardware-object';
 
 function fetchSampleViewAttribute(attribute) {
   return fetchAttribute('sample_view', 'sample_view', attribute);
@@ -75,7 +79,7 @@ export function sendMoveToBeam(x, y) {
 }
 
 export function sendTakeSnapshot(canvasData) {
-  return sendSampleViewCommand('snapshot', {
+  return sendExecuteCommandRaw('sample_view', 'sample_view', 'snapshot', {
     value: canvasData,
-  });
+  }).blob();
 }


### PR DESCRIPTION
This fixes an issue introduced in the "take snapshot" function when switching to  `SampleViewAdapter`. The return data was handled as `json` instead of `blob` and the date returned was "empty" because of the missing `seek(0)`