### PR TITLE
Changed single Overlap to Offset in label

### DIFF
--- a/ui/src/components/Tasks/Characterisation.jsx
+++ b/ui/src/components/Tasks/Characterisation.jsx
@@ -180,7 +180,7 @@ class Characterisation extends React.Component {
                     list={this.props.detector_mode_list}
                   />
                 )}
-                <InputField propName="offset" label="Overlap" />
+                <InputField propName="offset" label="Offset" />
               </FieldsRow>
             </CollapsableRows>
           </Form>


### PR DESCRIPTION
There was one forgotten instance of 'Overlap' that neded changng.

NB 'overlap still occurs in XSData... objects, mxcubecore.HardwareObjects.abstract.ISPyBValueFactory, ESRFMetadataManagerClient, mxcubecore.HardwareObjects.,ICATLIMS, and EMBLCollect.

If any of this needs to be updated the owners of tegh relevant code need to step in. 
