### PR TITLE
Add tooltip to Sample View select widgets

### DIFF
--- a/demo.yaml/mxcube-web/ui.yaml
+++ b/demo.yaml/mxcube-web/ui.yaml
@@ -13,8 +13,14 @@ sample_view:
   components:
     - attribute: phase_control
       label: Phase Control
+      tooltip: >
+        Use this widget to trigger a concerted change
+        in the diffractomer devices to reach the  desired phase.
     - attribute: beam_size
       label: Beam size
+      tooltip: >
+        Use this widget to trim the beam just before it
+        hits the sample.
 
 sample_view_motors:
   id: sample_view_motors

--- a/docs/source/config/ui.rst
+++ b/docs/source/config/ui.rst
@@ -79,20 +79,31 @@ The section has the following syntax:
     sample_view:
       id: sample_view
       components:
-        - attribute: <attribute id>
-          label: <label>
-
+        - attribute: phase_control
+          label: Phase Control
+          tooltip: >
+            Use this widget to trigger a concerted change
+            in the diffractomer devices to reach the  desired phase.
+        - attribute: beam_size
+          label: Beam size
+          tooltip: >
+            Use this widget to trim the beam just before it
+            hits the sample.
+        - attribute: diffractometer.zoom
+          label: Zoom
 
 The ``components`` key contains a list of auxiliary control widget specifications.
 Each widget specification has the following keys:
 
-+-----------+-------------------------------------+
-| key       | purpose                             |
-+===========+=====================================+
-| attribute | attribute id                        |
-+-----------+-------------------------------------+
-| label     | widget's text label                 |
-+-----------+-------------------------------------+
++-----------------+-------------------------------+
+| key             | purpose                       |
++=================+===============================+
+| attribute       | attribute id                  |
++-----------------+-------------------------------+
+| label           | widget's text label           |
++-----------------+-------------------------------+
+| description     | optional hover tooltip text   |
++-----------------+-------------------------------+
 
 Below is an example showing all auxiliary controls of the ``sample_view`` section:
 

--- a/mxcubeweb/core/models/configmodels.py
+++ b/mxcubeweb/core/models/configmodels.py
@@ -109,6 +109,7 @@ class UIComponentModel(BaseModel):
     object_type: str | None = None
     format: str | None = None
     invert_color_semantics: bool | None = None
+    tooltip: str | None = None
 
 
 class _UICameraConfigModel(BaseModel):

--- a/ui/src/components/SampleView/ApertureInput.jsx
+++ b/ui/src/components/SampleView/ApertureInput.jsx
@@ -1,33 +1,29 @@
-import { Form } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { changeAperture } from '../../actions/sampleview';
-import styles from './ApertureInput.module.css';
+import { NStateSelect } from './NStateSelect';
 
