### PR TITLE
Fixed position of mesh overlay

### DIFF
--- a/ui/src/components/SampleView/DrawGridPlugin.jsx
+++ b/ui/src/components/SampleView/DrawGridPlugin.jsx
@@ -650,7 +650,6 @@ export default class DrawGridPlugin {
         const image = new fabric.Image(imageElement);
         image.scaleToHeight(height);
         image.scaleX = width / imageElement.naturalWidth;
-        image.set({ top, left });
         shapes.push(image);
       }
     }


### PR DESCRIPTION
Its no longer necessary to set the image position, setting it results in an offset.