### PR TITLE
Fix caching dependencies.

### DIFF
--- a/.github/workflows/ui.yaml
+++ b/.github/workflows/ui.yaml
@@ -39,16 +39,16 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ~/setup-pnpm/node_modules/.bin/store
             ~/.cache/Cypress
-          key: cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+            ~/setup-pnpm/node_modules/.bin/store
+          key: cache-${{ runner.os }}-${{ hashFiles('ui/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-
 
       - name: Install UI dependencies
-        run: "${MAMBA_EXE} run --name mxcubeweb pnpm --prefix ui install"
+        run: "${MAMBA_EXE} run --name mxcubeweb pnpm --dir ui install"
 
       - name: Run Prettier
-        run: "${MAMBA_EXE} run --name mxcubeweb pnpm --prefix ui prettier"
+        run: "${MAMBA_EXE} run --name mxcubeweb pnpm --dir ui prettier"
 
   lint:
     name: JS-Lint
@@ -73,17 +73,17 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ~/setup-pnpm/node_modules/.bin/store
             ~/.cache/Cypress
-          key: cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+            ~/setup-pnpm/node_modules/.bin/store
+          key: cache-${{ runner.os }}-${{ hashFiles('ui/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-
 
       - name: Install UI dependencies
-        run: "${MAMBA_EXE} run --name mxcubeweb pnpm --prefix ui install"
+        run: "${MAMBA_EXE} run --name mxcubeweb pnpm --dir ui install"
 
       - name: Run ESLint
         # fail on warnings
-        run: "${MAMBA_EXE} run --name mxcubeweb pnpm --prefix ui eslint --max-warnings=0"
+        run: "${MAMBA_EXE} run --name mxcubeweb pnpm --dir ui eslint --max-warnings=0"
 
   e2e:
     name: E2E-Test
@@ -130,22 +130,22 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ~/setup-pnpm/node_modules/.bin/store
             ~/.cache/Cypress
-          key: cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+            ~/setup-pnpm/node_modules/.bin/store
+          key: cache-${{ runner.os }}-${{ hashFiles('ui/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-
 
       - name: Install UI dependencies
-        run: "${MAMBA_EXE} run --name mxcubeweb pnpm --prefix ui install"
+        run: "${MAMBA_EXE} run --name mxcubeweb pnpm --dir ui install"
 
       - name: Build UI
-        run: "${MAMBA_EXE} run --name mxcubeweb pnpm --prefix ui build"
+        run: "${MAMBA_EXE} run --name mxcubeweb pnpm --dir ui build"
 
       - name: Start MXCuBE-Web server (XML config)
         run: |
           ${MAMBA_EXE} run --name mxcubeweb mxcubeweb-server -r ./demo/ --static-folder $(pwd)/ui/build/ -L debug &
-          ${MAMBA_EXE} run --name mxcubeweb pnpm --prefix ui exec wait-on http://127.0.0.1:8081
-          ${MAMBA_EXE} run --name mxcubeweb pnpm --prefix ui e2e
+          ${MAMBA_EXE} run --name mxcubeweb pnpm --dir ui exec wait-on http://127.0.0.1:8081
+          ${MAMBA_EXE} run --name mxcubeweb pnpm --dir ui e2e
         env:
           CYPRESS_BASE_URL: http://127.0.0.1:8081
 
@@ -153,8 +153,8 @@ jobs:
         run: |
           pkill -f mxcubeweb-server || true
           ${MAMBA_EXE} run --name mxcubeweb mxcubeweb-server -r ./demo.yaml/ --static-folder $(pwd)/ui/build/ -L debug &
-          ${MAMBA_EXE} run --name mxcubeweb pnpm --prefix ui exec wait-on http://127.0.0.1:8081
-          ${MAMBA_EXE} run --name mxcubeweb pnpm --prefix ui e2e
+          ${MAMBA_EXE} run --name mxcubeweb pnpm --dir ui exec wait-on http://127.0.0.1:8081
+          ${MAMBA_EXE} run --name mxcubeweb pnpm --dir ui e2e
         env:
           CYPRESS_BASE_URL: http://127.0.0.1:8081
 
@@ -191,7 +191,7 @@ jobs:
           post-cleanup: "all"
 
       - name: Update pnpm-lock.yaml
-        run: "${MAMBA_EXE} run --name mxcubeweb pnpm --prefix ui install --lockfile-only"
+        run: "${MAMBA_EXE} run --name mxcubeweb pnpm --dir ui install --lockfile-only"
 
       - name: Commit changes (if lockfile updated)
         env:

--- a/docs/source/dev/environment.md
+++ b/docs/source/dev/environment.md
@@ -79,8 +79,8 @@ poetry install
 ### 6. Install the front-end dependencies and build the UI
 
 ```
-pnpm --prefix ui install
-pnpm --prefix ui build
+pnpm --dir ui install
+pnpm --dir ui build
 ```
 
 ### 7. Running the application (server)
@@ -165,7 +165,7 @@ conda activate mxcubeweb
 mxcubeweb-server -r $(pwd)/mxcubeweb/demo/ --static-folder $(pwd)/mxcubeweb/ui/build/ --log-level debug
 
 # In another terminal, from the root directory of `mxcubeweb`
-pnpm --prefix ui start
+pnpm --dir ui start
 ```
 
 The above will automatically open a browser with the URL: <http://localhost:5173>
@@ -183,7 +183,7 @@ The above will automatically open a browser with the URL: <http://localhost:5173
 Keep both the backend and front-end servers running then run the following command in a third terminal, from the root directory of the project:
 
 ```
-pnpm --prefix ui e2e
+pnpm --dir ui e2e
 ```
 
 The result should look like this:

--- a/docs/source/dev/front-end.md
+++ b/docs/source/dev/front-end.md
@@ -40,7 +40,7 @@ The codebase is formatted with [Prettier](https://prettier.io/), linted with [ES
 - `pnpm dlx <pkg-name>` - fetch a package from the registry and run its default
   command binary (equivalent to `npx <pkg-name>`)
 
-> You can run all `pnpm` commands from the root of the repository with `pnpm --prefix ui <cmd>`.
+> You can run all `pnpm` commands from the root of the repository with `pnpm --dir ui <cmd>`.
 
 ## Guidelines
 

--- a/docs/source/dev/tests.md
+++ b/docs/source/dev/tests.md
@@ -34,7 +34,7 @@ The end-to-end tests are located in the `ui/cypress/e2e` folder and organised in
 To run all the tests consecutively in a headless browser environment, start both the backend and front-end servers in separate terminals, and then run the following command from the root of the project:
 
 ```
-pnpm --prefix ui e2e
+pnpm --dir ui e2e
 ```
 
 This should give you a result similar to this:
@@ -46,7 +46,7 @@ The default browser for this process is chosen to be [Firefox](https://www.mozil
 Another possibility is to use the [Cypress App](https://www.cypress.io/app) to run the tests. This gives you some additional possibilities such as choosing the browser environment, run only specific specs or using an interactive debugging mode. To run the Cypress App, run the following command:
 
 ```
-pnpm --prefix ui cypress
+pnpm --dir ui cypress
 ```
 
 ![cypress_app](assets/cypress_client.png)
@@ -54,8 +54,8 @@ pnpm --prefix ui cypress
 If you'd like to run Cypress against the front-end production build of MXCuBE-Web, like in the CI, run the following:
 
 ```
-pnpm --prefix ui build
-CYPRESS_BASE_URL="http://127.0.0.1:8081" pnpm --prefix ui e2e
+pnpm --dir ui build
+CYPRESS_BASE_URL="http://127.0.0.1:8081" pnpm --dir ui e2e
 ```
 
 ### Best Practices


### PR DESCRIPTION
For now cache key used for storing pnpm store and Cypress binary is
computed of a common prefix and a hash of unexisting file.
When `hashFiles()` has non-existent path provided, it defaults to
empty string; thus each cache shares a common `cache-Linux` key.

This bug has been encountered when attempting to bump cypress version,
in that case it can't be resolved as Cypress changes it's exact path
depending on version and a new one is not installed.
New binary is notinstalled, because postinstall scripts are ignored in
the CI job, somehow omitting `pnpm-workspace.yml` specifications.
This is related to a regression fixed in `pnpm@10.34.0`.
https://github.com/pnpm/pnpm/releases/tag/v10.34.0
Since that version `--prefix` is an alias of `--dir`, which we will use
for now.