### PR TITLE
`move_to_beam` is on Diffratcomter not on SampleView

### DIFF
--- a/mxcubeweb/core/adapter/sample_view_adapter.py
+++ b/mxcubeweb/core/adapter/sample_view_adapter.py
@@ -416,7 +416,7 @@ class SampleViewAdapter(AdapterBase):
         return {}
 
     def move_to_beam(self, x: float, y: float):
-        self._ho.move_to_beam(x, y)
+        HWR.beamline.diffractometer.move_to_beam(x, y)
         return {}
 
     def start_auto_centring(self):


### PR DESCRIPTION
The method `move_to_beam` is on the Diffratctomter hardware object not on `SampleView`