### PR TITLE
Enable site diffraction viewer

### DIFF
--- a/mxcubeweb/core/adapter/detector_adapter.py
+++ b/mxcubeweb/core/adapter/detector_adapter.py
@@ -47,7 +47,7 @@ class DetectorAdapter(AdapterBase):
 
         if path:
             fpath, img = HWR.beamline.detector.get_actual_file_path(path, img_num)
-            HWR.beamline.collect.adxv_notify(fpath, img)
+            HWR.beamline.collect.display_image(fpath, img)
             fpath = HWR.beamline.session.get_path_with_proposal_as_root(fpath)
 
             if self.app.CONFIG.braggy is not None and self.app.CONFIG.braggy.USE_BRAGGY:

--- a/ui/src/actions/general.js
+++ b/ui/src/actions/general.js
@@ -44,6 +44,8 @@ export function displayImage(path, imgNum) {
       'display_image',
       { path, img_num: imgNum },
     );
-    window.open(data.image_url, 'braggy');
+    if (data.image_url) {
+      window.open(data.image_url, 'braggy');
+    }
   };
 }


### PR DESCRIPTION
Enabling [#1616](https://github.com/mxcube/mxcubecore/pull/1616) if accepted

- Change `hw.beamline.collect.adxv_notify` call to `.site_diffraction_viewer`
- prevent opening _blank page when braggy is not enabled