### PR TITLE
Beam position not needed when image size changes

### DIFF
--- a/mxcubeweb/core/adapter/sample_view_adapter.py
+++ b/mxcubeweb/core/adapter/sample_view_adapter.py
@@ -209,12 +209,6 @@ class SampleViewAdapter(AdapterBase):
 
         pixels_per_mm = HWR.beamline.diffractometer.get_pixels_per_mm()
 
-        # We need to get the beam size when changing the image
-        # size because of the current front end implementation.
-        # This not necessary and can be removed.
-        beam_ho = HWR.beamline.beam
-        sx, sy, shape, _label = beam_ho.get_value()
-
         return {
             "pixelsPerMm": pixels_per_mm,
             "imageWidth": width,
@@ -225,10 +219,6 @@ class SampleViewAdapter(AdapterBase):
             "videoSizes": video_sizes,
             "videoHash": self._ho.camera.stream_hash,
             "videoURL": self.app.CONFIG.app.VIDEO_STREAM_URL,
-            "position": beam_ho.get_beam_position_on_screen(),
-            "size_x": sx,
-            "size_y": sy,
-            "shape": shape.value,
         }
 
     def shapes(self) -> list:

--- a/ui/src/actions/sampleview.js
+++ b/ui/src/actions/sampleview.js
@@ -109,7 +109,6 @@ export function setVideoSize(width, height) {
       width: json.imageWidth,
       height: json.imageHeight,
       pixelsPerMm: json.pixelsPerMm,
-      beamPosition: json.position,
       sourceScale: json.scale,
     });
 

--- a/ui/src/reducers/sampleview.js
+++ b/ui/src/reducers/sampleview.js
@@ -69,7 +69,6 @@ function sampleViewReducer(state = INITIAL_STATE, action = {}) {
         width: action.width,
         height: action.height,
         pixelsPerMm: action.pixelsPerMm,
-        beamPosition: action.beamPosition,
         sourceScale: action.sourceScale,
       };
     }


### PR DESCRIPTION
The actual beam position does not change when the size of the video stream changes. Removed beam position from "SET_IMAGE_SIZE" action. 