### PR TITLE
fix datacollection ui crash on unmounted sample

### DIFF
--- a/ui/src/components/Tasks/DataCollection.jsx
+++ b/ui/src/components/Tasks/DataCollection.jsx
@@ -394,7 +394,7 @@ export default connect((state) => {
     cellC,
     cellGamma,
     crystalSpaceGroup,
-  } = state.sampleGrid.sampleList[state.queue.currentSampleID];
+  } = state.sampleGrid.sampleList[state.queue.currentSampleID] ?? {};
 
   return {
     path: `${state.login.rootPath}/${subdir}`,


### PR DESCRIPTION
This PR closes #2026.
The UI crash explained in #2026 happens, since `state.sampleGrid.sampleList[state.queue.currentSampleID]` is `undefined` if no sample is mounted (`currentSampleID` is null in that case) by defaulting the call to an empty object in this case, the crash will be prevented.

This crash was introduced in #1998. This PR aimed at pre-filling some processing field parameters for a mounted sample. The suggested change would just not pre-fill the parameters in the dialog if the sample is not mounted