### PR TITLE
Simplify interleaved data collection availability logic in queue UI

### DIFF
--- a/ui/src/components/SampleQueue/TaskItemContainer.jsx
+++ b/ui/src/components/SampleQueue/TaskItemContainer.jsx
@@ -65,10 +65,10 @@ export default function TaskItemContainer({
   }
 
   function taskHeaderOnClick(e) {
-    if (!e.ctrlKey) {
-      dispatch(collapseItem(data.queueID));
-    } else {
+    if (e.ctrlKey) {
       dispatch(selectItem(data.queueID));
+    } else {
+      dispatch(collapseItem(data.queueID));
     }
   }
 
@@ -140,10 +140,7 @@ export default function TaskItemContainer({
             />
           )}
         </div>
-        <Collapse
-          id={`collapse-${data.queueID}`}
-          in={Boolean(displayData.collapsed)}
-        >
+        <Collapse id={`collapse-${data.queueID}`} in={displayData.collapsed}>
           {children}
         </Collapse>
       </div>

--- a/ui/src/reducers/queueGUI.js
+++ b/ui/src/reducers/queueGUI.js
@@ -88,16 +88,34 @@ function queueGUIReducer(state = INITIAL_STATE, action = {}) {
       return { ...state, showConfirmCollectDialog: action.show };
     }
     case 'COLLAPSE_ITEM': {
-      const displayData = { ...state.displayData };
-      displayData[action.queueID].collapsed ^= 1; // eslint-disable-line no-bitwise
+      const { displayData } = state;
+      const { queueID } = action;
 
-      return { ...state, displayData };
+      return {
+        ...state,
+        displayData: {
+          ...displayData,
+          [queueID]: {
+            ...displayData[queueID],
+            collapsed: !displayData[queueID].collapsed,
+          },
+        },
+      };
     }
     case 'SELECT_ITEM': {
-      const displayData = { ...state.displayData };
-      displayData[action.queueID].selected ^= 1; // eslint-disable-line no-bitwise
+      const { displayData } = state;
+      const { queueID } = action;
 
-      return { ...state, displayData };
+      return {
+        ...state,
+        displayData: {
+          ...displayData,
+          [queueID]: {
+            ...displayData[queueID],
+            selected: !displayData[queueID].selected,
+          },
+        },
+      };
     }
     case 'SET_INITIAL_STATE': {
       const sampleList = { ...action.data.queue.sampleList.sampleList };


### PR DESCRIPTION
- Simplify some code in `CurrentTree` related to creating interleaved data collections
- Remove a couple of bitwise operators in the `queueGUI` reducer to avoid ending up with `0`/`1` values in the `displayData.collapsed/selected` state instead of booleans.