### PR TITLE
Improve queue and logs layout

### DIFF
--- a/ui/src/components/MXNavbar/MXNavbar.module.css
+++ b/ui/src/components/MXNavbar/MXNavbar.module.css
@@ -1,4 +1,5 @@
 .navBar {
+  flex: none;
   padding: 0;
   z-index: 9999;
   color: rgba(255, 255, 255, 0.8);

--- a/ui/src/components/Main.jsx
+++ b/ui/src/components/Main.jsx
@@ -42,7 +42,7 @@ function Main() {
   }
 
   return (
-    <div className={styles.main}>
+    <div className={styles.root}>
       {showReadOnlyDiv && (
         <div
           className={styles.readOnly}
@@ -66,9 +66,9 @@ function Main() {
 
       <MXNavbar />
 
-      <Stack className="mb-4" gap={2}>
+      <main className={styles.main}>
         <Outlet />
-      </Stack>
+      </main>
 
       <ChatWidget />
     </div>

--- a/ui/src/components/Main.jsx
+++ b/ui/src/components/Main.jsx
@@ -1,5 +1,4 @@
 import { useEffect } from 'react';
-import { Stack } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 import { Outlet, useLocation } from 'react-router-dom';
 

--- a/ui/src/components/Main.module.css
+++ b/ui/src/components/Main.module.css
@@ -7,7 +7,7 @@
 
 .main {
   flex: 1;
-  display: grid;
+  display: flex;
 }
 
 .readOnly {

--- a/ui/src/components/Main.module.css
+++ b/ui/src/components/Main.module.css
@@ -1,6 +1,13 @@
-.main {
-  flex: 1 1 0%;
+.root {
+  flex: 1;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.main {
+  flex: 1;
+  display: grid;
 }
 
 .readOnly {

--- a/ui/src/components/Notify/UserMessage.jsx
+++ b/ui/src/components/Notify/UserMessage.jsx
@@ -6,7 +6,7 @@ export default function UserMessage() {
   const messages = useSelector((state) => state.logger.logRecords);
 
   return (
-    <div id="usermessages" className={styles.messageBody}>
+    <>
       {[...messages].reverse().map((message) => (
         <div
           key={`${message.id}`}
@@ -22,6 +22,6 @@ export default function UserMessage() {
           </span>
         </div>
       ))}
-    </div>
+    </>
   );
 }

--- a/ui/src/components/Notify/UserMessage.jsx
+++ b/ui/src/components/Notify/UserMessage.jsx
@@ -5,23 +5,24 @@ import styles from './UserMessage.module.css';
 export default function UserMessage() {
   const messages = useSelector((state) => state.logger.logRecords);
 
+  if (messages.length === 0) {
+    return <div className={styles.empty}>No messages yet</div>;
+  }
+
   return (
     <>
-      {[...messages].reverse().map((message) => (
-        <div
-          key={`${message.id}`}
-          className={`${styles.message} ${styles[message.severity]}`}
-        >
-          {message.severity === 'INFO' ? (
-            <span className="fas fa-lg fa-check-circle" />
-          ) : (
-            <span className="fas fa-lg fa-exclamation-circle" />
-          )}
-          <span className={styles.messageText}>
-            {`[${message.timestamp.slice(11, 19)}]: ${message.message}`}
-          </span>
-        </div>
-      ))}
+      {[...messages].reverse().map((msg) => {
+        const { id, timestamp, message, severity } = msg;
+        const icon =
+          severity === 'INFO' ? 'fa-check-circle' : 'fa-exclamation-circle';
+
+        return (
+          <div key={id} className={styles.message} data-severity={severity}>
+            <span className={`${styles.icon} fas fa-md ${icon} me-2`} />
+            {`[${timestamp.slice(11, 19)}] ${message}`}
+          </div>
+        );
+      })}
     </>
   );
 }

--- a/ui/src/components/Notify/UserMessage.module.css
+++ b/ui/src/components/Notify/UserMessage.module.css
@@ -1,35 +1,39 @@
 .message {
-  position: relative;
-  padding: 0.4em;
-  opacity: 1;
+  padding: 0.25rem 0.75rem;
+  border-color: rgb(var(--user-message-color));
+  background-color: rgba(var(--user-message-color), 0.2);
 }
 
-.message:not(:first-child) {
-  border-top: 2px solid #333;
+.message:first-child {
+  padding-top: 0.5rem;
 }
 
-.INFO {
-  border-color: #4e677b;
-  background-color: rgba(91, 141, 180, 0.8);
+.message:last-child {
+  padding-bottom: 0.5rem;
 }
 
-.WARNING {
-  border-color: #2196f3;
-  background-color: rgba(240, 173, 78, 0.8);
+.message[data-severity='INFO'] {
+  --user-message-color: 91, 141, 180;
 }
 
-.ERROR {
-  border-color: #d9534f;
-  background-color: rgba(217, 83, 79, 0.8);
+.message[data-severity='WARNING'] {
+  --user-message-color: 240, 173, 78;
 }
 
-.DEBUG {
-  border-color: #d9534f;
-  background-color: rgba(217, 83, 79, 0.8);
+.message[data-severity='ERROR'] {
+  --user-message-color: 217, 83, 79;
 }
 
-.messageText {
-  color: #fff;
-  margin-left: 7px;
-  font-weight: bold;
+.message[data-severity='DEBUG'] {
+  --user-message-color: 217, 83, 79;
+}
+
+.icon {
+  color: rgb(var(--user-message-color));
+}
+
+.empty {
+  padding: 0.5rem 0.75rem;
+  background-color: #fafafa;
+  font-style: italic;
 }

--- a/ui/src/components/Notify/UserMessage.module.css
+++ b/ui/src/components/Notify/UserMessage.module.css
@@ -1,37 +1,30 @@
-.messageBody {
-  position: flex;
-  justify-content: flex-end;
-  flex-direction: column-reverse;
-  background-color: rgba(255, 255, 255, 0);
-  display: 'flex';
-  z-index: 1000;
-}
-
 .message {
   position: relative;
   padding: 0.4em;
-  border-color: #333;
   opacity: 1;
 }
 
+.message:not(:first-child) {
+  border-top: 2px solid #333;
+}
+
 .INFO {
-  border-top: 5px solid #4e677b;
+  border-color: #4e677b;
   background-color: rgba(91, 141, 180, 0.8);
-  border-radius: 2px;
 }
 
 .WARNING {
-  border-top: 5px solid #2196f3;
+  border-color: #2196f3;
   background-color: rgba(240, 173, 78, 0.8);
 }
 
 .ERROR {
-  border-top: 5px solid #d9534f;
+  border-color: #d9534f;
   background-color: rgba(217, 83, 79, 0.8);
 }
 
 .DEBUG {
-  border-top: 5px solid #d9534f;
+  border-color: #d9534f;
   background-color: rgba(217, 83, 79, 0.8);
 }
 

--- a/ui/src/components/SampleQueue/CurrentTree.jsx
+++ b/ui/src/components/SampleQueue/CurrentTree.jsx
@@ -111,8 +111,8 @@ export default class CurrentTree extends React.Component {
       return <div />;
     }
     return (
-      <div>
-        <div style={{ top: '6%', height: '69%' }} className={styles.listBody}>
+      <>
+        <div className={styles.listBody}>
           {sampleTasks.map((taskData, i) => {
             let task = null;
 
@@ -225,7 +225,7 @@ export default class CurrentTree extends React.Component {
             Duplicate this item
           </Item>
         </Menu>
-      </div>
+      </>
     );
   }
 }

--- a/ui/src/components/SampleQueue/Item.module.css
+++ b/ui/src/components/SampleQueue/Item.module.css
@@ -1,7 +1,10 @@
 .nodeSample {
   font-size: 1em;
-  margin-bottom: 1rem;
   background-color: white;
+}
+
+.nodeSample:not(:last-child) {
+  margin-bottom: 1rem;
 }
 
 .taskHead {

--- a/ui/src/components/SampleQueue/QueueControl.jsx
+++ b/ui/src/components/SampleQueue/QueueControl.jsx
@@ -13,7 +13,7 @@ export default function QueueControl() {
   const showBusyIndicator = queueStatus === QUEUE_RUNNING ? 'inline' : 'none';
 
   return (
-    <Navbar className={styles.mTree}>
+    <Navbar className={styles.queueControl}>
       <Nav
         className="me-auto my-2 my-lg-0"
         style={{ maxHeight: '100px' }}

--- a/ui/src/components/SampleQueue/QueueControl.module.css
+++ b/ui/src/components/SampleQueue/QueueControl.module.css
@@ -1,9 +1,8 @@
-.mTree {
+.queueControl {
   position: relative;
   user-select: none;
   background-color: white;
   padding: 0.5em;
-  border: 1px solid #aaa;
-  border-radius: 3px;
-  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
+  border: 1px solid var(--bs-border-color);
+  border-radius: var(--bs-border-radius);
 }

--- a/ui/src/components/SampleQueue/Tree.module.css
+++ b/ui/src/components/SampleQueue/Tree.module.css
@@ -3,14 +3,10 @@
   border: 0;
   display: flex;
 }
+
 .listBody {
-  padding: 0.5rem 1rem;
+  flex: 1;
   display: flex;
   flex-direction: column;
-  position: absolute;
-  overflow-y: auto;
-  overflow-x: hidden;
-  top: 15%;
-  height: 60%;
-  width: 100%;
+  padding: 0.75rem;
 }

--- a/ui/src/containers/SampleQueueContainer.jsx
+++ b/ui/src/containers/SampleQueueContainer.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/destructuring-assignment */
 import React from 'react';
-import { Nav } from 'react-bootstrap';
+import { Nav, Stack } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
@@ -65,17 +65,18 @@ class SampleQueueContainer extends React.Component {
     }
 
     return (
-      <div className={styles.container}>
+      <Stack className="flex-grow-1" gap={3}>
         <QueueControl />
-        <div className={styles.queueBody}>
+
+        <div className={styles.queue}>
           <Nav
+            className={styles.queueNav}
             variant="tabs"
             fill
             justify
             defaultActiveKey="current"
             activeKey={visibleList}
             onSelect={this.handleSelect}
-            className={styles.queueNav}
           >
             <Nav.Item>
               <Nav.Link eventKey="current" className={styles.queueNavLink}>
@@ -92,42 +93,46 @@ class SampleQueueContainer extends React.Component {
               </Nav.Link>
             </Nav.Item>
           </Nav>
-          {loading ? (
-            <div className={styles.centerInBox} style={{ zIndex: '1000' }}>
-              <img src={loader} className="img-fluid" width="100" alt="" />
-            </div>
-          ) : null}
-          <CurrentTree
-            show={visibleList === 'current'}
-            mounted={currentSampleID}
-            sampleList={sampleList}
-            checked={checked}
-            showForm={showForm}
-            displayData={displayData}
-            addTask={this.props.addTask}
-            plotsData={this.props.plotsData}
-            plotsInfo={this.props.plotsInfo}
-            shapes={this.props.shapes}
-            showDialog={this.props.showDialog}
-            showWorkflowParametersDialog={
-              this.props.showWorkflowParametersDialog
-            }
-          />
-          {visibleList === 'todo' && <TodoTree list={todo} />}
-          <div className={styles.queueMessages}>
-            <div className={styles.queueMessagesTitle}>
-              <span
-                style={{ marginRight: '7px' }}
-                className="fas fa-lg fa-info-circle"
-              />
-              Log messages:
-            </div>
-            <div className={styles.queueMessagesBody}>
-              <UserMessage />
-            </div>
+
+          <div className={styles.queueBody}>
+            {loading && (
+              <div className={styles.loader} style={{ zIndex: '1000' }}>
+                <img src={loader} className="img-fluid" width="100" alt="" />
+              </div>
+            )}
+            <CurrentTree
+              show={visibleList === 'current'}
+              mounted={currentSampleID}
+              sampleList={sampleList}
+              checked={checked}
+              showForm={showForm}
+              displayData={displayData}
+              addTask={this.props.addTask}
+              plotsData={this.props.plotsData}
+              plotsInfo={this.props.plotsInfo}
+              shapes={this.props.shapes}
+              showDialog={this.props.showDialog}
+              showWorkflowParametersDialog={
+                this.props.showWorkflowParametersDialog
+              }
+            />
+            {visibleList === 'todo' && <TodoTree list={todo} />}
           </div>
         </div>
-      </div>
+
+        <div className={styles.logs}>
+          <div className={styles.logsHeader}>
+            <span
+              style={{ marginRight: '7px' }}
+              className="fas fa-lg fa-info-circle"
+            />
+            Log messages:
+          </div>
+          <div className={styles.logsBody}>
+            <UserMessage />
+          </div>
+        </div>
+      </Stack>
     );
   }
 }

--- a/ui/src/containers/SampleQueueContainer.jsx
+++ b/ui/src/containers/SampleQueueContainer.jsx
@@ -122,11 +122,8 @@ class SampleQueueContainer extends React.Component {
 
         <div className={styles.logs}>
           <div className={styles.logsHeader}>
-            <span
-              style={{ marginRight: '7px' }}
-              className="fas fa-lg fa-info-circle"
-            />
-            Log messages:
+            <span className="fas fa-md fa-info-circle me-2" />
+            Log messages
           </div>
           <div className={styles.logsBody}>
             <UserMessage />

--- a/ui/src/containers/SampleQueueContainer.module.css
+++ b/ui/src/containers/SampleQueueContainer.module.css
@@ -23,17 +23,19 @@
 .logs {
   display: flex;
   flex-direction: column;
-  height: 25vh;
-  min-height: 10rem;
+  max-height: 25vh;
+  border: 1px solid var(--bs-border-color);
+  border-radius: var(--bs-border-radius);
 }
 .logsHeader {
   flex: none;
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
   background-color: #eef;
-  padding: 0.5rem 1rem;
   border-radius: var(--bs-border-radius) var(--bs-border-radius) 0 0;
 }
 .logsBody {
-  flex: 1;
   overflow: auto;
 }
 

--- a/ui/src/containers/SampleQueueContainer.module.css
+++ b/ui/src/containers/SampleQueueContainer.module.css
@@ -1,72 +1,51 @@
-.container {
-  box-sizing: border-box;
+.queue {
+  flex: 1;
   display: flex;
   flex-direction: column;
-  width: 100%;
-}
-
-.container *,
-.container *::before,
-.container *::after {
-  box-sizing: inherit;
-}
-
-.queueBody {
-  position: relative;
   user-select: none;
   background-color: white;
-  padding-bottom: 0.5em;
-  padding-top: 0;
-  margin-top: 10px;
-  overflow-x: hidden;
-  flex-grow: 1;
-  border: 1px solid #aaa;
-  border-radius: 3px;
-  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
 }
 
-.queueBody ul li.active {
+.queue ul li.active {
   background-color: rgba(0, 0, 0, 0);
 }
 
-.queueNav {
-  height: 6%;
-}
-.queueNavLink {
-  height: 100%;
-  padding: 0.4em 0 0;
-}
-
-.queueMessages {
-  height: 25%;
-  width: 100%;
-  bottom: 0;
-  position: absolute;
-  overflow-y: hidden;
-  overflow-x: hidden;
-}
-.queueMessagesTitle {
-  background-color: #eef;
-  border-top: 1px solid #ddd;
-  border-bottom: 1px solid #ddd;
-  padding: 0.5rem 1rem;
-}
-.queueMessagesBody {
-  height: 75%;
-  width: 100%;
-  overflow-y: auto;
-}
-
-.centerInBox {
+.queueBody {
+  flex: 1 1 0;
   display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 24em;
-  width: 100%;
-  height: 100%;
+  flex-direction: column;
+  overflow: auto;
+  position: relative; /* for loader */
+  border: 1px solid var(--bs-border-color);
+  border-top: 0;
+}
+
+.logs {
+  display: flex;
+  flex-direction: column;
+  height: 25vh;
+  min-height: 10rem;
+}
+.logsHeader {
+  flex: none;
+  background-color: #eef;
+  padding: 0.5rem 1rem;
+  border-radius: var(--bs-border-radius) var(--bs-border-radius) 0 0;
+}
+.logsBody {
+  flex: 1;
+  overflow: auto;
+}
+
+.loader {
   position: absolute;
   top: 0;
   left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background-color: #000;
   opacity: 0.5;
 }

--- a/ui/src/containers/SampleViewContainer.jsx
+++ b/ui/src/containers/SampleViewContainer.jsx
@@ -75,6 +75,7 @@ function SampleViewContainer() {
           </DefaultErrorBoundary>
         </Col>
       </Row>
+
       <Row className="flex-grow-1 gx-3 py-3">
         <Col sm={2} xxl={1} className={styles.controllers}>
           <DefaultErrorBoundary>
@@ -123,6 +124,7 @@ function SampleViewContainer() {
             <MotorControls />
           </DefaultErrorBoundary>
         </Col>
+
         <Col sm={6}>
           <DefaultErrorBoundary>
             <ContextMenu />
@@ -135,12 +137,8 @@ function SampleViewContainer() {
             />
           </DefaultErrorBoundary>
         </Col>
-        <Col
-          sm={4}
-          xxl={5}
-          className={styles.queue}
-          style={{ display: 'flex' }}
-        >
+
+        <Col className={styles.queue} sm={4} xxl={5}>
           <DefaultErrorBoundary>
             <SampleQueueContainer />
           </DefaultErrorBoundary>

--- a/ui/src/containers/SampleViewContainer.jsx
+++ b/ui/src/containers/SampleViewContainer.jsx
@@ -60,9 +60,10 @@ function SampleViewContainer() {
   const selectedGrids = Object.values(grids).filter((s) => s.selected);
 
   return (
-    <Container fluid>
+    <Container className="d-flex flex-column" fluid>
       <Row
         style={{
+          flex: 'none',
           background: '#fafafa',
           borderBottom: '1px solid lightgray',
           paddingBottom: '0em',
@@ -74,7 +75,7 @@ function SampleViewContainer() {
           </DefaultErrorBoundary>
         </Col>
       </Row>
-      <Row className="gx-3 mt-2 pt-1">
+      <Row className="flex-grow-1 gx-3 py-3">
         <Col sm={2} xxl={1} className={styles.controllers}>
           <DefaultErrorBoundary>
             {phaseControl !== undefined && (

--- a/ui/src/containers/SampleViewContainer.module.css
+++ b/ui/src/containers/SampleViewContainer.module.css
@@ -1,3 +1,7 @@
+.queue {
+  display: flex;
+}
+
 @media screen and (min-width: 1300px) and (max-width: 1920px) {
   .controllers {
     width: 12%;


### PR DESCRIPTION
### BEFORE

- The motors and queue sidebars are constrained by the height of the sample image.
-  The logs are flush against the queue so look like they are part of the queue tabs' contents.
- The active queue tab doesn't look quite right because of the bottom border.
- There's an annoying white gap at the bottom of the logs above a certain screen size.
- The general design of the queue/logs sidebar is a bit heavy (dark borders, heavy separators between logs, etc.)
- The CSS of the queue/logs sidebar has a bunch of fixed percentage-based heights and absolutely positioned elements.

<img width="1944" height="1121" alt="image" src="https://github.com/user-attachments/assets/b8d6bcdf-da5c-486d-b763-e9abbee415d0" />

The annoying white gap at the bottom of the logs:

<img width="989" height="238" alt="image" src="https://github.com/user-attachments/assets/11bede23-d42d-4dfe-9aae-b4c35374d32c" />

### AFTER

- The motors and queue sidebars grow to fill the available vertical space.
- The logs are spaced out from the queue.
- The active queue tab looks right.
- The white gap at the bottom of the logs is no longer present.
- The general design is a bit cleaner and lighter. Note, however, that I didn't go as far as to rethink the design of the logs and queue items. I focused more on the layout.
- The CSS of the queue/logs sidebar is a lot simpler and more straightforward.

[Screencast from 2025-12-02 15-03-43.webm](https://github.com/user-attachments/assets/49bfa500-1a2f-4081-8f59-ab2a670b85e8)