### PR TITLE
Changing filename validation to prefix validation in the Tasks forms

### DIFF
--- a/ui/src/components/Tasks/validate.js
+++ b/ui/src/components/Tasks/validate.js
@@ -10,18 +10,16 @@ function validate(values, props) {
   }
   const currEnergy = Number.parseFloat(values.energy);
   const currTransmission = Number.parseFloat(values.transmission);
-  // here we update the resolution limits based on the energy the typed in the form,
-  // the limits come from a table sent by the client
-
-  const validFname = /^[\w#\-[\]{}]+$/u.test(props.filename);
 
   const emptyField = 'field is empty';
 
-  if (!validFname) {
+  const validPrefix = !values.prefix || /^[\w-]+$/u.test(values.prefix);
+
+  if (!validPrefix) {
     errors.prefix = INVALID_CHAR_MSG;
   }
 
-  if (props.subdir && !/^[\w\-/{}]+$/u.test(props.subdir)) {
+  if (values.subdir && !/^[\w\-/{}]+$/u.test(values.subdir)) {
     errors.subdir = INVALID_CHAR_MSG;
   }
 

--- a/ui/src/components/Tasks/warning.js
+++ b/ui/src/components/Tasks/warning.js
@@ -75,6 +75,10 @@ function warn(values, props) {
       'The given oscillation range might be to large for this centring';
   }
 
+  if (!values.prefix) {
+    warnings.prefix = 'Prefix is empty';
+  }
+
   return warnings;
 }
 


### PR DESCRIPTION
- adding a warning for an empty prefix
- fixes subdir validation,
- also removing some legacy comments.

Fixes #2044, follows this PR #2038:

```
The current validation regexp allows characters that are not UNIX friendly because it validates against the filename prop that is used to indicate the template of the filenames that will be generated:
DataCollection.jsx +370

  if (state.taskForm.sampleID) {
    fname = state.taskForm.taskData.parameters.fileName;
  } else {
    const prefix = selector(state, 'prefix');
    fname = `${prefix}_[RUN#]_[IMG#]`;
  }
this simplified regexp validates only against valid UNIX characters except the 'dot' character

it also validates the prefix prop which is editable by the user instead of the filename
```