### PR TITLE
Fix displayImage command and validation

### DIFF
--- a/mxcubeweb/core/adapter/detector_adapter.py
+++ b/mxcubeweb/core/adapter/detector_adapter.py
@@ -2,6 +2,7 @@ from typing import ClassVar
 
 from mxcubecore import HardwareRepository as HWR
 from mxcubecore.HardwareObjects.abstract import AbstractDetector
+from pydantic import BaseModel, Field, FilePath
 
 from mxcubeweb.core.adapter.adapter_base import AdapterBase
 from mxcubeweb.core.models.configmodels import ResourceHandlerConfigModel
@@ -10,6 +11,11 @@ resource_handler_config = ResourceHandlerConfigModel(
     commands=["display_image"],
     attributes=["data", "get_value"],
 )
+
+
+class DisplayImageParams(BaseModel):
+    path: FilePath = Field(description="Path to images' masterfile")
+    img_num: int = Field(description="Index of the image to display")
 
 
 class DetectorAdapter(AdapterBase):
@@ -36,9 +42,10 @@ class DetectorAdapter(AdapterBase):
     def state(self):
         return self._ho.get_state().name.upper()
 
-    def display_image(self, path: str, img_num) -> dict:
+    def display_image(self, params: DisplayImageParams) -> dict:
         """Notify ADXV and/or Braggy of the image to display."""
         res = {"image_url": ""}
+        path, img_num = str(params.path), params.img_num
 
         if path:
             fpath, img = HWR.beamline.detector.get_actual_file_path(path, img_num)

--- a/ui/src/actions/general.js
+++ b/ui/src/actions/general.js
@@ -42,7 +42,7 @@ export function displayImage(path, imgNum) {
       'detector',
       'detector',
       'display_image',
-      { path, imgNum },
+      { path, img_num: imgNum },
     );
     window.open(data.image_url, 'braggy');
   };


### PR DESCRIPTION
More on `displayImage` executeCommand. I've noticed that the adapter `display_image` is expecting the param `img_num` instead of `imgNum` and that it did'nt had a type annotation so it was never getting validated. Also, for the `path` arg the `validate_input_str` does not handle the case if the string is a valid path string. So, for the changes:

- make input string validation include path chars ( "/", "-") but this IMO should be handled in a dedicated validator for path strings, which i don't know if it is in development along with the pydantic schemas that could be great addition to the resource handler validation. Please, share thoughts on this one.
- camelCase to snake_case object call in reducer: i wonder if this one could be automatically converted by the `resource_handler` ??
- include type hint in img_num param to get it validated by resource handler