### PR TITLE
`scandir` is part of the python standard library since Python 3.5

### DIFF
--- a/mxcubeweb/core/util/fsutils.py
+++ b/mxcubeweb/core/util/fsutils.py
@@ -1,8 +1,6 @@
 import contextlib
 import os
 
-from scandir import scandir
-
 
 def scantree(path, include):
     res = []
@@ -14,7 +12,7 @@ def scantree(path, include):
 
 
 def _scantree_rec(path, include=[], files=[]):
-    for entry in scandir(path):
+    for entry in os.scandir(path):
         if entry.is_dir(follow_symlinks=False):
             _scantree_rec(entry.path, include, files)
         elif entry.is_file() and os.path.splitext(entry.path)[1][1:] in include:

--- a/poetry.lock
+++ b/poetry.lock
@@ -3465,27 +3465,6 @@ files = [
 ]
 
 [[package]]
-name = "scandir"
-version = "1.10.0"
-description = "scandir, a better directory iterator and faster os.walk()"
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "scandir-1.10.0-cp27-cp27m-win32.whl", hash = "sha256:92c85ac42f41ffdc35b6da57ed991575bdbe69db895507af88b9f499b701c188"},
-    {file = "scandir-1.10.0-cp27-cp27m-win_amd64.whl", hash = "sha256:cb925555f43060a1745d0a321cca94bcea927c50114b623d73179189a4e100ac"},
-    {file = "scandir-1.10.0-cp34-cp34m-win32.whl", hash = "sha256:2c712840c2e2ee8dfaf36034080108d30060d759c7b73a01a52251cc8989f11f"},
-    {file = "scandir-1.10.0-cp34-cp34m-win_amd64.whl", hash = "sha256:2586c94e907d99617887daed6c1d102b5ca28f1085f90446554abf1faf73123e"},
-    {file = "scandir-1.10.0-cp35-cp35m-win32.whl", hash = "sha256:2b8e3888b11abb2217a32af0766bc06b65cc4a928d8727828ee68af5a967fa6f"},
-    {file = "scandir-1.10.0-cp35-cp35m-win_amd64.whl", hash = "sha256:8c5922863e44ffc00c5c693190648daa6d15e7c1207ed02d6f46a8dcc2869d32"},
-    {file = "scandir-1.10.0-cp36-cp36m-win32.whl", hash = "sha256:2ae41f43797ca0c11591c0c35f2f5875fa99f8797cb1a1fd440497ec0ae4b022"},
-    {file = "scandir-1.10.0-cp36-cp36m-win_amd64.whl", hash = "sha256:7d2d7a06a252764061a020407b997dd036f7bd6a175a5ba2b345f0a357f0b3f4"},
-    {file = "scandir-1.10.0-cp37-cp37m-win32.whl", hash = "sha256:67f15b6f83e6507fdc6fca22fedf6ef8b334b399ca27c6b568cbfaa82a364173"},
-    {file = "scandir-1.10.0-cp37-cp37m-win_amd64.whl", hash = "sha256:b24086f2375c4a094a6b51e78b4cf7ca16c721dcee2eddd7aa6494b42d6d519d"},
-    {file = "scandir-1.10.0.tar.gz", hash = "sha256:4d4631f6062e658e9007ab3149a9b914f3548cb38bfb021c64f39a025ce578ae"},
-]
-
-[[package]]
 name = "scipy"
 version = "1.10.1"
 description = "Fundamental algorithms for scientific computing in Python"
@@ -4600,4 +4579,4 @@ graylog = ["graypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "55b7f559a42fa90cfd4c47425b98d0f3cd507dc976f5f72d02c02d4022c027ce"
+content-hash = "eab5751986453db42d2a2bf17a09e286762f93b5e87143d282ed5997f36e10f6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ pydantic = ">=2.8.2,<2.9.0"
 pytz = "^2022.6"
 requests = "^2.33.0"
 "ruamel.yaml" = "^0.17.21"
-scandir = "^1.10.0"
 sqlalchemy = "^2.0.37"
 tomli = { version = "^2.2.1", python = "<=3.10" }
 tzlocal = "^4.2"


### PR DESCRIPTION
This PR removes the depedency on `scandir`.

The `scandir` library is part of the python standard library since Python 3.5 see (https://pypi.org/project/scandir/)