### PR TITLE
Pre-fill unit cell params for DC in samples tab

### DIFF
--- a/ui/src/components/Tasks/DataCollection.jsx
+++ b/ui/src/components/Tasks/DataCollection.jsx
@@ -386,6 +386,9 @@ export default connect((state) => {
       ].acq_parameters.osc_range;
   }
 
+  const currentSampleId =
+    state.taskForm.sampleIds.length === 1 ? state.taskForm.sampleIds[0] : null;
+
   const {
     cellA,
     cellAlpha,
@@ -394,7 +397,7 @@ export default connect((state) => {
     cellC,
     cellGamma,
     crystalSpaceGroup,
-  } = state.sampleGrid.sampleList[state.queue.currentSampleID] ?? {};
+  } = state.sampleGrid.sampleList[currentSampleId] ?? {};
 
   return {
     path: `${state.login.rootPath}/${subdir}`,
@@ -416,7 +419,7 @@ export default connect((state) => {
       cellBeta,
       cellC,
       cellGamma,
-      crystalSpaceGroup,
+      space_group: crystalSpaceGroup,
     },
   };
 })(DataCollectionForm);


### PR DESCRIPTION
github.com/mxcube/mxcubeweb/pull/1998 has introduced a way of filling unit cell parameters using LIMS data.

Current approach has two flaws:
  1. It works only when invoking DC from sample view's context menu due to the way information about selected state is stored in the redux state.
  2. It does not fill the crystal space group properly. The UI control is named 'space_group', rather than 'crystalSpaceGroup'.