### PR TITLE
Adapted to in_plate_mode being a property

### DIFF
--- a/mxcubeweb/core/adapter/sample_changer_adapter.py
+++ b/mxcubeweb/core/adapter/sample_changer_adapter.py
@@ -190,7 +190,7 @@ class SampleChangerAdapter(AdapterBase):
                     res
                     and HWR.beamline.queue_manager.centring_method
                     == queue_entry.CENTRING_METHOD.LOOP
-                    and not HWR.beamline.diffractometer.in_plate_mode()
+                    and not HWR.beamline.diffractometer.in_plate_mode
                     and not self.app.harvester.mount_from_harvester()
                 ):
                     HWR.beamline.diffractometer.reject_centring()
@@ -199,7 +199,7 @@ class SampleChangerAdapter(AdapterBase):
                     HWR.beamline.diffractometer.start_centring_method(
                         HWR.beamline.diffractometer.C3D_MODE
                     )
-                elif HWR.beamline.diffractometer.in_plate_mode():
+                elif HWR.beamline.diffractometer.in_plate_mode:
                     msg = "Starting autoloop Focusing ..."
                     logging.getLogger("MX3.HWR").info(msg)
                     sc.move_to_crystal_position(None)
@@ -287,7 +287,7 @@ class SampleChangerAdapter(AdapterBase):
             },
             "cmds": {"cmds": cmds},
             "msg": msg,
-            "plate_mode": HWR.beamline.diffractometer.in_plate_mode(),
+            "plate_mode": HWR.beamline.diffractometer.in_plate_mode,
         }
 
     def state(self):

--- a/mxcubeweb/core/components/harvester.py
+++ b/mxcubeweb/core/components/harvester.py
@@ -61,7 +61,7 @@ class Harvester(ComponentBase):
             "global_state": {"global_state": global_state, "commands_state": cmdstate},
             "cmds": {"cmds": cmds},
             "msg": msg,
-            "plate_mode": HWR.beamline.diffractometer.in_plate_mode(),
+            "plate_mode": HWR.beamline.diffractometer.in_plate_mode,
         }
 
     def mount_from_harvester(self):

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -923,7 +923,7 @@ class Queue(ComponentBase):
 
         if sample_model.free_pin_mode:
             sample_model.location = (None, sample_id)
-        elif HWR.beamline.diffractometer.in_plate_mode():
+        elif HWR.beamline.diffractometer.in_plate_mode:
             component = HWR.beamline.sample_changer._resolve_component(item["location"])
             sample_model.location = component.get_coords()
         else:


### PR DESCRIPTION
This removes some of the errors that prevent the mockup from being run, and should hopefully be obvious enough to pass. It does not remove all of them, though, so this could not be tested. See Issue https://github.com/mxcube/mxcubecore/issues/1504 for more info on this.

There are consequent problems in both mxcubeqt and mxcubecore - I have made parallel PRs there too