### PR TITLE
Fixed broken `rotate_to` logic

### DIFF
--- a/mxcubeweb/core/adapter/sample_view_adapter.py
+++ b/mxcubeweb/core/adapter/sample_view_adapter.py
@@ -367,11 +367,11 @@ class SampleViewAdapter(AdapterBase):
         if sid:
             shape = self._ho.get_shape(sid)
             cp = shape.get_centred_position()
-            phi_value = round(float(cp.as_dict().get("omega", None)), 3)
+            omega_value = round(float(cp.as_dict().get("omega", None)), 3)
 
-            if phi_value:
+            if omega_value:
                 try:
-                    HWR.beamline.diffractometer.centringPhi.set_value(phi_value)
+                    HWR.beamline.diffractometer.omega.set_value(omega_value)
                 except Exception as e:
                     msg = "Rotate to shape failed"
                     raise RuntimeError(msg) from e

--- a/mxcubeweb/core/adapter/sample_view_adapter.py
+++ b/mxcubeweb/core/adapter/sample_view_adapter.py
@@ -367,7 +367,7 @@ class SampleViewAdapter(AdapterBase):
         if sid:
             shape = self._ho.get_shape(sid)
             cp = shape.get_centred_position()
-            phi_value = round(float(cp.as_dict().get("phi", None)), 3)
+            phi_value = round(float(cp.as_dict().get("omega", None)), 3)
 
             if phi_value:
                 try:

--- a/mxcubeweb/core/adapter/sample_view_adapter.py
+++ b/mxcubeweb/core/adapter/sample_view_adapter.py
@@ -364,11 +364,17 @@ class SampleViewAdapter(AdapterBase):
         return {}
 
     def rotate_to(self, sid: str):
-        try:
-            self._ho.rotate_to(sid)
-        except Exception as e:
-            msg = "Rotate to shape failed"
-            raise RuntimeError(msg) from e
+        if sid:
+            shape = self._ho.get_shape(sid)
+            cp = shape.get_centred_position()
+            phi_value = round(float(cp.as_dict().get("phi", None)), 3)
+
+            if phi_value:
+                try:
+                    HWR.beamline.diffractometer.centringPhi.set_value(phi_value)
+                except Exception as e:
+                    msg = "Rotate to shape failed"
+                    raise RuntimeError(msg) from e
 
         return {}
 


### PR DESCRIPTION
Fixed broken `rotate_to` logic, sample_view does not have any `rotate_to` method. This mistake was introduced when moving from sample view component to sample view adapter