### PR TITLE
Convert `SampleQueueContainer` and `CurrentTree` to function components

### DIFF
--- a/ui/src/components/SampleQueue/CurrentTree.jsx
+++ b/ui/src/components/SampleQueue/CurrentTree.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/destructuring-assignment */
-import React from 'react';
 import { Item, Menu } from 'react-contexify';
 
 import CharacterisationTaskItem from './CharacterisationTaskItem';
@@ -9,29 +7,31 @@ import styles from './Tree.module.css';
 import WorkflowTaskItem from './WorkflowTaskItem';
 import XRFTaskItem from './XRFTaskItem';
 
-export default class CurrentTree extends React.Component {
-  constructor(props) {
-    super(props);
-    this.showInterleavedDialog = this.showInterleavedDialog.bind(this);
-    this.interleavedAvailable = this.interleavedAvailable.bind(this);
-    this.selectedTasks = this.selectedTasks.bind(this);
-    this.duplicateTask = this.duplicateTask.bind(this);
-  }
+function CurrentTree(props) {
+  const {
+    show,
+    sampleList,
+    mounted,
+    displayData,
+    shapes,
+    addTask,
+    checked,
+    plotsData,
+    plotsInfo,
+    showForm,
+    showDialog,
+    showWorkflowParametersDialog,
+  } = props;
 
-  selectedTasks() {
+  function getSelectedTasks() {
     const selectedTasks = [];
-    const taskList = this.props.sampleList[this.props.mounted]
-      ? this.props.sampleList[this.props.mounted].tasks
-      : [];
+    const taskList = sampleList[mounted] ? sampleList[mounted].tasks : [];
 
     taskList.forEach((task, taskIdx) => {
-      const displayData = this.props.displayData[task.queueID];
+      const data = displayData[task.queueID];
 
-      if (displayData && displayData.selected) {
-        const tData =
-          this.props.sampleList[this.props.mounted].tasks[
-            Number.parseInt(taskIdx, 10)
-          ];
+      if (data && data.selected) {
+        const tData = sampleList[mounted].tasks[Number.parseInt(taskIdx, 10)];
 
         if (tData) {
           selectedTasks.push(tData);
@@ -42,9 +42,9 @@ export default class CurrentTree extends React.Component {
     return selectedTasks;
   }
 
-  interleavedAvailable() {
+  function isInterleavedAvailable() {
     let available = false;
-    const selectedTasks = this.selectedTasks();
+    const selectedTasks = getSelectedTasks();
 
     // Interleaved is only available if more than one DataCollection task is selected
     available = selectedTasks.length > 1;
@@ -59,8 +59,8 @@ export default class CurrentTree extends React.Component {
     return available;
   }
 
-  duplicateTask(taskIndex) {
-    const task = this.props.sampleList[this.props.mounted].tasks[taskIndex];
+  function duplicateTask(taskIndex) {
+    const task = sampleList[mounted].tasks[taskIndex];
 
     if (task) {
       const tpars = {
@@ -68,164 +68,156 @@ export default class CurrentTree extends React.Component {
         label: task.label,
         ...task.parameters,
       };
-      this.props.addTask([task.sampleID], tpars, false);
+      addTask([task.sampleID], tpars, false);
     }
   }
 
-  showInterleavedDialog() {
+  function showInterleavedDialog() {
     const wedges = [];
     const taskIndexList = [];
 
-    Object.values(this.props.sampleList[this.props.mounted].tasks).forEach(
-      (task, taskIdx) => {
-        if (this.props.displayData[task.queueID].selected) {
-          wedges.push(
-            this.props.sampleList[this.props.mounted].tasks[
-              Number.parseInt(taskIdx, 10)
-            ],
-          );
-          taskIndexList.push(taskIdx);
-        }
-      },
-    );
+    Object.values(sampleList[mounted].tasks).forEach((task, taskIdx) => {
+      if (displayData[task.queueID].selected) {
+        wedges.push(sampleList[mounted].tasks[Number.parseInt(taskIdx, 10)]);
+        taskIndexList.push(taskIdx);
+      }
+    });
 
-    this.props.showForm(
+    showForm(
       'Interleaved',
-      [this.props.mounted],
+      [mounted],
       { type: 'DataCollection', parameters: { taskIndexList, wedges } },
       -1,
     );
   }
 
-  render() {
-    const sampleId = this.props.mounted;
-    let sampleData = {};
-    let sampleTasks = [];
+  const sampleId = mounted;
+  let sampleData = {};
+  let sampleTasks = [];
 
-    if (sampleId) {
-      sampleData = this.props.sampleList[sampleId];
-      sampleTasks = sampleData ? this.props.sampleList[sampleId].tasks : [];
-    }
-
-    if (!this.props.show) {
-      return <div />;
-    }
-    return (
-      <>
-        <div className={styles.listBody}>
-          {sampleTasks.map((taskData, i) => {
-            let task = null;
-
-            switch (taskData.type) {
-              case 'Workflow':
-              case 'GphlWorkflow': {
-                task = (
-                  <WorkflowTaskItem
-                    key={taskData.queueID}
-                    index={i}
-                    id={`${taskData.queueID}`}
-                    data={taskData}
-                    sampleId={sampleData.sampleID}
-                    checked={this.props.checked}
-                    showForm={this.props.showForm}
-                    shapes={this.props.shapes}
-                    showDialog={this.props.showDialog}
-                    showWorkflowParametersDialog={
-                      this.props.showWorkflowParametersDialog
-                    }
-                  />
-                );
-
-                break;
-              }
-              case 'xrf_spectrum': {
-                task = (
-                  <XRFTaskItem
-                    key={taskData.queueID}
-                    index={i}
-                    id={`${taskData.queueID}`}
-                    data={taskData}
-                    sampleId={sampleData.sampleID}
-                    checked={this.props.checked}
-                    showForm={this.props.showForm}
-                    plotsData={this.props.plotsData}
-                    plotsInfo={this.props.plotsInfo}
-                    showDialog={this.props.showDialog}
-                  />
-                );
-
-                break;
-              }
-              case 'energy_scan': {
-                task = (
-                  <EnergyScanTaskItem
-                    key={taskData.queueID}
-                    index={i}
-                    id={`${taskData.queueID}`}
-                    data={taskData}
-                    sampleId={sampleData.sampleID}
-                    checked={this.props.checked}
-                    showForm={this.props.showForm}
-                    shapes={this.props.shapes}
-                    showDialog={this.props.showDialog}
-                  />
-                );
-
-                break;
-              }
-              case 'Characterisation': {
-                task = (
-                  <CharacterisationTaskItem
-                    key={taskData.queueID}
-                    index={i}
-                    id={`${taskData.queueID}`}
-                    data={taskData}
-                    sampleId={sampleData.sampleID}
-                    checked={this.props.checked}
-                    state={
-                      this.props.sampleList[taskData.sampleID].tasks[i].state
-                    }
-                    showForm={this.props.showForm}
-                    addTask={this.props.addTask}
-                    shapes={this.props.shapes}
-                    showDialog={this.props.showDialog}
-                  />
-                );
-
-                break;
-              }
-              default: {
-                task = (
-                  <TaskItem
-                    key={taskData.queueID}
-                    index={i}
-                    id={`${taskData.queueID}`}
-                    data={taskData}
-                    sampleId={sampleData.sampleID}
-                    checked={this.props.checked}
-                    showForm={this.props.showForm}
-                    shapes={this.props.shapes}
-                    showDialog={this.props.showDialog}
-                  />
-                );
-              }
-            }
-
-            return task;
-          })}
-        </div>
-        <Menu id="currentSampleQueueContextMenu">
-          <Item
-            onClick={this.showInterleavedDialog}
-            disabled={!this.interleavedAvailable()}
-          >
-            Create interleaved data collection
-          </Item>
-          <Item onClick={({ props }) => this.duplicateTask(props.taskIndex)}>
-            Duplicate this item
-          </Item>
-        </Menu>
-      </>
-    );
+  if (sampleId) {
+    sampleData = sampleList[sampleId];
+    sampleTasks = sampleData ? sampleList[sampleId].tasks : [];
   }
+
+  if (!show) {
+    return <div />;
+  }
+
+  return (
+    <>
+      <div className={styles.listBody}>
+        {sampleTasks.map((taskData, i) => {
+          let task = null;
+
+          switch (taskData.type) {
+            case 'Workflow':
+            case 'GphlWorkflow': {
+              task = (
+                <WorkflowTaskItem
+                  key={taskData.queueID}
+                  index={i}
+                  id={`${taskData.queueID}`}
+                  data={taskData}
+                  sampleId={sampleData.sampleID}
+                  checked={checked}
+                  showForm={showForm}
+                  shapes={shapes}
+                  showDialog={showDialog}
+                  showWorkflowParametersDialog={showWorkflowParametersDialog}
+                />
+              );
+
+              break;
+            }
+            case 'xrf_spectrum': {
+              task = (
+                <XRFTaskItem
+                  key={taskData.queueID}
+                  index={i}
+                  id={`${taskData.queueID}`}
+                  data={taskData}
+                  sampleId={sampleData.sampleID}
+                  checked={checked}
+                  showForm={showForm}
+                  plotsData={plotsData}
+                  plotsInfo={plotsInfo}
+                  showDialog={showDialog}
+                />
+              );
+
+              break;
+            }
+            case 'energy_scan': {
+              task = (
+                <EnergyScanTaskItem
+                  key={taskData.queueID}
+                  index={i}
+                  id={`${taskData.queueID}`}
+                  data={taskData}
+                  sampleId={sampleData.sampleID}
+                  checked={checked}
+                  showForm={showForm}
+                  shapes={shapes}
+                  showDialog={showDialog}
+                />
+              );
+
+              break;
+            }
+            case 'Characterisation': {
+              task = (
+                <CharacterisationTaskItem
+                  key={taskData.queueID}
+                  index={i}
+                  id={`${taskData.queueID}`}
+                  data={taskData}
+                  sampleId={sampleData.sampleID}
+                  checked={checked}
+                  state={sampleList[taskData.sampleID].tasks[i].state}
+                  showForm={showForm}
+                  addTask={addTask}
+                  shapes={shapes}
+                  showDialog={showDialog}
+                />
+              );
+
+              break;
+            }
+            default: {
+              task = (
+                <TaskItem
+                  key={taskData.queueID}
+                  index={i}
+                  id={`${taskData.queueID}`}
+                  data={taskData}
+                  sampleId={sampleData.sampleID}
+                  checked={checked}
+                  showForm={showForm}
+                  shapes={shapes}
+                  showDialog={showDialog}
+                />
+              );
+            }
+          }
+
+          return task;
+        })}
+      </div>
+
+      <Menu id="currentSampleQueueContextMenu">
+        <Item
+          onClick={() => showInterleavedDialog()}
+          disabled={!isInterleavedAvailable()}
+        >
+          Create interleaved data collection
+        </Item>
+        <Item onClick={({ props: pp }) => duplicateTask(pp.taskIndex)}>
+          Duplicate this item
+        </Item>
+      </Menu>
+    </>
+  );
 }
+
+export default CurrentTree;

--- a/ui/src/containers/SampleQueueContainer.jsx
+++ b/ui/src/containers/SampleQueueContainer.jsx
@@ -1,8 +1,5 @@
-/* eslint-disable react/destructuring-assignment */
-import React from 'react';
 import { Nav, Stack } from 'react-bootstrap';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { showDialog } from '../actions/general';
 import { addTask } from '../actions/queue';
@@ -16,161 +13,113 @@ import TodoTree from '../components/SampleQueue/TodoTree';
 import loader from '../img/loader.gif';
 import styles from './SampleQueueContainer.module.css';
 
-class SampleQueueContainer extends React.Component {
-  constructor(props) {
-    super(props);
-    this.handleSelect = this.handleSelect.bind(this);
-  }
+function SampleQueueContainer() {
+  const dispatch = useDispatch();
 
-  handleSelect(selectedKey) {
-    this.props.showList(selectedKey);
-  }
+  const checked = useSelector((state) => state.queue.checked);
+  const currentSampleID = useSelector((state) => state.queue.currentSampleID);
+  const sampleOrder = useSelector((state) => state.sampleGrid.order);
+  const queue = useSelector((state) => state.queue.queue);
+  const sampleList = useSelector((state) => state.sampleGrid.sampleList);
+  const displayData = useSelector((state) => state.queueGUI.displayData);
+  const visibleList = useSelector((state) => state.queueGUI.visibleList);
+  const loading = useSelector((state) => state.queueGUI.loading);
+  const plotsData = useSelector((state) => state.beamline.plotsData);
+  const plotsInfo = useSelector((state) => state.beamline.plotsInfo);
+  const shapes = useSelector((state) => state.shapes);
 
-  render() {
-    const {
-      checked,
-      currentSampleID,
-      sampleOrder,
-      queue,
-      sampleList,
-      showForm,
-      displayData,
-      visibleList,
-      loading,
-    } = this.props;
+  // go through the queue, check if sample has been collected or not
+  // to make todo lists
+  const todo = [];
 
-    // go through the queue, check if sample has been collected or not
-    // to make todo lists
-    const todo = [];
+  for (const key of sampleOrder) {
+    if (queue.includes(key)) {
+      const sample = sampleList[key];
 
-    for (const key of sampleOrder) {
-      if (queue.includes(key)) {
-        const sample = sampleList[key];
-
-        if (sample.sampleID !== currentSampleID && sample.checked) {
-          todo.push(sample.sampleID);
-        }
+      if (sample.sampleID !== currentSampleID && sample.checked) {
+        todo.push(sample.sampleID);
       }
     }
-
-    let sampleName = '';
-    let proteinAcronym = '';
-
-    if (currentSampleID) {
-      const sampleData = sampleList[currentSampleID] || {};
-      sampleName = sampleData.sampleName || '';
-      proteinAcronym = sampleData.proteinAcronym
-        ? `${sampleData.proteinAcronym} -`
-        : '';
-    }
-
-    return (
-      <Stack className="flex-grow-1" gap={3}>
-        <QueueControl />
-
-        <div className={styles.queue}>
-          <Nav
-            className={styles.queueNav}
-            variant="tabs"
-            fill
-            justify
-            defaultActiveKey="current"
-            activeKey={visibleList}
-            onSelect={this.handleSelect}
-          >
-            <Nav.Item>
-              <Nav.Link eventKey="current" className={styles.queueNavLink}>
-                <b>
-                  {currentSampleID
-                    ? `Sample: ${proteinAcronym} ${sampleName}`
-                    : 'Current'}
-                </b>
-              </Nav.Link>
-            </Nav.Item>
-            <Nav.Item>
-              <Nav.Link eventKey="todo" className={styles.queueNavLink}>
-                <b>Queued Samples ({todo.length})</b>
-              </Nav.Link>
-            </Nav.Item>
-          </Nav>
-
-          <div className={styles.queueBody}>
-            {loading && (
-              <div className={styles.loader} style={{ zIndex: '1000' }}>
-                <img src={loader} className="img-fluid" width="100" alt="" />
-              </div>
-            )}
-            <CurrentTree
-              show={visibleList === 'current'}
-              mounted={currentSampleID}
-              sampleList={sampleList}
-              checked={checked}
-              showForm={showForm}
-              displayData={displayData}
-              addTask={this.props.addTask}
-              plotsData={this.props.plotsData}
-              plotsInfo={this.props.plotsInfo}
-              shapes={this.props.shapes}
-              showDialog={this.props.showDialog}
-              showWorkflowParametersDialog={
-                this.props.showWorkflowParametersDialog
-              }
-            />
-            {visibleList === 'todo' && <TodoTree list={todo} />}
-          </div>
-        </div>
-
-        <div className={styles.logs}>
-          <div className={styles.logsHeader}>
-            <span className="fas fa-md fa-info-circle me-2" />
-            Log messages
-          </div>
-          <div className={styles.logsBody}>
-            <UserMessage />
-          </div>
-        </div>
-      </Stack>
-    );
   }
+
+  let sampleName = '';
+  let proteinAcronym = '';
+
+  if (currentSampleID) {
+    const sampleData = sampleList[currentSampleID] || {};
+    sampleName = sampleData.sampleName || '';
+    proteinAcronym = sampleData.proteinAcronym
+      ? `${sampleData.proteinAcronym} -`
+      : '';
+  }
+
+  return (
+    <Stack className="flex-grow-1" gap={3}>
+      <QueueControl />
+
+      <div className={styles.queue}>
+        <Nav
+          className={styles.queueNav}
+          variant="tabs"
+          fill
+          justify
+          defaultActiveKey="current"
+          activeKey={visibleList}
+          onSelect={(selectedKey) => dispatch(showList(selectedKey))}
+        >
+          <Nav.Item>
+            <Nav.Link eventKey="current" className={styles.queueNavLink}>
+              <b>
+                {currentSampleID
+                  ? `Sample: ${proteinAcronym} ${sampleName}`
+                  : 'Current'}
+              </b>
+            </Nav.Link>
+          </Nav.Item>
+          <Nav.Item>
+            <Nav.Link eventKey="todo" className={styles.queueNavLink}>
+              <b>Queued Samples ({todo.length})</b>
+            </Nav.Link>
+          </Nav.Item>
+        </Nav>
+
+        <div className={styles.queueBody}>
+          {loading && (
+            <div className={styles.loader} style={{ zIndex: '1000' }}>
+              <img src={loader} className="img-fluid" width="100" alt="" />
+            </div>
+          )}
+          <CurrentTree
+            show={visibleList === 'current'}
+            mounted={currentSampleID}
+            sampleList={sampleList}
+            checked={checked}
+            showForm={(...args) => dispatch(showTaskForm(...args))}
+            displayData={displayData}
+            addTask={(...args) => dispatch(addTask(...args))}
+            plotsData={plotsData}
+            plotsInfo={plotsInfo}
+            shapes={shapes}
+            showDialog={(...args) => dispatch(showDialog(...args))}
+            showWorkflowParametersDialog={(...args) => {
+              dispatch(showWorkflowParametersDialog(...args));
+            }}
+          />
+          {visibleList === 'todo' && <TodoTree list={todo} />}
+        </div>
+      </div>
+
+      <div className={styles.logs}>
+        <div className={styles.logsHeader}>
+          <span className="fas fa-md fa-info-circle me-2" />
+          Log messages
+        </div>
+        <div className={styles.logsBody}>
+          <UserMessage />
+        </div>
+      </div>
+    </Stack>
+  );
 }
 
-function mapStateToProps(state) {
-  return {
-    searchString: state.queueGUI.searchString,
-    currentSampleID: state.queue.currentSampleID,
-    visibleList: state.queueGUI.visibleList,
-    queue: state.queue.queue,
-    sampleList: state.sampleGrid.sampleList,
-    sampleOrder: state.sampleGrid.order,
-    checked: state.queue.checked,
-    displayData: state.queueGUI.displayData,
-    loading: state.queueGUI.loading,
-    plotsData: state.beamline.plotsData,
-    plotsInfo: state.beamline.plotsInfo,
-    selectedShapes: state.sampleview.selectedShapes,
-    shapes: state.shapes,
-  };
-}
-
-function mapDispatchToProps(dispatch) {
-  return {
-    // Queue actions
-    addTask: bindActionCreators(addTask, dispatch),
-
-    // Workflow action
-    showWorkflowParametersDialog: bindActionCreators(
-      showWorkflowParametersDialog,
-      dispatch,
-    ),
-
-    showList: bindActionCreators(showList, dispatch),
-
-    showForm: bindActionCreators(showTaskForm, dispatch),
-    showDialog: bindActionCreators(showDialog, dispatch),
-  };
-}
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(SampleQueueContainer);
+export default SampleQueueContainer;


### PR DESCRIPTION
... and use Redux hooks API as always and destructure props. No logic or UI changes here. I'm not even moving props down or anything like that. I only renamed a couple of functions/variables to avoid conflicts and for clarity.

As always I'll rebase and mark as ready once #1982 is merged, and I recommend hiding white-space changes when reviewing :grin: 