### PR TITLE
Pre-fill the data collection for with sample data

### DIFF
--- a/ui/src/components/Tasks/DataCollection.jsx
+++ b/ui/src/components/Tasks/DataCollection.jsx
@@ -386,6 +386,16 @@ export default connect((state) => {
       ].acq_parameters.osc_range;
   }
 
+  const {
+    cellA,
+    cellAlpha,
+    cellB,
+    cellBeta,
+    cellC,
+    cellGamma,
+    crystalSpaceGroup,
+  } = state.sampleGrid.sampleList[state.queue.currentSampleID];
+
   return {
     path: `${state.login.rootPath}/${subdir}`,
     filename: fname,
@@ -400,6 +410,13 @@ export default connect((state) => {
       energy: toFixed(state, 'energy'),
       transmission: toFixed(state, 'transmission'),
       osc_start: toFixed(state, 'diffractometer.phi', 'osc_start'),
+      cellA,
+      cellAlpha,
+      cellB,
+      cellBeta,
+      cellC,
+      cellGamma,
+      crystalSpaceGroup,
     },
   };
 })(DataCollectionForm);


### PR DESCRIPTION
Unit cell parameter data and space group for a particular sample are already included for a particular sample when using ISPyB and possible other LIMS.

> [!NOTE]
> I am not sure how generic are these sampeData paremeters; e.g. if using different LIMS could lead to `cellA` being available under different name. In that case it would be undefined and nothing would be prefilled.