### PR TITLE
Refactor queue task item components

### DIFF
--- a/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
+++ b/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/destructuring-assignment */
 /* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable react/no-array-index-key */
 import { Button, Table } from 'react-bootstrap';
@@ -9,15 +8,18 @@ import styles from './Item.module.css';
 import TaskItemContainer from './TaskItemContainer';
 
 function TaskItem(props) {
-  function getResult(_state, data) {
-    if (props.data.state !== TASK_COLLECTED) {
+  const { index, data, sampleId, pointID, shapes, showForm, addTask } = props;
+  const wedges = data.type === 'Interleaved' ? data.parameters.wedges : [data];
+
+  function getResult() {
+    if (data.state !== TASK_COLLECTED) {
       return <span />;
     }
 
-    return <div className={styles.resultBody}>{getDiffPlan(data)}</div>;
+    return <div className={styles.resultBody}>{getDiffPlan()}</div>;
   }
 
-  function getDiffPlan(data) {
+  function getDiffPlan() {
     let diffPlan = [];
     if (
       'diffractionPlan' in data &&
@@ -41,7 +43,6 @@ function TaskItem(props) {
   }
 
   function showDiffPlan() {
-    const { data, sampleId } = props;
     const tasks = data.diffractionPlan;
 
     // if there is a single wedge, display the form, otherwise, add all wedges as differente dc-s
@@ -50,29 +51,28 @@ function TaskItem(props) {
       delete data.diffractionPlan[0].sampleID;
       const [{ type, parameters }] = data.diffractionPlan;
 
-      props.showForm(type, sampleId, data.diffractionPlan[0], parameters.shape);
+      showForm(type, sampleId, data.diffractionPlan[0], parameters.shape);
     } else {
       tasks.forEach((t) => {
         const pars = {
           type: 'DataCollection',
           label: 'Data Collection',
           helical: false,
-          shape: props.pointID,
+          shape: pointID,
           ...t.parameters,
         };
 
-        props.addTask([sampleId], pars, false);
+        addTask([sampleId], pars, false);
       });
     }
   }
 
-  function showForm() {
-    const { data, sampleId } = props;
+  function handleParamsTableClick() {
     const { type, parameters } = data;
-    props.showForm(type, sampleId, data, parameters.shape);
+    showForm(type, sampleId, data, parameters.shape);
   }
 
-  function pointIDString(wedges) {
+  function pointIDString() {
     let res = '';
 
     wedges.forEach((wedge) => {
@@ -81,7 +81,7 @@ function TaskItem(props) {
         !res.includes(`${wedge.parameters.shape}`)
       ) {
         try {
-          res += `${props.shapes.shapes[wedge.parameters.shape].name} :`;
+          res += `${shapes.shapes[wedge.parameters.shape].name} :`;
         } catch {
           res = String(res);
         }
@@ -155,14 +155,11 @@ function TaskItem(props) {
     );
   }
 
-  const { data, state } = props;
-  const wedges = data.type === 'Interleaved' ? data.parameters.wedges : [data];
-
   return (
     <TaskItemContainer
-      index={props.index}
+      index={index}
       data={data}
-      pointIDString={pointIDString(wedges)}
+      pointIDString={pointIDString()}
     >
       <div className={styles.taskBody}>
         {wedges.map((wedge, i) => {
@@ -192,7 +189,7 @@ function TaskItem(props) {
                 striped
                 bordered
                 hover
-                onClick={showForm}
+                onClick={handleParamsTableClick}
                 className={styles.taskParametersTable}
               >
                 <thead>
@@ -212,7 +209,7 @@ function TaskItem(props) {
                 </thead>
                 <tbody>{wedgeParameters(wedge)}</tbody>
               </Table>
-              {getResult(state, data)}
+              {getResult()}
             </div>
           );
         })}

--- a/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
+++ b/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
@@ -1,11 +1,6 @@
 /* eslint-disable react/destructuring-assignment */
 /* eslint-disable jsx-a11y/anchor-is-valid */
-/* eslint-disable react/no-unused-prop-types */
-
 /* eslint-disable react/no-array-index-key */
-
-import PropTypes from 'prop-types';
-import { Component } from 'react';
 import { Button, Table } from 'react-bootstrap';
 
 import { TASK_COLLECTED } from '../../constants';
@@ -13,29 +8,16 @@ import TooltipTrigger from '../TooltipTrigger';
 import styles from './Item.module.css';
 import TaskItemContainer from './TaskItemContainer';
 
-export default class TaskItem extends Component {
-  static propTypes = {
-    id: PropTypes.string.isRequired,
-    index: PropTypes.number.isRequired,
-  };
-
-  constructor(props) {
-    super(props);
-    this.showForm = this.showForm.bind(this);
-    this.getResult = this.getResult.bind(this);
-    this.showDiffPlan = this.showDiffPlan.bind(this);
-    this.pointIDString = this.pointIDString.bind(this);
-  }
-
-  getResult(_state, data) {
-    if (this.props.data.state !== TASK_COLLECTED) {
+function TaskItem(props) {
+  function getResult(_state, data) {
+    if (props.data.state !== TASK_COLLECTED) {
       return <span />;
     }
 
-    return <div className={styles.resultBody}>{this.getDiffPlan(data)}</div>;
+    return <div className={styles.resultBody}>{getDiffPlan(data)}</div>;
   }
 
-  getDiffPlan(data) {
+  function getDiffPlan(data) {
     let diffPlan = [];
     if (
       'diffractionPlan' in data &&
@@ -47,7 +29,7 @@ export default class TaskItem extends Component {
           <Button
             size="sm"
             style={{ width: 'auto', marginTop: '-4px' }}
-            onClick={this.showDiffPlan}
+            onClick={showDiffPlan}
           >
             <i className="fas fa-plus" />
             Add Diffraction Plan
@@ -58,8 +40,8 @@ export default class TaskItem extends Component {
     return diffPlan;
   }
 
-  showDiffPlan() {
-    const { data, sampleId } = this.props;
+  function showDiffPlan() {
+    const { data, sampleId } = props;
     const tasks = data.diffractionPlan;
 
     // if there is a single wedge, display the form, otherwise, add all wedges as differente dc-s
@@ -68,34 +50,29 @@ export default class TaskItem extends Component {
       delete data.diffractionPlan[0].sampleID;
       const [{ type, parameters }] = data.diffractionPlan;
 
-      this.props.showForm(
-        type,
-        sampleId,
-        data.diffractionPlan[0],
-        parameters.shape,
-      );
+      props.showForm(type, sampleId, data.diffractionPlan[0], parameters.shape);
     } else {
       tasks.forEach((t) => {
         const pars = {
           type: 'DataCollection',
           label: 'Data Collection',
           helical: false,
-          shape: this.props.pointID,
+          shape: props.pointID,
           ...t.parameters,
         };
 
-        this.props.addTask([sampleId], pars, false);
+        props.addTask([sampleId], pars, false);
       });
     }
   }
 
-  showForm() {
-    const { data, sampleId } = this.props;
+  function showForm() {
+    const { data, sampleId } = props;
     const { type, parameters } = data;
-    this.props.showForm(type, sampleId, data, parameters.shape);
+    props.showForm(type, sampleId, data, parameters.shape);
   }
 
-  pointIDString(wedges) {
+  function pointIDString(wedges) {
     let res = '';
 
     wedges.forEach((wedge) => {
@@ -104,7 +81,7 @@ export default class TaskItem extends Component {
         !res.includes(`${wedge.parameters.shape}`)
       ) {
         try {
-          res += `${this.props.shapes.shapes[wedge.parameters.shape].name} :`;
+          res += `${props.shapes.shapes[wedge.parameters.shape].name} :`;
         } catch {
           res = String(res);
         }
@@ -114,7 +91,7 @@ export default class TaskItem extends Component {
     return `${res}`;
   }
 
-  wedgePath(wedge) {
+  function wedgePath(wedge) {
     const { parameters } = wedge;
     const value = parameters.fileName;
     const path = parameters.path || '';
@@ -138,7 +115,7 @@ export default class TaskItem extends Component {
     );
   }
 
-  wedgeParameters(wedge) {
+  function wedgeParameters(wedge) {
     const { parameters } = wedge;
 
     return (
@@ -178,73 +155,70 @@ export default class TaskItem extends Component {
     );
   }
 
-  render() {
-    const { data, state } = this.props;
-    const wedges =
-      data.type === 'Interleaved' ? data.parameters.wedges : [data];
+  const { data, state } = props;
+  const wedges = data.type === 'Interleaved' ? data.parameters.wedges : [data];
 
-    return (
-      <TaskItemContainer
-        index={this.props.index}
-        data={data}
-        pointIDString={this.pointIDString(wedges)}
-      >
-        <div className={styles.taskBody}>
-          {wedges.map((wedge, i) => {
-            const padding = i > 0 ? '1.5em' : '0.5em';
-            return (
-              <div key={`wedge-${i}`}>
-                <div
-                  className={styles.dataPath}
-                  style={{
-                    paddingTop: padding,
+  return (
+    <TaskItemContainer
+      index={props.index}
+      data={data}
+      pointIDString={pointIDString(wedges)}
+    >
+      <div className={styles.taskBody}>
+        {wedges.map((wedge, i) => {
+          const padding = i > 0 ? '1.5em' : '0.5em';
+          return (
+            <div key={`wedge-${i}`}>
+              <div
+                className={styles.dataPath}
+                style={{
+                  paddingTop: padding,
+                }}
+              >
+                <b>Path:</b>
+                {wedgePath(wedge)}
+                <Button
+                  variant="outline-secondary"
+                  style={{ width: '3em' }}
+                  title="Copy path"
+                  onClick={() => {
+                    navigator.clipboard.writeText(`${wedge.parameters.path}`);
                   }}
                 >
-                  <b>Path:</b>
-                  {this.wedgePath(wedge)}
-                  <Button
-                    variant="outline-secondary"
-                    style={{ width: '3em' }}
-                    title="Copy path"
-                    onClick={() => {
-                      navigator.clipboard.writeText(`${wedge.parameters.path}`);
-                    }}
-                  >
-                    <i className="fa fa-copy" aria-hidden="true" />
-                  </Button>
-                </div>
-                <Table
-                  striped
-                  bordered
-                  hover
-                  onClick={this.showForm}
-                  className={styles.taskParametersTable}
-                >
-                  <thead>
-                    <tr>
-                      <th>Start &deg; </th>
-                      <th>Osc. &deg; </th>
-                      <th>t (s)</th>
-                      <th># Img</th>
-                      <th>T (%)</th>
-                      <th>Res. (&Aring;)</th>
-                      <th>E (keV)</th>
-                      {wedge.parameters.kappa_phi !== null && (
-                        <th>&phi; &deg;</th>
-                      )}
-                      {wedge.parameters.kappa !== null && (
-                        <th>&kappa; &deg;</th>
-                      )}
-                    </tr>
-                  </thead>
-                  <tbody>{this.wedgeParameters(wedge)}</tbody>
-                </Table>
-                {this.getResult(state, data)}
+                  <i className="fa fa-copy" aria-hidden="true" />
+                </Button>
               </div>
-            );
-          })}
-        </div>
-      </TaskItemContainer>
-    );
-  }
+              <Table
+                striped
+                bordered
+                hover
+                onClick={showForm}
+                className={styles.taskParametersTable}
+              >
+                <thead>
+                  <tr>
+                    <th>Start &deg; </th>
+                    <th>Osc. &deg; </th>
+                    <th>t (s)</th>
+                    <th># Img</th>
+                    <th>T (%)</th>
+                    <th>Res. (&Aring;)</th>
+                    <th>E (keV)</th>
+                    {wedge.parameters.kappa_phi !== null && (
+                      <th>&phi; &deg;</th>
+                    )}
+                    {wedge.parameters.kappa !== null && <th>&kappa; &deg;</th>}
+                  </tr>
+                </thead>
+                <tbody>{wedgeParameters(wedge)}</tbody>
+              </Table>
+              {getResult(state, data)}
+            </div>
+          );
+        })}
+      </div>
+    </TaskItemContainer>
+  );
 }
+
+export default TaskItem;

--- a/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
+++ b/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
@@ -1,15 +1,21 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable react/no-array-index-key */
 import { Button, Table } from 'react-bootstrap';
+import { useDispatch, useSelector } from 'react-redux';
 
+import { addTask } from '../../actions/queue';
+import { showTaskForm } from '../../actions/taskForm';
 import { TASK_COLLECTED } from '../../constants';
 import TooltipTrigger from '../TooltipTrigger';
 import styles from './Item.module.css';
 import TaskItemContainer from './TaskItemContainer';
 
 function CharacterisationTaskItem(props) {
-  const { index, data, sampleId, pointID, shapes, showForm, addTask } = props;
+  const { index, data, sampleId } = props;
   const wedges = data.type === 'Interleaved' ? data.parameters.wedges : [data];
+
+  const dispatch = useDispatch();
+  const shapes = useSelector((state) => state.shapes);
 
   function showDiffPlan() {
     const tasks = data.diffractionPlan;
@@ -20,25 +26,26 @@ function CharacterisationTaskItem(props) {
       delete data.diffractionPlan[0].sampleID;
       const [{ type, parameters }] = data.diffractionPlan;
 
-      showForm(type, sampleId, data.diffractionPlan[0], parameters.shape);
+      dispatch(
+        showTaskForm(type, sampleId, data.diffractionPlan[0], parameters.shape),
+      );
     } else {
       tasks.forEach((t) => {
         const pars = {
           type: 'DataCollection',
           label: 'Data Collection',
           helical: false,
-          shape: pointID,
           ...t.parameters,
         };
 
-        addTask([sampleId], pars, false);
+        dispatch(addTask([sampleId], pars, false));
       });
     }
   }
 
   function handleParamsTableClick() {
     const { type, parameters } = data;
-    showForm(type, sampleId, data, parameters.shape);
+    dispatch(showTaskForm(type, sampleId, data, parameters.shape));
   }
 
   function pointIDString() {

--- a/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
+++ b/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
@@ -7,40 +7,9 @@ import TooltipTrigger from '../TooltipTrigger';
 import styles from './Item.module.css';
 import TaskItemContainer from './TaskItemContainer';
 
-function TaskItem(props) {
+function CharacterisationTaskItem(props) {
   const { index, data, sampleId, pointID, shapes, showForm, addTask } = props;
   const wedges = data.type === 'Interleaved' ? data.parameters.wedges : [data];
-
-  function getResult() {
-    if (data.state !== TASK_COLLECTED) {
-      return <span />;
-    }
-
-    return <div className={styles.resultBody}>{getDiffPlan()}</div>;
-  }
-
-  function getDiffPlan() {
-    let diffPlan = [];
-    if (
-      'diffractionPlan' in data &&
-      Object.keys(data.diffractionPlan).length > 0
-    ) {
-      // it can be empty
-      diffPlan = (
-        <span className="float-end">
-          <Button
-            size="sm"
-            style={{ width: 'auto', marginTop: '-4px' }}
-            onClick={showDiffPlan}
-          >
-            <i className="fas fa-plus" />
-            Add Diffraction Plan
-          </Button>
-        </span>
-      );
-    }
-    return diffPlan;
-  }
 
   function showDiffPlan() {
     const tasks = data.diffractionPlan;
@@ -91,70 +60,6 @@ function TaskItem(props) {
     return `${res}`;
   }
 
-  function wedgePath(wedge) {
-    const { parameters } = wedge;
-    const value = parameters.fileName;
-    const path = parameters.path || '';
-    const pathEndPart = path.slice(-40);
-
-    return (
-      <TooltipTrigger
-        id="wedge-path-tooltip"
-        tooltipContent={
-          <>
-            {path}
-            {value}
-          </>
-        }
-      >
-        <a style={{ flexGrow: 1 }}>
-          .../{pathEndPart.slice(pathEndPart.indexOf('/') + 1)}
-          {value}
-        </a>
-      </TooltipTrigger>
-    );
-  }
-
-  function wedgeParameters(wedge) {
-    const { parameters } = wedge;
-
-    return (
-      <tr>
-        <td>
-          <a>{parameters.osc_start.toFixed(2)}</a>
-        </td>
-        <td>
-          <a>{parameters.osc_range.toFixed(2)}</a>
-        </td>
-        <td>
-          <a>{parameters.exp_time.toFixed(3)}</a>
-        </td>
-        <td>
-          <a>{parameters.num_images}</a>
-        </td>
-        <td>
-          <a>{parameters.transmission.toFixed(2)}</a>
-        </td>
-        <td>
-          <a>{parameters.resolution.toFixed(3)}</a>
-        </td>
-        <td>
-          <a>{parameters.energy.toFixed(4)}</a>
-        </td>
-        {parameters.kappa_phi !== null && (
-          <td>
-            <a>{parameters.kappa_phi.toFixed(2)}</a>
-          </td>
-        )}
-        {parameters.kappa !== null && (
-          <td>
-            <a>{parameters.kappa.toFixed(2)}</a>
-          </td>
-        )}
-      </tr>
-    );
-  }
-
   return (
     <TaskItemContainer
       index={index}
@@ -163,28 +68,43 @@ function TaskItem(props) {
     >
       <div className={styles.taskBody}>
         {wedges.map((wedge, i) => {
-          const padding = i > 0 ? '1.5em' : '0.5em';
+          const { parameters } = wedge;
+          const { fileName, path = '' } = parameters;
+          const pathEndPart = path.slice(-40);
+
           return (
             <div key={`wedge-${i}`}>
               <div
                 className={styles.dataPath}
-                style={{
-                  paddingTop: padding,
-                }}
+                style={{ paddingTop: i > 0 ? '1.5em' : '0.5em' }}
               >
                 <b>Path:</b>
-                {wedgePath(wedge)}
+                <TooltipTrigger
+                  id="wedge-path-tooltip"
+                  tooltipContent={
+                    <>
+                      {path}
+                      {fileName}
+                    </>
+                  }
+                >
+                  <a style={{ flexGrow: 1 }}>
+                    .../{pathEndPart.slice(pathEndPart.indexOf('/') + 1)}
+                    {fileName}
+                  </a>
+                </TooltipTrigger>
                 <Button
                   variant="outline-secondary"
                   style={{ width: '3em' }}
                   title="Copy path"
                   onClick={() => {
-                    navigator.clipboard.writeText(`${wedge.parameters.path}`);
+                    navigator.clipboard.writeText(path);
                   }}
                 >
                   <i className="fa fa-copy" aria-hidden="true" />
                 </Button>
               </div>
+
               <Table
                 striped
                 bordered
@@ -201,15 +121,64 @@ function TaskItem(props) {
                     <th>T (%)</th>
                     <th>Res. (&Aring;)</th>
                     <th>E (keV)</th>
-                    {wedge.parameters.kappa_phi !== null && (
-                      <th>&phi; &deg;</th>
-                    )}
-                    {wedge.parameters.kappa !== null && <th>&kappa; &deg;</th>}
+                    {parameters.kappa_phi !== null && <th>&phi; &deg;</th>}
+                    {parameters.kappa !== null && <th>&kappa; &deg;</th>}
                   </tr>
                 </thead>
-                <tbody>{wedgeParameters(wedge)}</tbody>
+                <tbody>
+                  <tr>
+                    <td>
+                      <a>{parameters.osc_start.toFixed(2)}</a>
+                    </td>
+                    <td>
+                      <a>{parameters.osc_range.toFixed(2)}</a>
+                    </td>
+                    <td>
+                      <a>{parameters.exp_time.toFixed(3)}</a>
+                    </td>
+                    <td>
+                      <a>{parameters.num_images}</a>
+                    </td>
+                    <td>
+                      <a>{parameters.transmission.toFixed(2)}</a>
+                    </td>
+                    <td>
+                      <a>{parameters.resolution.toFixed(3)}</a>
+                    </td>
+                    <td>
+                      <a>{parameters.energy.toFixed(4)}</a>
+                    </td>
+                    {parameters.kappa_phi !== null && (
+                      <td>
+                        <a>{parameters.kappa_phi.toFixed(2)}</a>
+                      </td>
+                    )}
+                    {parameters.kappa !== null && (
+                      <td>
+                        <a>{parameters.kappa.toFixed(2)}</a>
+                      </td>
+                    )}
+                  </tr>
+                </tbody>
               </Table>
-              {getResult()}
+
+              {data.state === TASK_COLLECTED && (
+                <div className={styles.resultBody}>
+                  {'diffractionPlan' in data &&
+                    Object.keys(data.diffractionPlan).length > 0 && (
+                      <span className="float-end">
+                        <Button
+                          size="sm"
+                          style={{ width: 'auto', marginTop: '-4px' }}
+                          onClick={showDiffPlan}
+                        >
+                          <i className="fas fa-plus" />
+                          Add Diffraction Plan
+                        </Button>
+                      </span>
+                    )}
+                </div>
+              )}
             </div>
           );
         })}
@@ -218,4 +187,4 @@ function TaskItem(props) {
   );
 }
 
-export default TaskItem;
+export default CharacterisationTaskItem;

--- a/ui/src/components/SampleQueue/CurrentTree.jsx
+++ b/ui/src/components/SampleQueue/CurrentTree.jsx
@@ -1,10 +1,8 @@
 import { Item, Menu } from 'react-contexify';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { showDialog } from '../../actions/general';
 import { addTask } from '../../actions/queue';
 import { showTaskForm } from '../../actions/taskForm';
-import { showWorkflowParametersDialog } from '../../actions/workflow';
 import CharacterisationTaskItem from './CharacterisationTaskItem';
 import EnergyScanTaskItem from './EnergyScanTaskItem';
 import TaskItem from './TaskItem';
@@ -17,12 +15,7 @@ function CurrentTree(props) {
   const { sampleID: sampleId, tasks = [] } = currentSample;
 
   const dispatch = useDispatch();
-
-  const checked = useSelector((state) => state.queue.checked);
   const displayData = useSelector((state) => state.queueGUI.displayData);
-  const plotsData = useSelector((state) => state.beamline.plotsData);
-  const plotsInfo = useSelector((state) => state.beamline.plotsInfo);
-  const shapes = useSelector((state) => state.shapes);
 
   function getSelectedTasks() {
     const selectedTasks = [];
@@ -98,16 +91,7 @@ function CurrentTree(props) {
                 <WorkflowTaskItem
                   key={taskData.queueID}
                   index={i}
-                  id={`${taskData.queueID}`}
                   data={taskData}
-                  sampleId={sampleId}
-                  checked={checked}
-                  showForm={(...args) => dispatch(showTaskForm(...args))}
-                  shapes={shapes}
-                  showDialog={(...args) => dispatch(showDialog(...args))}
-                  showWorkflowParametersDialog={(...args) => {
-                    dispatch(showWorkflowParametersDialog(...args));
-                  }}
                 />
               );
             }
@@ -116,14 +100,8 @@ function CurrentTree(props) {
                 <XRFTaskItem
                   key={taskData.queueID}
                   index={i}
-                  id={`${taskData.queueID}`}
                   data={taskData}
                   sampleId={sampleId}
-                  checked={checked}
-                  showForm={(...args) => dispatch(showTaskForm(...args))}
-                  plotsData={plotsData}
-                  plotsInfo={plotsInfo}
-                  showDialog={(...args) => dispatch(showDialog(...args))}
                 />
               );
             }
@@ -132,13 +110,8 @@ function CurrentTree(props) {
                 <EnergyScanTaskItem
                   key={taskData.queueID}
                   index={i}
-                  id={`${taskData.queueID}`}
                   data={taskData}
                   sampleId={sampleId}
-                  checked={checked}
-                  showForm={(...args) => dispatch(showTaskForm(...args))}
-                  shapes={shapes}
-                  showDialog={(...args) => dispatch(showDialog(...args))}
                 />
               );
             }
@@ -147,14 +120,8 @@ function CurrentTree(props) {
                 <CharacterisationTaskItem
                   key={taskData.queueID}
                   index={i}
-                  id={`${taskData.queueID}`}
                   data={taskData}
                   sampleId={sampleId}
-                  checked={checked}
-                  showForm={(...args) => dispatch(showTaskForm(...args))}
-                  addTask={addTask}
-                  shapes={shapes}
-                  showDialog={(...args) => dispatch(showDialog(...args))}
                 />
               );
             }
@@ -163,13 +130,8 @@ function CurrentTree(props) {
                 <TaskItem
                   key={taskData.queueID}
                   index={i}
-                  id={`${taskData.queueID}`}
                   data={taskData}
                   sampleId={sampleId}
-                  checked={checked}
-                  showForm={(...args) => dispatch(showTaskForm(...args))}
-                  shapes={shapes}
-                  showDialog={(...args) => dispatch(showDialog(...args))}
                 />
               );
             }

--- a/ui/src/components/SampleQueue/CurrentTree.jsx
+++ b/ui/src/components/SampleQueue/CurrentTree.jsx
@@ -91,12 +91,10 @@ function CurrentTree(props) {
     <>
       <div className={styles.listBody}>
         {tasks.map((taskData, i) => {
-          let task = null;
-
           switch (taskData.type) {
             case 'Workflow':
             case 'GphlWorkflow': {
-              task = (
+              return (
                 <WorkflowTaskItem
                   key={taskData.queueID}
                   index={i}
@@ -112,11 +110,9 @@ function CurrentTree(props) {
                   }}
                 />
               );
-
-              break;
             }
             case 'xrf_spectrum': {
-              task = (
+              return (
                 <XRFTaskItem
                   key={taskData.queueID}
                   index={i}
@@ -130,11 +126,9 @@ function CurrentTree(props) {
                   showDialog={(...args) => dispatch(showDialog(...args))}
                 />
               );
-
-              break;
             }
             case 'energy_scan': {
-              task = (
+              return (
                 <EnergyScanTaskItem
                   key={taskData.queueID}
                   index={i}
@@ -147,11 +141,9 @@ function CurrentTree(props) {
                   showDialog={(...args) => dispatch(showDialog(...args))}
                 />
               );
-
-              break;
             }
             case 'Characterisation': {
-              task = (
+              return (
                 <CharacterisationTaskItem
                   key={taskData.queueID}
                   index={i}
@@ -166,11 +158,9 @@ function CurrentTree(props) {
                   showDialog={(...args) => dispatch(showDialog(...args))}
                 />
               );
-
-              break;
             }
             default: {
-              task = (
+              return (
                 <TaskItem
                   key={taskData.queueID}
                   index={i}
@@ -185,8 +175,6 @@ function CurrentTree(props) {
               );
             }
           }
-
-          return task;
         })}
       </div>
 

--- a/ui/src/components/SampleQueue/CurrentTree.jsx
+++ b/ui/src/components/SampleQueue/CurrentTree.jsx
@@ -13,7 +13,7 @@ import WorkflowTaskItem from './WorkflowTaskItem';
 import XRFTaskItem from './XRFTaskItem';
 
 function CurrentTree(props) {
-  const { sampleList, currentSample } = props;
+  const { currentSample } = props;
   const { sampleID: sampleId, tasks = [] } = currentSample;
 
   const dispatch = useDispatch();
@@ -151,7 +151,6 @@ function CurrentTree(props) {
                   data={taskData}
                   sampleId={sampleId}
                   checked={checked}
-                  state={sampleList[taskData.sampleID].tasks[i].state}
                   showForm={(...args) => dispatch(showTaskForm(...args))}
                   addTask={addTask}
                   shapes={shapes}

--- a/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
+++ b/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
@@ -1,39 +1,24 @@
 /* eslint-disable react/destructuring-assignment */
 /* eslint-disable jsx-a11y/control-has-associated-label */
 /* eslint-disable jsx-a11y/anchor-is-valid */
-/* eslint-disable react/no-unused-prop-types */
-
-import PropTypes from 'prop-types';
-import { Component } from 'react';
 import { OverlayTrigger, Popover } from 'react-bootstrap';
 
 import styles from './Item.module.css';
 import TaskItemContainer from './TaskItemContainer';
 
-export default class EnergyScanTaskItem extends Component {
-  static propTypes = {
-    id: PropTypes.string.isRequired,
-    index: PropTypes.number.isRequired,
-  };
-
-  constructor(props) {
-    super(props);
-    this.showForm = this.showForm.bind(this);
-    this.pointIDString = this.pointIDString.bind(this);
-  }
-
-  showForm() {
-    const { data, sampleId } = this.props;
+function EnergyScanTaskItem(props) {
+  function showForm() {
+    const { data, sampleId } = props;
     const { type, parameters } = data;
-    this.props.showForm(type, sampleId, data, parameters.shape);
+    props.showForm(type, sampleId, data, parameters.shape);
   }
 
-  pointIDString(parameters) {
+  function pointIDString(parameters) {
     let res = '';
 
     if (parameters.shape !== -1) {
       try {
-        res = `${this.props.shapes.shapes[parameters.shape].name}: `;
+        res = `${props.shapes.shapes[parameters.shape].name}: `;
       } catch {
         res = '';
       }
@@ -42,7 +27,7 @@ export default class EnergyScanTaskItem extends Component {
     return res;
   }
 
-  path(parameters) {
+  function renderPath(parameters) {
     const value = parameters.fileName;
     const path = parameters.path || '';
 
@@ -72,31 +57,31 @@ export default class EnergyScanTaskItem extends Component {
     );
   }
 
-  render() {
-    const { data } = this.props;
+  const { data } = props;
 
-    const { parameters } = data;
+  const { parameters } = data;
 
-    return (
-      <TaskItemContainer
-        index={this.props.index}
-        data={data}
-        pointIDString={this.pointIDString(parameters)}
-      >
-        <div className={styles.taskBody}>
-          <div>
-            <div style={{ border: '1px solid #DDD' }}>
-              <div style={{ padding: '0.5em' }} onClick={this.showForm}>
-                <b>Path:</b> {this.path(parameters)}
-                <br />
-                <b>Element:</b> {parameters.element}
-                <br />
-                <b>Edge:</b> {parameters.edge}
-              </div>
+  return (
+    <TaskItemContainer
+      index={props.index}
+      data={data}
+      pointIDString={pointIDString(parameters)}
+    >
+      <div className={styles.taskBody}>
+        <div>
+          <div style={{ border: '1px solid #DDD' }}>
+            <div style={{ padding: '0.5em' }} onClick={showForm}>
+              <b>Path:</b> {renderPath(parameters)}
+              <br />
+              <b>Element:</b> {parameters.element}
+              <br />
+              <b>Edge:</b> {parameters.edge}
             </div>
           </div>
         </div>
-      </TaskItemContainer>
-    );
-  }
+      </div>
+    </TaskItemContainer>
+  );
 }
+
+export default EnergyScanTaskItem;

--- a/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
+++ b/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
@@ -9,6 +9,9 @@ function EnergyScanTaskItem(props) {
   const { index, data, sampleId, shapes, showForm } = props;
   const { type, parameters } = data;
 
+  const value = parameters.fileName;
+  const path = parameters.path || '';
+
   function handleParamsTableClick() {
     showForm(type, sampleId, data, parameters.shape);
   }
@@ -27,36 +30,6 @@ function EnergyScanTaskItem(props) {
     return res;
   }
 
-  function renderPath() {
-    const value = parameters.fileName;
-    const path = parameters.path || '';
-
-    return (
-      <OverlayTrigger
-        trigger="click"
-        placement="top"
-        rootClose
-        overlay={
-          <Popover
-            id="wedge-popover"
-            style={{ maxWidth: '2000px', width: 'auto' }}
-          >
-            <input
-              type="text"
-              onFocus={(e) => {
-                e.target.select();
-              }}
-              value={path}
-              size={path.length + 10}
-            />
-          </Popover>
-        }
-      >
-        <a onClick={(e) => e.stopPropagation()}>{value}</a>
-      </OverlayTrigger>
-    );
-  }
-
   return (
     <TaskItemContainer
       index={index}
@@ -67,7 +40,29 @@ function EnergyScanTaskItem(props) {
         <div>
           <div style={{ border: '1px solid #DDD' }}>
             <div style={{ padding: '0.5em' }} onClick={handleParamsTableClick}>
-              <b>Path:</b> {renderPath()}
+              <b>Path:</b>{' '}
+              <OverlayTrigger
+                trigger="click"
+                placement="top"
+                rootClose
+                overlay={
+                  <Popover
+                    id="wedge-popover"
+                    style={{ maxWidth: '2000px', width: 'auto' }}
+                  >
+                    <input
+                      type="text"
+                      size={path.length + 10}
+                      value={path}
+                      onFocus={(evt) => {
+                        evt.target.select();
+                      }}
+                    />
+                  </Popover>
+                }
+              >
+                <a onClick={(evt) => evt.stopPropagation()}>{value}</a>
+              </OverlayTrigger>
               <br />
               <b>Element:</b> {parameters.element}
               <br />

--- a/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
+++ b/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/destructuring-assignment */
 /* eslint-disable jsx-a11y/control-has-associated-label */
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import { OverlayTrigger, Popover } from 'react-bootstrap';
@@ -7,18 +6,19 @@ import styles from './Item.module.css';
 import TaskItemContainer from './TaskItemContainer';
 
 function EnergyScanTaskItem(props) {
-  function showForm() {
-    const { data, sampleId } = props;
-    const { type, parameters } = data;
-    props.showForm(type, sampleId, data, parameters.shape);
+  const { index, data, sampleId, shapes, showForm } = props;
+  const { type, parameters } = data;
+
+  function handleParamsTableClick() {
+    showForm(type, sampleId, data, parameters.shape);
   }
 
-  function pointIDString(parameters) {
+  function pointIDString() {
     let res = '';
 
     if (parameters.shape !== -1) {
       try {
-        res = `${props.shapes.shapes[parameters.shape].name}: `;
+        res = `${shapes.shapes[parameters.shape].name}: `;
       } catch {
         res = '';
       }
@@ -27,7 +27,7 @@ function EnergyScanTaskItem(props) {
     return res;
   }
 
-  function renderPath(parameters) {
+  function renderPath() {
     const value = parameters.fileName;
     const path = parameters.path || '';
 
@@ -57,21 +57,17 @@ function EnergyScanTaskItem(props) {
     );
   }
 
-  const { data } = props;
-
-  const { parameters } = data;
-
   return (
     <TaskItemContainer
-      index={props.index}
+      index={index}
       data={data}
-      pointIDString={pointIDString(parameters)}
+      pointIDString={pointIDString()}
     >
       <div className={styles.taskBody}>
         <div>
           <div style={{ border: '1px solid #DDD' }}>
-            <div style={{ padding: '0.5em' }} onClick={showForm}>
-              <b>Path:</b> {renderPath(parameters)}
+            <div style={{ padding: '0.5em' }} onClick={handleParamsTableClick}>
+              <b>Path:</b> {renderPath()}
               <br />
               <b>Element:</b> {parameters.element}
               <br />

--- a/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
+++ b/ui/src/components/SampleQueue/EnergyScanTaskItem.jsx
@@ -1,19 +1,24 @@
 /* eslint-disable jsx-a11y/control-has-associated-label */
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import { OverlayTrigger, Popover } from 'react-bootstrap';
+import { useDispatch, useSelector } from 'react-redux';
 
+import { showTaskForm } from '../../actions/taskForm';
 import styles from './Item.module.css';
 import TaskItemContainer from './TaskItemContainer';
 
 function EnergyScanTaskItem(props) {
-  const { index, data, sampleId, shapes, showForm } = props;
+  const { index, data, sampleId } = props;
   const { type, parameters } = data;
 
   const value = parameters.fileName;
   const path = parameters.path || '';
 
+  const dispatch = useDispatch();
+  const shapes = useSelector((state) => state.shapes);
+
   function handleParamsTableClick() {
-    showForm(type, sampleId, data, parameters.shape);
+    dispatch(showTaskForm(type, sampleId, data, parameters.shape));
   }
 
   function pointIDString() {

--- a/ui/src/components/SampleQueue/TaskItem.jsx
+++ b/ui/src/components/SampleQueue/TaskItem.jsx
@@ -47,98 +47,45 @@ function TaskItem(props) {
     return `${res} `;
   }
 
-  function wedgePath(wedge) {
-    const { parameters } = wedge;
-    const value = parameters.fileName;
-    const path = parameters.path || '';
-    const pathEndPart = path.slice(-40);
-
-    return (
-      <TooltipTrigger
-        id="wedge-path-tooltip"
-        tooltipContent={
-          <>
-            {path}
-            {value}
-          </>
-        }
-      >
-        <a style={{ flexGrow: 1 }}>
-          .../{pathEndPart.slice(pathEndPart.indexOf('/') + 1)}
-          {value}
-        </a>
-      </TooltipTrigger>
-    );
-  }
-
-  function wedgeParameters(wedge) {
-    const { parameters } = wedge;
-    return (
-      <tr>
-        {parameters.osc_start !== null && (
-          <td>
-            <a>{parameters.osc_start.toFixed(2)}</a>
-          </td>
-        )}
-        {parameters.osc_range !== null && (
-          <td>
-            <a>{parameters.osc_range.toFixed(2)}</a>
-          </td>
-        )}
-        <td>
-          <a>{parameters.exp_time.toFixed(6)}</a>
-        </td>
-        <td>
-          <a>{parameters.num_images}</a>
-        </td>
-        <td>
-          <a>{parameters.transmission.toFixed(2)}</a>
-        </td>
-        <td>
-          <a>{parameters.resolution.toFixed(3)}</a>
-        </td>
-        <td>
-          <a>{parameters.energy.toFixed(4)}</a>
-        </td>
-        {parameters.kappa_phi !== null && (
-          <td>
-            <a>{parameters.kappa_phi.toFixed(2)}</a>
-          </td>
-        )}
-        {parameters.kappa !== null && (
-          <td>
-            <a>{parameters.kappa.toFixed(2)}</a>
-          </td>
-        )}
-      </tr>
-    );
-  }
-
   return (
     <TaskItemContainer
       index={index}
       data={data}
-      pointIDString={pointIDString(wedges)}
+      pointIDString={pointIDString()}
     >
       <div className={styles.taskBody}>
         {wedges.map((wedge, i) => {
-          const padding = i > 0 ? '1.5em' : '0.5em';
+          const { parameters } = wedge;
+          const { fileName, path = '' } = parameters;
+          const pathEndPart = path.slice(-40);
+
           return (
             <div key={`wedge-${i}`}>
               <div
                 className={styles.dataPath}
-                style={{
-                  paddingTop: padding,
-                }}
+                style={{ paddingTop: i > 0 ? '1.5em' : '0.5em' }}
               >
                 <b>Path:</b>
-                {wedgePath(wedge)}
+                <TooltipTrigger
+                  id="wedge-path-tooltip"
+                  tooltipContent={
+                    <>
+                      {path}
+                      {fileName}
+                    </>
+                  }
+                >
+                  <a style={{ flexGrow: 1 }}>
+                    .../{pathEndPart.slice(pathEndPart.indexOf('/') + 1)}
+                    {fileName}
+                  </a>
+                </TooltipTrigger>
                 <Button
                   variant="outline-secondary"
                   style={{ width: '3em' }}
                   title="Copy path"
                   onClick={() => {
-                    navigator.clipboard.writeText(`${wedge.parameters.path}`);
+                    navigator.clipboard.writeText(path);
                   }}
                 >
                   <i className="fa fa-copy" aria-hidden="true" />
@@ -154,24 +101,56 @@ function TaskItem(props) {
               >
                 <thead>
                   <tr>
-                    {wedge.parameters.osc_start !== null && (
-                      <th>Start &deg; </th>
-                    )}
-                    {wedge.parameters.osc_range !== null && (
-                      <th>Osc. &deg; </th>
-                    )}
+                    {parameters.osc_start !== null && <th>Start &deg; </th>}
+                    {parameters.osc_range !== null && <th>Osc. &deg; </th>}
                     <th>t (s)</th>
                     <th># Img</th>
                     <th>T (%)</th>
                     <th>Res. (&Aring;)</th>
                     <th>E (keV)</th>
-                    {wedge.parameters.kappa_phi !== null && (
-                      <th>&phi; &deg;</th>
-                    )}
-                    {wedge.parameters.kappa !== null && <th>&kappa; &deg;</th>}
+                    {parameters.kappa_phi !== null && <th>&phi; &deg;</th>}
+                    {parameters.kappa !== null && <th>&kappa; &deg;</th>}
                   </tr>
                 </thead>
-                <tbody>{wedgeParameters(wedge)}</tbody>
+                <tbody>
+                  <tr>
+                    {parameters.osc_start !== null && (
+                      <td>
+                        <a>{parameters.osc_start.toFixed(2)}</a>
+                      </td>
+                    )}
+                    {parameters.osc_range !== null && (
+                      <td>
+                        <a>{parameters.osc_range.toFixed(2)}</a>
+                      </td>
+                    )}
+                    <td>
+                      <a>{parameters.exp_time.toFixed(6)}</a>
+                    </td>
+                    <td>
+                      <a>{parameters.num_images}</a>
+                    </td>
+                    <td>
+                      <a>{parameters.transmission.toFixed(2)}</a>
+                    </td>
+                    <td>
+                      <a>{parameters.resolution.toFixed(3)}</a>
+                    </td>
+                    <td>
+                      <a>{parameters.energy.toFixed(4)}</a>
+                    </td>
+                    {parameters.kappa_phi !== null && (
+                      <td>
+                        <a>{parameters.kappa_phi.toFixed(2)}</a>
+                      </td>
+                    )}
+                    {parameters.kappa !== null && (
+                      <td>
+                        <a>{parameters.kappa.toFixed(2)}</a>
+                      </td>
+                    )}
+                  </tr>
+                </tbody>
               </Table>
             </div>
           );

--- a/ui/src/components/SampleQueue/TaskItem.jsx
+++ b/ui/src/components/SampleQueue/TaskItem.jsx
@@ -1,44 +1,28 @@
 /* eslint-disable react/destructuring-assignment */
 /* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable react/no-array-index-key */
-/* eslint-disable react/no-unused-prop-types */
-
-import PropTypes from 'prop-types';
-import { Component } from 'react';
 import { Button, Table } from 'react-bootstrap';
 
 import TooltipTrigger from '../TooltipTrigger';
 import styles from './Item.module.css';
 import TaskItemContainer from './TaskItemContainer';
 
-export default class TaskItem extends Component {
-  static propTypes = {
-    id: PropTypes.string.isRequired,
-    index: PropTypes.number.isRequired,
-  };
-
-  constructor(props) {
-    super(props);
-    this.showForm = this.showForm.bind(this);
-    this.pointIDString = this.pointIDString.bind(this);
-    this.wedgeParameters = this.wedgeParameters.bind(this);
-  }
-
-  showForm() {
-    const { data, sampleId, shapes } = this.props;
+function TaskItem(props) {
+  function showForm() {
+    const { data, sampleId, shapes } = props;
     const { type, parameters } = data;
     if (parameters.helical) {
-      this.props.showForm('Helical', sampleId, data, parameters.shape);
+      props.showForm('Helical', sampleId, data, parameters.shape);
     } else if (parameters.mesh) {
       const shape = shapes.shapes[parameters.shape];
       data.parameters.cell_count = shape.numCols * shape.numRows;
-      this.props.showForm('Mesh', sampleId, data, parameters.shape);
+      props.showForm('Mesh', sampleId, data, parameters.shape);
     } else {
-      this.props.showForm(type, sampleId, data, parameters.shape);
+      props.showForm(type, sampleId, data, parameters.shape);
     }
   }
 
-  pointIDString(wedges) {
+  function pointIDString(wedges) {
     let res = '';
 
     wedges.forEach((wedge) => {
@@ -47,7 +31,7 @@ export default class TaskItem extends Component {
         !res.includes(`${wedge.parameters.shape}`)
       ) {
         try {
-          res += `${this.props.shapes.shapes[wedge.parameters.shape].name}`;
+          res += `${props.shapes.shapes[wedge.parameters.shape].name}`;
         } catch {
           res = String(res);
         }
@@ -61,7 +45,7 @@ export default class TaskItem extends Component {
     return `${res} `;
   }
 
-  wedgePath(wedge) {
+  function wedgePath(wedge) {
     const { parameters } = wedge;
     const value = parameters.fileName;
     const path = parameters.path || '';
@@ -85,7 +69,7 @@ export default class TaskItem extends Component {
     );
   }
 
-  wedgeParameters(wedge) {
+  function wedgeParameters(wedge) {
     const { parameters } = wedge;
     return (
       <tr>
@@ -128,77 +112,74 @@ export default class TaskItem extends Component {
     );
   }
 
-  render() {
-    const { data } = this.props;
-    const wedges =
-      data.type === 'Interleaved' ? data.parameters.wedges : [data];
+  const { data } = props;
+  const wedges = data.type === 'Interleaved' ? data.parameters.wedges : [data];
 
-    return (
-      <TaskItemContainer
-        index={this.props.index}
-        data={data}
-        pointIDString={this.pointIDString(wedges)}
-      >
-        <div className={styles.taskBody}>
-          {wedges.map((wedge, i) => {
-            const padding = i > 0 ? '1.5em' : '0.5em';
-            return (
-              <div key={`wedge-${i}`}>
-                <div
-                  className={styles.dataPath}
-                  style={{
-                    paddingTop: padding,
+  return (
+    <TaskItemContainer
+      index={props.index}
+      data={data}
+      pointIDString={pointIDString(wedges)}
+    >
+      <div className={styles.taskBody}>
+        {wedges.map((wedge, i) => {
+          const padding = i > 0 ? '1.5em' : '0.5em';
+          return (
+            <div key={`wedge-${i}`}>
+              <div
+                className={styles.dataPath}
+                style={{
+                  paddingTop: padding,
+                }}
+              >
+                <b>Path:</b>
+                {wedgePath(wedge)}
+                <Button
+                  variant="outline-secondary"
+                  style={{ width: '3em' }}
+                  title="Copy path"
+                  onClick={() => {
+                    navigator.clipboard.writeText(`${wedge.parameters.path}`);
                   }}
                 >
-                  <b>Path:</b>
-                  {this.wedgePath(wedge)}
-                  <Button
-                    variant="outline-secondary"
-                    style={{ width: '3em' }}
-                    title="Copy path"
-                    onClick={() => {
-                      navigator.clipboard.writeText(`${wedge.parameters.path}`);
-                    }}
-                  >
-                    <i className="fa fa-copy" aria-hidden="true" />
-                  </Button>
-                </div>
-
-                <Table
-                  striped
-                  bordered
-                  hover
-                  onClick={this.showForm}
-                  className={styles.taskParametersTable}
-                >
-                  <thead>
-                    <tr>
-                      {wedge.parameters.osc_start !== null && (
-                        <th>Start &deg; </th>
-                      )}
-                      {wedge.parameters.osc_range !== null && (
-                        <th>Osc. &deg; </th>
-                      )}
-                      <th>t (s)</th>
-                      <th># Img</th>
-                      <th>T (%)</th>
-                      <th>Res. (&Aring;)</th>
-                      <th>E (keV)</th>
-                      {wedge.parameters.kappa_phi !== null && (
-                        <th>&phi; &deg;</th>
-                      )}
-                      {wedge.parameters.kappa !== null && (
-                        <th>&kappa; &deg;</th>
-                      )}
-                    </tr>
-                  </thead>
-                  <tbody>{this.wedgeParameters(wedge)}</tbody>
-                </Table>
+                  <i className="fa fa-copy" aria-hidden="true" />
+                </Button>
               </div>
-            );
-          })}
-        </div>
-      </TaskItemContainer>
-    );
-  }
+
+              <Table
+                striped
+                bordered
+                hover
+                onClick={showForm}
+                className={styles.taskParametersTable}
+              >
+                <thead>
+                  <tr>
+                    {wedge.parameters.osc_start !== null && (
+                      <th>Start &deg; </th>
+                    )}
+                    {wedge.parameters.osc_range !== null && (
+                      <th>Osc. &deg; </th>
+                    )}
+                    <th>t (s)</th>
+                    <th># Img</th>
+                    <th>T (%)</th>
+                    <th>Res. (&Aring;)</th>
+                    <th>E (keV)</th>
+                    {wedge.parameters.kappa_phi !== null && (
+                      <th>&phi; &deg;</th>
+                    )}
+                    {wedge.parameters.kappa !== null && <th>&kappa; &deg;</th>}
+                  </tr>
+                </thead>
+                <tbody>{wedgeParameters(wedge)}</tbody>
+              </Table>
+            </div>
+          );
+        })}
+      </div>
+    </TaskItemContainer>
+  );
 }
+
+export default TaskItem;

--- a/ui/src/components/SampleQueue/TaskItem.jsx
+++ b/ui/src/components/SampleQueue/TaskItem.jsx
@@ -1,26 +1,31 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable react/no-array-index-key */
 import { Button, Table } from 'react-bootstrap';
+import { useDispatch, useSelector } from 'react-redux';
 
+import { showTaskForm } from '../../actions/taskForm';
 import TooltipTrigger from '../TooltipTrigger';
 import styles from './Item.module.css';
 import TaskItemContainer from './TaskItemContainer';
 
 function TaskItem(props) {
-  const { data, index, shapes, sampleId, showForm } = props;
+  const { data, index, sampleId } = props;
   const wedges = data.type === 'Interleaved' ? data.parameters.wedges : [data];
+
+  const dispatch = useDispatch();
+  const shapes = useSelector((state) => state.shapes);
 
   function handleParamsTableClick() {
     const { type, parameters } = data;
 
     if (parameters.helical) {
-      showForm('Helical', sampleId, data, parameters.shape);
+      dispatch(showTaskForm('Helical', sampleId, data, parameters.shape));
     } else if (parameters.mesh) {
       const shape = shapes.shapes[parameters.shape];
       data.parameters.cell_count = shape.numCols * shape.numRows;
-      showForm('Mesh', sampleId, data, parameters.shape);
+      dispatch(showTaskForm('Mesh', sampleId, data, parameters.shape));
     } else {
-      showForm(type, sampleId, data, parameters.shape);
+      dispatch(showTaskForm(type, sampleId, data, parameters.shape));
     }
   }
 

--- a/ui/src/components/SampleQueue/TaskItem.jsx
+++ b/ui/src/components/SampleQueue/TaskItem.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/destructuring-assignment */
 /* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable react/no-array-index-key */
 import { Button, Table } from 'react-bootstrap';
@@ -8,21 +7,24 @@ import styles from './Item.module.css';
 import TaskItemContainer from './TaskItemContainer';
 
 function TaskItem(props) {
-  function showForm() {
-    const { data, sampleId, shapes } = props;
+  const { data, index, shapes, sampleId, showForm } = props;
+  const wedges = data.type === 'Interleaved' ? data.parameters.wedges : [data];
+
+  function handleParamsTableClick() {
     const { type, parameters } = data;
+
     if (parameters.helical) {
-      props.showForm('Helical', sampleId, data, parameters.shape);
+      showForm('Helical', sampleId, data, parameters.shape);
     } else if (parameters.mesh) {
       const shape = shapes.shapes[parameters.shape];
       data.parameters.cell_count = shape.numCols * shape.numRows;
-      props.showForm('Mesh', sampleId, data, parameters.shape);
+      showForm('Mesh', sampleId, data, parameters.shape);
     } else {
-      props.showForm(type, sampleId, data, parameters.shape);
+      showForm(type, sampleId, data, parameters.shape);
     }
   }
 
-  function pointIDString(wedges) {
+  function pointIDString() {
     let res = '';
 
     wedges.forEach((wedge) => {
@@ -31,7 +33,7 @@ function TaskItem(props) {
         !res.includes(`${wedge.parameters.shape}`)
       ) {
         try {
-          res += `${props.shapes.shapes[wedge.parameters.shape].name}`;
+          res += `${shapes.shapes[wedge.parameters.shape].name}`;
         } catch {
           res = String(res);
         }
@@ -112,12 +114,9 @@ function TaskItem(props) {
     );
   }
 
-  const { data } = props;
-  const wedges = data.type === 'Interleaved' ? data.parameters.wedges : [data];
-
   return (
     <TaskItemContainer
-      index={props.index}
+      index={index}
       data={data}
       pointIDString={pointIDString(wedges)}
     >
@@ -150,7 +149,7 @@ function TaskItem(props) {
                 striped
                 bordered
                 hover
-                onClick={showForm}
+                onClick={handleParamsTableClick}
                 className={styles.taskParametersTable}
               >
                 <thead>

--- a/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
+++ b/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
@@ -1,16 +1,21 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import { Button } from 'react-bootstrap';
+import { useDispatch, useSelector } from 'react-redux';
 
+import { showWorkflowParametersDialog } from '../../actions/workflow';
 import TooltipTrigger from '../TooltipTrigger';
 import styles from './Item.module.css';
 import TaskItemContainer from './TaskItemContainer';
 
 function WorkflowTaskItem(props) {
-  const { index, data, shapes, showWorkflowParametersDialog } = props;
+  const { index, data } = props;
   const { parameters } = data;
 
   const path = parameters.path || '';
   const pathEndPart = path.slice(-40);
+
+  const dispatch = useDispatch();
+  const shapes = useSelector((state) => state.shapes);
 
   function pointIDString() {
     let res = '';
@@ -55,7 +60,7 @@ function WorkflowTaskItem(props) {
               variant="outline-secondary"
               style={{ width: '3em' }}
               title="Open parameters dialog"
-              onClick={() => showWorkflowParametersDialog(null, true)}
+              onClick={() => dispatch(showWorkflowParametersDialog(null, true))}
             >
               <i aria-hidden="true" className="fa fa-sliders-h" />
             </Button>

--- a/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
+++ b/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/destructuring-assignment */
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import { Button } from 'react-bootstrap';
 
@@ -7,12 +6,15 @@ import styles from './Item.module.css';
 import TaskItemContainer from './TaskItemContainer';
 
 function WorkflowTaskItem(props) {
-  function pointIDString(parameters) {
+  const { index, data, shapes, showWorkflowParametersDialog } = props;
+  const { parameters } = data;
+
+  function pointIDString() {
     let res = '';
 
     if (parameters.shape !== -1) {
       try {
-        res = `${props.shapes.shapes[parameters.shape].name}: `;
+        res = `${shapes.shapes[parameters.shape].name}: `;
       } catch {
         res = '';
       }
@@ -21,7 +23,7 @@ function WorkflowTaskItem(props) {
     return res;
   }
 
-  function renderPath(parameters) {
+  function renderPath() {
     const path = parameters.path || '';
     const pathEndPart = path.slice(-40);
 
@@ -34,21 +36,17 @@ function WorkflowTaskItem(props) {
     );
   }
 
-  const { data } = props;
-
-  const { parameters } = data;
-
   return (
     <TaskItemContainer
-      index={props.index}
+      index={index}
       data={data}
-      pointIDString={pointIDString(parameters)}
+      pointIDString={pointIDString()}
     >
       <div className={styles.taskBody}>
         <div>
           <div className={styles.dataPath}>
             <b>Path:</b>
-            {renderPath(parameters)}
+            {renderPath()}
             <Button
               variant="outline-secondary"
               style={{ width: '3em' }}
@@ -63,7 +61,7 @@ function WorkflowTaskItem(props) {
               variant="outline-secondary"
               style={{ width: '3em' }}
               title="Open parameters dialog"
-              onClick={() => props.showWorkflowParametersDialog(null, true)}
+              onClick={() => showWorkflowParametersDialog(null, true)}
             >
               <i aria-hidden="true" className="fa fa-sliders-h" />
             </Button>

--- a/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
+++ b/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
@@ -9,6 +9,9 @@ function WorkflowTaskItem(props) {
   const { index, data, shapes, showWorkflowParametersDialog } = props;
   const { parameters } = data;
 
+  const path = parameters.path || '';
+  const pathEndPart = path.slice(-40);
+
   function pointIDString() {
     let res = '';
 
@@ -23,19 +26,6 @@ function WorkflowTaskItem(props) {
     return res;
   }
 
-  function renderPath() {
-    const path = parameters.path || '';
-    const pathEndPart = path.slice(-40);
-
-    return (
-      <TooltipTrigger id="wedge-path-tooltip" tooltipContent={path}>
-        <a style={{ flexGrow: 1 }}>
-          .../{pathEndPart.slice(pathEndPart.indexOf('/') + 1)}
-        </a>
-      </TooltipTrigger>
-    );
-  }
-
   return (
     <TaskItemContainer
       index={index}
@@ -46,7 +36,11 @@ function WorkflowTaskItem(props) {
         <div>
           <div className={styles.dataPath}>
             <b>Path:</b>
-            {renderPath()}
+            <TooltipTrigger id="wedge-path-tooltip" tooltipContent={path}>
+              <a style={{ flexGrow: 1 }}>
+                .../{pathEndPart.slice(pathEndPart.indexOf('/') + 1)}
+              </a>
+            </TooltipTrigger>
             <Button
               variant="outline-secondary"
               style={{ width: '3em' }}

--- a/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
+++ b/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
@@ -1,39 +1,18 @@
 /* eslint-disable react/destructuring-assignment */
 /* eslint-disable jsx-a11y/anchor-is-valid */
-/* eslint-disable react/no-unused-prop-types */
-
-import PropTypes from 'prop-types';
-import { Component } from 'react';
 import { Button } from 'react-bootstrap';
 
 import TooltipTrigger from '../TooltipTrigger';
 import styles from './Item.module.css';
 import TaskItemContainer from './TaskItemContainer';
 
-export default class WorkflowTaskItem extends Component {
-  static propTypes = {
-    id: PropTypes.string.isRequired,
-    index: PropTypes.number.isRequired,
-  };
-
-  constructor(props) {
-    super(props);
-    this.showForm = this.showForm.bind(this);
-    this.pointIDString = this.pointIDString.bind(this);
-  }
-
-  showForm() {
-    const { data, sampleId } = this.props;
-    const { type, parameters } = data;
-    this.props.showForm(type, sampleId, data, parameters.shape);
-  }
-
-  pointIDString(parameters) {
+function WorkflowTaskItem(props) {
+  function pointIDString(parameters) {
     let res = '';
 
     if (parameters.shape !== -1) {
       try {
-        res = `${this.props.shapes.shapes[parameters.shape].name}: `;
+        res = `${props.shapes.shapes[parameters.shape].name}: `;
       } catch {
         res = '';
       }
@@ -42,7 +21,7 @@ export default class WorkflowTaskItem extends Component {
     return res;
   }
 
-  path(parameters) {
+  function renderPath(parameters) {
     const path = parameters.path || '';
     const pathEndPart = path.slice(-40);
 
@@ -55,46 +34,44 @@ export default class WorkflowTaskItem extends Component {
     );
   }
 
-  render() {
-    const { data } = this.props;
+  const { data } = props;
 
-    const { parameters } = data;
+  const { parameters } = data;
 
-    return (
-      <TaskItemContainer
-        index={this.props.index}
-        data={data}
-        pointIDString={this.pointIDString(parameters)}
-      >
-        <div className={styles.taskBody}>
-          <div>
-            <div className={styles.dataPath}>
-              <b>Path:</b>
-              {this.path(parameters)}
-              <Button
-                variant="outline-secondary"
-                style={{ width: '3em' }}
-                title="Copy path"
-                onClick={() => {
-                  navigator.clipboard.writeText(`${parameters.path}`);
-                }}
-              >
-                <i className="fa fa-copy" aria-hidden="true" />
-              </Button>
-              <Button
-                variant="outline-secondary"
-                style={{ width: '3em' }}
-                title="Open parameters dialog"
-                onClick={() =>
-                  this.props.showWorkflowParametersDialog(null, true)
-                }
-              >
-                <i aria-hidden="true" className="fa fa-sliders-h" />
-              </Button>
-            </div>
+  return (
+    <TaskItemContainer
+      index={props.index}
+      data={data}
+      pointIDString={pointIDString(parameters)}
+    >
+      <div className={styles.taskBody}>
+        <div>
+          <div className={styles.dataPath}>
+            <b>Path:</b>
+            {renderPath(parameters)}
+            <Button
+              variant="outline-secondary"
+              style={{ width: '3em' }}
+              title="Copy path"
+              onClick={() => {
+                navigator.clipboard.writeText(`${parameters.path}`);
+              }}
+            >
+              <i className="fa fa-copy" aria-hidden="true" />
+            </Button>
+            <Button
+              variant="outline-secondary"
+              style={{ width: '3em' }}
+              title="Open parameters dialog"
+              onClick={() => props.showWorkflowParametersDialog(null, true)}
+            >
+              <i aria-hidden="true" className="fa fa-sliders-h" />
+            </Button>
           </div>
         </div>
-      </TaskItemContainer>
-    );
-  }
+      </div>
+    </TaskItemContainer>
+  );
 }
+
+export default WorkflowTaskItem;

--- a/ui/src/components/SampleQueue/XRFTaskItem.jsx
+++ b/ui/src/components/SampleQueue/XRFTaskItem.jsx
@@ -9,6 +9,9 @@ function XRFTaskItem(props) {
   const { index, data, sampleId, shapes, showForm } = props;
   const { type, parameters } = data;
 
+  const value = parameters.fileName;
+  const path = parameters.path || '';
+
   function handleParamsTableClick() {
     showForm(type, sampleId, data, parameters.shape);
   }
@@ -27,36 +30,6 @@ function XRFTaskItem(props) {
     return `${res}`;
   }
 
-  function renderPath() {
-    const value = parameters.fileName;
-    const path = parameters.path || '';
-
-    return (
-      <OverlayTrigger
-        trigger="click"
-        placement="top"
-        rootClose
-        overlay={
-          <Popover
-            id="wedge-popover"
-            style={{ maxWidth: '2000px', width: 'auto' }}
-          >
-            <input
-              type="text"
-              onFocus={(e) => {
-                e.target.select();
-              }}
-              value={path}
-              size={path.length + 10}
-            />
-          </Popover>
-        }
-      >
-        <a onClick={(e) => e.stopPropagation()}>{value}</a>
-      </OverlayTrigger>
-    );
-  }
-
   return (
     <TaskItemContainer
       index={index}
@@ -67,7 +40,29 @@ function XRFTaskItem(props) {
         <div>
           <div style={{ border: '1px solid #DDD' }}>
             <div style={{ padding: '0.5em' }} onClick={handleParamsTableClick}>
-              <b>Path:</b> {renderPath()}
+              <b>Path:</b>{' '}
+              <OverlayTrigger
+                trigger="click"
+                placement="top"
+                rootClose
+                overlay={
+                  <Popover
+                    id="wedge-popover"
+                    style={{ maxWidth: '2000px', width: 'auto' }}
+                  >
+                    <input
+                      type="text"
+                      onFocus={(e) => {
+                        e.target.select();
+                      }}
+                      value={path}
+                      size={path.length + 10}
+                    />
+                  </Popover>
+                }
+              >
+                <a onClick={(evt) => evt.stopPropagation()}>{value}</a>
+              </OverlayTrigger>
               <br />
               <b>Count time:</b> {parameters.countTime}
             </div>

--- a/ui/src/components/SampleQueue/XRFTaskItem.jsx
+++ b/ui/src/components/SampleQueue/XRFTaskItem.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/destructuring-assignment */
 /* eslint-disable jsx-a11y/control-has-associated-label */
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import { OverlayTrigger, Popover } from 'react-bootstrap';
@@ -7,18 +6,19 @@ import styles from './Item.module.css';
 import TaskItemContainer from './TaskItemContainer';
 
 function XRFTaskItem(props) {
-  function showForm() {
-    const { data, sampleId } = props;
-    const { type, parameters } = data;
-    props.showForm(type, sampleId, data, parameters.shape);
+  const { index, data, sampleId, shapes, showForm } = props;
+  const { type, parameters } = data;
+
+  function handleParamsTableClick() {
+    showForm(type, sampleId, data, parameters.shape);
   }
 
-  function pointIDString(parameters) {
+  function pointIDString() {
     let res = '';
 
     if (parameters.shape !== -1) {
       try {
-        res = `${props.shapes.shapes[parameters.shape].name}: `;
+        res = `${shapes.shapes[parameters.shape].name}: `;
       } catch {
         res = '';
       }
@@ -27,7 +27,7 @@ function XRFTaskItem(props) {
     return `${res}`;
   }
 
-  function renderPath(parameters) {
+  function renderPath() {
     const value = parameters.fileName;
     const path = parameters.path || '';
 
@@ -57,20 +57,17 @@ function XRFTaskItem(props) {
     );
   }
 
-  const { data } = props;
-  const { parameters } = data;
-
   return (
     <TaskItemContainer
-      index={props.index}
+      index={index}
       data={data}
-      pointIDString={pointIDString(parameters)}
+      pointIDString={pointIDString()}
     >
       <div className={styles.taskBody}>
         <div>
           <div style={{ border: '1px solid #DDD' }}>
-            <div style={{ padding: '0.5em' }} onClick={showForm}>
-              <b>Path:</b> {renderPath(parameters)}
+            <div style={{ padding: '0.5em' }} onClick={handleParamsTableClick}>
+              <b>Path:</b> {renderPath()}
               <br />
               <b>Count time:</b> {parameters.countTime}
             </div>

--- a/ui/src/components/SampleQueue/XRFTaskItem.jsx
+++ b/ui/src/components/SampleQueue/XRFTaskItem.jsx
@@ -1,19 +1,24 @@
 /* eslint-disable jsx-a11y/control-has-associated-label */
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import { OverlayTrigger, Popover } from 'react-bootstrap';
+import { useDispatch, useSelector } from 'react-redux';
 
+import { showTaskForm } from '../../actions/taskForm';
 import styles from './Item.module.css';
 import TaskItemContainer from './TaskItemContainer';
 
 function XRFTaskItem(props) {
-  const { index, data, sampleId, shapes, showForm } = props;
+  const { index, data, sampleId } = props;
   const { type, parameters } = data;
 
   const value = parameters.fileName;
   const path = parameters.path || '';
 
+  const dispatch = useDispatch();
+  const shapes = useSelector((state) => state.shapes);
+
   function handleParamsTableClick() {
-    showForm(type, sampleId, data, parameters.shape);
+    dispatch(showTaskForm(type, sampleId, data, parameters.shape));
   }
 
   function pointIDString() {

--- a/ui/src/components/SampleQueue/XRFTaskItem.jsx
+++ b/ui/src/components/SampleQueue/XRFTaskItem.jsx
@@ -1,39 +1,24 @@
 /* eslint-disable react/destructuring-assignment */
 /* eslint-disable jsx-a11y/control-has-associated-label */
 /* eslint-disable jsx-a11y/anchor-is-valid */
-/* eslint-disable react/no-unused-prop-types */
-
-import PropTypes from 'prop-types';
-import { Component } from 'react';
 import { OverlayTrigger, Popover } from 'react-bootstrap';
 
 import styles from './Item.module.css';
 import TaskItemContainer from './TaskItemContainer';
 
-export default class XRFTaskItem extends Component {
-  static propTypes = {
-    id: PropTypes.string.isRequired,
-    index: PropTypes.number.isRequired,
-  };
-
-  constructor(props) {
-    super(props);
-    this.showForm = this.showForm.bind(this);
-    this.pointIDString = this.pointIDString.bind(this);
-  }
-
-  showForm() {
-    const { data, sampleId } = this.props;
+function XRFTaskItem(props) {
+  function showForm() {
+    const { data, sampleId } = props;
     const { type, parameters } = data;
-    this.props.showForm(type, sampleId, data, parameters.shape);
+    props.showForm(type, sampleId, data, parameters.shape);
   }
 
-  pointIDString(parameters) {
+  function pointIDString(parameters) {
     let res = '';
 
     if (parameters.shape !== -1) {
       try {
-        res = `${this.props.shapes.shapes[parameters.shape].name}: `;
+        res = `${props.shapes.shapes[parameters.shape].name}: `;
       } catch {
         res = '';
       }
@@ -42,7 +27,7 @@ export default class XRFTaskItem extends Component {
     return `${res}`;
   }
 
-  path(parameters) {
+  function renderPath(parameters) {
     const value = parameters.fileName;
     const path = parameters.path || '';
 
@@ -72,28 +57,28 @@ export default class XRFTaskItem extends Component {
     );
   }
 
-  render() {
-    const { data } = this.props;
-    const { parameters } = data;
+  const { data } = props;
+  const { parameters } = data;
 
-    return (
-      <TaskItemContainer
-        index={this.props.index}
-        data={data}
-        pointIDString={this.pointIDString(parameters)}
-      >
-        <div className={styles.taskBody}>
-          <div>
-            <div style={{ border: '1px solid #DDD' }}>
-              <div style={{ padding: '0.5em' }} onClick={this.showForm}>
-                <b>Path:</b> {this.path(parameters)}
-                <br />
-                <b>Count time:</b> {parameters.countTime}
-              </div>
+  return (
+    <TaskItemContainer
+      index={props.index}
+      data={data}
+      pointIDString={pointIDString(parameters)}
+    >
+      <div className={styles.taskBody}>
+        <div>
+          <div style={{ border: '1px solid #DDD' }}>
+            <div style={{ padding: '0.5em' }} onClick={showForm}>
+              <b>Path:</b> {renderPath(parameters)}
+              <br />
+              <b>Count time:</b> {parameters.countTime}
             </div>
           </div>
         </div>
-      </TaskItemContainer>
-    );
-  }
+      </div>
+    </TaskItemContainer>
+  );
 }
+
+export default XRFTaskItem;

--- a/ui/src/containers/SampleQueueContainer.jsx
+++ b/ui/src/containers/SampleQueueContainer.jsx
@@ -67,10 +67,7 @@ function SampleQueueContainer() {
             </div>
           )}
           {visibleList === 'current' && currentSample && (
-            <CurrentTree
-              currentSample={currentSample}
-              sampleList={sampleList}
-            />
+            <CurrentTree currentSample={currentSample} />
           )}
           {visibleList === 'todo' && <TodoTree list={todo} />}
         </div>


### PR DESCRIPTION
The first three commits are straightforward: 1) convert to function components, 2) destructure props, 3) inline JSX-returning functions.

In the fourth commit, [9b6cd6badcbe2c86f9d6a259fcdaa602aa1c202d](https://github.com/mxcube/mxcubeweb/pull/1994/commits/9b6cd6badcbe2c86f9d6a259fcdaa602aa1c202d), I clean up the props, move the dispatch calls down, etc. This is where things become a little more interesting. I'll leave some comments as usual.