### PR TITLE
Implement environment variable reading at yaml files

### DIFF
--- a/docs/source/dev/environment_variables_at_yaml_files.md
+++ b/docs/source/dev/environment_variables_at_yaml_files.md
@@ -1,0 +1,24 @@
+# Using environemtn variables at yaml files
+
+mxcubeweb `ConfigLoader` class reads all content from server.yaml and ui.yaml, from your configuration files repository.
+If a variable starts exactly with `_ENV_`, then instead of reading it, `ConfigLoader` will read that variable from the environment.
+
+## Example usage
+
+If server.yaml contains this content:
+
+```
+sso:
+  USE_SSO: true
+  META_DATA_URI: https://my_metadata_uri.cnpem.br
+  LOGOUT_URI: https://my_logout_uri.cnpem.br
+  CLIENT_ID: _ENV_CLIENT_ID
+```
+
+Then CLIENT_ID will be obtained via:
+
+```
+os.getenv("_ENV_CLIENT_ID")
+```
+
+The function that does this is located at `mxcubeweb/config.py`. It walks recursively through all of `ConfigLoader` content.

--- a/mxcubeweb/config.py
+++ b/mxcubeweb/config.py
@@ -20,9 +20,34 @@ from mxcubeweb.core.models.configmodels import (
 
 class ConfigLoader:
     @staticmethod
+    def resolve_env(value):
+        if isinstance(value, str) and value.startswith("_ENV_"):
+            env_value = os.getenv(value)
+            if env_value is None:
+                error_msg = f"{value} starts with _ENV_ but was not set in environment"
+                raise RuntimeError(error_msg)
+            logging.getLogger("HWR").debug(f"Environment variable {value} has been set")
+            return env_value
+        return value
+
+    @staticmethod
+    def walk_and_resolve(data):
+        if isinstance(data, dict):
+            return {
+                k: ConfigLoader.walk_and_resolve(ConfigLoader.resolve_env(v))
+                for k, v in data.items()
+            }
+        if isinstance(data, list):
+            return [
+                ConfigLoader.walk_and_resolve(ConfigLoader.resolve_env(x)) for x in data
+            ]
+        return ConfigLoader.resolve_env(data)
+
+    @staticmethod
     def load(path: str, schema: BaseModel):
         with open(os.path.join(path), encoding="utf-8") as f:
             config = ruamel.yaml.YAML().load(f.read())
+            config = ConfigLoader.walk_and_resolve(config)
             try:
                 model = schema.parse_obj(config)
             except ValidationError:


### PR DESCRIPTION
As discussed in the last developer's meeting, me and another developer of LNLS were having trouble having to share the same variables at our configuration repository. Specifically the variable CLIENT_ID from server.yaml cannot be the same for us, since it is used for our SSO authentication and must be different for each IP address (we test our codes in different machines).

This implementation replaces any string that starts with "_ENV_" with the environment variable of that string. This is done after the yaml file has been read.