### PR TITLE
Added missing type hint for `set_centring_method()`

### DIFF
--- a/mxcubeweb/core/adapter/sample_view_adapter.py
+++ b/mxcubeweb/core/adapter/sample_view_adapter.py
@@ -463,7 +463,7 @@ class SampleViewAdapter(AdapterBase):
 
         return {"clicksLeft": self.centring_clicks_left()}
 
-    def set_centring_method(self, method):
+    def set_centring_method(self, method: int) -> dict:
         if method == CENTRING_METHOD.LOOP:
             msg = "Using automatic loop centring when mounting samples"
             HWR.beamline.queue_manager.centring_method = CENTRING_METHOD.LOOP


### PR DESCRIPTION
The method `set_centring_method` was missing type hint for the argument which prevented it from being called (exported as a REST resource) properly