### PR TITLE
Make readonly text inputs gray in generic forms

### DIFF
--- a/ui/src/components/Tasks/CustomFieldTemplate.module.css
+++ b/ui/src/components/Tasks/CustomFieldTemplate.module.css
@@ -45,3 +45,8 @@
   font-family: monospace;
   color: var(--bs-secondary);
 }
+
+.fieldInput :global(.form-control):read-only {
+  background-color: var(--bs-secondary-bg);
+  opacity: 1;
+}


### PR DESCRIPTION
Currently when setting `ui:readonly` property in uiSchema, it behaves differently based on the input type.
For dropdowns `<select>` tag receives `disabled` property, which in turn triggers `.form-control:disabled` global boostrap css rule. It causes the input to have a gray background.

For text inputs it works different. `readonly` property is being set, which would require `:read-only` pseudo selector. Bootstrap does not define `.form-control:read-only`, so readonly input fields don't appear any different than "normal ones".

This change applies same styling `.form-control:disabled` for readonly inputs

Closes #1899