### PR TITLE
Fix cell counting related SampleView filling

### DIFF
--- a/ui/src/components/SampleView/DrawGridPlugin.jsx
+++ b/ui/src/components/SampleView/DrawGridPlugin.jsx
@@ -536,7 +536,7 @@ export default class DrawGridPlugin {
     ) {
       for (let nh = 0; nh < row; nh++) {
         for (let nw = 0; nw < col; nw++) {
-          const index = nw + nh * col + 1;
+          const index = this.countCells(gd.cellCountFun, nw, nh, row, col);
           if (result[index] !== undefined) {
             fillingMatrix[nw][nh] = this.heatMapColorForValue(
               gd,

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -894,7 +894,8 @@ function mapStateToProps(state) {
     hardwareObjects: state.beamline.hardwareObjects,
     contextMenuVisible: state.contextMenu.show,
     shapes: state.shapes.shapes,
-    cellCounting: state.taskForm.defaultParameters.mesh.cell_counting,
+    cellCounting:
+      state.taskForm.defaultParameters.mesh.acq_parameters.cell_counting,
     busy: state.queue.queueStatus === QUEUE_RUNNING,
     meshResultFormat: state.general.meshResultFormat,
     imageRatio: state.sampleview.sourceScale * state.sampleview.imageRatio, // <=== IMPORTANT!


### PR DESCRIPTION
While trying to update the heatmap results after a mesh scan we noticed that the cell filling was not considering the cell counting method (e.g. zig-zag, inverse-zig-zag) to fill the grid's result. This was due to the `SampleImage` component not being initialized correctly from config params from `state.taskForm.defaultParameters.mesh.cell_counting` -> `state.taskForm.defaultParameters.mesh.acq_parameters.cell_counting`. 

Then, we included the countCellFun call inside the cell filling function to populate the correct matrix position according to the cellCount order.