### PR TITLE
Draft: validate prefix instead of filename and stricter regexp

### DIFF
--- a/ui/src/components/Tasks/validate.js
+++ b/ui/src/components/Tasks/validate.js
@@ -13,7 +13,7 @@ function validate(values, props) {
   // here we update the resolution limits based on the energy the typed in the form,
   // the limits come from a table sent by the client
 
-  const validFname = /^[\w#\-[\]{}]+$/u.test(props.filename);
+  const validFname = /^[\w-]+$/u.test(props.prefix);
 
   const emptyField = 'field is empty';
 


### PR DESCRIPTION
- the current validation regexp allows characters that are not UNIX friendly because it validates against the filename prop that is used to indicate the *template* of the filenames that will be generated:

DataCollection.jsx +370
```javascript
  if (state.taskForm.sampleID) {
    fname = state.taskForm.taskData.parameters.fileName;
  } else {
    const prefix = selector(state, 'prefix');
    fname = `${prefix}_[RUN#]_[IMG#]`;
  }
```

- this simplified regexp validates only against valid UNIX characters except the **'dot'** character

- it also validates the **prefix** prop which is editable by the user instead of the **filename**