### PR TITLE
Change --prefix call to --dir in lint-tsc job.

### DIFF
--- a/.github/workflows/ui.yaml
+++ b/.github/workflows/ui.yaml
@@ -78,10 +78,10 @@ jobs:
           install-poetry: "false"
 
       - name: Install UI dependencies
-        run: "${MAMBA_EXE} run --name mxcubeweb pnpm --prefix ui install"
+        run: "${MAMBA_EXE} run --name mxcubeweb pnpm --dir ui install"
 
       - name: Run tsc
-        run: "${MAMBA_EXE} run --name mxcubeweb pnpm --prefix ui lint:tsc"
+        run: "${MAMBA_EXE} run --name mxcubeweb pnpm --dir ui lint:tsc"
 
   e2e:
     name: E2E-Test


### PR DESCRIPTION
--dir is the more idiomatic way to specify pnpm workspace. Also; before pnpm 10.34 there are problems with resolution of pnpm-workspace.yml files if --prefix is used instead of --dir.


---
I've missed this one when changing CI jobs to use `--dir` previously, as the tsc job was not yer merged as of that time.