### PR TITLE
Improving queue serialization

### DIFF
--- a/mxcubeweb/core/components/lims.py
+++ b/mxcubeweb/core/components/lims.py
@@ -317,7 +317,7 @@ class Lims(ComponentBase):
         if "{" in params.get("prefix", ""):
             sample = self.app.SAMPLE_LIST["sampleList"].get(sample_model.loc_str, {})
             prefix = self.get_default_prefix(sample)
-            shape = params["shape"] if params["shape"] > 0 else ""
+            shape = params.get("shape") or ""
             params["prefix"] = params["prefix"].format(PREFIX=prefix, POSITION=shape)
 
             if params["prefix"].endswith("_"):

--- a/mxcubeweb/core/components/lims.py
+++ b/mxcubeweb/core/components/lims.py
@@ -247,7 +247,7 @@ class Lims(ComponentBase):
 
     def synch_sample_list_with_queue(self, current_queue=None):
         if not current_queue:
-            current_queue = self.app.queue.queue_to_dict(include_lims_data=True)
+            current_queue = self.app.queue.queue_to_dict()
 
         current_queue.get("sample_order", [])
 

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -1094,7 +1094,7 @@ class Queue(ComponentBase):
             "sample_node": sample_model,
         }
 
-    def queue_to_dict(self, node=None, include_lims_data=False):
+    def queue_to_dict(self, node=None):
         """Returns the dictionary representation of the queue.
 
         :param TaskNode node: list of Node objects to get representation for,
@@ -1120,7 +1120,7 @@ class Queue(ComponentBase):
         """
         return self._qs.queue_to_dict(node)
 
-    def queue_to_json(self, node=None, include_lims_data=False):
+    def queue_to_json(self, node=None):
         """Return the json representation of the queue.
 
         :param TaskNode node: list of Node objects to get representation for,
@@ -1186,7 +1186,7 @@ class Queue(ComponentBase):
                     queueStatus: one of [QUEUE_PAUSED, QUEUE_RUNNING, QUEUE_STOPPED]
                 }
         """
-        queue = self.queue_to_dict(include_lims_data=True)
+        queue = self.queue_to_dict()
         sample_order = queue.get("sample_order", [])
         try:
             current = self.app.lims.get_current_sample().get("sampleID", "")

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -222,8 +222,8 @@ class DataCollectionParameters(TaskDataPathModel):
     osc_range: float = Field(0, description="Oscillation range per image")
     osc_total_range: float = 0
     overlap: float = 0
-    kappa: float = 0
-    kappa_phi: float = 0
+    kappa: float | None = 0
+    kappa_phi: float | None = 0
     exp_time: float = Field(0, description="Exposure time in seconds")
     num_lines: int = 1
     energy: float = Field(0, description="Energy in keV")

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -3,7 +3,6 @@ import itertools
 import json
 import logging
 import os
-from functools import reduce
 import re
 from unittest.mock import Mock
 
@@ -25,6 +24,9 @@ from mxcubeweb.core.models.generic import (
     GroupFolderModel,
     SettingNameValue,
 )
