### PR TITLE
Make better use of Bootstrap in `SampleChanger` equipment

### DIFF
--- a/ui/src/components/Equipment/SampleChanger.jsx
+++ b/ui/src/components/Equipment/SampleChanger.jsx
@@ -1,7 +1,5 @@
-/* eslint-disable jsx-a11y/control-has-associated-label */
 import { useState } from 'react';
-import { Button, Card, Dropdown, DropdownButton, Form } from 'react-bootstrap';
-import { contextMenu, Item, Menu, Separator } from 'react-contexify';
+import { Alert, Button, ButtonGroup, Card, Dropdown } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
@@ -14,119 +12,97 @@ import {
 } from '../../actions/sampleChanger';
 import styles from './equipment.module.css';
 
-function getUniqueId() {
-  if (SampleChangerTreeNode._uid_count === undefined) {
-    SampleChangerTreeNode._uid_count = 0;
-  }
-  return `SCTreeNodeID${SampleChangerTreeNode._uid_count++}`;
-}
-
-function treeNodeCbxClick(evt) {
-  const treeNodeIcon = document.querySelector(`#${evt.target.id}icon`);
-  if (treeNodeIcon) {
-    treeNodeIcon.className = `fa fa-${evt.target.checked ? 'minus' : 'plus'}`;
-  }
-}
-
 function SampleChangerTreeNode(props) {
-  const { label, children } = props;
+  const { label, disabled, children } = props;
 
   const dispatch = useDispatch();
-  const inputId = getUniqueId();
+  const [expanded, setExpanded] = useState(false);
 
   return (
-    <div key={label}>
-      <li className={styles.treeLi}>
-        <input
-          type="checkbox"
-          className={styles.treeNode}
-          id={inputId}
-          onClick={treeNodeCbxClick}
-        />
-        <Form.Label
-          className={styles.treeNodeLabel}
-          htmlFor={inputId}
-          onContextMenu={(event) => {
-            contextMenu.show({ id: `${label}`, event });
-          }}
+    <li className={styles.treeItem}>
+      <Dropdown as={ButtonGroup}>
+        <Button
+          variant="secondary"
+          size="sm"
+          disabled={disabled}
+          onClick={() => setExpanded(!expanded)}
         >
-          <i id={`${inputId}icon`} className="fa fa-plus" />
-          &nbsp;
+          <i className={`fa fa-${expanded ? 'minus' : 'plus'} me-2`} />
           {label}
-        </Form.Label>
-        <ul className={styles.treeUl}>{children}</ul>
-      </li>
+        </Button>
 
-      <Menu id={`${label}`}>
-        <li role="heading" aria-level="2" className="dropdown-header">
-          <b>Container {label}</b>
-        </li>
-        <Separator />
-        <Item onClick={() => dispatch(scan(label))}>Scan</Item>
-        <Item onClick={() => dispatch(select(label))}>
-          Move to this container
-        </Item>
-      </Menu>
-    </div>
+        <Dropdown.Toggle
+          id={`sample_changer_tree_node_${label}`}
+          split
+          variant="secondary"
+          disabled={disabled}
+        />
+        <Dropdown.Menu>
+          <Dropdown.Header className="fw-bold">
+            Container {label}
+          </Dropdown.Header>
+
+          <Dropdown.Divider />
+          <Dropdown.Item onClick={() => dispatch(scan(label))}>
+            Scan
+          </Dropdown.Item>
+          <Dropdown.Item onClick={() => dispatch(select(label))}>
+            Move to this container
+          </Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>
+
+      <ul hidden={!expanded}>{children}</ul>
+    </li>
   );
 }
 
 // eslint-disable-next-line react/no-multi-comp
 function SampleChangerTreeItem(props) {
-  const { label, status, dm } = props;
+  const { label, dm, disabled } = props;
   const dispatch = useDispatch();
 
-  const [dropdownIsOpen, setDropdownIsOpen] = useState(false);
-
-  const loadedSampleAddress = useSelector(
-    (state) => state.sampleChanger.loadedSample?.address,
+  const isMounted = useSelector(
+    (state) => state.sampleChanger.loadedSample?.address === label,
   );
 
-  function handleMountClick() {
-    toggleDropdown();
-    dispatch(mountSample({ sampleID: label, location: label }));
-  }
-
-  function handleUnmountClick() {
-    toggleDropdown();
-    dispatch(unmountSample());
-  }
-
-  function toggleDropdown() {
-    setDropdownIsOpen(!dropdownIsOpen);
-  }
-
-  const ls = status === 'Loaded' ? { display: 'inline' } : { display: 'none' };
-
   return (
-    <div>
-      <li className={styles.treeLi}>
-        <div className={styles.sampleLabel}>
-          <DropdownButton
-            style={{ fontStyle: 'italic', padding: '0.2em 0.2em' }}
-            title={`${label} ${dm}`}
-            variant="link"
-            onToggle={toggleDropdown}
-            open={dropdownIsOpen}
-          >
-            <Dropdown.Header aria-level="2" className="dropdown-header">
-              <b>Position : {label}</b>
-            </Dropdown.Header>
-            <Dropdown.Divider />
-            <Dropdown.Item onClick={handleMountClick}>Mount</Dropdown.Item>
-            {loadedSampleAddress === label && (
-              <Dropdown.Item onClick={handleUnmountClick}>
-                Umount this position
-              </Dropdown.Item>
-            )}
-          </DropdownButton>
-          <span style={ls}>
-            &nbsp;
-            <i className="fas fa-arrow-left" /> <b>(Mounted)</b>
+    <li className={styles.treeItem}>
+      <Dropdown className="d-inline-flex align-items-center mt-1">
+        <Dropdown.Toggle size="sm" variant="light" disabled={disabled}>
+          <span className="me-1">
+            {label} {dm}
           </span>
-        </div>
-      </li>
-    </div>
+        </Dropdown.Toggle>
+
+        <Dropdown.Menu>
+          <Dropdown.Header className="fw-bold">
+            Position: {label}
+          </Dropdown.Header>
+
+          <Dropdown.Divider />
+          {isMounted ? (
+            <Dropdown.Item onClick={() => dispatch(unmountSample())}>
+              Umount this position
+            </Dropdown.Item>
+          ) : (
+            <Dropdown.Item
+              onClick={() => {
+                dispatch(mountSample({ sampleID: label, location: label }));
+              }}
+            >
+              Mount
+            </Dropdown.Item>
+          )}
+        </Dropdown.Menu>
+
+        {isMounted && (
+          <>
+            <i className="fas fa-arrow-left mx-2" /> <b>Mounted</b>
+          </>
+        )}
+      </Dropdown>
+    </li>
   );
 }
 
@@ -134,7 +110,9 @@ function SampleChangerTreeItem(props) {
 function SampleChanger() {
   const dispatch = useDispatch();
 
-  const scState = useSelector((state) => state.sampleChanger.state);
+  const isLoading = useSelector(
+    (state) => state.sampleChanger.state === 'LOADING',
+  );
   const loadedSample = useSelector((state) => state.sampleChanger.loadedSample);
   const contents = useSelector((state) => state.sampleChanger.contents);
 
@@ -147,7 +125,7 @@ function SampleChanger() {
           selected={node.selected}
           root={root}
           dm={node.id}
-          status={node.status}
+          disabled={isLoading}
         >
           {node.children.map(renderTree)}
         </SampleChangerTreeNode>
@@ -156,10 +134,10 @@ function SampleChanger() {
 
     return (
       <SampleChangerTreeItem
+        key={node.name}
         label={node.name}
         dm={node.id}
-        status={node.status}
-        key={node.name}
+        disabled={isLoading}
       />
     );
   }
@@ -169,60 +147,53 @@ function SampleChanger() {
       <Card.Header>Content</Card.Header>
       <Card.Body>
         <Button
+          className="me-2"
+          size="sm"
           variant="outline-secondary"
-          onClick={() => {
-            dispatch(refresh());
-          }}
+          onClick={() => dispatch(refresh())}
         >
           <i className="fas fa-sync" /> Refresh
         </Button>
 
         <Button
-          style={{ marginLeft: '1em' }}
+          className="me-2"
+          size="sm"
           variant="outline-secondary"
-          onClick={() => {
-            dispatch(scan(''));
-          }}
+          onClick={() => dispatch(scan(''))}
         >
           <i className="fas fa-qrcode" /> Scan all containers
         </Button>
 
-        <span style={{ marginLeft: '1em' }}>
-          {scState === 'MOVING' && (
-            <Button
-              variant="danger"
-              className={styles.abortButton}
-              onClick={() => {
-                dispatch(abort());
-              }}
-            >
-              <i className="fas fa-stop" /> Abort
-            </Button>
-          )}
-        </span>
-
-        {loadedSample.address ? (
-          <div style={{ marginTop: '1em' }}>
-            Currently loaded: {loadedSample.address}
-            <span style={{ marginRight: '1em' }} />( {loadedSample.barcode} )
-            <span style={{ marginRight: '1em' }} />
-            <Button
-              variant="outline-secondary"
-              onClick={() => {
-                dispatch(unmountSample());
-              }}
-            >
-              <i className="fas fa-download" /> Unload
-            </Button>
-          </div>
-        ) : (
-          <div style={{ marginTop: '1em', marginBottom: '1em' }} />
+        {isLoading && (
+          <Button size="sm" variant="danger" onClick={() => dispatch(abort())}>
+            <i className="fas fa-stop" /> Abort
+          </Button>
         )}
 
-        <div style={{ marginBottom: '1em' }} />
-        <div style={{ maxHeight: '60vh', overflowY: 'auto' }}>
-          {renderTree(contents, true)}
-        </div>
+        {loadedSample.address && (
+          <Button
+            size="sm"
+            variant="outline-secondary"
+            onClick={() => dispatch(unmountSample())}
+          >
+            <i className="fas fa-download" /> Unmount
+          </Button>
+        )}
+
+        <Alert className="mt-3">
+          {loadedSample.address ? (
+            <>
+              Currently mounted:{' '}
+              <strong className="me-2 text-nowrap">
+                {loadedSample.address} ({loadedSample.barcode})
+              </strong>
+            </>
+          ) : (
+            'No sample loaded'
+          )}
+        </Alert>
+
+        <div className={styles.treeWrapper}>{renderTree(contents, true)}</div>
       </Card.Body>
     </Card>
   );

--- a/ui/src/components/Equipment/equipment.module.css
+++ b/ui/src/components/Equipment/equipment.module.css
@@ -1,51 +1,3 @@
-.treeNode {
-  display: none;
-}
-
-.treeNode ~ ul {
-  display: none;
-}
-
-.treeNode:checked ~ ul {
-  display: block;
-}
-
-.treeNodeLabel {
-  font-weight: normal;
-  cursor: pointer;
-  margin: 0;
-}
-
-.treeNodeLabel:hover {
-  font-weight: bold;
-  color: hsl(208, 56%, 35%);
-}
-
-.treeUl {
-  background-color: #fff;
-  cursor: pointer;
-}
-
-.treeLi {
-  width: 200px;
-  display: block;
-  padding-top: 0.2em;
-  padding-left: 0.2em;
-}
-
-.sampleLabel:hover {
-  background-clip: content-box;
-  background-color: #d9edf7;
-}
-
-.custom-btn-color {
-  color: hsl(0, 0%, 50%) !important;
-}
-
-.custom-btn-color:hover {
-  color: hsl(0, 0%, 0%) !important;
-}
-
 .scMessage {
   background-color: white;
   color: blue;
@@ -54,17 +6,23 @@
   text-align: center;
 }
 
-.abortButton {
-  background-color: #ffdddd;
-  font-weight: bold;
+/* Sample Changer */
+.treeWrapper {
+  min-height: 20vh;
+  max-height: 60vh;
+  overflow: auto;
 }
 
-.actionHeader {
-  background-color: #eeeeee;
-  text-align: center;
+.treeItem {
+  list-style-type: none;
+  margin-top: 0.25rem;
+}
+.treeItem > ul {
+  padding-left: 1rem;
+  margin-bottom: 0.75rem;
 }
 
-/* Plate Manipulator*/
+/* Plate Manipulator */
 .plate_div {
   height: '55vh';
   margin: 20px;
@@ -147,6 +105,7 @@
   opacity: 1;
 }
 
+/* Harvester */
 .ha_grid_container {
   display: grid;
   grid-template-rows: repeat(auto-fit, auto);


### PR DESCRIPTION
This is based off #1977 so I'll rebase manually and mark it as ready once #1977 is merged.

### BEFORE

- The code of `SampleChangerTreeNode` was particularly outdated. It made use of a hidden checkbox for toggling the tree items, used `react-contextify` to implement a very hard-to-discover context menu, etc.
- While comparing the code and the UI, I also noticed a few bugs, like the "<- Mounted" text and the "Abort" button not appearing when they should.
- The UI was not particularly pretty or usable (layout shift while mounting a different sample, link-like text for dropdown toggles, etc.)

[Screencast from 2025-12-01 15-05-43.webm](https://github.com/user-attachments/assets/11834965-0f91-487a-9a8d-8aa353907c50)

### AFTER

- I make better use of Bootstrap overall to improve the UI, remove a bunch of custom/inline styles, and remove one occurrence of `react-contextify` (cf. #1844 #1906).
- I use a proper local React state to manage the expanded state of each tree node.
- I fix the bug with the "<- Mounted" text and "Abort" button.
- I improve the UX slightly by:
  - disabling the drop-downs while mounting a sample;
  - removing the "Mount" option for an already-mounted sample;
  - showing a fallback text when no sample is mounted.

[Screencast from 2025-12-01 15-03-43.webm](https://github.com/user-attachments/assets/c08b0649-649a-4ddb-aadd-967d3f0cba77)