### PR TITLE
Remove unused logic from `CharacterisationTaskItem`

### DIFF
--- a/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
+++ b/ui/src/components/SampleQueue/CharacterisationTaskItem.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-/* eslint-disable react/no-array-index-key */
+
 import { Button, Table } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -12,30 +12,29 @@ import TaskItemContainer from './TaskItemContainer';
 
 function CharacterisationTaskItem(props) {
   const { index, data, sampleId } = props;
-  const wedges = data.type === 'Interleaved' ? data.parameters.wedges : [data];
+  const { parameters, diffractionPlan } = data;
+
+  const { type, fileName, path = '', shape } = parameters;
+  const pathEndPart = path.slice(-40);
 
   const dispatch = useDispatch();
   const shapes = useSelector((state) => state.shapes);
 
   function showDiffPlan() {
-    const tasks = data.diffractionPlan;
-
-    // if there is a single wedge, display the form, otherwise, add all wedges as differente dc-s
-    if (tasks.length <= 1) {
-      delete data.diffractionPlan[0].run_number;
-      delete data.diffractionPlan[0].sampleID;
-      const [{ type, parameters }] = data.diffractionPlan;
-
+    // If there is a single wedge, display the form; otherwise, add all wedges as different data collections
+    if (diffractionPlan.length === 1) {
+      const [task] = diffractionPlan;
+      const { run_number, sampleID, ...taskData } = task;
       dispatch(
-        showTaskForm(type, sampleId, data.diffractionPlan[0], parameters.shape),
+        showTaskForm(task.type, sampleId, taskData, task.parameters.shape),
       );
     } else {
-      tasks.forEach((t) => {
+      diffractionPlan.forEach((task) => {
         const pars = {
           type: 'DataCollection',
           label: 'Data Collection',
           helical: false,
-          ...t.parameters,
+          ...task.parameters,
         };
 
         dispatch(addTask([sampleId], pars, false));
@@ -44,27 +43,21 @@ function CharacterisationTaskItem(props) {
   }
 
   function handleParamsTableClick() {
-    const { type, parameters } = data;
-    dispatch(showTaskForm(type, sampleId, data, parameters.shape));
+    dispatch(showTaskForm(type, sampleId, data, shape));
   }
 
   function pointIDString() {
     let res = '';
 
-    wedges.forEach((wedge) => {
-      if (
-        wedge.parameters.shape !== -1 &&
-        !res.includes(`${wedge.parameters.shape}`)
-      ) {
-        try {
-          res += `${shapes.shapes[wedge.parameters.shape].name} :`;
-        } catch {
-          res = String(res);
-        }
+    if (shape !== -1) {
+      try {
+        res = `${shapes.shapes[shape].name} :`;
+      } catch {
+        res = '';
       }
-    });
+    }
 
-    return `${res}`;
+    return res;
   }
 
   return (
@@ -74,121 +67,107 @@ function CharacterisationTaskItem(props) {
       pointIDString={pointIDString()}
     >
       <div className={styles.taskBody}>
-        {wedges.map((wedge, i) => {
-          const { parameters } = wedge;
-          const { fileName, path = '' } = parameters;
-          const pathEndPart = path.slice(-40);
+        <div className={styles.dataPath}>
+          <b>Path:</b>
+          <TooltipTrigger
+            id="wedge-path-tooltip"
+            tooltipContent={
+              <>
+                {path}
+                {fileName}
+              </>
+            }
+          >
+            <a style={{ flexGrow: 1 }}>
+              .../{pathEndPart.slice(pathEndPart.indexOf('/') + 1)}
+              {fileName}
+            </a>
+          </TooltipTrigger>
+          <Button
+            variant="outline-secondary"
+            style={{ width: '3em' }}
+            title="Copy path"
+            onClick={() => {
+              navigator.clipboard.writeText(path);
+            }}
+          >
+            <i className="fa fa-copy" aria-hidden="true" />
+          </Button>
+        </div>
 
-          return (
-            <div key={`wedge-${i}`}>
-              <div
-                className={styles.dataPath}
-                style={{ paddingTop: i > 0 ? '1.5em' : '0.5em' }}
-              >
-                <b>Path:</b>
-                <TooltipTrigger
-                  id="wedge-path-tooltip"
-                  tooltipContent={
-                    <>
-                      {path}
-                      {fileName}
-                    </>
-                  }
-                >
-                  <a style={{ flexGrow: 1 }}>
-                    .../{pathEndPart.slice(pathEndPart.indexOf('/') + 1)}
-                    {fileName}
-                  </a>
-                </TooltipTrigger>
-                <Button
-                  variant="outline-secondary"
-                  style={{ width: '3em' }}
-                  title="Copy path"
-                  onClick={() => {
-                    navigator.clipboard.writeText(path);
-                  }}
-                >
-                  <i className="fa fa-copy" aria-hidden="true" />
-                </Button>
-              </div>
-
-              <Table
-                striped
-                bordered
-                hover
-                onClick={handleParamsTableClick}
-                className={styles.taskParametersTable}
-              >
-                <thead>
-                  <tr>
-                    <th>Start &deg; </th>
-                    <th>Osc. &deg; </th>
-                    <th>t (s)</th>
-                    <th># Img</th>
-                    <th>T (%)</th>
-                    <th>Res. (&Aring;)</th>
-                    <th>E (keV)</th>
-                    {parameters.kappa_phi !== null && <th>&phi; &deg;</th>}
-                    {parameters.kappa !== null && <th>&kappa; &deg;</th>}
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>
-                      <a>{parameters.osc_start.toFixed(2)}</a>
-                    </td>
-                    <td>
-                      <a>{parameters.osc_range.toFixed(2)}</a>
-                    </td>
-                    <td>
-                      <a>{parameters.exp_time.toFixed(3)}</a>
-                    </td>
-                    <td>
-                      <a>{parameters.num_images}</a>
-                    </td>
-                    <td>
-                      <a>{parameters.transmission.toFixed(2)}</a>
-                    </td>
-                    <td>
-                      <a>{parameters.resolution.toFixed(3)}</a>
-                    </td>
-                    <td>
-                      <a>{parameters.energy.toFixed(4)}</a>
-                    </td>
-                    {parameters.kappa_phi !== null && (
-                      <td>
-                        <a>{parameters.kappa_phi.toFixed(2)}</a>
-                      </td>
-                    )}
-                    {parameters.kappa !== null && (
-                      <td>
-                        <a>{parameters.kappa.toFixed(2)}</a>
-                      </td>
-                    )}
-                  </tr>
-                </tbody>
-              </Table>
-
-              {data.state === TASK_COLLECTED && (
-                <div className={styles.resultBody}>
-                  {'diffractionPlan' in data &&
-                    Object.keys(data.diffractionPlan).length > 0 && (
-                      <span className="float-end">
-                        <Button
-                          size="sm"
-                          style={{ width: 'auto', marginTop: '-4px' }}
-                          onClick={showDiffPlan}
-                        >
-                          <i className="fas fa-plus" />
-                          Add Diffraction Plan
-                        </Button>
-                      </span>
-                    )}
-                </div>
+        <Table
+          striped
+          bordered
+          hover
+          onClick={handleParamsTableClick}
+          className={styles.taskParametersTable}
+        >
+          <thead>
+            <tr>
+              <th>Start &deg; </th>
+              <th>Osc. &deg; </th>
+              <th>t (s)</th>
+              <th># Img</th>
+              <th>T (%)</th>
+              <th>Res. (&Aring;)</th>
+              <th>E (keV)</th>
+              {parameters.kappa_phi !== null && <th>&phi; &deg;</th>}
+              {parameters.kappa !== null && <th>&kappa; &deg;</th>}
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <a>{parameters.osc_start.toFixed(2)}</a>
+              </td>
+              <td>
+                <a>{parameters.osc_range.toFixed(2)}</a>
+              </td>
+              <td>
+                <a>{parameters.exp_time.toFixed(3)}</a>
+              </td>
+              <td>
+                <a>{parameters.num_images}</a>
+              </td>
+              <td>
+                <a>{parameters.transmission.toFixed(2)}</a>
+              </td>
+              <td>
+                <a>{parameters.resolution.toFixed(3)}</a>
+              </td>
+              <td>
+                <a>{parameters.energy.toFixed(4)}</a>
+              </td>
+              {parameters.kappa_phi !== null && (
+                <td>
+                  <a>{parameters.kappa_phi.toFixed(2)}</a>
+                </td>
               )}
-            </div>
-          );
-        })}
+              {parameters.kappa !== null && (
+                <td>
+                  <a>{parameters.kappa.toFixed(2)}</a>
+                </td>
+              )}
+            </tr>
+          </tbody>
+        </Table>
+
+        {data.state === TASK_COLLECTED && (
+          <div className={styles.resultBody}>
+            {diffractionPlan && diffractionPlan.length > 0 && (
+              <span className="float-end">
+                <Button
+                  size="sm"
+                  style={{ width: 'auto', marginTop: '-4px' }}
+                  onClick={showDiffPlan}
+                >
+                  <i className="fas fa-plus" />
+                  Add Diffraction Plan
+                </Button>
+              </span>
+            )}
+          </div>
+        )}
       </div>
     </TaskItemContainer>
   );

--- a/ui/src/components/SampleQueue/XRFTaskItem.jsx
+++ b/ui/src/components/SampleQueue/XRFTaskItem.jsx
@@ -10,9 +10,7 @@ import TaskItemContainer from './TaskItemContainer';
 function XRFTaskItem(props) {
   const { index, data, sampleId } = props;
   const { type, parameters } = data;
-
-  const value = parameters.fileName;
-  const path = parameters.path || '';
+  const { fileName, path = '' } = parameters;
 
   const dispatch = useDispatch();
   const shapes = useSelector((state) => state.shapes);
@@ -32,7 +30,7 @@ function XRFTaskItem(props) {
       }
     }
 
-    return `${res}`;
+    return res;
   }
 
   return (
@@ -66,7 +64,7 @@ function XRFTaskItem(props) {
                   </Popover>
                 }
               >
-                <a onClick={(evt) => evt.stopPropagation()}>{value}</a>
+                <a onClick={(evt) => evt.stopPropagation()}>{fileName}</a>
               </OverlayTrigger>
               <br />
               <b>Count time:</b> {parameters.countTime}


### PR DESCRIPTION
In `CurrentTree`, `CharacterisationTaskItem` is rendered when the task's `type` is `'Characterisation'`, yet in `CharacterisationTaskItem`, there's logic that checks if the task's `type` is `'Interleaved'`.

So I simplify `CharacterisationTaskItem` accordingly.