### PR TITLE
Allow defining controls for generic NState hardware objects.

### DIFF
--- a/ui/src/components/SampleView/NStateSelect.jsx
+++ b/ui/src/components/SampleView/NStateSelect.jsx
@@ -1,0 +1,44 @@
+import { Form } from 'react-bootstrap';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { setAttribute } from '../../actions/beamline';
+import styles from './NStateSelect.module.css';
+
+/**
+ *
+ * @typedef {Object} Props
+ * @property {string} name - The name of the hardware object to control.
+ * @property {string} id -The id for the select element.
+ *
+ * @param {Props} param0
+ * @returns {JSX.Element}
+ */
+export function NStateSelect({ name, id }) {
+  const dispatch = useDispatch();
+
+  const ho = useSelector((state) => state.beamline.hardwareObjects[name]);
+
+  if (!ho) {
+    return null;
+  }
+
+  const { value, commands, state } = ho;
+  const isBusy = state === 'BUSY';
+
+  return (
+    <Form.Select
+      id={id}
+      className={styles.select}
+      value={value}
+      data-busy={isBusy || undefined}
+      disabled={isBusy}
+      onChange={(evt) => {
+        dispatch(setAttribute(name, evt.target.value));
+      }}
+    >
+      {commands.map((option) => (
+        <option key={option}>{option}</option>
+      ))}
+    </Form.Select>
+  );
+}

--- a/ui/src/components/SampleView/NStateSelect.module.css
+++ b/ui/src/components/SampleView/NStateSelect.module.css
@@ -1,0 +1,10 @@
+.select {
+  background-color: var(--hw-ready--bg);
+  transition: background-color 100ms ease-in;
+}
+
+.select[data-busy] {
+  background-color: var(--hw-busy--bg);
+  font-weight: 600;
+  cursor: wait;
+}

--- a/ui/src/containers/SampleViewContainer.jsx
+++ b/ui/src/containers/SampleViewContainer.jsx
@@ -6,6 +6,7 @@ import motorInputStyles from '../components/MotorInput/MotorInput.module.css';
 import ApertureInput from '../components/SampleView/ApertureInput';
 import ContextMenu from '../components/SampleView/ContextMenu';
 import MotorControls from '../components/SampleView/MotorControls';
+import { NStateSelect } from '../components/SampleView/NStateSelect';
 import PhaseInput from '../components/SampleView/PhaseInput';
 import SampleImage from '../components/SampleView/SampleImage';
 import BeamlineSetupContainer from './BeamlineSetupContainer';
@@ -22,6 +23,9 @@ function getShapes(shapes, type) {
 function SampleViewContainer() {
   const shapes = useSelector((state) => state.shapes.shapes) || {};
   const uiproperties = useSelector((state) => state.uiproperties);
+  const hardwareObjects = useSelector(
+    (state) => state.beamline.hardwareObjects,
+  );
   const sampleChangerContents = useSelector(
     (state) => state.sampleChanger.contents,
   );
@@ -30,12 +34,18 @@ function SampleViewContainer() {
     return null;
   }
 
-  const phaseControl = uiproperties.sample_view?.components?.find(
-    (c) => c.attribute === 'phase_control',
+  const { components } = uiproperties?.sample_view ?? [];
+
+  const phaseControl = components.find((c) => c.attribute === 'phase_control');
+  const beamSize = components.find((c) => c.attribute === 'beam_size');
+
+  const nStates = new Set(
+    Object.entries(hardwareObjects)
+      .filter(([_, ho]) => ho.type === 'NSTATE')
+      .map(([name, _]) => name),
   );
-  const beamSize = uiproperties.sample_view?.components.find(
-    (c) => c.attribute === 'beam_size',
-  );
+  const nStatesComponents =
+    components.filter((component) => nStates.has(component.attribute)) ?? [];
 
   const points = getShapes(shapes, 'P');
   const twoDPoints = getShapes(shapes, '2DP');
@@ -82,6 +92,23 @@ function SampleViewContainer() {
                 <ApertureInput />
               </div>
             )}
+            {nStatesComponents.map((component) => (
+              <div
+                className={motorInputStyles.container}
+                key={component.attribute}
+              >
+                <label
+                  className={motorInputStyles.label}
+                  htmlFor={component.attribute}
+                >
+                  {component.label || component.attribute}
+                </label>
+                <NStateSelect
+                  name={component.attribute}
+                  id={component.attribute}
+                />
+              </div>
+            ))}
             {sampleChangerContents.name === 'PlateManipulator' && (
               <PlateManipulator inPopover />
             )}
@@ -112,5 +139,4 @@ function SampleViewContainer() {
     </Container>
   );
 }
-
 export default SampleViewContainer;


### PR DESCRIPTION
Makes it possible to create a sample view select widget via ui.yaml config, like so:
```yaml
sample_view:
  id: sample_view
  components:
    - attribute: beam.definer
      label: Beam Focus
```
works for NState HWOs only for now.


Example:
<img width="215" height="311" alt="image" src="https://github.com/user-attachments/assets/a638ffb2-4163-4907-84bb-35fd9e49de83" />

(front light is a weird choice, but went with whatever is available in the demo beamline :))