### PR TITLE
Fix for Wrong name for an argument in a call

### DIFF
--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -264,7 +264,7 @@ class BaseUserManager(ComponentBase):
         try:
             self._login(login_id, password)
         except Exception as e:
-            self._signout()
+            self._signout(sso_data=sso_data)
             logging.getLogger("MX3.HWR").error(str(e))
             raise e
         else:
@@ -287,7 +287,7 @@ class BaseUserManager(ComponentBase):
             logging.getLogger("MX3.HWR").info(msg)
 
     # Abstract method to be implemented by concrete implementation
-    def _signout(self):
+    def _signout(self, sso_data={}):
         pass
 
     def signout(self) -> None:

--- a/mxcubeweb/core/components/user/usermanager.py
+++ b/mxcubeweb/core/components/user/usermanager.py
@@ -264,7 +264,7 @@ class BaseUserManager(ComponentBase):
         try:
             self._login(login_id, password)
         except Exception as e:
-            self._signout(sso_data=sso_data)
+            self._signout()
             logging.getLogger("MX3.HWR").error(str(e))
             raise e
         else:


### PR DESCRIPTION
**Edit: The text below was generated by the GitHub copilot no sane person would write half a page for such a simple fix :). However, the issue was identified correctly and ~the fix is also correct~, quite interesting. Perhaps we will try to make more use of this feature**

**Edit 2: Finally its actually the wrong fix, its a mismatch between method signatures that is the actual problem. The problem was well identified by the the proposed fix is not really the good one !**

To fix this, we need to ensure that the call to `_signout` matches its declared parameters. Since we cannot modify the definition of `_signout` (not shown) and CodeQL says it does not accept an `sso_data` keyword, the safest, non‑behavior‑changing fix in this file is to remove the unsupported keyword and call `_signout` without it (or in a way that matches its actual signature). The exception handling in `login` remains the same: on any exception from `_login`, we attempt to sign the user out and then re‑raise the error.

Concretely, in `mxcubeweb/core/components/user/usermanager.py`, inside the `login` method’s `except` block, replace `self._signout(sso_data=sso_data)` with `self._signout()`. This assumes `_signout` takes no required positional arguments (typical for a signout/logout helper in such a class). No additional imports or helper methods are needed; we only adjust the call site to remove the invalid keyword.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._