### PR TITLE
Move props down and refactor `CurrentTree`

### DIFF
--- a/ui/src/components/SampleQueue/TodoTree.jsx
+++ b/ui/src/components/SampleQueue/TodoTree.jsx
@@ -8,13 +8,11 @@ import { QUEUE_RUNNING } from '../../constants';
 import TodoItem from './TodoItem';
 import styles from './Tree.module.css';
 
-export default function TodoTree(props) {
+function TodoTree(props) {
   const { list } = props;
 
   const dispatch = useDispatch();
-
   const queueStatus = useSelector((state) => state.queue.queueStatus);
-  const sampleList = useSelector((state) => state.sampleGrid.sampleList);
 
   const [searchWord, setSearchWord] = useState('');
 
@@ -23,8 +21,8 @@ export default function TodoTree(props) {
     dispatch(showTaskForm('AddSample'));
   }
 
-  const current_list = list.filter((sampleID) =>
-    String(sampleID).includes(searchWord),
+  const filteredList = list.filter((sample) =>
+    String(sample.sampleID).includes(searchWord),
   );
 
   return (
@@ -54,11 +52,12 @@ export default function TodoTree(props) {
         </div>
       </ListGroup.Item>
       <ListGroup.Item className={styles.listBody}>
-        {current_list.map((key) => {
-          const sampleData = sampleList[key];
-          return <TodoItem sampleData={sampleData} key={`Sample ${key}`} />;
-        })}
+        {filteredList.map((sample) => (
+          <TodoItem key={sample.sampleID} sampleData={sample} />
+        ))}
       </ListGroup.Item>
     </ListGroup>
   );
 }
+
+export default TodoTree;

--- a/ui/src/containers/SampleQueueContainer.jsx
+++ b/ui/src/containers/SampleQueueContainer.jsx
@@ -1,11 +1,7 @@
 import { Nav, Stack } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { showDialog } from '../actions/general';
-import { addTask } from '../actions/queue';
 import { showList } from '../actions/queueGUI';
-import { showTaskForm } from '../actions/taskForm';
-import { showWorkflowParametersDialog } from '../actions/workflow';
 import UserMessage from '../components/Notify/UserMessage';
 import CurrentTree from '../components/SampleQueue/CurrentTree';
 import QueueControl from '../components/SampleQueue/QueueControl';
@@ -16,42 +12,28 @@ import styles from './SampleQueueContainer.module.css';
 function SampleQueueContainer() {
   const dispatch = useDispatch();
 
-  const checked = useSelector((state) => state.queue.checked);
   const currentSampleID = useSelector((state) => state.queue.currentSampleID);
   const sampleOrder = useSelector((state) => state.sampleGrid.order);
   const queue = useSelector((state) => state.queue.queue);
   const sampleList = useSelector((state) => state.sampleGrid.sampleList);
-  const displayData = useSelector((state) => state.queueGUI.displayData);
   const visibleList = useSelector((state) => state.queueGUI.visibleList);
   const loading = useSelector((state) => state.queueGUI.loading);
-  const plotsData = useSelector((state) => state.beamline.plotsData);
-  const plotsInfo = useSelector((state) => state.beamline.plotsInfo);
-  const shapes = useSelector((state) => state.shapes);
 
-  // go through the queue, check if sample has been collected or not
-  // to make todo lists
-  const todo = [];
+  // Find samples in the queue that have not yet been collected
+  const todo = sampleOrder
+    .filter((id) => queue.includes(id))
+    .map((id) => sampleList[id])
+    .filter((sample) => sample.sampleID !== currentSampleID && sample.checked);
 
-  for (const key of sampleOrder) {
-    if (queue.includes(key)) {
-      const sample = sampleList[key];
+  const currentSample = currentSampleID
+    ? sampleList[currentSampleID]
+    : undefined;
 
-      if (sample.sampleID !== currentSampleID && sample.checked) {
-        todo.push(sample.sampleID);
-      }
-    }
-  }
-
-  let sampleName = '';
-  let proteinAcronym = '';
-
-  if (currentSampleID) {
-    const sampleData = sampleList[currentSampleID] || {};
-    sampleName = sampleData.sampleName || '';
-    proteinAcronym = sampleData.proteinAcronym
-      ? `${sampleData.proteinAcronym} -`
-      : '';
-  }
+  const currentTabLabel = currentSample
+    ? `Sample: ${
+        currentSample.proteinAcronym ? `${currentSample.proteinAcronym} - ` : ''
+      }${currentSample.sampleName}`
+    : 'Current';
 
   return (
     <Stack className="flex-grow-1" gap={3}>
@@ -69,11 +51,7 @@ function SampleQueueContainer() {
         >
           <Nav.Item>
             <Nav.Link eventKey="current" className={styles.queueNavLink}>
-              <b>
-                {currentSampleID
-                  ? `Sample: ${proteinAcronym} ${sampleName}`
-                  : 'Current'}
-              </b>
+              <b>{currentTabLabel}</b>
             </Nav.Link>
           </Nav.Item>
           <Nav.Item>
@@ -89,22 +67,12 @@ function SampleQueueContainer() {
               <img src={loader} className="img-fluid" width="100" alt="" />
             </div>
           )}
-          <CurrentTree
-            show={visibleList === 'current'}
-            mounted={currentSampleID}
-            sampleList={sampleList}
-            checked={checked}
-            showForm={(...args) => dispatch(showTaskForm(...args))}
-            displayData={displayData}
-            addTask={(...args) => dispatch(addTask(...args))}
-            plotsData={plotsData}
-            plotsInfo={plotsInfo}
-            shapes={shapes}
-            showDialog={(...args) => dispatch(showDialog(...args))}
-            showWorkflowParametersDialog={(...args) => {
-              dispatch(showWorkflowParametersDialog(...args));
-            }}
-          />
+          {visibleList === 'current' && currentSample && (
+            <CurrentTree
+              currentSample={currentSample}
+              sampleList={sampleList}
+            />
+          )}
           {visibleList === 'todo' && <TodoTree list={todo} />}
         </div>
       </div>


### PR DESCRIPTION
Apart from moving `useSelector`/`dispatch()` down and renaming/destructuring a few variables, I simplify the code of `SampleQueueContainer`, `CurrentTree` and `TodoTree` a little as well (I'll explain in comments).

I'll stop here for the time being.