### PR TITLE
Fixed typo, centering to centring

### DIFF
--- a/demo.yaml/beamline.yaml
+++ b/demo.yaml/beamline.yaml
@@ -68,7 +68,7 @@ objects:
 configuration:
   advanced_methods:
     - MeshScan
-    - XrayCentering
+    - XrayCentring
 
   tunable_wavelength: true
   disable_num_passes: true

--- a/demo/beamline.yaml
+++ b/demo/beamline.yaml
@@ -71,7 +71,7 @@ configuration:
   # Non-object attributes:
   advanced_methods:
     - MeshScan
-    - XrayCentering
+    - XrayCentring
 
   tunable_wavelength: true
   disable_num_passes: true

--- a/mxcubeweb/core/adapter/sample_view_adapter.py
+++ b/mxcubeweb/core/adapter/sample_view_adapter.py
@@ -131,7 +131,7 @@ class SampleViewAdapter(AdapterBase):
         if self.app.lims.get_current_sample().get("sampleID", "") == "":
             return
 
-        # If centering is valid add the point, otherwise remove it
+        # If centring is valid add the point, otherwise remove it
         if centring_status["valid"]:
             motor_positions = centring_status["motors"]
             motor_positions.pop("zoom", None)
@@ -470,9 +470,9 @@ class SampleViewAdapter(AdapterBase):
             self._ho.start_manual_centring(nb_clicks)
         else:
             logging.getLogger("user_level_log").warning(
-                "Diffractometer is busy, cannot start centering"
+                "Diffractometer is busy, cannot start centring"
             )
-            msg = "Diffractometer is busy, cannot start centering"
+            msg = "Diffractometer is busy, cannot start centring"
             raise RuntimeError(msg)
 
         return {"clicksLeft": self.centring_clicks_left()}

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -1738,7 +1738,7 @@ class Queue(ComponentBase):
 
             elif isinstance(child, qmo.XrayCentring2):
                 # Added rhfogh 20211001
-                entry = qe.XrayCentering2QueueEntry(Mock(), child)
+                entry = qe.XrayCentring2QueueEntry(Mock(), child)
                 self.enable_entry(entry, True)
                 parent_entry.enqueue(entry)
 

--- a/ui/src/components/Tasks/warning.js
+++ b/ui/src/components/Tasks/warning.js
@@ -72,7 +72,7 @@ function warn(values, props) {
       5
   ) {
     warnings.osc_range =
-      'The given oscillation range might be to large for this centering';
+      'The given oscillation range might be to large for this centring';
   }
 
   return warnings;


### PR DESCRIPTION
Fixed typo, centering to centring

https://github.com/mxcube/mxcubecore/pull/1554 needs to be merged first, and `pyproject.toml` updated