### PR TITLE
Added access logs

### DIFF
--- a/mxcubeweb/__init__.py
+++ b/mxcubeweb/__init__.py
@@ -80,6 +80,7 @@ def parse_args(argv):
             "queue_logger",
             "ui_logger",
             "csp_logger",
+            "server_access_logger",
         ],
     )
 

--- a/mxcubeweb/app.py
+++ b/mxcubeweb/app.py
@@ -213,6 +213,29 @@ class MXCUBEApplication:
 
     @staticmethod
     def init_logging(log_file: str, log_level, enabled_logger_list) -> None:
+        """Initializes and configures logging.
+
+        Sets up logging behavior including log file output, logging level,
+        and which loggers are enabled. This function should be called once
+        during application startup to ensure consistent logging across
+        all modules.
+
+        `uilog_file_handler`, `access_file_handler` and `csp_file_handler` are logged
+        to separate files with the suffixes: `_ui.log`, `_server_access.log` and
+        `_server_csp.log` if `log_file` is provided.
+
+        Args:
+            log_file (str): Path to the log file where log messages will be written.
+                            The path may be absolute or relative.
+            log_level: Logging severity level that determines which messages are
+                       recorded. Typically a constant from the standard `logging`
+                       module (e.g., `logging.INFO`, `logging.DEBUG`).
+            enabled_logger_list: Iterable of logger names to enable and configure.
+                                 Only the specified loggers will be active.
+
+        Returns:
+            None
+        """
         removeLoggingHandlers()
 
         fmt = "%(asctime)s |%(name)-7s|%(levelname)-7s| %(message)s"

--- a/mxcubeweb/server.py
+++ b/mxcubeweb/server.py
@@ -10,6 +10,7 @@ from flask import (
     Flask,
     request,
 )
+from flask_login import current_user
 from flask_socketio import SocketIO
 from werkzeug.middleware.proxy_fix import ProxyFix
 
@@ -149,6 +150,10 @@ class Server:
 
     @staticmethod
     def emit(*args, **kwargs):
+        if current_user and current_user.is_authenticated:
+            logging.getLogger("server_access").debug(
+                f"{current_user.username} websocket emit: {args} {kwargs}"
+            )
         Server.flask_socketio.emit(*args, **kwargs)
 
     @staticmethod


### PR DESCRIPTION
This PR;

   - Attempts to cleanup the logic in `init_logging` to some extent
   - Adds a `server_access_log` that logs calls and returns to HTTP and websockets and by which user
   - `ui_logger`, `csp_logger` and `server_access_logger` are no longer written to the "main" `mxcube.log` log file but to separate files `mxcube_csp.log`, `mxcube_server_acess.log` and ` mxcube_ui.log`