### PR TITLE
update supported pnpm and nodejs version

### DIFF
--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -28,8 +28,8 @@ dependencies:
   # Development dependencies
   # ========================
 
-  - nodejs ==18.*|20.*  # Make sure it matches `ui/package.json`
-  - pnpm ==9.*  # Make sure it matches `ui/package.json`
+  - nodejs ==22.*|24.*  # Make sure it matches `ui/package.json`
+  - pnpm ==10.*  # Make sure it matches `ui/package.json`
   - poetry ==2.2.1  # Make sure it matches `.pre-commit-config.yaml` and `poetry.lock`
 
 

--- a/ui/.npmrc
+++ b/ui/.npmrc
@@ -1,5 +1,0 @@
-# Enforce Node and pnpm versions as specified in `package.json`
-engine-strict=true
-
-# Save exact dependency versions in `package.json`
-save-prefix=""

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": "18.x || 20.x",
-    "pnpm": "9.x"
+    "node": "22.x || 24.x",
+    "pnpm": "10.x"
   },
   "scripts": {
     "start": "vite",

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -1,0 +1,19 @@
+%YAML 1.2
+---
+# Enforce Node and pnpm versions specified in `engines` field of `package.json`
+engineStrict: true
+
+# Fail install if any dependency has unreviewed build scripts
+strictDepBuilds: true
+onlyBuiltDependencies:
+  - '@fortawesome/fontawesome-free'
+  - '@swc/core'
+  - 'canvas'
+  - 'cypress'
+  - 'esbuild'
+
+# Save exact dependency versions in `package.json`
+savePrefix: ''
+
+# Only allow releases that are at least 24 hours old to be installed
+minimumReleaseAge: 1440


### PR DESCRIPTION
This PR updates the supported pnpm version to 10 and nodejs versions to 22 and 24.

Mainly pnpm v9 support will be removed at the end of the month. (see [active pnpm version](https://endoflife.date/pnpm).

While our current nodejs version either already reached their eol or will reach it at the end of the month (see [node versions](https://nodejs.org/en/about/previous-releases))