### PR TITLE
Fixing mxcubecore to < 2.x before PR #2000 is merged

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4510,4 +4510,4 @@ graylog = ["graypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "5e6247450bc1e260168e424a70b761b4ea2ca8dd7bf925dee792d147101e82d2"
+content-hash = "35ce4222e8169ce422bddc9c897743dd7cfd52cc9830a2a9b9a9da82356ce420"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ Flask-Security = { version = "5.7.1", extras = ["common", "fsqla"] }
 Flask-SocketIO = "^5.3.6"
 gevent = "^23.9.1"
 markupsafe = "^2.1.5"
-mxcubecore =  ">=1.419.0"
+mxcubecore =  "<2.0.0"
 pillow = "^10.4.0"
 pydantic = ">=2.8.2,<2.9.0"
 pytz = "^2022.6"


### PR DESCRIPTION
Fixing `mxcubecore` to < 2.x before PR #2000 is merged