### PR TITLE
Passing data in strucutre 'value` for PyDantic validation

### DIFF
--- a/ui/src/actions/beamlineActions.js
+++ b/ui/src/actions/beamlineActions.js
@@ -47,8 +47,10 @@ export function startBeamlineAction(cmdName, parameters, showOutput = true) {
     }
 
     sendExecuteCommand('beamlineaction', 'beamline_actions', 'run_action', {
-      cmd: cmdName,
-      parameters,
+      value: {
+        cmd: cmdName,
+        parameters,
+      },
     });
   };
 }


### PR DESCRIPTION
The method `BeamlineActionAdapter.run_action` takes a  `BeamlineActionInputModel` input and expects the data to be passed in one structure.