### PR TITLE
remove dangerouslySetInnerHTML

### DIFF
--- a/ui/src/actions/sampleview.js
+++ b/ui/src/actions/sampleview.js
@@ -166,7 +166,7 @@ export function recordCentringClick(x, y) {
     const { clicksLeft } = json;
     dispatch(centringClicksLeft(clicksLeft));
 
-    let msg = `${general.clickCentringNumClicks}-Click Centring: <br />`;
+    let msg = `${general.clickCentringNumClicks}-Click Centring: \n`;
     if (clicksLeft === 0) {
       msg += 'Save centring or clicking on screen to restart';
     } else if (clicksLeft === -1) {
@@ -283,7 +283,7 @@ function startClickCentring() {
     dispatch(startClickCentringAction());
     dispatch(centringClicksLeft(clicksLeft));
 
-    const msg = `${general.clickCentringNumClicks}-Click Centring: <br />${
+    const msg = `${general.clickCentringNumClicks}-Click Centring: \n${
       clicksLeft === 0
         ? 'Save centring or clicking on screen to restart'
         : `Clicks left: ${clicksLeft}`

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -60,7 +60,6 @@ class SampleImage extends React.Component {
     this.configureGrid = this.configureGrid.bind(this);
     this.updateGridResults = this.updateGridResults.bind(this);
     this.selectedGrid = this.selectedGrid.bind(this);
-    this.centringMessage = this.centringMessage.bind(this);
     this.selectShape = this.selectShape.bind(this);
     this.deSelectShape = this.deSelectShape.bind(this);
     this.clearSelection = this.clearSelection.bind(this);
@@ -737,25 +736,6 @@ class SampleImage extends React.Component {
     this.props.updateShapes([grid]);
   }
 
-  centringMessage() {
-    let result = null;
-
-    if (this.props.videoMessageOverlay.show) {
-      result = (
-        <div
-          dangerouslySetInnerHTML={{
-            __html: this.props.videoMessageOverlay.msg,
-          }}
-          key={this.props.clickCentringClicksLeft}
-          id="video-message-overlay"
-          className={styles.videoMessageOverlay}
-        />
-      );
-    }
-
-    return result;
-  }
-
   renderSampleView() {
     const {
       imageRatio,
@@ -892,7 +872,15 @@ class SampleImage extends React.Component {
             </div>
 
             <SampleControls canvas={this.canvas} />
-            <div>{this.centringMessage()}</div>
+            {this.props.videoMessageOverlay.show && (
+              <div
+                key={this.props.clickCentringClicksLeft}
+                id="video-message-overlay"
+                className={styles.videoMessageOverlay}
+              >
+                {this.props.videoMessageOverlay.msg}
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/ui/src/components/SampleView/SampleImage.module.css
+++ b/ui/src/components/SampleView/SampleImage.module.css
@@ -42,6 +42,7 @@
   animation: fade 2s 2s forwards;
   opacity: 1;
   font-weight: bold;
+  white-space: pre-line;
 }
 
 .videoCanvasWrapper {

--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -290,10 +290,10 @@ class ServerIO {
 
       if (data.method === CLICK_CENTRING) {
         dispatch(startClickCentringAction());
-        const msg = `${numClicks}-Click Centring: <br />Select centered position or center`;
+        const msg = `${numClicks}-Click Centring: \nSelect centered position or center`;
         dispatch(videoMessageOverlay(true, msg));
       } else {
-        const msg = 'Auto loop centring: <br /> Save position or re-center';
+        const msg = 'Auto loop centring: \n Save position or re-center';
         dispatch(videoMessageOverlay(true, msg));
       }
     });


### PR DESCRIPTION
This PR removes a `dangerouslySetInnerHTML` call within the centring message box. It was used to make it possible to add a line break with an html tag (`<br/>`). The PR replaces the possible line-break html tags with `\n`. Then css will handle the line break. 

Currently, this is not a security vulnerability in our code, since the messages cannot be broadcasted to other users nor the back-end but generally an improvement of the usage of best -practices (separates data in state from presentation (HTML) ) and reduces possible future risks, which may come from a code refactoring. 