### PR TITLE
Make sample name consistent

### DIFF
--- a/ui/src/components/ConfirmCollectDialog/TaskTable.jsx
+++ b/ui/src/components/ConfirmCollectDialog/TaskTable.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { OverlayTrigger, Popover, Table } from 'react-bootstrap';
 import { useSelector } from 'react-redux';
 
+import { getSampleName } from '../../utils';
 import TaskOverlayTable from './TaskOverlayTable';
 import styles from './TaskTable.module.css';
 
@@ -47,7 +48,6 @@ export default function TaskTable(props) {
                 : task.parameters;
 
             const sample = sampleList[task.sampleID];
-            const sampleName = `${sample.sampleName} - ${sample.proteinAcronym}`;
             const relativePath = parameters.fullPath.split(rootPath).pop();
 
             return (
@@ -70,7 +70,7 @@ export default function TaskTable(props) {
                 <tr id={task.queueID}>
                   <td>{task.label}</td>
                   <td>
-                    {sampleName} ({sample.location})
+                    {getSampleName(sample)} ({sample.location})
                   </td>
                   <td>
                     <b style={{ color: '#337ab7' }}>...{relativePath}</b>

--- a/ui/src/components/SampleGrid/SampleGridTableItem.jsx
+++ b/ui/src/components/SampleGrid/SampleGridTableItem.jsx
@@ -11,10 +11,11 @@ import { BsCheck2Square, BsSquare } from 'react-icons/bs';
 import CopyToClipboard from '../../components/CopyToClipboard/CopyToClipboard';
 import { isCollected } from '../../constants';
 import containerStyles from '../../containers/SampleGridTableContainer.module.css';
+import { getSampleName } from '../../utils';
 import TooltipTrigger from '../TooltipTrigger';
 import styles from './SampleGridTableItem.module.css';
 import SampleInformation from './SampleInformation';
-import { getSampleName, sampleStateBackground } from './util';
+import { sampleStateBackground } from './util';
 
 export default function SampleGridTableItem({
   sampleData = {},

--- a/ui/src/components/SampleGrid/util.js
+++ b/ui/src/components/SampleGrid/util.js
@@ -16,15 +16,3 @@ export function sampleStateBackground(key) {
 
   return map[key] || 'secondary';
 }
-
-export function getSampleName(sampleData) {
-  let name = sampleData?.proteinAcronym || '';
-
-  if (sampleData?.sampleName && name) {
-    name += ` - ${sampleData?.sampleName}`;
-  } else {
-    name = sampleData?.sampleName || '';
-  }
-
-  return name;
-}

--- a/ui/src/components/SampleQueue/QueueControlOptions.jsx
+++ b/ui/src/components/SampleQueue/QueueControlOptions.jsx
@@ -11,6 +11,7 @@ import {
 import { showConfirmCollectDialog } from '../../actions/queueGUI';
 import { unmountSample } from '../../actions/sampleChanger';
 import { QUEUE_PAUSED, QUEUE_RUNNING, QUEUE_STOPPED } from '../../constants';
+import { getSampleName } from '../../utils';
 
 export default function QueueControlOptions() {
   const dispatch = useDispatch();
@@ -39,79 +40,73 @@ export default function QueueControlOptions() {
     }
   }
 
-  switch (queueStatus) {
-    case QUEUE_RUNNING: {
-      return (
-        <div>
-          <Button
-            variant="danger"
-            style={{ marginRight: '0.6em' }}
-            onClick={() => dispatch(stopQueue())}
-          >
-            Stop
+  if (queueStatus === QUEUE_RUNNING) {
+    return (
+      <div>
+        <Button
+          variant="danger"
+          style={{ marginRight: '0.6em' }}
+          onClick={() => dispatch(stopQueue())}
+        >
+          Stop
+        </Button>
+        {currentSampleID && (
+          <Button variant="warning" onClick={() => dispatch(pauseQueue())}>
+            Pause
           </Button>
-          {currentSampleID && (
-            <Button variant="warning" onClick={() => dispatch(pauseQueue())}>
-              Pause
-            </Button>
-          )}
-        </div>
-      );
-    }
-    case QUEUE_STOPPED: {
-      let buttonText = 'Unmount';
-      let buttonStyle = 'primary';
-      // If there is a next sample in the queue, set the button text and style accordingly
-      if (currentSampleID) {
-        const idx = queue.indexOf(currentSampleID);
-        if (queue.length > idx + 1) {
-          const sampleData = sampleList[queue[idx + 1]] || {};
-          const sampleName = sampleData.sampleName || '';
-          const proteinAcronym = sampleData.proteinAcronym
-            ? `${sampleData.proteinAcronym} - `
-            : '';
-          buttonText = `Next Sample (${proteinAcronym}${sampleName})`;
-          buttonStyle = 'outline-secondary';
-        }
-      }
-
-      return (
-        <div>
-          <Button
-            variant="success"
-            style={{ marginRight: '0.6em' }}
-            onClick={() => dispatch(showConfirmCollectDialog())}
-          >
-            Run Queue
-          </Button>
-          {currentSampleID && (
-            <Button variant={buttonStyle} onClick={getNextSample}>
-              {buttonText}
-            </Button>
-          )}
-        </div>
-      );
-    }
-    case QUEUE_PAUSED: {
-      return (
-        <div>
-          <Button
-            variant="danger"
-            style={{ marginRight: '0.6em' }}
-            onClick={() => dispatch(stopQueue())}
-          >
-            Stop
-          </Button>
-          {currentSampleID && (
-            <Button variant="success" onClick={() => dispatch(resumeQueue())}>
-              Resume
-            </Button>
-          )}
-        </div>
-      );
-    }
-    default: {
-      return null;
-    }
+        )}
+      </div>
+    );
   }
+
+  if (queueStatus === QUEUE_STOPPED) {
+    const currentIndex = currentSampleID ? queue.indexOf(currentSampleID) : -1;
+    const nextSample =
+      queue.length > currentIndex + 1
+        ? sampleList[queue[currentIndex + 1]]
+        : undefined;
+
+    return (
+      <div>
+        <Button
+          variant="success"
+          style={{ marginRight: '0.6em' }}
+          onClick={() => dispatch(showConfirmCollectDialog())}
+        >
+          Run Queue
+        </Button>
+        {currentSampleID && (
+          <Button
+            variant={nextSample ? 'outline-secondary' : 'primary'}
+            onClick={getNextSample}
+          >
+            {nextSample
+              ? `Next Sample (${getSampleName(nextSample)})`
+              : 'Unmount'}
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  if (queueStatus === QUEUE_PAUSED) {
+    return (
+      <div>
+        <Button
+          variant="danger"
+          style={{ marginRight: '0.6em' }}
+          onClick={() => dispatch(stopQueue())}
+        >
+          Stop
+        </Button>
+        {currentSampleID && (
+          <Button variant="success" onClick={() => dispatch(resumeQueue())}>
+            Resume
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  return null;
 }

--- a/ui/src/components/SampleQueue/TodoItem.jsx
+++ b/ui/src/components/SampleQueue/TodoItem.jsx
@@ -3,6 +3,7 @@ import { useDispatch } from 'react-redux';
 
 import { showList } from '../../actions/queueGUI';
 import { mountSample } from '../../actions/sampleChanger';
+import { getSampleName } from '../../utils';
 import styles from './Item.module.css';
 
 export default function TodoItem({ sampleData }) {
@@ -17,7 +18,7 @@ export default function TodoItem({ sampleData }) {
     dispatch(showList('current'));
   }
 
-  const { sampleID, sampleName = '', proteinAcronym = '' } = sampleData;
+  const { sampleID } = sampleData;
 
   return (
     <div className={styles.nodeSample}>
@@ -25,7 +26,7 @@ export default function TodoItem({ sampleData }) {
         <div className={styles.nodeName}>
           <p className="pt-1 me-auto">
             <b>{`${sampleID} `}</b>
-            {`${proteinAcronym} ${sampleName}`}
+            {`${getSampleName(sampleData)}`}
           </p>
 
           <Button

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -40,6 +40,7 @@ import {
   SAMPLE_LIST_VIEW_MODES,
 } from '../constants';
 import loader from '../img/loader.gif';
+import { getSampleName } from '../utils';
 import QueueSettings from './QueueSettings';
 import SampleGridTableContainer from './SampleGridTableContainer';
 import styles from './SampleListViewContainer.module.css';
@@ -316,10 +317,8 @@ export default function SampleListViewContainer() {
     const sample = sampleList[key];
     let fi = false;
     if (sample) {
-      const sampleFilter =
-        `${sample.sampleName} ${sample.proteinAcronym}`.toLowerCase();
-
-      fi = sampleFilter.includes(filterOptions.text.toLowerCase());
+      const filterText = filterOptions.text.trim().toLowerCase();
+      fi = getSampleName(sample).toLowerCase().includes(filterText);
 
       // eslint-disable-next-line no-bitwise
       fi &= mutualExclusiveFilterOption(
@@ -357,7 +356,7 @@ export default function SampleListViewContainer() {
       filterOptions.notInQueue ||
       filterOptions.collected ||
       filterOptions.notCollected ||
-      filterOptions.text.length > 0 ||
+      filterOptions.text.trim().length > 0 ||
       filterOptions.cellFilter !== '' ||
       filterOptions.puckFilter !== ''
     );
@@ -367,7 +366,7 @@ export default function SampleListViewContainer() {
    * Applies filter defined by user
    */
   function sampleGridFilter(e) {
-    let filterValue = e.target.value.trim();
+    let filterValue = e.target.value;
     if (e.target.type === 'checkbox') {
       filterValue = e.target.checked;
     }

--- a/ui/src/containers/SampleQueueContainer.jsx
+++ b/ui/src/containers/SampleQueueContainer.jsx
@@ -7,6 +7,7 @@ import CurrentTree from '../components/SampleQueue/CurrentTree';
 import QueueControl from '../components/SampleQueue/QueueControl';
 import TodoTree from '../components/SampleQueue/TodoTree';
 import loader from '../img/loader.gif';
+import { getSampleName } from '../utils';
 import styles from './SampleQueueContainer.module.css';
 
 function SampleQueueContainer() {
@@ -30,9 +31,7 @@ function SampleQueueContainer() {
     : undefined;
 
   const currentTabLabel = currentSample
-    ? `Sample: ${
-        currentSample.proteinAcronym ? `${currentSample.proteinAcronym} - ` : ''
-      }${currentSample.sampleName}`
+    ? `Sample: ${getSampleName(currentSample)}`
     : 'Current';
 
   return (

--- a/ui/src/utils.js
+++ b/ui/src/utils.js
@@ -1,0 +1,4 @@
+export function getSampleName(sample) {
+  const { sampleName, proteinAcronym } = sample;
+  return `${proteinAcronym ? `${proteinAcronym} - ` : ''}${sampleName}`;
+}


### PR DESCRIPTION
Sometimes the sample name was displayed as `<proteinAcronym> - <sampleName>`, sometimes as `<proteinAcronym> <sampleName>` (no dash), sometimes as `<sampleName> - <proteinAcronym>`, ...

I'm now making sure it's the same everywhere. I went with `<proteinAcronym> - <sampleName>` (or just `<sampleName>` if `proteinAcronym` is not defined), which was used in the current sample tab of the queue.