### PR TITLE
Improved validation of sample name, to match front end code

### DIFF
--- a/mxcubeweb/core/models/adaptermodels.py
+++ b/mxcubeweb/core/models/adaptermodels.py
@@ -100,7 +100,7 @@ class FrontEndStackTraceModel(BaseModel):
 
 class SampleInputModel(BaseModel):
     location: str
-    sample_name: str = Field(default="", alias="sampleName")
+    sample_name: str = Field(default="", alias="sampleName", pattern=r"^[\w+\-:]*$")
     sample_id: str = Field(default="", alias="sampleID")
 
     class Config:


### PR DESCRIPTION
We noticed, with some help ;), that the sample name "validation" is any string (server side). So we improved validation of sample name, to match front end code.