### PR TITLE
update SnapshotControl, to work with latest Fabric

### DIFF
--- a/ui/src/components/SampleControls/SnapshotControl.jsx
+++ b/ui/src/components/SampleControls/SnapshotControl.jsx
@@ -26,19 +26,21 @@ function SnapshotControl(props) {
 
   const takeSnapshot = useCallback(async () => {
     const img = document.querySelector('#sample-img');
-    const fimg = new FabricImage(img);
+    const fimg = new FabricImage(img, { originX: 'left', originY: 'top' });
     fimg.scale(ratio);
 
-    canvas.setBackgroundImage(fimg);
-    canvas.renderAll();
+    const previousBG = canvas.backgroundImage;
+
+    canvas.backgroundImage = fimg;
+    canvas.requestRenderAll();
 
     const imgDataURI = canvas.toDataURL({
       format: 'jpeg',
       backgroundColor: null,
     });
 
-    canvas.setBackgroundImage(0);
-    canvas.renderAll();
+    canvas.backgroundImage = previousBG;
+    canvas.requestRenderAll();
 
     const filename = `${proposal}-${currentSampleName}.jpeg`;
     const processedImgBlob = await sendTakeSnapshot(imgDataURI);


### PR DESCRIPTION
Since the last `Fabric` update, it seems that taking a snapshot using the button on the `SampleControls`, does not work anymore. The reason lies on an old function call to `setBackgroundImage` of the fabric canvas, which was removed, instead, we can set the backgroundImage directly and we also have to reset the origin of the `Image` we create