### PR TITLE
verify positionID as string before calling .includes()

### DIFF
--- a/ui/src/components/Tasks/Characterisation.jsx
+++ b/ui/src/components/Tasks/Characterisation.jsx
@@ -501,7 +501,7 @@ export default connect((state) => {
   const { parameters } = state.taskForm.taskData;
 
   // Set number of images to 1 for 2D points
-  if (position.includes('2D')) {
+  if (typeof position === 'string' && position.includes('2D')) {
     parameters.num_images = 1;
   }
 


### PR DESCRIPTION
There was an internal `.includes()` call on the `pointID` object of the `state.taskForm.pointID`. However, the default value of this parameter is `-1`. Since the expected type should be a `string`, any other value (like the default) would create a crash on the front-end. 

This scenario happened in #1627 . The `includes()` function call is only used inside an `if` condition, to set the default of images taken to 1 when using 2D points. This PR adds a type check in the condition to prevent the crash. 