### PR TITLE
Add image and more info to sample information page

### DIFF
--- a/ui/src/components/Equipment/Harvester.jsx
+++ b/ui/src/components/Equipment/Harvester.jsx
@@ -90,7 +90,7 @@ export default function Harvester(props) {
                       </h6>
                       <ImageViewer
                         galleryView={false}
-                        imgUrl={item.img_url}
+                        imageUrl={item.img_url}
                         imageName={item.name}
                         imgAlt=""
                         imgTargetX={item.img_target_x}

--- a/ui/src/components/ImageViewer/ImageViewer.jsx
+++ b/ui/src/components/ImageViewer/ImageViewer.jsx
@@ -4,8 +4,16 @@ import GalleryModal from './GalleryModal';
 import styles from './imageViewer.module.css';
 
 export default function ImageViewer(props) {
-  const { galleryView, imgUrls, imgAlt, imgTargetX, imgTargetY, imageName } =
-    props;
+  const {
+    galleryView,
+    imageUrlList,
+    imageUrl,
+    imgAlt,
+    imgTargetX,
+    imgTargetY,
+    imageName,
+    drawTarget,
+  } = props;
 
   const [showModal, setShowModal] = useState(false);
   const [imgUrl, setImgUrl] = useState('');
@@ -23,7 +31,7 @@ export default function ImageViewer(props) {
   return galleryView ? (
     <div className="container-fluid gallery-container">
       <div className="row">
-        {imgUrls.map((url) => {
+        {imageUrlList.map((url) => {
           return (
             <div key={url} className="col-sm-6 col-md-3 col-xl-2">
               <div className={styles.gallery_card}>
@@ -48,6 +56,7 @@ export default function ImageViewer(props) {
         imgTargetX={imgTargetX}
         imgTargetY={imgTargetY}
         imageName={imageName}
+        drawTarget={drawTarget}
       />
     </div>
   ) : (
@@ -55,18 +64,18 @@ export default function ImageViewer(props) {
       <div className={styles.gallery_card}>
         <img
           className={`${styles.gallery_thumbnail} img-fluid`}
-          src={imgUrl}
+          src={imageUrl}
           alt={imgAlt}
         />
         <span
           className={`${styles.viewer_icon_open} fa fa-expand`}
-          onClick={() => openModal(imgUrl)}
+          onClick={() => openModal(imageUrl)}
         />
       </div>
       <GalleryModal
         isOpen={showModal}
         handleClose={closeModal}
-        src={imgUrl}
+        src={imageUrl}
         imgTargetX={imgTargetX}
         imgTargetY={imgTargetY}
         imageName={imageName}

--- a/ui/src/components/ImageViewer/imageViewer.module.css
+++ b/ui/src/components/ImageViewer/imageViewer.module.css
@@ -9,6 +9,7 @@
 
 .gallery_card img[alt] {
   color: rgb(212, 9, 9);
+  font-size: 1rem;
 }
 
 .gallery_thumbnail {

--- a/ui/src/components/SampleGrid/SampleGridTableItem.jsx
+++ b/ui/src/components/SampleGrid/SampleGridTableItem.jsx
@@ -69,6 +69,8 @@ export default function SampleGridTableItem({
           <div>
             <OverlayTrigger
               placement="right"
+              trigger="click"
+              rootClose
               overlay={
                 <Popover id={sampleName}>
                   <Popover.Header className="d-flex">

--- a/ui/src/components/SampleGrid/SampleGridTableItem.module.css
+++ b/ui/src/components/SampleGrid/SampleGridTableItem.module.css
@@ -18,7 +18,7 @@
 .samplesGridTableItemNameProteinAcronym {
   font-size: small;
   font-weight: bold;
-  pointer-events: auto;
+  cursor: pointer;
   max-width: 160px;
   background: #5cb85c;
   overflow: hidden;

--- a/ui/src/components/SampleGrid/SampleInformation.jsx
+++ b/ui/src/components/SampleGrid/SampleInformation.jsx
@@ -75,9 +75,9 @@ export default function SampleInformation({ sampleData = {} }) {
           {sampleData.image_url ? (
             <ImageViewer
               galleryView={false}
-              imagegUrl={sampleData.image_url}
+              imageUrl={sampleData.image_url}
               imageName={sampleData.sampleName || 'Sample Image'}
-              imgAlt={sampleData.sampleName}
+              imgAlt={sampleData.sampleName || 'Sample Image'}
               imgTargetX={sampleData.image_x}
               imgTargetY={sampleData.image_y}
               drawTarget={!!(sampleData.image_x && sampleData.image_y)}

--- a/ui/src/components/SampleGrid/SampleInformation.jsx
+++ b/ui/src/components/SampleGrid/SampleInformation.jsx
@@ -1,41 +1,94 @@
+import ImageViewer from '../ImageViewer/ImageViewer';
+
 export default function SampleInformation({ sampleData = {} }) {
   return (
-    <div>
+    <div className="container-fluid" style={{ width: '700px' }}>
       <div className="row">
-        <span className="col-sm-6">Location:</span>
-        <span className="col-sm-6">{sampleData.location}</span>
-        <span className="col-sm-6">Data matrix / ID:</span>
-        <span className="col-sm-6">{sampleData.code}</span>
-        <span className="col-sm-6">State in Container:</span>
-        <span className="col-sm-6">{sampleData?.container_info?.state}</span>
-      </div>
-      {sampleData.limsID && (
-        <div>
+        <div className="col-md-6">
           <div className="row">
-            <span className="col-sm-6">Space group:</span>
-            <span className="col-sm-6">{sampleData.crystalSpaceGroup}</span>
-          </div>
-          <div className="row">
-            <span style={{ paddingTop: '0.5em' }} className="col-sm-12">
-              <b>Crystal unit cell:</b>
+            <span className="col-sm-6">State :</span>
+            <span className="col-sm-6">
+              <strong>
+                {sampleData?.container_info?.state?.replaceAll('_', ' ')}
+              </strong>
             </span>
-            <span className="col-sm-1">A:</span>
-            <span className="col-sm-2">{sampleData.cellA}</span>
-            <span className="col-sm-1">B:</span>
-            <span className="col-sm-2">{sampleData.cellB}</span>
-            <span className="col-sm-1">C:</span>
-            <span className="col-sm-2">{sampleData.cellC}</span>
           </div>
           <div className="row">
-            <span className="col-sm-1">&alpha;:</span>
-            <span className="col-sm-2">{sampleData.cellAlpha}</span>
-            <span className="col-sm-1">&beta;:</span>
-            <span className="col-sm-2">{sampleData.cellBeta}</span>
-            <span className="col-sm-1">&gamma;:</span>
-            <span className="col-sm-2">{sampleData.cellGamma}</span>
+            <span className="col-sm-6">Location :</span>
+            <span className="col-sm-6">{sampleData.location}</span>
           </div>
+          <div className="row">
+            <span className="col-sm-6">Data matrix / ID :</span>
+            <span className="col-sm-6">{sampleData.code}</span>
+          </div>
+          <div className="row">
+            <span className="col-sm-6">Puck barcode :</span>
+            <span className="col-sm-6">
+              {sampleData?.container_info?.puck_barcode}
+            </span>
+          </div>
+          <div className="row">
+            <span className="col-sm-6">puck type :</span>
+            <span className="col-sm-6">
+              {sampleData?.container_info?.puck_type}
+            </span>
+          </div>
+          <div className="row">
+            <span className="col-sm-6">Sample barcode :</span>
+            <span className="col-sm-6">
+              {sampleData?.container_info?.sample_barcode}
+            </span>
+          </div>
+          {sampleData.limsID && (
+            <>
+              <div className="row mt-3">
+                <span className="col-sm-6">Space group :</span>
+                <span className="col-sm-6">{sampleData.crystalSpaceGroup}</span>
+              </div>
+              <div className="row mt-3">
+                <span className="col-sm-12">
+                  <b>Crystal unit cell</b>
+                </span>
+              </div>
+              <div className="row">
+                <span className="col-sm-2">A :</span>
+                <span className="col-sm-4">{sampleData.cellA}</span>
+                <span className="col-sm-2">B :</span>
+                <span className="col-sm-4">{sampleData.cellB}</span>
+              </div>
+              <div className="row">
+                <span className="col-sm-2">C :</span>
+                <span className="col-sm-4">{sampleData.cellC}</span>
+                <span className="col-sm-2">α :</span>
+                <span className="col-sm-4">{sampleData.cellAlpha}</span>
+              </div>
+              <div className="row">
+                <span className="col-sm-2">β :</span>
+                <span className="col-sm-4">{sampleData.cellBeta}</span>
+                <span className="col-sm-2">γ :</span>
+                <span className="col-sm-4">{sampleData.cellGamma}</span>
+              </div>
+            </>
+          )}
         </div>
-      )}
+        <div className="col-md-6">
+          {sampleData.image_url ? (
+            <ImageViewer
+              galleryView={false}
+              imagegUrl={sampleData.image_url}
+              imageName={sampleData.sampleName || 'Sample Image'}
+              imgAlt={sampleData.sampleName}
+              imgTargetX={sampleData.image_x}
+              imgTargetY={sampleData.image_y}
+              drawTarget={!!(sampleData.image_x && sampleData.image_y)}
+            />
+          ) : (
+            <div className="text-center text-muted p-4 border rounded">
+              <p>No image available</p>
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
This PR give the possibility to display sample image when it exist.


What changed

SampleInformation.jsx
Expanded layout to show information in 2 Column
Display more info and image coming from the Sample Changer

ImageViewer.jsx
Fix imagegUrl  props  for single-image mode (used by Sample Information) .

SampleGridTableItem.jsx
Makes the sample name popover open on click (rootClose). 

Minor CSS tweaks
Image viewer styling 
SampleInformation Row & Col change. 


[Screencast from 2025-11-13 16-30-35.webm](https://github.com/user-attachments/assets/f03a1081-0624-4e54-bc9e-fc882ab2a03a)
