### PR TITLE
fix displayImage parameters in SampleImage

### DIFF
--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -533,20 +533,20 @@ class SampleImage extends React.Component {
       const [cellIdxX, cellIdxY] = this.drawGridPlugin.getClickedCellIndex(
         shapeData,
         option.target,
-        option.pointer,
+        option.e,
       );
 
       const imgNum = this.drawGridPlugin.countCells(
         shapeData.cellCountFun,
-        cellIdxY,
         cellIdxX,
+        cellIdxY,
         shapeData.numRows,
         shapeData.numCols,
       );
 
       const { resultDataPath } = shapeData;
       if (resultDataPath !== undefined) {
-        this.props.displayImage(`${resultDataPath}&img_num=${imgNum}`);
+        this.props.displayImage(resultDataPath, imgNum);
       }
     }
   }


### PR DESCRIPTION
Fixing `displayImage` call in `SampleImage`, this function expects two args to be sent separately and not a single string.