### PR TITLE
Handling update of a sample state for specific samples

### DIFF
--- a/mxcubeweb/core/adapter/sample_changer_adapter.py
+++ b/mxcubeweb/core/adapter/sample_changer_adapter.py
@@ -54,7 +54,7 @@ class SampleChangerAdapter(AdapterBase):
         sc.connect("stateChanged", self._sc_state_changed)
         sc.connect("isCollisionSafe", self._is_collision_safe)
         sc.connect("loadedSampleChanged", self._loaded_sample_changed)
-        sc.connect("contentsUpdated", self._sc_contents_update)
+        sc.connect("infoChanged", self._sample_state_update)
 
         if HWR.beamline.sample_changer_maintenance is not None:
             HWR.beamline.sample_changer_maintenance.connect(
@@ -106,6 +106,8 @@ class SampleChangerAdapter(AdapterBase):
                 namespace="/hwr",
             )
 
+            self._sc_contents_update()
+
             self._sc_load_ready(address)
         except Exception:
             logging.getLogger("HWR").exception("Error setting loaded sample")
@@ -128,8 +130,19 @@ class SampleChangerAdapter(AdapterBase):
 
         self.app.server.emit("sc", msg, namespace="/hwr")
 
-    def _sc_contents_update(self):
-        self.app.server.emit("sc_contents_update", {}, namespace="/hwr")
+    def _sample_state_update(self, sample):
+        sample_data = {
+            "sampleID": sample.get_address(),
+            "location": sample.get_address(),
+            "state": sample.state
+        }
+
+        self.app.server.emit(
+            "sc_sample_state_update",
+            {"sample": sample_data},
+            namespace="/hwr",
+        )
+
 
     def _sc_maintenance_update(self, *args):
         if len(args) == 3:

--- a/mxcubeweb/core/adapter/sample_changer_adapter.py
+++ b/mxcubeweb/core/adapter/sample_changer_adapter.py
@@ -106,8 +106,6 @@ class SampleChangerAdapter(AdapterBase):
                 namespace="/hwr",
             )
 
-            self._sc_contents_update()
-
             self._sc_load_ready(address)
         except Exception:
             logging.getLogger("HWR").exception("Error setting loaded sample")
@@ -130,19 +128,19 @@ class SampleChangerAdapter(AdapterBase):
 
         self.app.server.emit("sc", msg, namespace="/hwr")
 
-    def _sample_state_update(self, sample):
-        sample_data = {
-            "sampleID": sample.get_address(),
-            "location": sample.get_address(),
-            "state": sample.state
-        }
+    def _sample_state_update(self, sample=None):
+        if sample:
+            sample_data = {
+                "sampleID": sample.get_address(),
+                "location": sample.get_address(),
+                "state": sample.state,
+            }
 
-        self.app.server.emit(
-            "sc_sample_state_update",
-            {"sample": sample_data},
-            namespace="/hwr",
-        )
-
+            self.app.server.emit(
+                "sc_sample_state_update",
+                {"sample": sample_data},
+                namespace="/hwr",
+            )
 
     def _sc_maintenance_update(self, *args):
         if len(args) == 3:

--- a/mxcubeweb/core/components/lims.py
+++ b/mxcubeweb/core/components/lims.py
@@ -192,9 +192,10 @@ class Lims(ComponentBase):
                 "code": sample_dm,
                 "loadable": True,
                 "state": state,
-                "container_info": (
-                    s.container_info if hasattr(s, "container_info") else {}
-                ),
+                "sc_state": s.state,
+                "puck_barcode": s.puck_barcode,
+                "puck_type": s.puck_type,
+                "sample_barcode": s.sample_barcode,
                 "image_url": s.get_image_url() or "",
                 "image_x": s.get_image_x() or "",
                 "image_y": s.get_image_y() or "",

--- a/poetry.lock
+++ b/poetry.lock
@@ -2217,14 +2217,14 @@ tango = ["pytango (>=9.3.6,<10.0.0)"]
 
 [[package]]
 name = "mxcubecore"
