### PR TITLE
Show all sections by default for the custom forms

### DIFF
--- a/ui/src/components/Tasks/CustomObjectFieldTemplate.jsx
+++ b/ui/src/components/Tasks/CustomObjectFieldTemplate.jsx
@@ -32,7 +32,7 @@ export default function CustomObjectFieldTemplate({
         return (
           <div key={group}>
             <FieldsHeader title={group} />
-            <CollapsableRows>
+            <CollapsableRows defaultCollapsed={false}>
               <div className="row">{fields.map(({ content }) => content)}</div>
             </CollapsableRows>
           </div>

--- a/ui/src/components/Tasks/fields.jsx
+++ b/ui/src/components/Tasks/fields.jsx
@@ -2,7 +2,7 @@
 /* eslint-disable react/no-multi-comp */
 import './style.css';
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Button, Col, Form, Row } from 'react-bootstrap';
 import { TiTimes, TiWarning } from 'react-icons/ti';
 import { Field } from 'redux-form';
@@ -359,6 +359,7 @@ export function FieldsRow({ children }) {
 /**
  * @typedef {Object} CollapsableRowsProps
  * @property {React.ReactNode} children
+ * @property {boolean} [defaultCollapsed=true]
  */
 
 /**
@@ -366,8 +367,8 @@ export function FieldsRow({ children }) {
  * @param {CollapsableRowsProps} props
  * @returns {JSX.Element}
  */
-export function CollapsableRows({ children }) {
-  const [collapsed, setCollapsed] = useState(true);
+export function CollapsableRows({ children, defaultCollapsed = true }) {
+  const [collapsed, setCollapsed] = useState(defaultCollapsed);
 
   return (
     <div>

--- a/ui/src/components/Tasks/fields.jsx
+++ b/ui/src/components/Tasks/fields.jsx
@@ -2,7 +2,7 @@
 /* eslint-disable react/no-multi-comp */
 import './style.css';
 
-import React from 'react';
+import React, { useState } from 'react';
 import { Button, Col, Form, Row } from 'react-bootstrap';
 import { TiTimes, TiWarning } from 'react-icons/ti';
 import { Field } from 'redux-form';
@@ -356,43 +356,37 @@ export function FieldsRow({ children }) {
   );
 }
 
-export class CollapsableRows extends React.Component {
-  constructor(props) {
-    super(props);
+/**
+ * @typedef {Object} CollapsableRowsProps
+ * @property {React.ReactNode} children
+ */
 
-    this.state = { collapsed: true };
-  }
+/**
+ * CollapsableRows component
+ * @param {CollapsableRowsProps} props
+ * @returns {JSX.Element}
+ */
+export function CollapsableRows({ children }) {
+  const [collapsed, setCollapsed] = useState(true);
 
-  render() {
-    return (
-      <div>
-        <Row>
-          <Col sm={12}>
-            <center>
-              {this.state.collapsed ? (
-                <Button
-                  variant="link"
-                  onClick={() => {
-                    this.setState({ collapsed: false });
-                  }}
-                >
-                  Show more
-                </Button>
-              ) : (
-                <Button
-                  variant="link"
-                  onClick={() => {
-                    this.setState({ collapsed: true });
-                  }}
-                >
-                  Hide
-                </Button>
-              )}
-            </center>
-          </Col>
-        </Row>
-        {this.state.collapsed ? '' : this.props.children}
-      </div>
-    );
-  }
+  return (
+    <div>
+      <Row>
+        <Col sm={12}>
+          <center>
+            {collapsed ? (
+              <Button variant="link" onClick={() => setCollapsed(false)}>
+                Show more
+              </Button>
+            ) : (
+              <Button variant="link" onClick={() => setCollapsed(true)}>
+                Hide
+              </Button>
+            )}
+          </center>
+        </Col>
+      </Row>
+      {collapsed ? null : children}
+    </div>
+  );
 }


### PR DESCRIPTION
This PR introduces two distinct changes in fact (I hope it's okay, both are small :))
The `<CollapsableRows>` component has been rewrote in functional style. 

Additionally, the default behaviour of said component, when used in generic forms, is to be expanded. For this purpose `defaultCollapsed` prop has been added there.
Closes #1898 


Happy new year! :tada: 