### PR TITLE
fix non JSON-serializable data

### DIFF
--- a/mxcubeweb/core/adapter/sample_view_adapter.py
+++ b/mxcubeweb/core/adapter/sample_view_adapter.py
@@ -176,7 +176,9 @@ class SampleViewAdapter(AdapterBase):
 
     def _handle_grid_result(self, shape):
         self.app.server.emit(
-            "grid_result_available", {"shape": shape}, namespace="/hwr"
+            "grid_result_available",
+            {"shape": to_camel(shape.as_dict())},
+            namespace="/hwr",
         )
 
     def centring_clicks_left(self):


### PR DESCRIPTION
When calling the `_handle_grid_result` function, the data was not correctly forwarded to the front-end, as the `shape` parameter might not be JSON-serializable. This issue seems to have been introduced by #1933 when the `sample_view` adapter was introduced.

This PR fixes the issue by transforming the data into a dictionary, before sending it to the front-end