-function ApertureInput() {
+/**
+ * @typedef {Object} Props
+ * @property {string?} tooltip - Optional hover tooltip text.
+ *
+ * @param {Props} props
+ */
+function ApertureInput({ tooltip }) {
   const dispatch = useDispatch();
 
-  const value = useSelector((state) => state.sampleview.currentAperture);
-  const options = useSelector((state) => state.sampleview.apertureList);
-  const isBusy = useSelector(
-    (state) =>
-      state.beamline.hardwareObjects['beam.aperture']?.state === 'BUSY',
-  );
-
   return (
-    <Form.Select
+    <NStateSelect
       id="ApertureInput"
-      className={styles.select}
-      value={value}
-      data-busy={isBusy || undefined}
-      onChange={(evt) => {
-        dispatch(changeAperture(evt.target.value));
-      }}
-    >
-      {options.map((option) => (
-        <option key={option}>{option}</option>
-      ))}
-    </Form.Select>
+      value={useSelector((state) => state.sampleview.currentAperture)}
+      options={useSelector((state) => state.sampleview.apertureList)}
+      isBusy={useSelector(
+        (state) =>
+          state.beamline.hardwareObjects['beam.aperture']?.state === 'BUSY',
+      )}
+      onSelect={(value) => dispatch(changeAperture(value))}
+      tooltip={tooltip}
+    />
   );
 }
 

--- a/ui/src/components/SampleView/ApertureInput.module.css
+++ b/ui/src/components/SampleView/ApertureInput.module.css
@@ -1,9 +1,0 @@
-.select {
-  background-color: var(--hw-ready--bg) !important;
-  transition: background-color 100ms ease-in;
-}
-
-.select[data-busy] {
-  background-color: var(--hw-busy--bg) !important;
-  font-weight: 600;
-}

--- a/ui/src/components/SampleView/NStateHOInput.jsx
+++ b/ui/src/components/SampleView/NStateHOInput.jsx
@@ -1,0 +1,33 @@
+import { useDispatch, useSelector } from 'react-redux';
+
+import { setAttribute } from '../../actions/beamline.js';
+import { NStateSelect } from './NStateSelect';
+
+/**
+ * Generic NState input bound to an `AbstractNState` hardware object by name.
+ *
+ * @typedef {Object} Props
+ * @property {string} name - Hardware object name.
+ * @property {string} id - DOM id for the underlying select element.
+ * @property {string?} description - Optional hover tooltip text.
+ *
+ * @param {Props} props
+ */
+export function NStateHOInput({ name, id, description }) {
+  const dispatch = useDispatch();
+  const ho = useSelector((state) => state.beamline.hardwareObjects[name]);
+  if (!ho) {
+    throw new Error(`Can't find ${name} hardware object.`);
+  }
+
+  return (
+    <NStateSelect
+      id={id}
+      value={ho?.value ?? ''}
+      options={ho?.commands ?? []}
+      isBusy={ho?.state === 'BUSY'}
+      onSelect={(value) => dispatch(setAttribute(name, value))}
+      description={description}
+    />
+  );
+}

--- a/ui/src/components/SampleView/NStateSelect.jsx
+++ b/ui/src/components/SampleView/NStateSelect.jsx
@@ -1,44 +1,53 @@
 import { Form } from 'react-bootstrap';
-import { useDispatch, useSelector } from 'react-redux';
 
-import { setAttribute } from '../../actions/beamline';
+import TooltipTrigger from '../TooltipTrigger';
 import styles from './NStateSelect.module.css';
 
 /**
+ * Select-type input for hardware objects with discrete states, e.g.
+ * ones accessed with NStateAdapter.
  *
  * @typedef {Object} Props
- * @property {string} name - The name of the hardware object to control.
- * @property {string} id -The id for the select element.
+ * @property {string} id - DOM id for the select element.
+ * @property {string} value - Currently selected value.
+ * @property {string[]} options - Selectable values shown in the dropdown.
+ * @property {boolean} isBusy - Whether the hardware is busy.
+ * @property {(value: string) => void} onSelect - Called with the new value on user change.
+ * @property {string?} tooltip - Hover tooltip text.
+ * @property {string[]?} readOnlyOptions - Values that may be reported by the
+ *   hardware but are not user-selectable.
  *
- * @param {Props} param0
- * @returns {JSX.Element}
+ * @param {Props} props
  */
-export function NStateSelect({ name, id }) {
-  const dispatch = useDispatch();
-
-  const ho = useSelector((state) => state.beamline.hardwareObjects[name]);
-
-  if (!ho) {
-    return null;
-  }
-
-  const { value, commands, state } = ho;
-  const isBusy = state === 'BUSY';
-
+export function NStateSelect({
+  id,
+  value,
+  options,
+  isBusy,
+  onSelect,
+  tooltip,
+  readOnlyOptions = [],
+}) {
   return (
-    <Form.Select
-      id={id}
-      className={styles.select}
-      value={value}
-      data-busy={isBusy || undefined}
-      disabled={isBusy}
-      onChange={(evt) => {
-        dispatch(setAttribute(name, evt.target.value));
-      }}
-    >
-      {commands.map((option) => (
-        <option key={option}>{option}</option>
-      ))}
-    </Form.Select>
+    <TooltipTrigger id={`${id}-tooltip`} tooltipContent={tooltip}>
+      <Form.Select
+        id={id}
+        className={styles.select}
+        value={value}
+        data-busy={isBusy || undefined}
+        disabled={isBusy}
+        onChange={(evt) => onSelect(evt.target.value)}
+      >
+        {/* readOnlyOptions maybe shown as a value, but are not selectable. */}
+        {readOnlyOptions.map((option) => (
+          <option key={option} hidden>
+            {option}
+          </option>
+        ))}
+        {options.map((option) => (
+          <option key={option}>{option}</option>
+        ))}
+      </Form.Select>
+    </TooltipTrigger>
   );
 }

--- a/ui/src/components/SampleView/PhaseInput.jsx
+++ b/ui/src/components/SampleView/PhaseInput.jsx
@@ -1,40 +1,38 @@
-import { Form } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { changeCurrentPhase } from '../../actions/sampleview';
-import styles from './PhaseInput.module.css';
+import { NStateSelect } from './NStateSelect';
 
-function PhaseInput() {
+const READ_ONLY_OPTIONS = ['Unknown'];
+
+/**
+ * Source hook for the diffractometer phase.
+ *
+ * @returns {NStateSource}
+ */
+
+/**
+ * @typedef {Object} Props
+ * @property {string?} tooltip - Optional hover tooltip text.
+ *
+ * @param {Props} props
+ */
+function PhaseInput({ tooltip }) {
   const dispatch = useDispatch();
 
-  const value = useSelector((state) => state.sampleview.currentPhase);
-  const options = useSelector((state) => state.sampleview.phaseList);
-  const isBusy = useSelector(
-    (state) => state.beamline.hardwareObjects.diffractometer?.state === 'BUSY',
-  );
-
   return (
-    <Form.Select
+    <NStateSelect
       id="PhaseInput"
-      className={styles.select}
-      value={value}
-      data-busy={isBusy || undefined}
-      onChange={(evt) => {
-        dispatch(changeCurrentPhase(evt.target.value));
-      }}
-    >
-      <option hidden key="Unknown">
-        Unknown
-      </option>
-
-      {options.map((option) => (
-        // The "Unknown" option is hidden, so that it only appears as the selected value
-        // when the diffractometer hardware object sets it.
-        <option key={option} hidden={option === 'Unknown'}>
-          {option}
-        </option>
-      ))}
-    </Form.Select>
+      value={useSelector((state) => state.sampleview.currentPhase)}
+      options={useSelector((state) => state.sampleview.phaseList)}
+      isBusy={useSelector(
+        (state) =>
+          state.beamline.hardwareObjects.diffractometer?.state === 'BUSY',
+      )}
+      onSelect={(value) => dispatch(changeCurrentPhase(value))}
+      readOnlyOptions={READ_ONLY_OPTIONS}
+      tooltip={tooltip}
+    />
   );
 }
 

--- a/ui/src/components/SampleView/PhaseInput.module.css
+++ b/ui/src/components/SampleView/PhaseInput.module.css
@@ -1,9 +1,0 @@
-.select {
-  background-color: var(--hw-ready--bg) !important;
-  transition: background-color 100ms ease-in;
-}
-
-.select[data-busy] {
-  background-color: var(--hw-busy--bg) !important;
-  font-weight: 600;
-}

--- a/ui/src/components/TooltipTrigger.jsx
+++ b/ui/src/components/TooltipTrigger.jsx
@@ -10,6 +10,10 @@ function TooltipTrigger(props) {
     inModal = false,
   } = props;
 
+  if (!tooltipContent) {
+    return children;
+  }
+
   return (
     <OverlayTrigger
       rootClose={rootClose} // ensures whether focus is removed from child (and tooltip closed) when clicking anywhere else

--- a/ui/src/containers/SampleViewContainer.jsx
+++ b/ui/src/containers/SampleViewContainer.jsx
@@ -6,7 +6,7 @@ import motorInputStyles from '../components/MotorInput/MotorInput.module.css';
 import ApertureInput from '../components/SampleView/ApertureInput';
 import ContextMenu from '../components/SampleView/ContextMenu';
 import MotorControls from '../components/SampleView/MotorControls';
-import { NStateSelect } from '../components/SampleView/NStateSelect';
+import { NStateHOInput } from '../components/SampleView/NStateHOInput';
 import PhaseInput from '../components/SampleView/PhaseInput';
 import SampleImage from '../components/SampleView/SampleImage';
 import BeamlineSetupContainer from './BeamlineSetupContainer';
@@ -78,7 +78,7 @@ function SampleViewContainer() {
                 <label className={motorInputStyles.label} htmlFor="PhaseInput">
                   {phaseControl.label}
                 </label>
-                <PhaseInput />
+                <PhaseInput tooltip={phaseControl.tooltip} />
               </div>
             )}
             {beamSize !== undefined && (
@@ -89,7 +89,7 @@ function SampleViewContainer() {
                 >
                   {beamSize.label}
                 </label>
-                <ApertureInput />
+                <ApertureInput tooltip={beamSize.tooltip} />
               </div>
             )}
             {nStatesComponents.map((component) => (
@@ -103,9 +103,10 @@ function SampleViewContainer() {
                 >
                   {component.label || component.attribute}
                 </label>
-                <NStateSelect
+                <NStateHOInput
                   name={component.attribute}
                   id={component.attribute}
+                  tooltip={component.tooltip}
                 />
               </div>
             ))}


### PR DESCRIPTION
Made NStateSelect more generic, allowing to share the same code for NState hardware objects along the existing inputs for phase and aperture.
Also adds a tooltip for these based off of description field in sample_view.components field inside ui.yaml config file.

The TooltipTrigger has been slightly modified to not render the tooltip in case no content is provided - it is helpful for the case where no tooltip has been provided for the sample view widget.