+from mxcubeweb.core.models.generic import (
+    validate_path as validate_path_value,
+)
 from mxcubeweb.core.util.convertutils import (
     str_to_camel,
     str_to_snake,
@@ -45,6 +47,89 @@ UNCOLLECTED = 0x0
 READY = 0
 
 ORIGIN_MX3 = "MX3"
+
+
+VALID_PREFIX_TEMPLATE_FIELDS = ("{PREFIX}", "{POSITION}")
+VALID_SUBDIR_TEMPLATE_FIELDS = ("{ACRONYM}", "{NAME}", "{POSITION}")
+
+
+def validate_safe_string(value: str | None, field_name: str) -> str | None:
+    if value is None:
+        return None
+
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+
+    value = value.strip()
+
+    invalid_char = re.search(r"[^a-zA-Z0-9:+_ -]", value)
+    if invalid_char:
+        raise ValueError(
+            f"{field_name} contains invalid character: {invalid_char.group(0)!r}"
+        )
+
+    return value
+
+
+def validate_safe_template_prefix(value: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError("prefix must be a string")
+
+    value = value.strip()
+    literal_value = value
+
+    for field in VALID_PREFIX_TEMPLATE_FIELDS:
+        literal_value = literal_value.replace(field, "")
+
+    validate_safe_string(literal_value, "prefix")
+    return value
+
+
+def validate_safe_template_subdir(value: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError("subdir must be a string")
+
+    value = value.strip()
+    literal_value = value
+
+    for field in VALID_SUBDIR_TEMPLATE_FIELDS:
+        literal_value = literal_value.replace(field, "")
+
+    invalid_template = re.search(r"\{[^{}]*\}", literal_value)
+    if invalid_template:
+        raise ValueError(
+            f"subdir contains invalid template variable: {invalid_template.group(0)!r}"
+        )
+
+    for part in literal_value.split("/"):
+        validate_safe_string(part, "subdir")
+
+    return value
+
+
+def validate_position(value: str | int) -> str | int:
+    if value in ("", None):
+        return ""
+
+    if value == -1:
+        return value
+
+    if not isinstance(value, str):
+        raise ValueError("shape must be -1 or a single letter followed by a digit")
+
+    value = value.strip()
+
+    if value == "-1":
+        return value
+
+    if not re.fullmatch(r"[a-zA-Z][0-9]", value):
+        raise ValueError("shape must be -1 or a single letter followed by a digit")
+
+    return value
+
+
+def validate_path(path: str) -> str:
+    return validate_path_value(path)
 
 
 class TaskDataPathModel(BaseModel):
@@ -77,6 +162,38 @@ class TaskDataPathModel(BaseModel):
         "use_enum_values": True,
     }
 
+    @field_validator("directory", "path", "process_directory", "xds_dir", mode="before")
+    @classmethod
+    def validate_path_fields(cls, value: str) -> str:
+        return validate_path(value)
+
+    @field_validator(
+        "base_prefix",
+        "mad_prefix",
+        "reference_image_prefix",
+        "wedge_prefix",
+        "suffix",
+        mode="before",
+    )
+    @classmethod
+    def validate_safe_string_fields(cls, value: str, info) -> str:
+        return validate_safe_string(value, info.field_name)
+
+    @field_validator("prefix", mode="before")
+    @classmethod
+    def validate_prefix(cls, value: str) -> str:
+        return validate_safe_template_prefix(value)
+
+    @field_validator("subdir", mode="before")
+    @classmethod
+    def validate_subdir(cls, value: str) -> str:
+        return validate_safe_template_subdir(value)
+
+    @field_validator("shape", mode="before")
+    @classmethod
+    def validate_shape(cls, value: str | int) -> str | int:
+        return validate_position(value)
+
 
 class XRFParameters(TaskDataPathModel):
     # From mxcbecore xrf:
@@ -87,6 +204,11 @@ class EnergyScanParameters(TaskDataPathModel):
     # From mxcbecore energy scan:
     element: str = ""
     edge: str = ""
+
+    @field_validator("element", "edge", mode="before")
+    @classmethod
+    def validate_energy_scan_strings(cls, value: str, info) -> str:
+        return validate_safe_string(value, info.field_name)
 
 
 class DataCollectionParameters(TaskDataPathModel):
@@ -121,6 +243,17 @@ class DataCollectionParameters(TaskDataPathModel):
     # From mxcubeweb"
     helical: bool = False
     mesh: bool = False
+
+    @field_validator(
+        "detector_binning_mode",
+        "cell_counting",
+        "mesh_center",
+        "cell_spacing",
+        mode="before",
+    )
+    @classmethod
+    def validate_safe_string_fields(cls, value: str | None, info) -> str | None:
+        return validate_safe_string(value, info.field_name)
 
 
 class CharacterisationParameters(DataCollectionParameters):
@@ -158,6 +291,13 @@ class CharacterisationParameters(DataCollectionParameters):
     beta: float = 0
     gamma: float = 0
 
+    @field_validator(
+        "experiment_type", "strategy_program", "space_group", mode="before"
+    )
+    @classmethod
+    def validate_characterisation_strings(cls, value: str, info) -> str:
+        return validate_safe_string(value, info.field_name)
+
     @field_validator("strategy_complexity", mode="before")
     @classmethod
     def strategy_complexity_to_int(cls, value: int | str) -> str:
@@ -180,6 +320,11 @@ class QueueNodeModel(BaseModel):
     checked: bool = False
     state: int = UNCOLLECTED
 
+    @field_validator("type", mode="before")
+    @classmethod
+    def validate_type(cls, value: str) -> str:
+        return validate_safe_string(value, "type")
+
 
 class TaskNodeModel(QueueNodeModel):
     label: str = ""
@@ -193,6 +338,11 @@ class TaskNodeModel(QueueNodeModel):
     diffractionPlan: list["TaskNodeModel"] | None = None  # noqa: N815
     diffractionPlanID: int | None = None  # noqa: N815
     name: str | None = None
+
+    @field_validator("sampleID", "name", mode="before")
+    @classmethod
+    def validate_task_strings(cls, value: str | None, info) -> str | None:
+        return validate_safe_string(value, info.field_name)
 
 
 class DataCollectionNodeModel(TaskNodeModel):
@@ -227,6 +377,19 @@ class SampleNode(QueueNodeModel):
         | XRFNodeModel
         | EnergyScanNodeModel
     ]
+
+    @field_validator("sampleID", "code", "location", "defaultPrefix", mode="before")
+    @classmethod
+    def validate_sample_safe_strings(cls, value: str | None, info) -> str | None:
+        return validate_safe_string(value, info.field_name)
+
+    @field_validator("sampleName", "proteinAcronym", mode="before")
+    @classmethod
+    def validate_sample_strings(cls, value: str, info) -> str:
+        if value is None and info.field_name == "proteinAcronym":
+            return ""
+
+        return validate_safe_string(value, info.field_name)
 
 
 class QueueSerializer:
@@ -266,6 +429,8 @@ class QueueSerializer:
                     proteinAcronym=n.crystals[0].protein_acronym,
                     defaultPrefix=self.app.lims.get_default_prefix(n),
                     defaultSubDir=self.app.lims.get_default_subdir(n),
+                    cell_no=getattr(n, "cell_no", 0),
+                    puck_no=getattr(n, "puck_no", 1),
                     checked=n.is_enabled(),
                     state=self.get_node_state(n._node_id)[1],
                     tasks=self._queue_to_dict_rec(n),
@@ -358,6 +523,21 @@ class QueueSerializer:
 
         return enabled, state
 
+    def _subdir_from_path(self, path: str) -> str:
+        try:
+            base_path = HWR.beamline.session.get_base_image_directory()
+            rel_path = os.path.relpath(path, base_path)
+
+            if rel_path not in (".", "..") and not rel_path.startswith(f"..{os.sep}"):
+                return rel_path.strip(os.sep).replace(os.sep, "/")
+
+        except (TypeError, ValueError) as ex:
+            raise RuntimeError(
+                "Could not de-serialize subdir from path: %s" % path
+            ) from ex
+
+        raise RuntimeError("Could not de-serialize subdir from path: %s" % path)
+
     def _handle_char_node(self, sample_node, node) -> TaskNodeModel:
         enabled, state = self.get_node_state(node._node_id)
         originID, tasks = self._handle_diffraction_plan(node, sample_node)
@@ -388,6 +568,7 @@ class QueueSerializer:
         enabled, state = self.get_node_state(node._node_id)
         parameters = node.as_dict()
         parameters["shape"] = getattr(node, "shape", "")
+        parameters["subdir"] = self._subdir_from_path(parameters["path"])
 
         pt = node.acquisitions[0].path_template
 
@@ -428,6 +609,7 @@ class QueueSerializer:
         parameters = node.parameters.copy()
         parameters.update(node.path_template.as_dict())
         parameters["path"] = parameters["directory"]
+        parameters["subdir"] = self._subdir_from_path(parameters["path"])
         pt = node.path_template
         parameters["fileName"] = pt.get_image_file_name().replace(
             "%" + ("%sd" % str(pt.precision)), int(pt.precision) * "#"
@@ -452,6 +634,7 @@ class QueueSerializer:
         pt = node.path_template
         parameters = pt.as_dict()
         parameters["path"] = parameters["directory"]
+        parameters["subdir"] = self._subdir_from_path(parameters["path"])
         parameters["strategy_name"] = node.strategy_name
         parameters["label"] = f"GΦL {parameters['strategy_name']}"
         parameters["shape"] = node.shape
@@ -479,6 +662,7 @@ class QueueSerializer:
         parameters = {"countTime": node.count_time, "shape": str(node.shape)}
         parameters.update(node.path_template.as_dict())
         parameters["path"] = parameters["directory"]
+        parameters["subdir"] = self._subdir_from_path(parameters["path"])
         pt = node.path_template
         parameters["prefix"] = pt.get_prefix()
         parameters["fileName"] = pt.get_image_file_name().replace(
@@ -509,6 +693,7 @@ class QueueSerializer:
         }
         parameters.update(node.path_template.as_dict())
         parameters["path"] = parameters["directory"]
+        parameters["subdir"] = self._subdir_from_path(parameters["path"])
         pt = node.path_template
         parameters["prefix"] = pt.get_prefix()
         parameters["fileName"] = pt.get_image_file_name().replace(
@@ -627,14 +812,16 @@ class QueueSerializer:
             self.app.queue.add_queue_entry(parent_node_id, item.dict(), item.type)
 
         # Print the queue after adding an item for easier debugging
-        try:
-            self.pretty_print_queue(
-                f"Added item type={item.type} parent={parent_node_id}"
-            )
-        except Exception:
-            logging.getLogger("MX3.HWR").exception(
-                "Failed to pretty print queue after adding item"
-            )
+
+        if self.app.server.flask.debug:
+            try:
+                self.pretty_print_queue(
+                    f"Added item type={item.type} parent={parent_node_id}"
+                )
+            except Exception:
+                logging.getLogger("MX3.HWR").exception(
+                    "Failed to pretty print queue after adding item"
+                )
 
     def queue_add_item(self, item_list):
         """Add queue items to the queue.
@@ -1052,6 +1239,8 @@ class Queue(ComponentBase):
         # Explicitly set parameters that are not sent by the client
         sample_model.loc_str = sample_id
         sample_model.free_pin_mode = item["location"] == "Manual"
+        sample_model.cell_no = item.get("cell_no", 0)
+        sample_model.puck_no = item.get("puck_no", 1)
         sample_model.set_name(item["sampleName"])
         sample_model.name = item["sampleName"]
 

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -300,6 +300,15 @@ class DataCollectionParameters(TaskDataPathModel):
     sub_wedge_size: int = 10
     disable_processing: bool = False
 
+    # Unit cell parameters, sent by the frontend as cellA/cellB/cellC/
+    # cellAlpha/cellBeta/cellGamma
+    cellA: float = 0  # noqa: N815
+    cellB: float = 0  # noqa: N815
+    cellC: float = 0  # noqa: N815
+    cellAlpha: float = 0  # noqa: N815
+    cellBeta: float = 0  # noqa: N815
+    cellGamma: float = 0  # noqa: N815
+
     # From mxcubeweb"
     helical: bool = False
     mesh: bool = False

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -866,7 +866,7 @@ class QueueSerializer:
         parameters["path"] = pt.directory
         parameters["subdir"] = os.path.join(
             *parameters["path"].split(
-                self.app.HWR.beamline.session.raw_data_folder_name
+                HWR.beamline.session.raw_data_folder_name
             )[1:]
         ).lstrip("/")
         parameters["fileName"] = pt.get_image_file_name().replace(

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -1196,14 +1196,7 @@ class Queue(ComponentBase):
         params = task_data["parameters"]
         acq.acquisition_parameters.set_from_dict(params)
 
-        processing_params = model.processing_parameters
-        processing_params.space_group = params.get("space_group", "")
-        processing_params.cell_a = params.get("cellA", "")
-        processing_params.cell_alpha = params.get("cellAlpha", "")
-        processing_params.cell_b = params.get("cellB", "")
-        processing_params.cell_beta = params.get("cellBeta", "")
-        processing_params.cell_c = params.get("cellC", "")
-        processing_params.cell_gamma = params.get("cellGamma", "")
+        self._set_processing_params(model.processing_parameters, params)
 
         ftype = HWR.beamline.detector.get_property("file_suffix")
         ftype = ftype if ftype else ".?"
@@ -1218,12 +1211,7 @@ class Queue(ComponentBase):
 
         self.app.lims.apply_template(params, sample_model, acq.path_template)
 
-        if params["prefix"]:
-            acq.path_template.base_prefix = params["prefix"]
-        else:
-            acq.path_template.base_prefix = HWR.beamline.session.get_default_prefix(
-                sample_model
-            )
+        self._set_default_prefix(acq.path_template, params, sample_model)
 
         run_number_dir_parts = (
             params.get("subdir", "").strip("/").split("/")[-1].split("_")
@@ -1348,18 +1336,11 @@ class Queue(ComponentBase):
         params = task_data["parameters"]
         model.parameters = params
         model.path_template.set_from_dict(params)
-        model.path_template.base_prefix = params["prefix"]
         model.path_template.num_files = 0
         model.path_template.precision = "0" + str(qmo.PathTemplate.precision)
 
         self.app.lims.apply_template(params, sample_model, model.path_template)
-
-        if params["prefix"]:
-            model.path_template.base_prefix = params["prefix"]
-        else:
-            model.path_template.base_prefix = HWR.beamline.session.get_default_prefix(
-                sample_model
-            )
+        self._set_default_prefix(model.path_template, params, sample_model)
 
         full_path = os.path.join(
             HWR.beamline.session.get_base_image_directory(),
@@ -1442,13 +1423,7 @@ class Queue(ComponentBase):
         model.path_template.set_from_dict(params)
         model.path_template.suffix = ftype
         model.path_template.precision = "0" + str(qmo.PathTemplate.precision)
-
-        if params["prefix"]:
-            model.path_template.base_prefix = params["prefix"]
-        else:
-            model.path_template.base_prefix = HWR.beamline.session.get_default_prefix(
-                sample_model
-            )
+        self._set_default_prefix(model.path_template, params, sample_model)
 
         full_path, process_path = HWR.beamline.session.get_full_paths(
             params.get("subdir", ""), "xrf"
@@ -1484,13 +1459,7 @@ class Queue(ComponentBase):
         model.path_template.set_from_dict(params)
         model.path_template.suffix = ftype
         model.path_template.precision = "0" + str(qmo.PathTemplate.precision)
-
-        if params["prefix"]:
-            model.path_template.base_prefix = params["prefix"]
-        else:
-            model.path_template.base_prefix = HWR.beamline.session.get_default_prefix(
-                sample_model
-            )
+        self._set_default_prefix(model.path_template, params, sample_model)
 
         full_path, process_path = HWR.beamline.session.get_full_paths(
             params.get("subdir", ""), "energy_scan"
@@ -1620,6 +1589,42 @@ class Queue(ComponentBase):
 
         return escan_model, escan_entry
 
+    def _create_and_enqueue_task_group(self, parent_model, parent_entry, group_model=None):
+        """Create and enqueue a task group wrapper for a task model."""
+        if group_model is None:
+            group_model = qmo.TaskGroup()
+
+        group_model.set_origin(ORIGIN_MX3)
+        group_model.set_enabled(True)
+        HWR.beamline.queue_model.add_child(parent_model, group_model)
+
+        group_entry = qe.TaskGroupQueueEntry(Mock(), group_model)
+        group_entry.set_enabled(True)
+        parent_entry.enqueue(group_entry)
+
+        return group_model, group_entry
+
+    def _attach_model_to_group(self, group_model, group_entry, model, entry):
+        HWR.beamline.queue_model.add_child(group_model, model)
+        group_entry.enqueue(entry)
+
+    def _set_processing_params(self, processing_params, params):
+        processing_params.space_group = params.get("space_group", "")
+        processing_params.cell_a = params.get("cellA", "")
+        processing_params.cell_alpha = params.get("cellAlpha", "")
+        processing_params.cell_b = params.get("cellB", "")
+        processing_params.cell_beta = params.get("cellBeta", "")
+        processing_params.cell_c = params.get("cellC", "")
+        processing_params.cell_gamma = params.get("cellGamma", "")
+
+    def _set_default_prefix(self, path_template, params, sample_model):
+        prefix = params.get("prefix", "")
+        path_template.base_prefix = (
+            prefix
+            if prefix
+            else HWR.beamline.session.get_default_prefix(sample_model)
+        )
+
     def add_characterisation(self, node_id, task):
         """Add a data characterisation task to the sample with id: <id>.
 
@@ -1652,16 +1657,10 @@ class Queue(ComponentBase):
         # A characterisation has two TaskGroups one for the characterisation itself
         # and its reference collection and one for the resulting diffraction plans.
         # But we only create a reference group if there is a result !
-        refgroup_model = qmo.TaskGroup()
-        refgroup_model.set_origin(ORIGIN_MX3)
-
-        HWR.beamline.queue_model.add_child(sample_model, refgroup_model)
-        HWR.beamline.queue_model.add_child(refgroup_model, char_model)
-        refgroup_entry = qe.TaskGroupQueueEntry(Mock(), refgroup_model)
-
-        refgroup_entry.set_enabled(True)
-        sample_entry.enqueue(refgroup_entry)
-        refgroup_entry.enqueue(char_entry)
+        refgroup_model, refgroup_entry = self._create_and_enqueue_task_group(
+            sample_model, sample_entry
+        )
+        self._attach_model_to_group(refgroup_model, refgroup_entry, char_model, char_entry)
 
         char_model.set_enabled(task["checked"])
         char_entry.set_enabled(task["checked"])
@@ -1681,16 +1680,10 @@ class Queue(ComponentBase):
         dc_model, dc_entry = self._create_dc()
         self.set_dc_params(dc_model, dc_entry, task, sample_model)
 
-        group_model = qmo.TaskGroup()
-        group_model.set_origin(ORIGIN_MX3)
-        group_model.set_enabled(True)
-        HWR.beamline.queue_model.add_child(sample_model, group_model)
-        HWR.beamline.queue_model.add_child(group_model, dc_model)
-
-        group_entry = qe.TaskGroupQueueEntry(Mock(), group_model)
-        group_entry.set_enabled(True)
-        sample_entry.enqueue(group_entry)
-        group_entry.enqueue(dc_entry)
+        group_model, group_entry = self._create_and_enqueue_task_group(
+            sample_model, sample_entry
+        )
+        self._attach_model_to_group(group_model, group_entry, dc_model, dc_entry)
 
         return dc_model._node_id
 
@@ -1709,14 +1702,7 @@ class Queue(ComponentBase):
         acq = model.acquisitions[0]
         params = task["parameters"]
 
-        processing_params = model.processing_parameters
-        processing_params.space_group = params.get("space_group", "")
-        processing_params.cell_a = params.get("cellA", "")
-        processing_params.cell_alpha = params.get("cellAlpha", "")
-        processing_params.cell_b = params.get("cellB", "")
-        processing_params.cell_beta = params.get("cellBeta", "")
-        processing_params.cell_c = params.get("cellC", "")
-        processing_params.cell_gamma = params.get("cellGamma", "")
+        self._set_processing_params(model.processing_parameters, params)
 
         ftype = HWR.beamline.detector.get_property("file_suffix")
         ftype = ftype if ftype else ".?"
@@ -1729,12 +1715,7 @@ class Queue(ComponentBase):
         acq.path_template.suffix = ftype
         acq.path_template.precision = "0" + str(qmo.PathTemplate.precision)
 
-        if params["prefix"]:
-            acq.path_template.base_prefix = params["prefix"]
-        else:
-            acq.path_template.base_prefix = HWR.beamline.session.get_default_prefix(
-                sample_model
-            )
+        self._set_default_prefix(acq.path_template, params, sample_model)
 
         full_path, process_path = HWR.beamline.session.get_full_paths(
             # Note that 'experiment_name' field can either be omitted, set to None
@@ -1750,16 +1731,10 @@ class Queue(ComponentBase):
 
         model.shape = params["shape"]
 
-        group_model = qmo.TaskGroup()
-        group_model.set_origin(ORIGIN_MX3)
-        group_model.set_enabled(True)
-        HWR.beamline.queue_model.add_child(sample_model, group_model)
-        HWR.beamline.queue_model.add_child(group_model, model)
-
-        group_entry = qe.TaskGroupQueueEntry(Mock(), group_model)
-        group_entry.set_enabled(True)
-        sample_entry.enqueue(group_entry)
-        group_entry.enqueue(entry)
+        group_model, group_entry = self._create_and_enqueue_task_group(
+            sample_model, sample_entry
+        )
+        self._attach_model_to_group(group_model, group_entry, model, entry)
 
         return model._node_id
 
@@ -1783,24 +1758,16 @@ class Queue(ComponentBase):
                 wf_model,
                 dc_entry,
                 task,
-                parent_model.get_sample_node(),
+                sample_model,
             )
         else:
             wf_model, dc_entry = self._create_wf()
-
-        group_model = qmo.TaskGroup()
-        group_model.set_origin(ORIGIN_MX3)
-        group_model.set_enabled(True)
-        HWR.beamline.queue_model.add_child(parent_model, group_model)
-        HWR.beamline.queue_model.add_child(group_model, wf_model)
-
-        if task["parameters"]["wfpath"] != "Gphl":
             self.set_wf_params(wf_model, dc_entry, task, sample_model)
 
-        group_entry = qe.TaskGroupQueueEntry(Mock(), group_model)
-        group_entry.set_enabled(True)
-        parent_entry.enqueue(group_entry)
-        group_entry.enqueue(dc_entry)
+        group_model, group_entry = self._create_and_enqueue_task_group(
+            parent_model, parent_entry
+        )
+        self._attach_model_to_group(group_model, group_entry, wf_model, dc_entry)
 
         return wf_model._node_id
 
@@ -1815,15 +1782,10 @@ class Queue(ComponentBase):
         """
         sample_model, sample_entry = self.get_entry(node_id)
 
-        group_model = qmo.TaskGroup()
-        group_model.set_origin(ORIGIN_MX3)
-        group_model.set_enabled(True)
+        group_model, group_entry = self._create_and_enqueue_task_group(
+            sample_model, sample_entry
+        )
         group_model.interleave_num_images = task["parameters"]["swNumImages"]
-
-        group_entry = qe.TaskGroupQueueEntry(Mock(), group_model)
-        group_entry.set_enabled(True)
-        sample_entry.enqueue(group_entry)
-        HWR.beamline.queue_model.add_child(sample_model, group_model)
 
         wc = 0
 
@@ -1856,16 +1818,10 @@ class Queue(ComponentBase):
         xrf_model, xrf_entry = self._create_xrf(sample_model)
         self.set_xrf_params(xrf_model, xrf_entry, task, sample_model)
 
-        group_model = qmo.TaskGroup()
-        group_model.set_origin(ORIGIN_MX3)
-        group_model.set_enabled(True)
-        HWR.beamline.queue_model.add_child(sample_model, group_model)
-        HWR.beamline.queue_model.add_child(group_model, xrf_model)
-
-        group_entry = qe.TaskGroupQueueEntry(Mock(), group_model)
-        group_entry.set_enabled(True)
-        sample_entry.enqueue(group_entry)
-        group_entry.enqueue(xrf_entry)
+        group_model, group_entry = self._create_and_enqueue_task_group(
+            sample_model, sample_entry
+        )
+        self._attach_model_to_group(group_model, group_entry, xrf_model, xrf_entry)
 
         return xrf_model._node_id
 
@@ -1882,16 +1838,10 @@ class Queue(ComponentBase):
         escan_model, escan_entry = self._create_energy_scan(sample_model)
         self.set_energy_scan_params(escan_model, escan_entry, task, sample_model)
 
-        group_model = qmo.TaskGroup()
-        group_model.set_origin(ORIGIN_MX3)
-        group_model.set_enabled(True)
-        HWR.beamline.queue_model.add_child(sample_model, group_model)
-        HWR.beamline.queue_model.add_child(group_model, escan_model)
-
-        group_entry = qe.TaskGroupQueueEntry(Mock(), group_model)
-        group_entry.set_enabled(True)
-        sample_entry.enqueue(group_entry)
-        group_entry.enqueue(escan_entry)
+        group_model, group_entry = self._create_and_enqueue_task_group(
+            sample_model, sample_entry
+        )
+        self._attach_model_to_group(group_model, group_entry, escan_model, escan_entry)
 
         return escan_model._node_id
 

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -124,12 +124,12 @@ def validate_position(value: str | int) -> str | int:
     if value == "-1":
         return value
 
-    if re.fullmatch(r"2DP(?:[0-9]+)?", value) or re.fullmatch(
-        r"[a-zA-Z][0-9]+", value
-    ):
+    if re.fullmatch(r"2DP(?:[0-9]+)?", value) or re.fullmatch(r"[a-zA-Z][0-9]+", value):
         return value
 
-    raise ValueError("shape must be -1 or a single letter followed by one or more digits")
+    raise ValueError(
+        "shape must be -1 or a single letter followed by one or more digits"
+    )
 
 
 def validate_path(path: str) -> str:
@@ -865,9 +865,7 @@ class QueueSerializer:
         pt = node.acquisitions[0].path_template
         parameters["path"] = pt.directory
         parameters["subdir"] = os.path.join(
-            *parameters["path"].split(
-                HWR.beamline.session.raw_data_folder_name
-            )[1:]
+            *parameters["path"].split(HWR.beamline.session.raw_data_folder_name)[1:]
         ).lstrip("/")
         parameters["fileName"] = pt.get_image_file_name().replace(
             "%" + ("%sd" % str(pt.precision)), int(pt.precision) * "#"

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -122,10 +122,12 @@ def validate_position(value: str | int) -> str | int:
     if value == "-1":
         return value
 
-    if not re.fullmatch(r"[a-zA-Z][0-9]", value):
-        raise ValueError("shape must be -1 or a single letter followed by a digit")
+    if re.fullmatch(r"2DP(?:[0-9]+)?", value) or re.fullmatch(
+        r"[a-zA-Z][0-9]", value
+    ):
+        return value
 
-    return value
+    raise ValueError("shape must be -1 or a single letter followed by a digit")
 
 
 def validate_path(path: str) -> str:

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -315,7 +315,7 @@ class DataCollectionParameters(TaskDataPathModel):
 
     # Only set for Interleaved data collections
     taskIndexList: list[int] | None = None  # noqa: N815
-    wedges: list[dict] = []
+    wedges: list["DataCollectionNodeModel"] = []
     swNumImages: int = 0  # noqa: N815
 
     @field_validator("mesh_range", mode="before")

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -214,6 +214,63 @@ class EnergyScanParameters(TaskDataPathModel):
         return validate_safe_string(value, info.field_name)
 
 
+class WorkflowParameters(TaskDataPathModel):
+    beam_size: str | None = None
+    cell_count: int | None = None
+    doc: str = ""
+    label: str = ""
+    name: str | None = None
+    numCols: int = 0  # noqa: N815
+    numRows: int = 0  # noqa: N815
+    requires: str | None = None
+    type: str = ""
+    wfname: str = ""
+    wfpath: str = ""
+
+    @field_validator(
+            "wfname",
+            "wfpath",
+            "type",
+            "requires",
+            "name",
+            "label",
+            "doc",
+            "beam_size", 
+            mode="before"
+    )
+    @classmethod
+    def validate_energy_scan_strings(cls, value: str, info) -> str:
+        return validate_safe_string(value, info.field_name)
+
+
+
+def normalize_mesh_range(value):
+    if value in (None, "", []):
+        return {}
+    
+    if isinstance(value, float) or isinstance(value, int):
+        return {
+            "horizontal_range": 0,
+            "vertical_range": 0,
+        }
+
+    if isinstance(value, dict):
+        return {
+            "horizontal_range": float(value.get("horizontal_range", 0)),
+            "vertical_range": float(value.get("vertical_range", 0)),
+        }
+
+    if isinstance(value, (list, tuple)):
+        if len(value) != 2:
+            raise ValueError("mesh_range must contain two values")
+        return {
+            "horizontal_range": float(value[0]),
+            "vertical_range": float(value[1]),
+        }
+
+    raise ValueError("mesh_range must be a dictionary with horizontal/vertical ranges")
+
+
 class DataCollectionParameters(TaskDataPathModel):
     # From mxcubecore Datacollection, osc, mesh, helical
     first_image: int = Field(0, description="First image number")
@@ -234,24 +291,29 @@ class DataCollectionParameters(TaskDataPathModel):
     take_snapshots: int = 0
     detector_binning_mode: str | None = None
     detector_roi_mode: int = 0
-    mesh_range: float = 0
+    mesh_range: dict[str, float] = {}
     num_triggers: int = 0
     num_images_per_trigger: int = 0
     cell_counting: str | None = None
     mesh_center: str | None = None
-    cell_spacing: str | None = None
+    cell_spacing: tuple[float, float] | None = None
     sub_wedge_size: int = 10
     disable_processing: bool = False
+
 
     # From mxcubeweb"
     helical: bool = False
     mesh: bool = False
 
+    @field_validator("mesh_range", mode="before")
+    @classmethod
+    def validate_mesh_range(cls, value):
+        return normalize_mesh_range(value)
+
     @field_validator(
         "detector_binning_mode",
         "cell_counting",
         "mesh_center",
-        "cell_spacing",
         mode="before",
     )
     @classmethod
@@ -364,6 +426,10 @@ class EnergyScanNodeModel(TaskNodeModel):
     parameters: EnergyScanParameters
 
 
+class WorkflowNodeModel(TaskNodeModel):
+    parameters: WorkflowParameters
+
+
 def build_task_node_model(value: object):
     if not isinstance(value, dict):
         return value
@@ -385,7 +451,7 @@ def build_task_node_model(value: object):
         return EnergyScanNodeModel.model_validate(normalized)
 
     if task_type in {"Workflow", "GphlWorkflow"}:
-        return DataCollectionNodeModel.model_validate(normalized)
+        return WorkflowNodeModel.model_validate(normalized)
 
     return DataCollectionNodeModel.model_validate(normalized)
 
@@ -395,6 +461,7 @@ TaskNodeUnion = (
     | CharacterisationNodeModel
     | XRFNodeModel
     | EnergyScanNodeModel
+    | WorkflowNodeModel
 )
 
 
@@ -663,7 +730,7 @@ class QueueSerializer:
         parameters["fullPath"] = os.path.join(
             parameters["path"], parameters["fileName"]
         )
-        return DataCollectionNodeModel(
+        return WorkflowNodeModel(
             label=parameters["label"],
             type="Workflow",
             name=node._type,
@@ -841,9 +908,7 @@ class QueueSerializer:
             self.app.queue.add_characterisation(parent_node_id, item.dict())
 
         elif item.type in ("Workflow", "GphlWorkflow"):
-            wf_node_id = self.app.queue.add_workflow(parent_node_id, item.dict())
-            for task in item.tasks or []:
-                self._queue_add_item_rec(wf_node_id, task)
+            self.app.queue.add_workflow(parent_node_id, item.dict())
 
         elif item.type == "Interleaved":
             self.app.queue.add_interleaved(parent_node_id, item.dict())

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -115,17 +115,21 @@ def validate_position(value: str | int) -> str | int:
         return value
 
     if not isinstance(value, str):
-        raise ValueError("shape must be -1 or a single letter followed by a digit")
+        raise ValueError(
+            "shape must be -1 or a single letter followed by one or more digits"
+        )
 
     value = value.strip()
 
     if value == "-1":
         return value
 
-    if re.fullmatch(r"2DP(?:[0-9]+)?", value) or re.fullmatch(r"[a-zA-Z][0-9]", value):
+    if re.fullmatch(r"2DP(?:[0-9]+)?", value) or re.fullmatch(
+        r"[a-zA-Z][0-9]+", value
+    ):
         return value
 
-    raise ValueError("shape must be -1 or a single letter followed by a digit")
+    raise ValueError("shape must be -1 or a single letter followed by one or more digits")
 
 
 def validate_path(path: str) -> str:

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -607,23 +607,21 @@ class QueueSerializer:
             q = self.queue_to_dict()
             # Prefer devtools.debug for nice printing of pydantic models
             try:
-                from devtools import debug as _debug
+                from devtools import debug
 
                 header = msg or "Queue state after addition:"
                 print(f"[QueueSerializer] {header}")
-                _debug(q)
+                debug(q)
                 return
             except Exception:
-                import json as _json
+                import json
 
-                pretty = _json.dumps(q, indent=2, sort_keys=True, ensure_ascii=False)
+                pretty = json.dumps(q, indent=2, sort_keys=True, ensure_ascii=False)
                 header = msg or "Queue state after addition:"
                 print(f"[QueueSerializer] {header}\n{pretty}")
         except Exception as e:
             try:
-                import logging as _logging
-
-                _logging.getLogger("MX3.QUEUE").exception(
+                logging.getLogger("MX3.QUEUE").exception(
                     "Failed to pretty print queue: %s", e
                 )
             except Exception:

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -245,7 +245,7 @@ class WorkflowParameters(TaskDataPathModel):
 
 
 def normalize_mesh_range(value):
-    if value in (None, "", []):
+    if value in (None, "", [], ()):
         return {}
     
     if isinstance(value, float) or isinstance(value, int):

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -379,7 +379,7 @@ class CharacterisationParameters(DataCollectionParameters):
                 "FEW",
                 "MANY",
             ][value]
-        except ValueError:
+        except (IndexError, TypeError):
             return "SINGLE"
 
 

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -63,7 +63,7 @@ def validate_safe_string(value: str | None, field_name: str) -> str | None:
 
     value = value.strip()
 
-    invalid_char = re.search(r"[^a-zA-Z0-9:+_ -]", value)
+    invalid_char = re.search(r"[^a-zA-Z0-9:+_. -]", value)
     if invalid_char:
         raise ValueError(
             f"{field_name} contains invalid character: {invalid_char.group(0)!r}"

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import re
+from typing import Annotated
 from unittest.mock import Mock
 
 from mxcubecore import HardwareRepository as HWR
@@ -363,6 +364,15 @@ class EnergyScanNodeModel(TaskNodeModel):
     parameters: EnergyScanParameters
 
 
+TaskNodeUnion = Annotated[
+    DataCollectionNodeModel
+    | CharacterisationNodeModel
+    | XRFNodeModel
+    | EnergyScanNodeModel,
+    Field(discriminator="type"),
+]
+
+
 class SampleNode(QueueNodeModel):
     sampleID: str  # noqa: N815
     code: str | None = None
@@ -373,12 +383,7 @@ class SampleNode(QueueNodeModel):
     proteinAcronym: str | None = ""  # noqa: N815
     defaultPrefix: str | None = ""  # noqa: N815
     defaultSubDir: str | None = ""  # noqa: N815
-    tasks: list[
-        DataCollectionNodeModel
-        | CharacterisationNodeModel
-        | XRFNodeModel
-        | EnergyScanNodeModel
-    ]
+    tasks: list[TaskNodeUnion]
 
     @field_validator("sampleID", "code", "location", "defaultPrefix", mode="before")
     @classmethod

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 from functools import reduce
+import re
 from unittest.mock import Mock
 
 from mxcubecore import HardwareRepository as HWR
@@ -13,6 +14,7 @@ from mxcubecore.model import queue_model_enumerables as qme
 from mxcubecore.model import queue_model_objects as qmo
 from mxcubecore.model.queue_model_enumerables import CENTRING_METHOD
 from mxcubecore.queue_entry.base_queue_entry import QUEUE_ENTRY_STATUS
+from pydantic import BaseModel, Field, field_validator
 
 from mxcubeweb.core.components.component_base import ComponentBase
 from mxcubeweb.core.models.adaptermodels import (
@@ -45,10 +47,656 @@ READY = 0
 ORIGIN_MX3 = "MX3"
 
 
+class TaskDataPathModel(BaseModel):
+    shape: str | int = ""
+    directory: str = ""
+    process_directory: str = ""
+    xds_dir: str = ""
+    base_prefix: str = ""
+    mad_prefix: str = ""
+    reference_image_prefix: str = ""
+    wedge_prefix: str = ""
+    run_number: int = 0
+    suffix: str = ""
+    precision: int = 0
+    start_num: int = 0
+    num_files: int = 0
+    compression: str = ""
+    path: str = ""
+    prefix: str = ""
+
+    # Optional added by mxcubeweb, used but the frontend
+    fileName: str | None = ""  # noqa: N815
+    fullPath: str | None = ""  # noqa: N815
+    subdir: str = ""
+
+    model_config = {
+        "validate_assignment": True,
+        "extra": "ignore",
+        "str_strip_whitespace": True,
+        "use_enum_values": True,
+    }
+
+
+class XRFParameters(TaskDataPathModel):
+    # From mxcbecore xrf:
+    countTime: float = 0  # noqa: N815
+
+
+class EnergyScanParameters(TaskDataPathModel):
+    # From mxcbecore energy scan:
+    element: str = ""
+    edge: str = ""
+
+
+class DataCollectionParameters(TaskDataPathModel):
+    # From mxcubecore Datacollection, osc, mesh, helical
+    first_image: int = Field(0, description="First image number")
+    num_images: int = Field(0, description="Total number of images")
+    osc_start: float = Field(0, description="Starting oscillation angle")
+    osc_range: float = Field(0, description="Oscillation range per image")
+    osc_total_range: float = 0
+    overlap: float = 0
+    kappa: float = 0
+    kappa_phi: float = 0
+    exp_time: float = Field(0, description="Exposure time in seconds")
+    num_lines: int = 1
+    energy: float = Field(0, description="Energy in keV")
+    resolution: float = Field(0, description="Resolution in Angstrom")
+    detector_distance: float = 0
+    transmission: float = 100
+    shutterless: bool = True
+    take_snapshots: int = 0
+    detector_binning_mode: str | None = None
+    detector_roi_mode: int = 0
+    mesh_range: float = 0
+    num_triggers: int = 0
+    num_images_per_trigger: int = 0
+    cell_counting: str | None = None
+    mesh_center: str | None = None
+    cell_spacing: str | None = None
+    sub_wedge_size: int = 10
+    disable_processing: bool = False
+
+    # From mxcubeweb"
+    helical: bool = False
+    mesh: bool = False
+
+
+class CharacterisationParameters(DataCollectionParameters):
+    # From mxcubecore Characterisation
+    experiment_type: str = ""
+    use_aimed_resolution: float = 0
+    use_aimed_multiplicity: float = 0
+    aimed_multiplicity: float = 0
+    aimed_i_sigma: float = 0
+    aimed_completness: float = 0
+    strategy_complexity: str = ""
+    strategy_program: str = ""
+    induce_burn: bool = False
+    use_permitted_rotation: bool = False
+    permitted_phi_start: float = 0
+    permitted_phi_end: float = 0
+    low_res_pass_strat: bool = False
+    max_crystal_vdim: float = 0
+    min_crystal_vdim: float = 0
+    max_crystal_vphi: float = 0
+    min_crystal_vphi: float = 0
+    space_group: str = ""
+    use_min_dose: float = 0
+    use_min_time: float = 0
+    min_dose: float = 0
+    min_time: float = 0
+    account_rad_damage: bool = False
+    auto_res: bool = False
+    opt_sad: bool = False
+    sad_res: float = 0
+    determine_rad_params: bool = False
+    burn_osc_start: float = 0
+    burn_osc_interval: float = 0
+    rad_suscept: float = 0
+    beta: float = 0
+    gamma: float = 0
+
+    @field_validator("strategy_complexity", mode="before")
+    @classmethod
+    def strategy_complexity_to_int(cls, value: int | str) -> str:
+        if isinstance(value, str):
+            return value
+
+        try:
+            return [
+                "SINGLE",
+                "FEW",
+                "MANY",
+            ][value]
+        except ValueError:
+            return "SINGLE"
+
+
+class QueueNodeModel(BaseModel):
+    type: str = ""
+    queueID: int = -1  # noqa: N815
+    checked: bool = False
+    state: int = UNCOLLECTED
+
+
+class TaskNodeModel(QueueNodeModel):
+    label: str = ""
+    sampleID: str  # noqa: N815
+    sampleQueueID: int | None = None  # noqa: N815
+
+    # Only known once queued (given by mxcubecore queue)
+    taskIndex: int | None = None  # noqa: N815
+
+    # Optional fields
+    diffractionPlan: list["TaskNodeModel"] | None = None  # noqa: N815
+    diffractionPlanID: int | None = None  # noqa: N815
+    name: str | None = None
+
+
+class DataCollectionNodeModel(TaskNodeModel):
+    parameters: DataCollectionParameters
+
+
+class CharacterisationNodeModel(TaskNodeModel):
+    parameters: CharacterisationParameters
+
+
+class XRFNodeModel(TaskNodeModel):
+    parameters: XRFParameters
+
+
+class EnergyScanNodeModel(TaskNodeModel):
+    parameters: EnergyScanParameters
+
+
+class SampleNode(QueueNodeModel):
+    sampleID: str  # noqa: N815
+    code: str | None = None
+    location: str
+    cell_no: int = 0
+    puck_no: int = 1
+    sampleName: str  # noqa: N815
+    proteinAcronym: str | None = ""  # noqa: N815
+    defaultPrefix: str | None = ""  # noqa: N815
+    defaultSubDir: str | None = ""  # noqa: N815
+    tasks: list[
+        DataCollectionNodeModel
+        | CharacterisationNodeModel
+        | XRFNodeModel
+        | EnergyScanNodeModel
+    ]
+
+
+class QueueSerializer:
+    def __init__(self, app):
+        self.app = app
+
+    def queue_to_dict(self, node=None) -> list[dict]:
+        if node is None:
+            node = HWR.beamline.queue_model.get_model_root()
+            queue_dict = {
+                _n.sampleID: _n.model_dump() for _n in self._queue_to_dict_rec(node)
+            }
+
+            if queue_dict:
+                queue_dict["sample_order"] = list(queue_dict.keys())
+
+        else:
+            queue_dict = self._queue_to_dict_rec(node)[0].model_dump()
+
+        return queue_dict
+
+    def _queue_to_dict_rec(self, node) -> list[QueueNodeModel]:
+        result = []
+        node_list = node if isinstance(node, list) else node.get_children()
+
+        for n in node_list:
+            sample_node = n.get_sample_node() if hasattr(n, "get_sample_node") else None
+
+            if isinstance(n, qmo.Sample):
+                sample = SampleNode(
+                    sampleID=n.loc_str,
+                    queueID=n._node_id,
+                    code=n.code,
+                    type="Sample",
+                    location="Manual" if n.free_pin_mode else n.loc_str,
+                    sampleName=n.get_name(),
+                    proteinAcronym=n.crystals[0].protein_acronym,
+                    defaultPrefix=self.app.lims.get_default_prefix(n),
+                    defaultSubDir=self.app.lims.get_default_subdir(n),
+                    checked=n.is_enabled(),
+                    state=self.get_node_state(n._node_id)[1],
+                    tasks=self._queue_to_dict_rec(n),
+                )
+                result.append(sample)
+
+            elif isinstance(n, qmo.Characterisation):
+                result.append(self._handle_char_node(sample_node, n))
+
+            elif isinstance(n, qmo.DataCollection):
+                result.append(self._handle_dc_node(sample_node, n))
+
+            elif isinstance(n, qmo.Workflow):
+                result.append(self._handle_wf_node(sample_node, n))
+
+            elif isinstance(n, qmo.GphlWorkflow):
+                result.append(self._handle_gphl_node(sample_node, n))
+
+            elif isinstance(n, qmo.XRFSpectrum):
+                result.append(self._handle_xrf_node(sample_node, n))
+
+            elif isinstance(n, qmo.EnergyScan):
+                result.append(self._handle_energy_node(sample_node, n))
+
+            elif isinstance(n, qmo.TaskGroup) and getattr(
+                n, "interleave_num_images", 0
+            ):
+                result.append(self._handle_interleaved_node(sample_node, n))
+
+            elif isinstance(n, qmo.TaskNode) and getattr(n, "task_data", None):
+                result.append(self._handle_task_node(sample_node, n))
+
+            else:
+                result.extend(self._queue_to_dict_rec(n))
+
+        return result
+
+    def queue_to_json(self, root_node=None) -> str:
+        return json.dumps(self.queue_to_dict(root_node), sort_keys=True, indent=4)
+
+    def pretty_print_queue(self, msg: str | None = None) -> None:
+        """Pretty print current queue state for debugging."""
+        try:
+            q = self.queue_to_dict()
+            # Prefer devtools.debug for nice printing of pydantic models
+            try:
+                from devtools import debug as _debug
+
+                header = msg or "Queue state after addition:"
+                print(f"[QueueSerializer] {header}")
+                _debug(q)
+                return
+            except Exception:
+                import json as _json
+
+                pretty = _json.dumps(q, indent=2, sort_keys=True, ensure_ascii=False)
+                header = msg or "Queue state after addition:"
+                print(f"[QueueSerializer] {header}\n{pretty}")
+        except Exception as e:
+            try:
+                import logging as _logging
+
+                _logging.getLogger("MX3.QUEUE").exception(
+                    "Failed to pretty print queue: %s", e
+                )
+            except Exception:
+                # last resort fallback
+                print("[QueueSerializer] Failed to pretty print queue:", e)
+
+    def get_node_state(self, node_id):
+        if node_id is None:
+            return True, UNCOLLECTED
+
+        node, entry = self.app.queue.get_entry(node_id)
+
+        enabled = node.is_enabled()
+        curr_entry = HWR.beamline.queue_manager.get_current_entry()
+        running = HWR.beamline.queue_manager.is_executing() and (
+            curr_entry == entry or curr_entry == entry._parent_container
+        )
+
+        if entry.status == QUEUE_ENTRY_STATUS.FAILED:
+            state = FAILED
+        elif node.is_executed() or entry.status == QUEUE_ENTRY_STATUS.SUCCESS:
+            state = COLLECTED
+        elif running or entry.status == QUEUE_ENTRY_STATUS.RUNNING:
+            state = RUNNING
+        else:
+            state = UNCOLLECTED
+
+        return enabled, state
+
+    def _handle_char_node(self, sample_node, node) -> TaskNodeModel:
+        enabled, state = self.get_node_state(node._node_id)
+        originID, tasks = self._handle_diffraction_plan(node, sample_node)
+
+        parameters = node.characterisation_parameters.as_dict()
+        parameters["shape"] = node.get_point_index()
+        refp = self._handle_dc_node(
+            sample_node, node.reference_image_collection
+        ).parameters.dict()
+
+        parameters.update(refp)
+
+        return CharacterisationNodeModel(
+            label="CHARACTERISATION",
+            type="Characterisation",
+            parameters=parameters,
+            checked=node.is_enabled(),
+            sampleID=sample_node.loc_str,
+            sampleQueueID=sample_node._node_id,
+            taskIndex=self.app.queue.node_index(node)["idx"],
+            queueID=node._node_id,
+            state=state,
+            diffractionPlan=tasks if isinstance(tasks, list) else None,
+            diffractionPlanID=originID,
+        )
+
+    def _handle_dc_node(self, sample_node, node) -> TaskNodeModel:
+        enabled, state = self.get_node_state(node._node_id)
+        parameters = node.as_dict()
+        parameters["shape"] = getattr(node, "shape", "")
+
+        pt = node.acquisitions[0].path_template
+
+        # Remove python %s formatting for number of images and replace with #
+        parameters["fileName"] = pt.get_image_file_name().replace(
+            "%" + ("0%sd" % str(pt.precision)), int(pt.precision) * "#"
+        )
+
+        parameters["fullPath"] = os.path.join(
+            parameters["path"], parameters["fileName"]
+        )
+
+        # Create a more user friendly label
+        dtype_label = qme.EXPERIMENT_TYPE._fields[node.experiment_type]
+        dtype_label = "OSCILLATION" if dtype_label == "NATIVE" else dtype_label
+        dtype_label = (
+            "LINE"
+            if dtype_label == "HELICAL" and parameters["osc_range"] == 0
+            else dtype_label
+        )
+
+        return DataCollectionNodeModel(
+            label=dtype_label + " (" + parameters["fileName"] + ")",
+            type="DataCollection",
+            parameters=parameters,
+            checked=node.is_enabled(),
+            sampleID=sample_node.loc_str,
+            sampleQueueID=sample_node._node_id,
+            # node._node_id and taskIndex are None for reference collections for an
+            # characterisation, we should default handle this case in mxcubecore
+            taskIndex=self.app.queue.node_index(node)["idx"] or 0,
+            queueID=node._node_id or -1,
+            state=state,
+        )
+
+    def _handle_wf_node(self, sample_node, node) -> TaskNodeModel:
+        enabled, state = self.get_node_state(node._node_id)
+        parameters = node.parameters.copy()
+        parameters.update(node.path_template.as_dict())
+        parameters["path"] = parameters["directory"]
+        pt = node.path_template
+        parameters["fileName"] = pt.get_image_file_name().replace(
+            "%" + ("%sd" % str(pt.precision)), int(pt.precision) * "#"
+        )
+        parameters["fullPath"] = os.path.join(
+            parameters["path"], parameters["fileName"]
+        )
+        return DataCollectionNodeModel(
+            label=parameters["label"],
+            type="Workflow",
+            name=node._type,
+            parameters=parameters,
+            checked=node.is_enabled(),
+            sampleID=sample_node.loc_str,
+            taskIndex=self.app.queue.node_index(node)["idx"],
+            queueID=node._node_id,
+            state=state,
+        )
+
+    def _handle_gphl_node(self, sample_node, node) -> TaskNodeModel:
+        enabled, state = self.get_node_state(node._node_id)
+        pt = node.path_template
+        parameters = pt.as_dict()
+        parameters["path"] = parameters["directory"]
+        parameters["strategy_name"] = node.strategy_name
+        parameters["label"] = f"GΦL {parameters['strategy_name']}"
+        parameters["shape"] = node.shape
+        parameters["fileName"] = pt.get_image_file_name().replace(
+            "%" + ("%sd" % str(pt.precision)), int(pt.precision) * "#"
+        )
+        parameters["fullPath"] = os.path.join(
+            parameters["directory"], parameters["fileName"]
+        )
+        return DataCollectionNodeModel(
+            label=parameters["label"],
+            type="GphlWorkflow",
+            parameters=parameters,
+            checked=node.is_enabled(),
+            sampleID=sample_node.loc_str,
+            sampleQueueID=sample_node._node_id,
+            taskIndex=self.app.queue.node_index(node)["idx"],
+            queueID=node._node_id,
+            state=state,
+        )
+
+    def _handle_xrf_node(self, sample_node, node) -> TaskNodeModel:
+        enabled, state = self.get_node_state(node._node_id)
+        # This should be moved to as_dict of the XRFSpectrum node in mxcubecore
+        parameters = {"countTime": node.count_time, "shape": str(node.shape)}
+        parameters.update(node.path_template.as_dict())
+        parameters["path"] = parameters["directory"]
+        pt = node.path_template
+        parameters["prefix"] = pt.get_prefix()
+        parameters["fileName"] = pt.get_image_file_name().replace(
+            "%" + ("%sd" % str(pt.precision)), int(pt.precision) * "#"
+        )
+        parameters["fullPath"] = os.path.join(
+            parameters["path"], parameters["fileName"]
+        )
+
+        return XRFNodeModel(
+            label="XRF Scan",
+            type="xrf_spectrum",
+            parameters=parameters,
+            checked=node.is_enabled(),
+            sampleID=sample_node.loc_str,
+            sampleQueueID=sample_node._node_id,
+            taskIndex=self.app.queue.node_index(node)["idx"],
+            queueID=node._node_id,
+            state=state,
+        )
+
+    def _handle_energy_node(self, sample_node, node) -> TaskNodeModel:
+        enabled, state = self.get_node_state(node._node_id)
+        parameters = {
+            "element": node.element_symbol,
+            "edge": node.edge,
+            "shape": str(node.shape),
+        }
+        parameters.update(node.path_template.as_dict())
+        parameters["path"] = parameters["directory"]
+        pt = node.path_template
+        parameters["prefix"] = pt.get_prefix()
+        parameters["fileName"] = pt.get_image_file_name().replace(
+            "%" + ("%sd" % str(pt.precision)), int(pt.precision) * "#"
+        )
+        parameters["fullPath"] = os.path.join(
+            parameters["path"], parameters["fileName"]
+        )
+
+        return EnergyScanNodeModel(
+            label="Energy Scan",
+            type="energy_scan",
+            parameters=parameters,
+            checked=node.is_enabled(),
+            sampleID=sample_node.loc_str,
+            sampleQueueID=sample_node._node_id,
+            taskIndex=self.app.queue.node_index(node)["idx"],
+            queueID=node._node_id,
+            state=state,
+        )
+
+    def _handle_interleaved_node(self, sample_node, node) -> TaskNodeModel:
+        wedges = [self._handle_dc_node(sample_node, c) for c in node.get_children()]
+        _, state = self.get_node_state(node._node_id)
+        return DataCollectionNodeModel(
+            label="Interleaved",
+            type="Interleaved",
+            parameters={
+                "wedges": [w.dict() for w in wedges],
+                "swNumImages": node.interleave_num_images,
+            },
+            checked=node.is_enabled(),
+            sampleID=sample_node.loc_str,
+            sampleQueueID=sample_node._node_id,
+            taskIndex=self.app.queue.node_index(node)["idx"],
+            queueID=node._node_id,
+            state=state,
+        )
+
+    def _handle_task_node(self, sample_node, node) -> TaskNodeModel:
+        parameters = {
+            **node.task_data.collection_parameters.dict(),
+            **node.task_data.user_collection_parameters.dict(),
+            **node.task_data.path_parameters.dict(),
+            **node.task_data.common_parameters.dict(),
+            **node.task_data.legacy_parameters.dict(),
+        }
+        pt = node.acquisitions[0].path_template
+        parameters["path"] = pt.directory
+        parameters["subdir"] = os.path.join(
+            *parameters["path"].split(
+                self.app.HWR.beamline.session.raw_data_folder_name
+            )[1:]
+        ).lstrip("/")
+        parameters["fileName"] = pt.get_image_file_name().replace(
+            "%" + ("%sd" % str(pt.precision)), int(pt.precision) * "#"
+        )
+        parameters["fullPath"] = os.path.join(
+            parameters["path"], parameters["fileName"]
+        )
+        _, state = self.get_node_state(node._node_id)
+        return DataCollectionNodeModel(
+            label=parameters.get("label", "TaskNode"),
+            type=parameters.get("type", "TaskNode"),
+            parameters=parameters,
+            checked=node.is_enabled(),
+            sampleID=sample_node.loc_str,
+            sampleQueueID=sample_node._node_id,
+            taskIndex=self.app.queue.node_index(node)["idx"],
+            queueID=node._node_id,
+            state=state,
+        )
+
+    def _handle_diffraction_plan(self, node, sample_node):
+        model, _ = self.app.queue.get_entry(node._node_id)
+        originID = model.get_origin()
+        tasks = []
+        if len(model.diffraction_plan) > 0:
+            collections = model.diffraction_plan[0]
+            for col in collections:
+                t = self._handle_dc_node(sample_node, col)
+                t_dict = t.dict()
+                t_dict["isDiffractionPlan"] = True
+                tasks.append(t_dict)
+            return originID, tasks
+        return -1, []
+
+    def _queue_add_item_rec(self, parent_node_id: int | None, item: SampleNode):
+        if item.type == "Sample":
+            sample_node_id = self.app.queue.add_sample(item.sampleID, item.dict())
+
+            for task in item.tasks or []:
+                self._queue_add_item_rec(sample_node_id, task)
+
+        elif item.type == "DataCollection":
+            self.app.queue.add_data_collection(parent_node_id, item.dict())
+
+        elif item.type == "Characterisation":
+            self.app.queue.add_characterisation(parent_node_id, item.dict())
+
+        elif item.type in ("Workflow", "GphlWorkflow"):
+            wf_node_id = self.app.queue.add_workflow(parent_node_id, item.dict())
+            for task in item.tasks or []:
+                self._queue_add_item_rec(wf_node_id, task)
+
+        elif item.type == "Interleaved":
+            self.app.queue.add_interleaved(parent_node_id, item.dict())
+
+        elif item.type == "xrf_spectrum":
+            self.app.queue.add_xrf_scan(parent_node_id, item.dict())
+
+        elif item.type == "energy_scan":
+            self.app.queue.add_energy_scan(parent_node_id, item.dict())
+
+        else:
+            self.app.queue.add_queue_entry(parent_node_id, item.dict(), item.type)
+
+        # Print the queue after adding an item for easier debugging
+        try:
+            self.pretty_print_queue(
+                f"Added item type={item.type} parent={parent_node_id}"
+            )
+        except Exception:
+            logging.getLogger("MX3.HWR").exception(
+                "Failed to pretty print queue after adding item"
+            )
+
+    def queue_add_item(self, item_list):
+        """Add queue items to the queue.
+
+        Add the queue items in item_list to the queue. The items in the list can
+        be either samples and or tasks. Samples are only added if they are not
+        already in the queue  and tasks are appended to the end of an
+        (already existing) sample. A task is ignored if the sample is not already
+        in the queue.
+
+        The items in item_list are dictionaries with the following structure:
+
+        { "type": "Sample | DataCollection | Characterisation",
+        "sampleID": sid
+        ... task or sample specific data
+        }
+
+        Each item (dictionary) describes either a sample or a task.
+        """
+        parsed_items = [SampleNode.model_validate(i) for i in item_list]
+        for item in parsed_items:
+            self._queue_add_item_rec(None, item)
+
+        # Handling interleaved data collections, swap interleave task with
+        # the first of the data collections that are used as wedges, and then
+        # remove all collections that were used as wedges
+        first_tasks = parsed_items[0].tasks or []
+        for task in first_tasks:
+            if (
+                task.type == "Interleaved"
+                and task.parameters
+                and task.parameters.taskIndexList
+            ):
+                current_queue = self.queue_to_dict()
+                sid = task.sampleID
+                interleaved_tindex = len(current_queue[sid]["tasks"]) - 1
+                tindex_list = sorted(task.parameters.taskIndexList)
+
+                # Swap first "wedge task" and the actual interleaved collection
+                # so that the interleaved task is the first task
+                self.swap_task_entry(sid, interleaved_tindex, tindex_list[0])
+
+                # We remove the swapped wedge index from the list, (now pointing
+                # at the interleaved collection) and add its new position
+                # (last task item) to the list.
+                tindex_list = tindex_list[1:]
+                tindex_list.append(interleaved_tindex)
+
+                # The delete operation can be done all in one call if we make sure
+                # that we remove the items starting from the end (not altering
+                # previous indices)
+                for ti in reversed(tindex_list):
+                    self.delete_entry_at([[sid, int(ti)]])
+
+        return self.queue_to_dict()
+
+
 class Queue(ComponentBase):
     def __init__(self, app, config):
         super().__init__(app, config)
         self.init_queue_settings()
+        self._qs = QueueSerializer(app)
 
     def build_prefix_path_dict(self, path_list):
         prefix_path_dict = {}
@@ -127,20 +775,6 @@ class Queue(ComponentBase):
             "sample_node": sample_model,
         }
 
-    def load_queue_from_dict(self, queue_dict):
-        """Load the queue in queue_dict in to the current HWR.beamline.queue_model (HWR.beamline.queue_model).
-
-        :param dict queue_dict: Queue dictionary, on the same format as returned by
-                                queue_to_dict
-        """
-        if queue_dict:
-            item_list = []
-
-            for sid in queue_dict["sample_order"]:
-                item_list.append(queue_dict[sid])
-
-            self.queue_add_item(item_list)
-
     def queue_to_dict(self, node=None, include_lims_data=False):
         """Returns the dictionary representation of the queue.
 
@@ -165,14 +799,7 @@ class Queue(ComponentBase):
                 task dict can be directly used with the set_from_dict methods of
                 the corresponding node.
         """
-        if not node:
-            node = HWR.beamline.queue_model.get_model_root()
-
-        return reduce(
-            lambda x, y: x.update(y) or x,
-            self.queue_to_dict_rec(node, include_lims_data),
-            {},
-        )
+        return self._qs.queue_to_dict(node)
 
     def queue_to_json(self, node=None, include_lims_data=False):
         """Return the json representation of the queue.
@@ -198,16 +825,7 @@ class Queue(ComponentBase):
                 task dict can be directly used with the set_from_dict methods of
                 the corresponding node.
         """
-        if not node:
-            node = HWR.beamline.queue_model.get_model_root()
-
-        res = reduce(
-            lambda x, y: x.update(y) or x,
-            self.queue_to_dict_rec(node, include_lims_data),
-            {},
-        )
-
-        return json.dumps(res, sort_keys=True, indent=4)
+        return self._qs.queue_to_json(node)
 
     def get_node_state(self, node_id):
         """Get the state of the given node.
@@ -286,407 +904,6 @@ class Queue(ComponentBase):
 
         res.update(settings)
         return res
-
-    def _handle_task_node(self, sample_node, node):
-        parameters = {
-            **node.task_data.collection_parameters.dict(),
-            **node.task_data.user_collection_parameters.dict(),
-            **node.task_data.path_parameters.dict(),
-            **node.task_data.common_parameters.dict(),
-            **node.task_data.legacy_parameters.dict(),
-        }
-        pt = node.acquisitions[0].path_template
-        parameters["path"] = pt.directory
-
-        parameters["subdir"] = os.path.join(
-            *parameters["path"].split(HWR.beamline.session.raw_data_folder_name)[1:]
-        ).lstrip("/")
-
-        parameters["fileName"] = pt.get_image_file_name().replace(
-            "%" + ("%sd" % str(pt.precision)), int(pt.precision) * "#"
-        )
-
-        parameters["fullPath"] = os.path.join(
-            parameters["path"], parameters["fileName"]
-        )
-
-        return {
-            "label": parameters["label"],
-            "type": parameters["type"],
-            "parameters": parameters,
-            "sampleID": sample_node.loc_str,
-            "sampleQueueID": sample_node._node_id,
-            "taskIndex": self.node_index(node)["idx"],
-            "queueID": node._node_id,
-            "checked": node.is_enabled(),
-            "state": self.get_node_state(node._node_id)[1],
-        }
-
-    def _handle_dc(self, sample_node, node, include_lims_data=False):
-        parameters = node.as_dict()
-        parameters["shape"] = getattr(node, "shape", "")
-        parameters["helical"] = node.experiment_type == qme.EXPERIMENT_TYPE.HELICAL
-        parameters["mesh"] = node.experiment_type == qme.EXPERIMENT_TYPE.MESH
-
-        parameters.pop("sample")
-        parameters.pop("acquisitions")
-        parameters.pop("acq_parameters")
-        parameters.pop("centred_position")
-
-        queueID = node._node_id
-        _, state = self.get_node_state(queueID)
-
-        parameters["subdir"] = os.path.join(
-            *parameters["path"].split(HWR.beamline.session.raw_data_folder_name)[1:]
-        ).lstrip("/")
-
-        pt = node.acquisitions[0].path_template
-
-        parameters["fileName"] = pt.get_image_file_name().replace(
-            "%" + ("%sd" % str(pt.precision)), int(pt.precision) * "#"
-        )
-
-        parameters["fullPath"] = os.path.join(
-            parameters["path"], parameters["fileName"]
-        )
-
-        dtype_label = qme.EXPERIMENT_TYPE._fields[node.experiment_type]
-        dtype_label = "OSCILLATION" if dtype_label == "NATIVE" else dtype_label
-        dtype_label = (
-            "LINE"
-            if dtype_label == "HELICAL" and parameters["osc_range"] == 0
-            else dtype_label
-        )
-
-        return {
-            "label": dtype_label + " (" + parameters["fileName"] + ")",
-            "type": "DataCollection",
-            "parameters": parameters,
-            "sampleID": sample_node.loc_str,
-            "sampleQueueID": sample_node._node_id,
-            "taskIndex": self.node_index(node)["idx"],
-            "queueID": queueID,
-            "checked": node.is_enabled(),
-            "state": state,
-        }
-
-    def _handle_gphl_wf(self, sample_node, node, include_lims_data=False):
-        pt = node.path_template
-        parameters = pt.as_dict()
-        parameters["path"] = parameters["directory"]
-
-        parameters["strategy_name"] = node.strategy_name
-        parameters["label"] = "GΦL " + parameters["strategy_name"]
-        parameters["shape"] = node.shape
-
-        queueID = node._node_id
-        _, state = self.get_node_state(queueID)
-
-        raw_data = HWR.beamline.session.raw_data_folder_name
-        ddir = parameters["directory"]
-        if raw_data in ddir:
-            parameters["subdir"] = os.path.join(*ddir.split(raw_data)[1:]).lstrip("/")
-        else:
-            # We are given a relative directory. Thisa might or mightnto work.
-            parameters["subdir"] = ddir
-
-        parameters["fileName"] = pt.get_image_file_name().replace(
-            "%" + ("%sd" % str(pt.precision)), int(pt.precision) * "#"
-        )
-
-        parameters["fullPath"] = os.path.join(
-            parameters["directory"], parameters["fileName"]
-        )
-
-        return {
-            "label": parameters["label"],
-            "strategy_name": parameters["strategy_name"],
-            "type": "GphlWorkflow",
-            "parameters": parameters,
-            "sampleID": sample_node.loc_str,
-            "sampleQueueID": sample_node._node_id,
-            "taskIndex": self.node_index(node)["idx"],
-            "queueID": queueID,
-            "checked": node.is_enabled(),
-            "state": state,
-        }
-
-    def _handle_wf(self, sample_node, node, include_lims_data):
-        queueID = node._node_id
-        _, state = self.get_node_state(queueID)
-        parameters = node.parameters
-        parameters.update(node.path_template.as_dict())
-
-        parameters["path"] = parameters["directory"]
-
-        parameters["subdir"] = os.path.join(
-            *parameters["path"].split(HWR.beamline.session.raw_data_folder_name)[1:]
-        ).lstrip("/")
-
-        pt = node.path_template
-
-        parameters["fileName"] = pt.get_image_file_name().replace(
-            "%" + ("%sd" % str(pt.precision)), int(pt.precision) * "#"
-        )
-
-        parameters["fullPath"] = os.path.join(
-            parameters["path"], parameters["fileName"]
-        )
-
-        return {
-            "label": parameters["label"],
-            "type": "Workflow",
-            "name": node._type,
-            "parameters": parameters,
-            "sampleID": sample_node.loc_str,
-            "taskIndex": self.node_index(node)["idx"],
-            "queueID": queueID,
-            "checked": node.is_enabled(),
-            "state": state,
-        }
-
-    def _handle_xrf(self, sample_node, node):
-        queueID = node._node_id
-        _, state = self.get_node_state(queueID)
-        parameters = {
-            "countTime": node.count_time,
-            "shape": node.shape,
-        }
-        parameters.update(node.path_template.as_dict())
-        parameters["path"] = parameters["directory"]
-
-        parameters["subdir"] = os.path.join(
-            *parameters["path"].split(HWR.beamline.session.raw_data_folder_name)[1:]
-        ).lstrip("/")
-
-        pt = node.path_template
-
-        parameters["fileName"] = pt.get_image_file_name().replace(
-            "%" + ("%sd" % str(pt.precision)), int(pt.precision) * "#"
-        )
-
-        parameters["fullPath"] = os.path.join(
-            parameters["path"], parameters["fileName"]
-        )
-
-        return {
-            "label": "XRF Scan",
-            "type": "xrf_spectrum",
-            "parameters": parameters,
-            "sampleID": sample_node.loc_str,
-            "taskIndex": self.node_index(node)["idx"],
-            "queueID": queueID,
-            "sampleQueueID": sample_node._node_id,
-            "checked": node.is_enabled(),
-            "state": state,
-        }
-
-    def _handle_energy_scan(self, sample_node, node):
-        queueID = node._node_id
-        _, state = self.get_node_state(queueID)
-        parameters = {
-            "element": node.element_symbol,
-            "edge": node.edge,
-            "shape": -1,
-        }
-
-        parameters.update(node.path_template.as_dict())
-        parameters["path"] = parameters["directory"]
-
-        parameters["subdir"] = os.path.join(
-            *parameters["path"].split(HWR.beamline.session.raw_data_folder_name)[1:]
-        ).lstrip("/")
-
-        pt = node.path_template
-
-        parameters["fileName"] = pt.get_image_file_name().replace(
-            "%" + ("%sd" % str(pt.precision)), int(pt.precision) * "#"
-        )
-
-        parameters["fullPath"] = os.path.join(
-            parameters["path"], parameters["fileName"]
-        )
-
-        return {
-            "label": "Energy Scan",
-            "type": "energy_scan",
-            "parameters": parameters,
-            "sampleID": sample_node.loc_str,
-            "sampleQueueID": sample_node._node_id,
-            "taskIndex": self.node_index(node)["idx"],
-            "queueID": queueID,
-            "checked": node.is_enabled(),
-            "state": state,
-        }
-
-    def _handle_char(self, parent_node, node, include_lims_data=False):
-        sample_node = parent_node.get_sample_node()
-        parameters = node.characterisation_parameters.as_dict()
-        parameters["shape"] = node.get_point_index()
-        refp = self._handle_dc(sample_node, node.reference_image_collection)[
-            "parameters"
-        ]
-
-        parameters.update(refp)
-
-        queueID = node._node_id
-        _, state = self.get_node_state(queueID)
-
-        originID, task = self._handle_diffraction_plan(node, sample_node)
-
-        return {
-            "label": "CHARACTERISATION",
-            "type": "Characterisation",
-            "parameters": parameters,
-            "checked": node.is_enabled(),
-            "sampleID": sample_node.loc_str,
-            "sampleQueueID": sample_node._node_id,
-            "taskIndex": self.node_index(node)["idx"],
-            "queueID": node._node_id,
-            "state": state,
-            "diffractionPlan": task,
-            "diffractionPlanID": originID,
-        }
-
-    def _handle_diffraction_plan(self, node, sample_node):
-        model, _ = self.get_entry(node._node_id)
-        originID = model.get_origin()
-        tasks = []
-
-        if len(model.diffraction_plan) > 0:
-            collections = model.diffraction_plan[0]  # a list of lists
-
-            for col in collections:
-                t = self._handle_dc(sample_node, col)
-                if t is None:
-                    tasks.append({})
-                    continue
-
-                t["isDiffractionPlan"] = True
-                tasks.append(t)
-
-            return (originID, tasks)
-
-        return (-1, {})
-
-    def _handle_interleaved(self, sample_node, node):
-        wedges = []
-
-        for child in node.get_children():
-            wedges.append(self._handle_dc(sample_node, child))
-
-        queueID = node._node_id
-        _, state = self.get_node_state(queueID)
-
-        return {
-            "label": "Interleaved",
-            "type": "Interleaved",
-            "parameters": {
-                "wedges": wedges,
-                "swNumImages": node.interleave_num_images,
-            },
-            "checked": node.is_enabled(),
-            "sampleID": sample_node.loc_str,
-            "sampleQueueID": sample_node._node_id,
-            "taskIndex": self.node_index(node)["idx"],
-            "queueID": node._node_id,
-            "state": state,
-        }
-
-    def _handle_sample(self, node, include_lims_data=False):
-        location = "Manual" if node.free_pin_mode else node.loc_str
-        enabled, state = self.get_node_state(node._node_id)
-        children_states = []
-
-        for child in node.get_children():
-            for _c in child.get_children():
-                _, child_state = self.get_node_state(_c._node_id)
-                children_states.append(child_state)
-
-        if RUNNING in children_states:
-            state = RUNNING & SAMPLE_MOUNTED
-        elif 3 in children_states:
-            state = FAILED & SAMPLE_MOUNTED
-        elif all(i == COLLECTED for i in children_states) and len(children_states) > 0:
-            state = COLLECTED & SAMPLE_MOUNTED
-        else:
-            state = UNCOLLECTED
-
-        sample = {
-            "sampleID": node.loc_str,
-            "queueID": node._node_id,
-            "code": node.code,
-            "location": location,
-            "sampleName": node.get_name(),
-            "proteinAcronym": node.crystals[0].protein_acronym,
-            "defaultPrefix": self.app.lims.get_default_prefix(node),
-            "defaultSubDir": self.app.lims.get_default_subdir(node),
-            "type": "Sample",
-            "checked": enabled,
-            "state": state,
-            "tasks": self.queue_to_dict_rec(node, include_lims_data),
-        }
-
-        return {node.loc_str: sample}
-
-    def queue_to_dict_rec(self, node, include_lims_data=False):
-        """Parse node recursively and builds a representation of the queue based on python dictionaries.
-
-        :param TaskNode node: The node to parse
-        :returns: A list on the form:
-                [ { sampleID_1: sid_1,
-                    queueID: qid_1,
-                    location: location_n
-                    tasks: [task1, ... taskn]},
-                    .
-                    .
-                    .
-                    { sampleID_N: sid_N,
-                    queueID: qid_N,
-                    location: location_n,
-                    tasks: [task1, ... taskn]} ]
-        """
-        result = []
-
-        node_list = node if isinstance(node, list) else node.get_children()
-
-        for node in node_list:
-            # NB under GPhL workflow, nodes do not have predictable distance
-            # to their sample node
-            sample_node = node.get_sample_node()
-            if isinstance(node, qmo.Sample):
-                if len(result) == 0:
-                    result = [{"sample_order": []}]
-
-                result.append(self._handle_sample(node, include_lims_data))
-
-                if node.is_enabled():
-                    result[0]["sample_order"].append(node.loc_str)
-
-            elif isinstance(node, qmo.Characterisation):
-                result.append(self._handle_char(sample_node, node, include_lims_data))
-            elif (
-                node.__class__ is qmo.DataCollection
-            ):  # isinstance(node, qmo.DataCollection):
-                result.append(self._handle_dc(sample_node, node, include_lims_data))
-            elif isinstance(node, qmo.Workflow):
-                result.append(self._handle_wf(sample_node, node, include_lims_data))
-            elif isinstance(node, qmo.GphlWorkflow):
-                result.append(
-                    self._handle_gphl_wf(sample_node, node, include_lims_data)
-                )
-            elif isinstance(node, qmo.XRFSpectrum):
-                result.append(self._handle_xrf(sample_node, node))
-            elif isinstance(node, qmo.EnergyScan):
-                result.append(self._handle_energy_scan(sample_node, node))
-            elif isinstance(node, qmo.TaskGroup) and node.interleave_num_images:
-                result.append(self._handle_interleaved(sample_node, node))
-            elif isinstance(node, qmo.TaskNode) and node.task_data:
-                result.append(self._handle_task_node(sample_node, node))
-            else:
-                result.extend(self.queue_to_dict_rec(node, include_lims_data))
-
-        return result
 
     def queue_exec_state(self):
         """Queue execution state.
@@ -815,6 +1032,8 @@ class Queue(ComponentBase):
 
         Each item (dictionary) describes either a sample or a task.
         """
+        return self._qs.queue_add_item(item_list)
+
         self._queue_add_item_rec(item_list, None)
 
         # Handling interleaved data collections, swap interleave task with
@@ -914,6 +1133,11 @@ class Queue(ComponentBase):
         :param str sample_id: Sample id (often sample changer location)
         :returns: SampleQueueEntry
         """
+        # Sample is already in the queue, just enable it (incase it was disabled)
+        if item.get("queueID", -1) != -1:
+            self.set_enabled_entry(item["queueID"], True)
+            return item["queueID"]
+
         sample_model = qmo.Sample()
         sample_model.set_origin(ORIGIN_MX3)
         sample_model.set_from_dict(item)
@@ -1194,15 +1418,6 @@ class Queue(ComponentBase):
             task_data,
             sample_model,
         )
-
-        try:
-            params["strategy_complexity"] = [
-                "SINGLE",
-                "FEW",
-                "MANY",
-            ].index(params["strategy_complexity"])
-        except ValueError:
-            params["strategy_complexity"] = 0
 
         model.characterisation_parameters.set_from_dict(params)
 
@@ -1724,9 +1939,11 @@ class Queue(ComponentBase):
                 parent_entry.enqueue(dc_entry)
                 sample = parent.get_sample_node()
 
-                task = self._handle_dc(sample, child)
+                task = self._qs._handle_dc_node(sample, child)
 
-                self.app.server.emit("add_task", {"tasks": [task]}, namespace="/hwr")
+                self.app.server.emit(
+                    "add_task", {"tasks": [task.dict()]}, namespace="/hwr"
+                )
 
             elif isinstance(child, qmo.TaskGroup):
                 dcg_entry = qe.TaskGroupQueueEntry(Mock(), child)
@@ -1773,7 +1990,7 @@ class Queue(ComponentBase):
 
                 setattr(collection, "shape", origin_model.shape)
 
-                task = self._handle_dc(sample, collection)
+                task = self._qs._handle_dc_node(sample, collection).dict()
                 task.update(
                     {
                         "isDiffractionPlan": True,

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -304,6 +304,11 @@ class DataCollectionParameters(TaskDataPathModel):
     helical: bool = False
     mesh: bool = False
 
+    # Only set for Interleaved data collections
+    taskIndexList: list[int] | None = None  # noqa: N815
+    wedges: list[dict] = []
+    swNumImages: int = 0  # noqa: N815
+
     @field_validator("mesh_range", mode="before")
     @classmethod
     def validate_mesh_range(cls, value):
@@ -437,8 +442,14 @@ def build_task_node_model(value: object):
     task_type = normalized.get("type")
 
     if task_type == "Interleaved":
+        # Interleaved tasks are shaped like a DataCollection (plus wedges/
+        # taskIndexList), so validate against that schema, but restore the
+        # original type afterwards so downstream routing (add_interleaved,
+        # the interleave swap logic) still recognizes it as "Interleaved".
         normalized["type"] = "DataCollection"
-        return DataCollectionNodeModel.model_validate(normalized)
+        model = DataCollectionNodeModel.model_validate(normalized)
+        model.type = "Interleaved"
+        return model
 
     if task_type == "Characterisation":
         return CharacterisationNodeModel.model_validate(normalized)
@@ -976,7 +987,7 @@ class QueueSerializer:
 
                 # Swap first "wedge task" and the actual interleaved collection
                 # so that the interleaved task is the first task
-                self.swap_task_entry(sid, interleaved_tindex, tindex_list[0])
+                self.app.queue.swap_task_entry(sid, interleaved_tindex, tindex_list[0])
 
                 # We remove the swapped wedge index from the list, (now pointing
                 # at the interleaved collection) and add its new position
@@ -988,7 +999,7 @@ class QueueSerializer:
                 # that we remove the items starting from the end (not altering
                 # previous indices)
                 for ti in reversed(tindex_list):
-                    self.delete_entry_at([[sid, int(ti)]])
+                    self.app.queue.delete_entry_at([[sid, int(ti)]])
 
         return self.queue_to_dict()
 

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -4,7 +4,6 @@ import json
 import logging
 import os
 import re
-from typing import Annotated
 from unittest.mock import Mock
 
 from mxcubecore import HardwareRepository as HWR
@@ -14,7 +13,7 @@ from mxcubecore.model import queue_model_enumerables as qme
 from mxcubecore.model import queue_model_objects as qmo
 from mxcubecore.model.queue_model_enumerables import CENTRING_METHOD
 from mxcubecore.queue_entry.base_queue_entry import QUEUE_ENTRY_STATUS
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 
 from mxcubeweb.core.components.component_base import ComponentBase
 from mxcubeweb.core.models.adaptermodels import (
@@ -123,9 +122,7 @@ def validate_position(value: str | int) -> str | int:
     if value == "-1":
         return value
 
-    if re.fullmatch(r"2DP(?:[0-9]+)?", value) or re.fullmatch(
-        r"[a-zA-Z][0-9]", value
-    ):
+    if re.fullmatch(r"2DP(?:[0-9]+)?", value) or re.fullmatch(r"[a-zA-Z][0-9]", value):
         return value
 
     raise ValueError("shape must be -1 or a single letter followed by a digit")
@@ -228,26 +225,25 @@ class WorkflowParameters(TaskDataPathModel):
     wfpath: str = ""
 
     @field_validator(
-            "wfname",
-            "wfpath",
-            "type",
-            "requires",
-            "name",
-            "label",
-            "doc",
-            "beam_size", 
-            mode="before"
+        "wfname",
+        "wfpath",
+        "type",
+        "requires",
+        "name",
+        "label",
+        "doc",
+        "beam_size",
+        mode="before",
     )
     @classmethod
     def validate_energy_scan_strings(cls, value: str, info) -> str:
         return validate_safe_string(value, info.field_name)
 
 
-
 def normalize_mesh_range(value):
     if value in (None, "", [], ()):
         return {}
-    
+
     if isinstance(value, float) or isinstance(value, int):
         return {
             "horizontal_range": 0,
@@ -299,7 +295,6 @@ class DataCollectionParameters(TaskDataPathModel):
     cell_spacing: tuple[float, float] | None = None
     sub_wedge_size: int = 10
     disable_processing: bool = False
-
 
     # From mxcubeweb"
     helical: bool = False
@@ -484,9 +479,7 @@ class SampleNode(QueueNodeModel):
             tasks = value.get("tasks")
             if isinstance(tasks, list):
                 normalized = dict(value)
-                normalized["tasks"] = [
-                    build_task_node_model(task) for task in tasks
-                ]
+                normalized["tasks"] = [build_task_node_model(task) for task in tasks]
                 return normalized
 
         return value
@@ -952,7 +945,13 @@ class QueueSerializer:
 
         Each item (dictionary) describes either a sample or a task.
         """
-        parsed_items = [SampleNode.model_validate(i) for i in item_list]
+        try:
+            parsed_items = [SampleNode.model_validate(i) for i in item_list]
+        except ValidationError:
+            logging.getLogger("MX3.QUEUE").exception(
+                "Failed to validate queue item(s): %s" % item_list
+            )
+            raise
         for item in parsed_items:
             self._queue_add_item_rec(None, item)
 

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -1034,99 +1034,6 @@ class Queue(ComponentBase):
         """
         return self._qs.queue_add_item(item_list)
 
-        self._queue_add_item_rec(item_list, None)
-
-        # Handling interleaved data collections, swap interleave task with
-        # the first of the data collections that are used as wedges, and then
-        # remove all collections that were used as wedges
-        for task in item_list[0]["tasks"]:
-            if task["type"] == "Interleaved" and task["parameters"].get(
-                "taskIndexList", False
-            ):
-                current_queue = self.queue_to_dict()
-
-                sid = task["sampleID"]
-                interleaved_tindex = len(current_queue[sid]["tasks"]) - 1
-
-                tindex_list = sorted(task["parameters"]["taskIndexList"])
-
-                # Swap first "wedge task" and the actual interleaved collection
-                # so that the interleaved task is the first task
-                self.swap_task_entry(sid, interleaved_tindex, tindex_list[0])
-
-                # We remove the swapped wedge index from the list, (now pointing
-                # at the interleaved collection) and add its new position
-                # (last task item) to the list.
-                tindex_list = tindex_list[1:]
-                tindex_list.append(interleaved_tindex)
-
-                # The delete operation can be done all in one call if we make sure
-                # that we remove the items starting from the end (not altering
-                # previous indices)
-                for ti in reversed(tindex_list):
-                    self.delete_entry_at([[sid, int(ti)]])
-
-        return self.queue_to_dict()
-
-    def _queue_add_item_rec(self, item_list, sample_node_id=None):
-        """Add the queue items in item_list to the queue.
-
-        Adds the queue items in item_list to the queue. The items in the list can
-        be either samples and or tasks. Samples are only added if they are not
-        already in the queue  and tasks are appended to the end of an
-        (already existing) sample. A task is ignored if the sample is not already
-        in the queue.
-
-        The items in item_list are dictionaries with the following structure:
-
-        { "type": "Sample | DataCollection | Characterisation",
-        "sampleID": sid
-        ... task or sample specific data
-        }
-
-        Each item (dictionary) describes either a sample or a task.
-        """
-        for item in item_list:
-            item_t = item["type"]
-            # If the item is a sample, then add it and its tasks.
-            # Otherwise, get the node id for the sample of the
-            # new task and append it to the sample.
-            sample_id = str(item["sampleID"])
-
-            if item_t == "Sample":
-                # Do not add samples that are already in the queue
-                if not item.get("queueID", False):
-                    sample_node_id = self.add_sample(sample_id, item)
-                else:
-                    self.set_enabled_entry(item["queueID"], True)
-                    sample_node_id = item["queueID"]
-
-                tasks = item.get("tasks")
-
-                if tasks:
-                    self._queue_add_item_rec(tasks, sample_node_id)
-
-            else:
-                if not sample_node_id:
-                    sample_node_id = item.get("sampleQueueID", None)
-
-            if item_t == "DataCollection":
-                self.add_data_collection(sample_node_id, item)
-            elif item_t == "Interleaved":
-                self.add_interleaved(sample_node_id, item)
-            elif item_t == "Characterisation":
-                self.add_characterisation(sample_node_id, item)
-            elif item_t == "Workflow" or item_t == "GphlWorkflow":
-                self.add_workflow(sample_node_id, item)
-            elif item_t == "xrf_spectrum":
-                self.add_xrf_scan(sample_node_id, item)
-            elif item_t == "energy_scan":
-                self.add_energy_scan(sample_node_id, item)
-            elif item_t == "Sample":
-                pass
-            else:
-                self.add_queue_entry(sample_node_id, item, item_t)
-
     def add_sample(self, sample_id, item):
         """Add a sample with sample id <sample_id> the queue.
 
@@ -1589,7 +1496,9 @@ class Queue(ComponentBase):
 
         return escan_model, escan_entry
 
-    def _create_and_enqueue_task_group(self, parent_model, parent_entry, group_model=None):
+    def _create_and_enqueue_task_group(
+        self, parent_model, parent_entry, group_model=None
+    ):
         """Create and enqueue a task group wrapper for a task model."""
         if group_model is None:
             group_model = qmo.TaskGroup()
@@ -1620,9 +1529,7 @@ class Queue(ComponentBase):
     def _set_default_prefix(self, path_template, params, sample_model):
         prefix = params.get("prefix", "")
         path_template.base_prefix = (
-            prefix
-            if prefix
-            else HWR.beamline.session.get_default_prefix(sample_model)
+            prefix if prefix else HWR.beamline.session.get_default_prefix(sample_model)
         )
 
     def add_characterisation(self, node_id, task):
@@ -1660,7 +1567,9 @@ class Queue(ComponentBase):
         refgroup_model, refgroup_entry = self._create_and_enqueue_task_group(
             sample_model, sample_entry
         )
-        self._attach_model_to_group(refgroup_model, refgroup_entry, char_model, char_entry)
+        self._attach_model_to_group(
+            refgroup_model, refgroup_entry, char_model, char_entry
+        )
 
         char_model.set_enabled(task["checked"])
         char_entry.set_enabled(task["checked"])

--- a/mxcubeweb/core/components/queue.py
+++ b/mxcubeweb/core/components/queue.py
@@ -14,7 +14,7 @@ from mxcubecore.model import queue_model_enumerables as qme
 from mxcubecore.model import queue_model_objects as qmo
 from mxcubecore.model.queue_model_enumerables import CENTRING_METHOD
 from mxcubecore.queue_entry.base_queue_entry import QUEUE_ENTRY_STATUS
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from mxcubeweb.core.components.component_base import ComponentBase
 from mxcubeweb.core.models.adaptermodels import (
@@ -364,13 +364,38 @@ class EnergyScanNodeModel(TaskNodeModel):
     parameters: EnergyScanParameters
 
 
-TaskNodeUnion = Annotated[
+def build_task_node_model(value: object):
+    if not isinstance(value, dict):
+        return value
+
+    normalized = dict(value)
+    task_type = normalized.get("type")
+
+    if task_type == "Interleaved":
+        normalized["type"] = "DataCollection"
+        return DataCollectionNodeModel.model_validate(normalized)
+
+    if task_type == "Characterisation":
+        return CharacterisationNodeModel.model_validate(normalized)
+
+    if task_type == "xrf_spectrum":
+        return XRFNodeModel.model_validate(normalized)
+
+    if task_type == "energy_scan":
+        return EnergyScanNodeModel.model_validate(normalized)
+
+    if task_type in {"Workflow", "GphlWorkflow"}:
+        return DataCollectionNodeModel.model_validate(normalized)
+
+    return DataCollectionNodeModel.model_validate(normalized)
+
+
+TaskNodeUnion = (
     DataCollectionNodeModel
     | CharacterisationNodeModel
     | XRFNodeModel
-    | EnergyScanNodeModel,
-    Field(discriminator="type"),
-]
+    | EnergyScanNodeModel
+)
 
 
 class SampleNode(QueueNodeModel):
@@ -384,6 +409,20 @@ class SampleNode(QueueNodeModel):
     defaultPrefix: str | None = ""  # noqa: N815
     defaultSubDir: str | None = ""  # noqa: N815
     tasks: list[TaskNodeUnion]
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_tasks(cls, value):
+        if isinstance(value, dict):
+            tasks = value.get("tasks")
+            if isinstance(tasks, list):
+                normalized = dict(value)
+                normalized["tasks"] = [
+                    build_task_node_model(task) for task in tasks
+                ]
+                return normalized
+
+        return value
 
     @field_validator("sampleID", "code", "location", "defaultPrefix", mode="before")
     @classmethod

--- a/mxcubeweb/core/models/generic.py
+++ b/mxcubeweb/core/models/generic.py
@@ -63,7 +63,7 @@ def validate_path(path: str) -> str:
     if any(part == ".." for part in parts):
         raise ValueError("Relative path traversal is not allowed")
 
-    invalid_char = re.search(r"[^a-zA-Z0-9_/-]", path)
+    invalid_char = re.search(r"[^a-zA-Z0-9_/:. -]", path)
     if invalid_char:
         raise ValueError(f"Path contains invalid character: {invalid_char.group(0)!r}")
 

--- a/mxcubeweb/core/models/generic.py
+++ b/mxcubeweb/core/models/generic.py
@@ -42,39 +42,41 @@ class SettingNameValue(BaseModel):
         return value
 
 
+def validate_path(path: str) -> str:
+    """Validate a path without requiring it to exist."""
+    if not isinstance(path, str):
+        raise ValueError("Path must be a string")
+
+    if "\x00" in path:
+        raise ValueError("Path contains a null byte")
+
+    path = path.strip()
+
+    if not path:
+        return ""
+
+    if "//" in path:
+        raise ValueError("Path contains consecutive slashes")
+
+    parts = path.split("/")
+
+    if any(part == ".." for part in parts):
+        raise ValueError("Relative path traversal is not allowed")
+
+    invalid_char = re.search(r"[^a-zA-Z0-9_/-]", path)
+    if invalid_char:
+        raise ValueError(f"Path contains invalid character: {invalid_char.group(0)!r}")
+
+    return path
+
+
 class GroupFolderModel(BaseModel):
     path: str = ""
 
     @field_validator("path")
     @classmethod
     def validate_path(cls, path: str) -> str:
-        """Validate a path without requiring it to exist."""
-        if not isinstance(path, str):
-            raise ValueError("Path must be a string")
-
-        if "\x00" in path:
-            raise ValueError("Path contains a null byte")
-
-        path = path.strip()
-
-        if not path:
-            return ""
-
-        if "//" in path:
-            raise ValueError("Path contains consecutive slashes")
-
-        parts = path.split("/")
-
-        if any(part == ".." for part in parts):
-            raise ValueError("Relative path traversal is not allowed")
-
-        invalid_char = re.search(r"[^a-zA-Z0-9_/-]", path)
-        if invalid_char:
-            raise ValueError(
-                f"Path contains invalid character: {invalid_char.group(0)!r}"
-            )
-
-        return path
+        return validate_path(path)
 
 
 class AppSettingsModel(BaseModel):

--- a/mxcubeweb/routes/queue.py
+++ b/mxcubeweb/routes/queue.py
@@ -109,7 +109,7 @@ def init_route(app, server, url_prefix):  # noqa: C901
                 200: On success
                 409: On error, could not retrieve queue
         """
-        resp = jsonify(app.queue.queue_to_dict(include_lims_data=True))
+        resp = jsonify(app.queue.queue_to_dict())
         resp.status_code = 200
         return resp
 


### PR DESCRIPTION
Same as #1987, just trying to get rid of the CI cache issues....

The idea is to extract the queue json serialization so that we can re-use this part and related functionality in `mxcubecore` at a later stage. It also provides means for validating the queue input in a much better way.

This will be done in at least two steps; first extraction of the current logic that can be moved "back" to `mxcubecore`.  

After that, improvement of the PyDantic models. The later will need a few iterations to reach the desired result. The current models more or less match whats used in `mxcubecore` and the flat structure returned by the `QueueModel.as_dict()` methods. This is consequently whats also used in the UI.

This logic will most likely be moved in a separate sub-module that can be easily transferred to `mxubecore` . 



