### PR TITLE
Generic dialog look and feel update/improvement 

### DIFF
--- a/ui/src/components/Tasks/CustomFieldTemplate.jsx
+++ b/ui/src/components/Tasks/CustomFieldTemplate.jsx
@@ -27,7 +27,7 @@ export default function CustomFieldTemplate(props) {
 
   const span = Number(uiSchema['ui:options']?.col) || 6;
   const gridClass = `col-${span}`;
-  const fieldClassNames = `${gridClass} ${classNames}`.trim();
+  const fieldClassNames = `${gridClass} ${classNames} ${styles.field}`.trim();
 
   if (schema.type === 'boolean') {
     return (

--- a/ui/src/components/Tasks/CustomFieldTemplate.module.css
+++ b/ui/src/components/Tasks/CustomFieldTemplate.module.css
@@ -1,4 +1,8 @@
-.fieldTitle {
+.field {
+  margin-bottom: 1.5em;
+}
+
+.fieldTitle { 
   display: flex;
   align-items: center;
   gap: 0.5rem;

--- a/ui/src/components/Tasks/CustomFieldTemplate.module.css
+++ b/ui/src/components/Tasks/CustomFieldTemplate.module.css
@@ -2,7 +2,7 @@
   margin-bottom: 1.5em;
 }
 
-.fieldTitle { 
+.fieldTitle {
   display: flex;
   align-items: center;
   gap: 0.5rem;

--- a/ui/src/components/Tasks/GenericTaskForm.jsx
+++ b/ui/src/components/Tasks/GenericTaskForm.jsx
@@ -54,10 +54,7 @@ class GenericTaskForm extends React.Component {
   }
 
   get isFormValid() {
-    return (
-      this.props.valid &&
-      this.state.rjsfErrors.length === 0
-    );
+    return this.props.valid && this.state.rjsfErrors.length === 0;
   }
 
   clearCurrentJSFormParameters() {

--- a/ui/src/components/Tasks/GenericTaskForm.jsx
+++ b/ui/src/components/Tasks/GenericTaskForm.jsx
@@ -95,6 +95,7 @@ class GenericTaskForm extends React.Component {
       'selection',
       'experiment_name',
       'chip_type',
+      'beam_size',	
     ];
 
     saveToLastUsedParameters(this.props.taskData.type, parameters, [

--- a/ui/src/components/Tasks/GenericTaskForm.jsx
+++ b/ui/src/components/Tasks/GenericTaskForm.jsx
@@ -265,7 +265,7 @@ class GenericTaskForm extends React.Component {
             </Row>
             <Row>
               {this.props.useExperimentName ? (
-                <Col xs={6}>
+                <Col xs={6} style={{ marginBottom: '10px' }}>
                   <InputField
                     propName="experimentName"
                     label="Experiment Name"

--- a/ui/src/components/Tasks/GenericTaskForm.jsx
+++ b/ui/src/components/Tasks/GenericTaskForm.jsx
@@ -56,7 +56,6 @@ class GenericTaskForm extends React.Component {
   get isFormValid() {
     return (
       this.props.valid &&
-      this.props.taskData.parameters.shape !== -1 &&
       this.state.rjsfErrors.length === 0
     );
   }
@@ -95,7 +94,7 @@ class GenericTaskForm extends React.Component {
       'selection',
       'experiment_name',
       'chip_type',
-      'beam_size',	
+      'beam_size',
     ];
 
     saveToLastUsedParameters(this.props.taskData.type, parameters, [

--- a/ui/src/components/Tasks/Widgets/CheckboxWidget/CheckboxWidget.jsx
+++ b/ui/src/components/Tasks/Widgets/CheckboxWidget/CheckboxWidget.jsx
@@ -23,20 +23,25 @@ export default function CheckboxWidget({
   const { description } = schema;
 
   return (
-    <div className={styles.wrapper}>
-      <Form.Check
-        id={id}
-        checked={Boolean(value)}
-        disabled={disabled || readonly}
-        onChange={(e) => onChange(e.target.checked)}
-        onBlur={(e) => onBlur(id, e.target.checked)}
-        onFocus={(e) => onFocus(id, e.target.checked)}
-      />
-      <label htmlFor={id} className={styles.label}>
-        {label}
-        {required && <span className="text-danger">*</span>}
-      </label>
-      {description && <FieldDescriptionTooltip description={description} />}
+    <div>
+      <div>
+        <label htmlFor={id} className={styles.label}>
+          {label}
+          {required && <span className="text-danger">*</span>}
+        </label>
+        {description && <FieldDescriptionTooltip description={description} />}
+      </div>
+      <div>
+        <Form.Check
+          id={id}
+          type="switch"
+          checked={Boolean(value)}
+          disabled={disabled || readonly}
+          onChange={(e) => onChange(e.target.checked)}
+          onBlur={(e) => onBlur(id, e.target.checked)}
+          onFocus={(e) => onFocus(id, e.target.checked)}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Added some more margin and changed the boolean input from a check box to a switch, which looks nicer if the title of the input and title are on a separate rows. Having the checkbox and the title on the same row makes, in our opinion, the UI feel a bit un-balanced when there are a few controls in the dialog

**Before**
<img width="1485" height="804" alt="image" src="https://github.com/user-attachments/assets/ad8257af-ac76-4ea8-b1aa-308365e8acd5" />


**After**
<img width="1495" height="870" alt="image" src="https://github.com/user-attachments/assets/68b2a532-fa40-4cec-bb6a-ecaf734c864a" />

 - Removed the need of having a shape which is not necessarily a requirement for these forms
 - Added missing beam size data