### PR TITLE
[SampleViewAdapter] - Fixed abort centring

### DIFF
--- a/mxcubeweb/routes/signals.py
+++ b/mxcubeweb/routes/signals.py
@@ -137,7 +137,6 @@ def queue_execution_finished(entry, queue_state=None):
     mxcube.TEMP_DISABLED = []
 
     server.emit("queue", msg, namespace="/hwr")
-    mxcube.sample_view._emit_shapes_updated()
 
 
 def queue_execution_stopped(*args):


### PR DESCRIPTION
The implementation of `abort_centring` was copied incorrectly from the old Component this PR restores the missing logic.