-version = "2.4.0"
+version = "2.17.0"
 description = "Core libraries for the MXCuBE application"
 optional = false
 python-versions = "<3.12,>=3.10"
 groups = ["main"]
 files = [
-    {file = "mxcubecore-2.4.0-py3-none-any.whl", hash = "sha256:e9f07119ba73595798cef7f5a88b1a7c55b678fe843f55ee0b90bd60469aafee"},
-    {file = "mxcubecore-2.4.0.tar.gz", hash = "sha256:d976a0e4521c253e29983e14fabd697c440d6eab4f6b89a27a9ff2b40366d17b"},
+    {file = "mxcubecore-2.17.0-py3-none-any.whl", hash = "sha256:07d90b784687fde73f90df6d43a26720292bfdc3acbde941e7598d19d01c9ae8"},
+    {file = "mxcubecore-2.17.0.tar.gz", hash = "sha256:a1d968c12cc04cf5db4881e087639a7cf56769d7a189f76a57f27cc2896257c9"},
 ]
 
 [package.dependencies]
@@ -4547,4 +4547,4 @@ graylog = ["graypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "300bd9e2ff779fdfcbc109db3d515114c7d2825cf2d320db624bbfeb25532fdb"
+content-hash = "38be69ebbde78d0b83ef70a93016c0d2474c324814e1a09f90070e82dfcc0955"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ Flask-Security = { version = "5.7.1", extras = ["common", "fsqla"] }
 Flask-SocketIO = "^5.3.6"
 gevent = "^23.9.1"
 markupsafe = "^2.1.5"
-mxcubecore =  ">=2.4.0"
+mxcubecore =  ">=2.17.0"
 pillow = "^10.4.0"
 pydantic = ">=2.8.2,<2.9.0"
 pytz = "^2022.6"

--- a/ui/src/actions/sampleGrid.js
+++ b/ui/src/actions/sampleGrid.js
@@ -4,7 +4,11 @@ import { showErrorPanel } from './general';
 import { setQueue } from './queue';
 import { hideWaitDialog, showWaitDialog } from './waitDialog';
 
-function updateSampleList(sampleList, order) {
+export function updateSampleState(sampleData) {
+  return { type: 'UPDATE_SAMPLE_STATE', sampleData };
+}
+
+export function updateSampleList(sampleList, order) {
   return { type: 'UPDATE_SAMPLE_LIST', sampleList, order };
 }
 

--- a/ui/src/components/SampleGrid/SampleGridTableItem.jsx
+++ b/ui/src/components/SampleGrid/SampleGridTableItem.jsx
@@ -110,11 +110,7 @@ export default function SampleGridTableItem({
                 ' (MOUNTED)'
               ) : (
                 <div className={styles.sampleStateBadge}>
-                  <Badge
-                    bg={sampleStateBackground(
-                      sampleData?.sc_state,
-                    )}
-                  >
+                  <Badge bg={sampleStateBackground(sampleData?.sc_state)}>
                     {sampleData?.sc_state?.replaceAll('_', ' ')}
                   </Badge>
                 </div>

--- a/ui/src/components/SampleGrid/SampleGridTableItem.jsx
+++ b/ui/src/components/SampleGrid/SampleGridTableItem.jsx
@@ -112,10 +112,10 @@ export default function SampleGridTableItem({
                 <div className={styles.sampleStateBadge}>
                   <Badge
                     bg={sampleStateBackground(
-                      sampleData?.container_info?.state,
+                      sampleData?.sc_state,
                     )}
                   >
-                    {sampleData?.container_info?.state?.replaceAll('_', ' ')}
+                    {sampleData?.sc_state?.replaceAll('_', ' ')}
                   </Badge>
                 </div>
               )}

--- a/ui/src/components/SampleGrid/SampleInformation.jsx
+++ b/ui/src/components/SampleGrid/SampleInformation.jsx
@@ -9,7 +9,7 @@ export default function SampleInformation({ sampleData = {} }) {
             <span className="col-sm-6">State :</span>
             <span className="col-sm-6">
               <strong>
-                {sampleData?.container_info?.state?.replaceAll('_', ' ')}
+                {sampleData?.sc_state?.replaceAll('_', ' ')}
               </strong>
             </span>
           </div>
@@ -24,19 +24,19 @@ export default function SampleInformation({ sampleData = {} }) {
           <div className="row">
             <span className="col-sm-6">Puck barcode :</span>
             <span className="col-sm-6">
-              {sampleData?.container_info?.puck_barcode}
+              {sampleData?.puck_barcode}
             </span>
           </div>
           <div className="row">
             <span className="col-sm-6">puck type :</span>
             <span className="col-sm-6">
-              {sampleData?.container_info?.puck_type}
+              {sampleData?.puck_type}
             </span>
           </div>
           <div className="row">
             <span className="col-sm-6">Sample barcode :</span>
             <span className="col-sm-6">
-              {sampleData?.container_info?.sample_barcode}
+              {sampleData?.sample_barcode}
             </span>
           </div>
           {sampleData.limsID && (

--- a/ui/src/components/SampleGrid/SampleInformation.jsx
+++ b/ui/src/components/SampleGrid/SampleInformation.jsx
@@ -8,9 +8,7 @@ export default function SampleInformation({ sampleData = {} }) {
           <div className="row">
             <span className="col-sm-6">State :</span>
             <span className="col-sm-6">
-              <strong>
-                {sampleData?.sc_state?.replaceAll('_', ' ')}
-              </strong>
+              <strong>{sampleData?.sc_state?.replaceAll('_', ' ')}</strong>
             </span>
           </div>
           <div className="row">
@@ -23,21 +21,15 @@ export default function SampleInformation({ sampleData = {} }) {
           </div>
           <div className="row">
             <span className="col-sm-6">Puck barcode :</span>
-            <span className="col-sm-6">
-              {sampleData?.puck_barcode}
-            </span>
+            <span className="col-sm-6">{sampleData?.puck_barcode}</span>
           </div>
           <div className="row">
             <span className="col-sm-6">puck type :</span>
-            <span className="col-sm-6">
-              {sampleData?.puck_type}
-            </span>
+            <span className="col-sm-6">{sampleData?.puck_type}</span>
           </div>
           <div className="row">
             <span className="col-sm-6">Sample barcode :</span>
-            <span className="col-sm-6">
-              {sampleData?.sample_barcode}
-            </span>
+            <span className="col-sm-6">{sampleData?.sample_barcode}</span>
           </div>
           {sampleData.limsID && (
             <>

--- a/ui/src/reducers/sampleGrid.js
+++ b/ui/src/reducers/sampleGrid.js
@@ -220,7 +220,7 @@ function sampleGridReducer(state = INITIAL_STATE, action = {}) {
     }
     case 'UPDATE_SAMPLE_STATE': {
       const sampleList = { ...state.sampleList };
-      sampleList[action.sampleData.sampleID].sc_state = action.sampleData.state
+      sampleList[action.sampleData.sampleID].sc_state = action.sampleData.state;
 
       return { ...state, sampleList };
     }

--- a/ui/src/reducers/sampleGrid.js
+++ b/ui/src/reducers/sampleGrid.js
@@ -218,6 +218,12 @@ function sampleGridReducer(state = INITIAL_STATE, action = {}) {
 
       return { ...state, sampleList };
     }
+    case 'UPDATE_SAMPLE_STATE': {
+      const sampleList = { ...state.sampleList };
+      sampleList[action.sampleData.sampleID].sc_state = action.sampleData.state
+
+      return { ...state, sampleList };
+    }
     case 'SET_SAMPLE_ATTRIBUTE': {
       const sampleList = { ...state.sampleList };
       action.sampleIDList.forEach((sid) => {

--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -33,10 +33,14 @@ import {
 import { collapseItem, showResumeQueueDialog } from './actions/queueGUI';
 import { addChatMessage, getRaState } from './actions/remoteAccess';
 import {
+  setContents,
   setLoadedSample,
   setSCGlobalState,
   setSCState,
 } from './actions/sampleChanger';
+import {
+  updateSampleState
+} from './actions/sampleGrid';
 import {
   saveMotorPosition,
   setBeamInfo,
@@ -428,6 +432,10 @@ class ServerIO {
 
     this.hwrSocket.on('harvester_contents_update', () => {
       dispatch(updateHarvesterContents());
+    });
+
+    this.hwrSocket.on('sc_sample_state_update', (data) => {
+      dispatch(updateSampleState(data.sample));
     });
   }
 

--- a/ui/src/serverIO.js
+++ b/ui/src/serverIO.js
@@ -33,14 +33,11 @@ import {
 import { collapseItem, showResumeQueueDialog } from './actions/queueGUI';
 import { addChatMessage, getRaState } from './actions/remoteAccess';
 import {
-  setContents,
   setLoadedSample,
   setSCGlobalState,
   setSCState,
 } from './actions/sampleChanger';
-import {
-  updateSampleState
-} from './actions/sampleGrid';
+import { updateSampleState } from './actions/sampleGrid';
 import {
   saveMotorPosition,
   setBeamInfo,


### PR DESCRIPTION
This PR makes it possible to handle state changes of specific samples by listening to `infoChanged`. The sample state such as `on-gonio` and `in-puck` or `blacklisted` is displayed in the sample list.

~**Requires corresponding PR [#1530](https://github.com/mxcube/mxcubecore/pull/1530) on `mxcubecore`**~