### PR TITLE
introduced grid cache and mesh grid shape

### DIFF
--- a/ui/src/components/SampleView/DrawGridPlugin.jsx
+++ b/ui/src/components/SampleView/DrawGridPlugin.jsx
@@ -1,8 +1,228 @@
+/* eslint-disable max-classes-per-file */
+
 import 'fabric';
+
+import { isEqual } from 'lodash';
 
 const TAU = Math.PI * 2;
 
 const { fabric } = globalThis;
+
+/**
+ * @typedef {Object} CachedGrid
+ * @property {GridGroup} gridGroup - The Fabric.js group representing the grid.
+ * @property {GridData} gridData - The data used to define the grid.
+ */
+
+/**
+ * This class is responsible for caching grids and rendering them on a canvas.
+ * Drawing big grids can be slow, so we cache them to improve performance.
+ */
+export class GridCache {
+  /**
+   * @type {Map<string, CachedGrid>} - Map of grid id to CachedGrid.
+   */
+  grids = new Map();
+
+  /**
+   * Adds a grid to the cache and renders it on cache.
+   * If the grid has not changed, it will not be re-added.
+   *
+   * @param {GridData} gridData - The grid to add.
+   * @param {DrawGridPlugin} drawGridPlugin - A DrawGridPlugin instance.
+   * @param {number} pixelsPerMM - The number of pixels per millimeter.
+   * @param {number} scale - The scale of the grid.
+   * @returns {CachedGrid} the added grid.
+   */
+  addGrid(gridData, drawGridPlugin, pixelsPerMM, scale) {
+    const { id } = gridData;
+    const cachedGrid = this.getGrid(id);
+    const newGridData = drawGridPlugin.setPixelsPerMM(pixelsPerMM, gridData);
+    // We don't recreate the grid if it's already in the cache
+    // and the grid data is the same
+    const gridDataChanged =
+      cachedGrid && !isEqual(cachedGrid.gridData, newGridData);
+
+    if (cachedGrid && !gridDataChanged) {
+      return cachedGrid;
+    }
+    if (gridDataChanged) {
+      this.removeGrid(cachedGrid.gridGroup, this.canvas);
+    }
+
+    // there is no grid in the cache, or the grid data is different
+    drawGridPlugin.setScale(scale);
+    const updatedGrid = drawGridPlugin.shapeFromGridData(newGridData);
+    const grid = { gridGroup: updatedGrid.shapeGroup, gridData: newGridData };
+
+    this.canvas.add(updatedGrid.shapeGroup);
+    this.grids.set(grid.gridData.id, grid);
+    return grid;
+  }
+
+  /**
+   * @param {fabric.Canvas} canvas - The Fabric.js canvas.
+   */
+  constructor(canvas) {
+    this.canvas = canvas;
+  }
+
+  /**
+   * Retrieves a grid from the cache by its ID.
+   *
+   * @param {string} id - The ID of the grid to retrieve.
+   * @returns {CachedGrid | undefined} - The cached grid, or undefined if not found.
+   */
+  getGrid(id) {
+    return this.grids.get(id);
+  }
+
+  /**
+   * Removes a grid from the cache and the canvas.
+   *
+   * @param {GridGroup} gridGroup - The grid to remove.
+   * @param {fabric.Canvas} canvas - The Fabric.js canvas.
+   * @returns {boolean} - True if the grid was successfully removed, false otherwise.
+   */
+  removeGrid(gridGroup, canvas) {
+    canvas.remove(gridGroup); // if id is null then we have a TMP grid
+    const { id } = gridGroup;
+    if (id) {
+      this.grids.delete(id);
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Updates a grid in the cache and on the canvas.
+   *
+   * @param {string} id - The ID of the grid to update.
+   * @param {GridData} newGridData - The updated grid data.
+   * @param {fabric.Canvas} canvas - The Fabric.js canvas.
+   * @param {DrawGridPlugin} drawGridPlugin - A DrawGridPlugin instance.
+   * @returns {CachedGrid | undefined} - The updated cached grid, or undefined if not found.
+   */
+  updateGrid(id, newGridData, canvas, drawGridPlugin) {
+    const cachedGrid = this.grids.get(id);
+    if (!cachedGrid) {
+      return undefined;
+    }
+    canvas.remove(cachedGrid.gridGroup);
+
+    const newGridGroup =
+      drawGridPlugin.shapeFromGridData(newGridData).shapeGroup;
+    const updatedGrid = { gridGroup: newGridGroup, gridData: newGridData };
+
+    this.grids.set(id, updatedGrid);
+    canvas.add(newGridGroup);
+    return updatedGrid;
+  }
+}
+
+/**
+ * @typedef {Object} MeshGridOptions
+ * @property {number} cellRows - The number of rows in the grid.
+ * @property {number} cellCols - The number of columns in the grid.
+ * @property {number} cellWidth - The width of each cell in the grid.
+ * @property {number} cellHeight - The height of each cell in the grid.
+ * @property {number} cellHSpace - The horizontal space between cells.
+ * @property {number} cellVSpace - The vertical space between cells.
+ * @property {string} color - Color of the grid lines.
+ * @property {number} cellTW - The total width of each cell, including the horizontal space.
+ * @property {number} cellTH - The total height of each cell, including the vertical space.
+ * @property {boolean} [selected = false] - Whether the grid is selected.
+ */
+/**
+ * A custom Fabric.js object representing a mesh grid.
+ * @typedef {fabric.IObjectOptions & MeshGridOptions} MeshGrid
+ * @extends fabric.Object
+ */
+const MeshGrid = fabric.util.createClass(fabric.Object, {
+  type: 'MeshGrid',
+  selected: false,
+
+  /**
+   * Initializes the MeshGrid object.
+   *
+   * @param {MeshGridOptions & fabric.IObjectOptions} meshGridOptions
+   */
+  initialize(meshGridOptions) {
+    this.callSuper('initialize', meshGridOptions);
+    this.selected = !!this.selected;
+    this.cacheProperties.push('selected');
+  },
+
+  /**
+   * Renders the mesh grid on the canvas.
+   *
+   * @param {CanvasRenderingContext2D} ctx - The canvas rendering context.
+   * @private
+   */
+  _render(ctx) {
+    if (this.selected) {
+      this._drawInnerGridLines(ctx);
+    }
+    this._drawOuterBorder(ctx);
+  },
+
+  /**
+   * Draws the inner grid lines.
+   *
+   * @param {CanvasRenderingContext2D} ctx - The canvas rendering context.
+   * @private
+   */
+  _drawInnerGridLines(ctx) {
+    const lineColor = 'rgba(136, 255, 91, 0.5)';
+    // eslint-disable-next-line no-param-reassign
+    ctx.strokeStyle = lineColor;
+    const [left, right, top, bottom] = [
+      -this.width / 2,
+      this.width / 2,
+      -this.height / 2,
+      this.height / 2,
+    ];
+    if (inSmallCellSizeMode(this.cellTW, this.cellTH)) {
+      /* we don't draw inner lines for small cells, to reduce visual clutter */
+      return;
+    }
+    // Draw horizontal lines
+    for (let row = 1; row < this.cellRows; row++) {
+      const y = top + row * this.cellTH;
+      ctx.beginPath();
+      ctx.moveTo(left, y);
+      ctx.lineTo(right, y);
+      ctx.stroke();
+    }
+
+    // Draw vertical lines
+    for (let col = 1; col < this.cellCols; col++) {
+      const x = left + col * this.cellTW;
+      ctx.beginPath();
+      ctx.moveTo(x, top);
+      ctx.lineTo(x, bottom);
+      ctx.stroke();
+    }
+  },
+
+  /**
+   * Draws the outer border of the grid.
+   *
+   * @param {CanvasRenderingContext2D} ctx - The canvas rendering context.
+   * @private
+   */
+  _drawOuterBorder(ctx) {
+    // eslint-disable-next-line no-param-reassign
+    ctx.strokeStyle = this.color;
+    if (!this.selected) {
+      ctx.setLineDash([5, 5]);
+    } else {
+      ctx.setLineDash([]);
+    }
+
+    ctx.strokeRect(-this.width / 2, -this.height / 2, this.width, this.height);
+  },
+});
 
 /**
  * Based on cell width and height in pixels,
@@ -17,6 +237,7 @@ function inSmallCellSizeMode(cellWidth, cellHeight) {
 
 /**
  * Fabric Shape for drawing grid (defined by GridData)
+ * @typedef {fabric.Group & { id?: string }} GridGroup
  */
 const GridGroup = fabric.util.createClass(fabric.Group, {
   type: 'GridGroup',
@@ -26,7 +247,6 @@ const GridGroup = fabric.util.createClass(fabric.Group, {
     this.id = options.id;
   },
 });
-
 /**
  * Custom Fabric shape, for displaying mesh scan results.
  *
@@ -41,10 +261,14 @@ const GridGroup = fabric.util.createClass(fabric.Group, {
  *
  */
 const MeshGridResult = fabric.util.createClass(fabric.Object, {
-  type: 'GridGroup',
+  type: 'MeshGridResult',
 
   initialize(objects, options = {}) {
     this.callSuper('initialize', objects, options);
+    const { cellTW, cellTH, cellColumns, cellRows } = objects;
+    const width = cellTW * cellColumns;
+    const height = cellTH * cellRows;
+    this.set({ width, height });
   },
 
   _render(ctx) {
@@ -53,8 +277,8 @@ const MeshGridResult = fabric.util.createClass(fabric.Object, {
       // the cells are small, draw them as rectangles
       //
 
-      const xOffset = this.cellHSpace / 2;
-      const yOffset = this.cellVSpace / 2;
+      const xOffset = -this.width / 2 + this.cellTH / 2;
+      const yOffset = -this.height / 2 + this.cellTW / 2;
       const width = this.cellTW - this.cellHSpace;
       const height = this.cellTH - this.cellVSpace;
 
@@ -75,8 +299,8 @@ const MeshGridResult = fabric.util.createClass(fabric.Object, {
       // normal cells, draw them as ellipses
       //
 
-      const xOffset = this.cellTW / 2;
-      const yOffset = this.cellTH / 2;
+      const xOffset = -this.width / 2 + this.cellTW / 2;
+      const yOffset = -this.height / 2 + this.cellTH / 2;
       const width = (this.cellTW - this.cellHSpace) / 2;
       const height = (this.cellTH - this.cellVSpace) / 2;
 
@@ -398,12 +622,14 @@ export default class DrawGridPlugin {
     );
   }
 
+  /**
+   * Creates the heatmap data for later fill grid cells
+   * @param {GridData} gd grid data
+   * @param {number} col - number of columns
+   * @param {number} row - number of rows
+   * @returns {string[][]} fillingMatrix - matrix of colors for each cell
+   */
   cellFillingFromData(gd, col, row) {
-    /**
-     * Creates the heatmap data for later fill grid cells
-     * @param {GridData} gd
-     * @param 2d array data
-     */
     const fillingMatrix = this.initializeCellFilling(gd, col, row);
 
     // Assume flat result object to remain compatible with old format only
@@ -440,59 +666,13 @@ export default class DrawGridPlugin {
   }
 
   /**
-   * Adds dashed inner lines to a mesh grid.
-   *
-   * Does nothing if mesh is not selected,
-   * or if we are drawing in small cell size' mode.
-   */
-  addInnerLines(shapes, gridData, left, top, height, width, cellTH, cellTW) {
-    if (!gridData.selected) {
-      /* we only draw inner lines for selected meshes */
-      return;
-    }
-
-    if (inSmallCellSizeMode(cellTW, cellTH)) {
-      /* we don't draw inner lines for small cells, to reduce visual clutter */
-      return;
-    }
-
-    const lineColor = 'rgba(136, 255, 91, 0.5)';
-    const strokeArray = [5, 5];
-
-    for (let nw = 1; nw < gridData.numCols; nw++) {
-      shapes.push(
-        new fabric.Line(
-          [left + cellTW * nw, top, left + cellTW * nw, top + height],
-          {
-            stroke: lineColor,
-            strokeDashArray: strokeArray,
-            hasControls: false,
-            selectable: false,
-          },
-        ),
-      );
-    }
-
-    for (let nh = 1; nh < gridData.numRows; nh++) {
-      shapes.push(
-        new fabric.Line(
-          [left, top + cellTH * nh, left + width, top + cellTH * nh],
-          {
-            stroke: lineColor,
-            strokeDashArray: strokeArray,
-            hasControls: false,
-            selectable: false,
-          },
-        ),
-      );
-    }
-  }
-
-  /**
    * Creates a Fabric GridGroup shape from a GridData object
    *
    * @param {GridData} gd
-   * @return {Object} {shapeGroup, gridData}
+   * @return ({
+   *  shapeGroup: GridGroup,
+   *  gridData: GridData
+   * })
    */
   shapeFromGridData(gd) {
     const gridData = { ...gd };
@@ -521,100 +701,81 @@ export default class DrawGridPlugin {
       ? 'rgba(136, 255, 91, 1)'
       : 'rgba(228, 255, 9, 0.5)';
     color = gridData.result?.length > 0 ? 'rgba(228, 255, 9, 1)' : color;
-    const outlineStrokeArray = gridData.selected ? [] : [5, 5];
-
-    if (cellTW > 0 && cellTH > 0) {
-      this.addInnerLines(
-        shapes,
-        gridData,
-        left,
-        top,
-        height,
-        width,
-        cellTH,
-        cellTW,
-      );
-      if (!this.drawing) {
-        if (this.gridResultFormat === 'RGB') {
-          const fillingMatrix = this.cellFillingFromData(
+    const meshGrid = new MeshGrid({
+      cellRows: gridData.numRows,
+      cellCols: gridData.numCols,
+      cellWidth,
+      cellHeight,
+      cellHSpace,
+      cellVSpace,
+      cellTW,
+      cellTH,
+      color,
+      selected: gridData.selected,
+      height,
+      width,
+    });
+    shapes.push(meshGrid);
+    if (cellTW > 0 && cellTH > 0 && !this.drawing) {
+      if (this.gridResultFormat === 'RGB') {
+        const fillingMatrix = this.cellFillingFromData(
+          gridData,
+          gridData.numCols,
+          gridData.numRows,
+        );
+        shapes.push(
+          new MeshGridResult({
+            cellColumns: gridData.numCols,
+            cellRows: gridData.numRows,
             gridData,
-            gridData.numCols,
-            gridData.numRows,
-          );
-          shapes.push(
-            new MeshGridResult({
-              left,
-              top,
-              cellColumns: gridData.numCols,
-              cellRows: gridData.numRows,
-              gridData,
-              cellTW,
-              cellTH,
-              cellHSpace,
-              cellVSpace,
-              fillingMatrix,
-            }),
-          );
-
-          for (let nw = 0; nw < gridData.numCols; nw++) {
+            cellTW,
+            cellTH,
+            cellHSpace,
+            cellVSpace,
+            fillingMatrix,
+          }),
+        );
+        for (let nw = 0; nw < gridData.numCols; nw++) {
+          for (let nh = 0; nh < gridData.numRows; nh++) {
+            const cellCount = this.countCells(
+              gridData.cellCountFun,
+              nw,
+              nh,
+              gridData.numRows,
+              gridData.numCols,
+            );
             // eslint-disable-next-line max-depth
-            for (let nh = 0; nh < gridData.numRows; nh++) {
-              const cellCount = this.countCells(
-                gridData.cellCountFun,
-                nw,
-                nh,
-                gridData.numRows,
-                gridData.numCols,
+            if (this.include_cell_labels) {
+              shapes.push(
+                new fabric.Text(cellCount, {
+                  left: left + cellHSpace / 2 + cellTW * nw + cellWidth / 2,
+                  top: top + cellVSpace / 2 + cellTH * nh + cellHeight / 2,
+                  originX: 'center',
+                  originY: 'center',
+                  fill: 'rgba(0, 0, 200, 1)',
+                  fontFamily: 'Helvetica',
+                  fontSize: 18,
+                }),
               );
-
-              // eslint-disable-next-line max-depth
-              if (this.include_cell_labels) {
-                shapes.push(
-                  new fabric.Text(cellCount, {
-                    left: left + cellHSpace / 2 + cellTW * nw + cellWidth / 2,
-                    top: top + cellVSpace / 2 + cellTH * nh + cellHeight / 2,
-                    originX: 'center',
-                    originY: 'center',
-                    fill: 'rgba(0, 0, 200, 1)',
-                    fontFamily: 'Helvetica',
-                    fontSize: 18,
-                  }),
-                );
-              }
             }
           }
-        } else if (gridData.result && gridData.result.length > 0) {
-          const imageElement = document.createElement('img');
-          imageElement.src = `data:image/png;base64,${gridData.result}`;
-          const image = new fabric.Image(imageElement);
-          image.scaleToHeight(height);
-          image.scaleX = width / imageElement.naturalWidth;
-          image.set({ top, left });
-          shapes.push(image);
         }
+      } else if (gridData.result && gridData.result.length > 0) {
+        const imageElement = document.createElement('img');
+        imageElement.src = `data:image/png;base64,${gridData.result}`;
+        const image = new fabric.Image(imageElement);
+        image.scaleToHeight(height);
+        image.scaleX = width / imageElement.naturalWidth;
+        image.set({ top, left });
+        shapes.push(image);
       }
     }
-
-    shapes.push(
-      new fabric.Rect({
-        left,
-        top,
-        width,
-        height,
-        fill: 'rgba(0,0,0,0)',
-        strokeDashArray: outlineStrokeArray,
-        stroke: color,
-        hasControls: false,
-        selectable: true,
-        hoverCursor: 'pointer',
-      }),
-    );
 
     if (gridData.name) {
       shapes.push(
         new fabric.Text(gridData.name, {
-          left: left + width,
-          top: top - 20,
+          left: width,
+          top: height,
           fill: color,
           fontFamily: 'Helvetica',
           fontSize: 18,
@@ -634,8 +795,9 @@ export default class DrawGridPlugin {
       visible: true,
       hoverCursor: 'pointer',
       id: gd.id,
+      top,
+      left,
     });
-
     return { shapeGroup, gridData };
   }
 
@@ -768,7 +930,6 @@ export default class DrawGridPlugin {
    */
   saveGrid(_gd) {
     const gd = structuredClone(_gd);
-
     gd.screenCoord[0] /= this.scale;
     gd.screenCoord[1] /= this.scale;
     gd.width /= this.scale;

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -1,7 +1,5 @@
 /* eslint-disable react/destructuring-assignment */
 /* eslint-disable jsx-a11y/control-has-associated-label */
-import 'fabric';
-
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -24,7 +22,7 @@ import {
 } from '../../actions/sampleview.js';
 import { HW_STATE, QUEUE_RUNNING } from '../../constants';
 import SampleControls from '../SampleControls/SampleControls';
-import DrawGridPlugin from './DrawGridPlugin';
+import DrawGridPlugin, { GridCache } from './DrawGridPlugin';
 import GridForm from './GridForm';
 import { JSMpeg } from './jsmpeg.min.js';
 import styles from './SampleImage.module.css';
@@ -70,6 +68,7 @@ class SampleImage extends React.Component {
     this.clearSelectionEvent = this.clearSelectionEvent.bind(this);
     this.toggleGridVisibility = this.toggleGridVisibility.bind(this);
     this.canvas = {};
+    this.gridCache = null;
     this.drawGridPlugin = new DrawGridPlugin();
     this.drawGridPlugin.setGridResultFormat(props.meshResultFormat);
     this._keyPressed = null;
@@ -85,7 +84,7 @@ class SampleImage extends React.Component {
       selectionKey: 'ctrlKey',
       preserveObjectStacking: true,
     });
-
+    this.gridCache = new GridCache(this.canvas);
     this.drawGridPlugin.canvas = this.canvas;
 
     // Bind leftClick to function
@@ -358,7 +357,8 @@ class SampleImage extends React.Component {
     canvasWindow.height = h;
     // Set the size of the created FabricJS Canvas
     this.canvas.setDimensions({ width: w, height: h });
-    this.canvas.requestRenderAll();
+
+    // Removes all canvas objects, so these are not drawn multiple times
     this.canvas.clear();
 
     // Set size of the Image from
@@ -878,18 +878,37 @@ class SampleImage extends React.Component {
 
     const fabricSelectables = [...makeLines(lines, imageRatio)];
 
+    // We need to remove the grids that have been removed from the store.
+    // Also we remove hidden grids, they will be added again if unhidden
+    this.canvas.getObjects().forEach((obj) => {
+      if (
+        (obj.type === 'GridGroup' && !grids[obj.id]) ||
+        this.props.busy ||
+        grids[obj.id]?.state === 'HIDDEN' ||
+        grids[obj.id]?.user_state === 'HIDDEN'
+      ) {
+        this.gridCache.removeGrid(obj, this.canvas);
+      }
+    });
+
     // Grids already defined (drawn)
     Object.values(grids).forEach((gd) => {
-      let gridData = { ...gd };
-
-      if (!this.props.busy && gridData.state !== 'HIDDEN') {
-        this.drawGridPlugin.setScale(imageRatio);
-        gridData = this.drawGridPlugin.setPixelsPerMM(pixelsPerMm, gridData);
-        fabricSelectables.push(
-          this.drawGridPlugin.shapeFromGridData(gridData, this.canvas)
-            .shapeGroup,
-        );
+      const gridData = { ...gd };
+      if (
+        gridData.state === 'HIDDEN' ||
+        gridData.user_state === 'HIDDEN' ||
+        this.props.busy
+      ) {
+        return;
       }
+
+      const cachedGrid = this.gridCache.addGrid(
+        gridData,
+        this.drawGridPlugin,
+        pixelsPerMm,
+        imageRatio,
+      );
+      fabricSelectables.push(cachedGrid.gridGroup);
     });
 
     // Grid beeing defined (being drawn)


### PR DESCRIPTION
Currently grids are being redrawn when any property of `SampleImage` component changes. It leads to serious performance issues when very large grids are being drawn (over 100k cells) which is legitimate concern for MicroMAX users.

This change makes it so that the grids are being redrawn when any property of the `gridData` object changes, which greatly limits the amount of rerenders.
Each grid is being stored in a `gridCache` object which centralizes logic regarding adding and remoing grids.
Also logic regarding drawing grid cells has been moved to a custom fabricJS shape - `MeshGrid`. It is responsible for rendering the grid itself (without extra data like heatmap or cell labels).

It is pretty evident that additional improvements could be done to this code; both in the performance and code quality fronts. The shapes could still be reorganized, so that there is one that renders both the grid cells and, heatmap and so on to make things clearer. Also, moving motors still issues lots of costly re-renders. Nonetheless, it seems like a good starting point for some future changes.