### PR TITLE
Fixed issue with prefix validation

### DIFF
--- a/ui/src/components/Tasks/validate.js
+++ b/ui/src/components/Tasks/validate.js
@@ -13,7 +13,7 @@ function validate(values, props) {
 
   const emptyField = 'field is empty';
 
-  const validPrefix = !values.prefix || /^[\w-]+$/u.test(values.prefix);
+  const validPrefix = !values.prefix || /^[\w#\-[\]{}]+$/u.test(values.prefix);
 
   if (!validPrefix) {
     errors.prefix = INVALID_CHAR_MSG;


### PR DESCRIPTION
The validation was previously changed in https://github.com/mxcube/mxcubeweb/pull/2076. However the prefix also needs to be able to contain curly braces, hashes and brackets to function properly when using the sample list and collecting over several samples.

