### PR TITLE
split sampleImage and video

### DIFF
--- a/ui/src/actions/sampleview.js
+++ b/ui/src/actions/sampleview.js
@@ -111,8 +111,6 @@ export function setVideoSize(width, height) {
       pixelsPerMm: json.pixelsPerMm,
       sourceScale: json.scale,
     });
-
-    globalThis.initJSMpeg();
   };
 }
 

--- a/ui/src/components/SampleView/SampleImage.module.css
+++ b/ui/src/components/SampleView/SampleImage.module.css
@@ -44,7 +44,10 @@
   font-weight: bold;
 }
 
-.sampleImg {
-  position: absolute;
-  text-align: left;
+.videoCanvasWrapper {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  display: grid;
+  place-items: center;
 }

--- a/ui/src/components/SampleView/VideoPlayer.jsx
+++ b/ui/src/components/SampleView/VideoPlayer.jsx
@@ -1,0 +1,64 @@
+import { useEffect, useRef } from 'react';
+import { useSelector } from 'react-redux';
+
+import { JSMpeg } from './jsmpeg.min.js';
+import styles from './VideoPlayer.module.css';
+
+export default function VideoPlayer() {
+  const width = useSelector((state) => state.sampleview.width);
+  const height = useSelector((state) => state.sampleview.height);
+  const format = useSelector((state) => state.sampleview.videoFormat);
+  const source = useSelector((state) => {
+    const { videoURL, videoHash } = state.sampleview;
+    return videoURL ? `${videoURL}/${videoHash}` : undefined;
+  });
+
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || format !== 'MPEG1') {
+      return () => {};
+    }
+
+    canvas.width = width;
+    canvas.height = height;
+
+    const player = new JSMpeg.Player(source, {
+      canvas,
+      decodeFirstFrame: false,
+      preserveDrawingBuffer: true,
+      protocols: [],
+    });
+
+    player.play();
+
+    return () => {
+      player.pause();
+      player.source.destroy();
+      player.video?.destroy();
+    };
+  }, [format, source, width, height]);
+
+  if (!source) {
+    return null;
+  }
+
+  if (format === 'MJPEG') {
+    return <img id="sample-img" className={styles.video} src={source} alt="" />;
+  }
+
+  if (format === 'MPEG1') {
+    return (
+      <canvas
+        ref={canvasRef}
+        id="sample-img"
+        className={styles.video}
+        aria-hidden="true"
+        tabIndex={-1}
+      />
+    );
+  }
+
+  return null;
+}

--- a/ui/src/components/SampleView/VideoPlayer.module.css
+++ b/ui/src/components/SampleView/VideoPlayer.module.css
@@ -1,0 +1,8 @@
+.video {
+  position: absolute;
+  display: grid;
+  text-align: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
This PR intends a first refactoring of the `SampleImage` component, by extracting the video stream logic and putting it into its own functional component (`VideoPlayer`). This component handles the creation and management of the main stream.

See comments below for details on changes.

