### PR TITLE
Re-enabling exported commands using exports tag <exports> from hardware objects

### DIFF
--- a/demo/diffractometer_mockup.xml
+++ b/demo/diffractometer_mockup.xml
@@ -21,4 +21,6 @@
     <object href="/udiff_frontlightswitch" role="frontlightswitch"/>
     <object href="/udiff_zoom" role="zoom"/>
   </nstate_equipment>
+
+  <exports>["abort"]</exports>
 </object>

--- a/mxcubeweb/core/adapter/adapter_base.py
+++ b/mxcubeweb/core/adapter/adapter_base.py
@@ -60,6 +60,7 @@ class AdapterBase:
         self._type = type(self).__name__.replace("Adapter", "").upper()
         self._unique = True
         self._msg = ""
+        self._ho_exported_commands = []
 
         cls_name = self.__class__.__name__.lower()
 
@@ -74,6 +75,15 @@ class AdapterBase:
 
         if resource_handler_config:
             _name = resource_handler_config.name or cls_name
+            commands = list(resource_handler_config.commands)
+
+            # Add exported attributes from underlaying HardwareObject to commands,
+            # the Adapter takes presedence over the HardwareObject, ignore attributes
+            # that are already defined as commands in the Adapter.
+            for cmd_name in self._ho.exported_attributes:
+                if cmd_name not in commands:
+                    commands.append(cmd_name)
+                    self._ho_exported_commands.append(cmd_name)
 
             ResourceHandlerFactory.create_or_get(
                 name=_name,
@@ -82,7 +92,7 @@ class AdapterBase:
                 handler_dict=self.ADAPTER_DICT[cls_name],
                 app=self.app,
                 exports=resource_handler_config.exports,
-                commands=resource_handler_config.commands,
+                commands=commands,
                 attributes=resource_handler_config.attributes,
             )
 
@@ -267,20 +277,22 @@ class AdapterBase:
         # needs to be defined as a command in the ResourceHandlerConfigModel
         # to be exported.
 
-        configured_exported = self._ho.exported_attributes.keys()
-
         rh = ResourceHandlerFactory.get_handler(self.__class__.__name__.lower())
 
         if rh:
             for export in rh.commands:
-                attr = getattr(self, export["attr"], None)
+                attr = getattr(self, export["attr"], None) or getattr(
+                    self._ho, export["attr"], None
+                )
 
                 if inspect.ismethod(attr):
                     model = self._model_from_typehint(attr)
                     exported_methods[export["attr"]] = {
                         "signature": model["signature"],
                         "schema": model["args"].schema_json(),
-                        "display": export["attr"] in configured_exported,
+                        # Only display methods actually expoerted, not the ones that
+                        # are "overriden" by the Adapter but not explicitly exported.
+                        "display": export["attr"] in self._ho_exported_commands,
                     }
 
         return exported_methods

--- a/mxcubeweb/core/server/resource_handler.py
+++ b/mxcubeweb/core/server/resource_handler.py
@@ -227,6 +227,18 @@ class ResourceHandler:
             Callable: The view function.
         """
 
+    def _get_handler_function(self, handler_obj: object, attr_name: str):
+        """Get a method on the adapter or its underlying HO."""
+        if hasattr(handler_obj, attr_name):
+            return getattr(handler_obj, attr_name)
+
+        ho = getattr(handler_obj, "_ho", None)
+
+        if ho is not None and hasattr(ho, attr_name):
+            return getattr(ho, attr_name)
+
+        return None
+
     def _validate_params_and_call_handler_func(
         self,
         export: dict[str, str],
@@ -242,7 +254,21 @@ class ResourceHandler:
             The result of the handler function call or an error response.
         """
         # Get the method and its annotations
-        handler_func = getattr(handler_obj, export["attr"])
+        handler_func = self._get_handler_function(handler_obj, export["attr"])
+        # handler_func = getattr(handler_obj, export["attr"])
+        if handler_func is None:
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            f"Method '{export['attr']}' not found on object"
+                            f" '{handler_obj.__class__.__name__}'"
+                        )
+                    }
+                ),
+                404,
+            )
+
         annotations = handler_func.__annotations__
         http_method = export["method"]
 
@@ -299,7 +325,7 @@ class ResourceHandler:
     def _assert_valid_type_arguments(self, export):
         """Ensure the method referenced in the export uses Pydantic arguments."""
         obj = next(iter(self._handler_dict.values()))
-        assert_valid_type_arguments(getattr(obj, export["attr"]))
+        assert_valid_type_arguments(self._get_handler_function(obj, export["attr"]))
 
     def _create_openapi_doc_for_view(self, route, export):
         """Add OpenAPI documentation for a route."""
@@ -307,7 +333,7 @@ class ResourceHandler:
         # any will do for documentation purpose
         http_method = export["method"]
         obj = next(iter(self._handler_dict.values()))
-        view_func = getattr(obj, export["attr"])
+        view_func = self._get_handler_function(obj, export["attr"])
         annotations = view_func.__annotations__
 
         # Add OpenAPI documentation root for route
@@ -634,7 +660,7 @@ class AdapterResourceHandler(ResourceHandler):
                 return jsonify({"error": msg}), 404
 
             # We ensure that the object has the desired method
-            if not hasattr(obj, export["attr"]):
+            if not self._get_handler_function(obj, export["attr"]):
                 return (
                     jsonify(
                         {


### PR DESCRIPTION
The feature of exposing methods directly on hardware objects have been disabled for some time. Its not possible to use the <exports> tag again and the method (if type hinted) becomes available in the equipment tab.