### PR TITLE
Pass Parameter correctly

### DIFF
--- a/ui/src/containers/SampleGridTableContainer.jsx
+++ b/ui/src/containers/SampleGridTableContainer.jsx
@@ -527,7 +527,7 @@ export default function SampleGridTableContainer(props) {
 
   function getSamplesList() {
     return Object.keys(sampleList)
-      .filter(filterSampleByKey)
+      .filter((key) => filterSampleByKey(key))
       .map((sampleId) => <li key={sampleId}>{sampleId}</li>);
   }
 


### PR DESCRIPTION
fix: pass correct parameters to filterSampleByKey

The parameter was not pass properly this caused the Rubberband to not work  when applied filter. 

bug from here : https://github.com/mxcube/mxcubeweb/pull/1950/
Sorry about that.