### PR TITLE
Get the omega value on the data colletion form

### DIFF
--- a/ui/src/components/Tasks/DataCollection.jsx
+++ b/ui/src/components/Tasks/DataCollection.jsx
@@ -412,7 +412,7 @@ export default connect((state) => {
       resolution: toFixed(state, 'resolution'),
       energy: toFixed(state, 'energy'),
       transmission: toFixed(state, 'transmission'),
-      osc_start: toFixed(state, 'diffractometer.phi', 'osc_start'),
+      osc_start: toFixed(state, 'diffractometer.omega', 'osc_start'),
       cellA,
       cellAlpha,
       cellB,


### PR DESCRIPTION
This was done because the phi attribute name changed to omega in the new GenericDiffractometer device.