### PR TITLE
Sync samples with Lims on proposal selection

### DIFF
--- a/demo.yaml/mxcube-web/server.yaml
+++ b/demo.yaml/mxcube-web/server.yaml
@@ -38,6 +38,13 @@ mxcube:
   # by the client application.
   SESSION_REFRESH_INTERVAL: 9000
 
+  # This is used to determine whether we can get samples from the sample changer
+  # if false, Only LIMS samples will be available to fetch for the sample list
+  USE_GET_SAMPLES_FROM_SC: true
+
+  # Sync samples with LIMS on proposal selection
+  AUTOSYNC_LIMS: false
+
   usermanager:
     class: UserManager
     inhouse_is_staff: true

--- a/demo/mxcube-web/server.yaml
+++ b/demo/mxcube-web/server.yaml
@@ -71,9 +71,12 @@ mxcube:
   # Mode, SSX-CHIP, SSX-INJECTOR, OSC
   mode: OSC
 
-  USE_GET_SAMPLES_FROM_SC: true
   # This is used to determine whether we can get samples from the sample changer
-  # if false, Only LIMS samples will be availble to fetch for the sample list
+  # if false, Only LIMS samples will be available to fetch for the sample list
+  USE_GET_SAMPLES_FROM_SC: true
+
+  # Sync samples with LIMS on proposal selection
+  AUTOSYNC_LIMS: false
 
   # Interval with which request to refresh token is made
   # by the client application.

--- a/docs/source/config/server.rst
+++ b/docs/source/config/server.rst
@@ -177,6 +177,8 @@ The section has the following syntax:
       VIDEO_STREAM_PORT: <stream port>
       MXCUBE_STARTS_VIDEO_STREAM: <boolean>
       SESSION_REFRESH_INTERVAL: <refresh interval>
+      USE_GET_SAMPLES_FROM_SC: <boolean>
+      AUTOSYNC_LIMS: <boolean>
       usermanager:
         class: <class name>
         inhouse_is_staff: <boolean>
@@ -240,6 +242,19 @@ The interval in milliseconds at which the front-end makes
 requests to refresh the session.
 
 Default interval is ``9000`` milliseconds.
+
+``USE_GET_SAMPLES_FROM_SC``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Allow get samples from the sample changer.
+If ``False``, Only LIMS samples will be available to fetch for the sample list in the UI.
+
+Default value is ``True``
+
+``AUTOSYNC_LIMS``
+~~~~~~~~~~~~~~~~~
+Enable sync samples from LIMS on proposal selection.
+
+Default value is ``False``
 
 ``usermanager``
 ~~~~~~~~~~~~~~~

--- a/mxcubeweb/core/models/configmodels.py
+++ b/mxcubeweb/core/models/configmodels.py
@@ -222,6 +222,11 @@ class MXCUBEAppConfigModel(BaseModel):
             "True to activate or be able to get samples from the sample changer, false otherwise"
         ),
     )
+
+    AUTOSYNC_LIMS: bool = Field(
+        False, description="True to synchronize samples with LIMS on proposal selection"
+    )
+
     mode: ModeEnum = Field(
         ModeEnum.OSC, description="MXCuBE mode OSC, SSX-CHIP or SSX-INJECTOR"
     )

--- a/mxcubeweb/routes/main.py
+++ b/mxcubeweb/routes/main.py
@@ -51,6 +51,7 @@ def init_route(app, server, url_prefix):
                 "use_native_mesh": _blc.use_native_mesh,
                 "enable_2d_points": _blc.enable_2d_points,
                 "use_get_samples_from_sc": app.CONFIG.app.USE_GET_SAMPLES_FROM_SC,
+                "autosync_lims": app.CONFIG.app.AUTOSYNC_LIMS,
                 "click_centring_num_clicks": _blc.click_centring_num_clicks,
             }
         )

--- a/ui/src/components/LoginForm/SelectProposal.jsx
+++ b/ui/src/components/LoginForm/SelectProposal.jsx
@@ -7,6 +7,7 @@ import {
   selectProposal,
   signOut,
 } from '../../actions/login';
+import { getLimsSamples } from '../../actions/sampleGrid';
 import ActionButton from './ActionButton';
 import SessionTable from './SessionTable';
 import styles from './SessionTable.module.css';
@@ -21,8 +22,13 @@ function SelectProposal() {
   const dispatch = useDispatch();
 
   const login = useSelector((state) => state.login);
-  const { loginType, proposalList, selectedProposalID, showProposalsForm } =
-    login;
+  const {
+    loginType,
+    proposalList,
+    selectedProposalID,
+    showProposalsForm,
+    limsName,
+  } = login;
 
   const show =
     showProposalsForm || (loginType === 'User' && selectedProposalID === null);
@@ -43,6 +49,11 @@ function SelectProposal() {
 
   const defaultActiveTab =
     TAB_PRIORITY.find((tabId) => showTab[tabId]) ?? TAB_PRIORITY[0];
+
+  /**
+   * @type {boolean}
+   */
+  const autosyncLims = useSelector((state) => state.general.autosyncLims);
 
   const filteredSessions = proposalList.filter(
     ({ title, number, code }) =>
@@ -69,6 +80,14 @@ function SelectProposal() {
       dispatch(signOut());
     } else {
       dispatch(hideProposalsForm());
+    }
+  }
+
+  function handleSelectProposal(sessionId) {
+    dispatch(selectProposal(sessionId));
+
+    if (autosyncLims) {
+      dispatch(getLimsSamples(limsName[0].name));
     }
   }
 
@@ -159,7 +178,7 @@ function SelectProposal() {
       <Modal.Footer>
         <ActionButton
           selectedSession={selectedSession}
-          onClick={() => dispatch(selectProposal(selectedSessionId))}
+          onClick={() => handleSelectProposal(selectedSessionId)}
         />
         <Button
           variant="outline-secondary"

--- a/ui/src/reducers/general.js
+++ b/ui/src/reducers/general.js
@@ -9,6 +9,7 @@ const INITIAL_STATE = {
   showConfirmClearQueueDialog: false,
   mode: 'OSC',
   useGetSamplesFromSC: true,
+  autosyncLims: false,
   serverVersion: '3',
   applicationFetched: false,
 };
@@ -42,6 +43,7 @@ function generalReducer(state = INITIAL_STATE, action = {}) {
         ...state,
         mode: action.data.general.mode,
         useGetSamplesFromSC: action.data.general.use_get_samples_from_sc,
+        autosyncLims: action.data.general.autosync_lims,
         serverVersion: action.data.general.version,
         enable2DPoints: action.data.general.enable_2d_points,
         meshResultFormat: action.data.general.mesh_result_format,


### PR DESCRIPTION
Closes #1981 . I chose to handle the sync directly in SelectProposal dialog since both `selectProposal`and `getLimsSamples` actions were already implemented.