### PR TITLE
Put poetry into it's own virtual environment

### DIFF
--- a/.github/actions/install_server/action.yml
+++ b/.github/actions/install_server/action.yml
@@ -1,0 +1,64 @@
+---
+name: Install MXCuBE server
+description: Sets up environments for Conda and Poetry, then install server app.
+
+inputs:
+  python-version:
+    description: Python version used by MXCuBE.
+    required: true
+    default: "3.11"
+  environment-file:
+    description: File specifying conda environments
+    default: conda-environment.yml
+  poetry-version:
+    description: Version of poetry to use
+    default: 2.4.1
+  micromamba-version:
+    description: Version of micromamba to use
+    default: 1.5.10-0
+  install-poetry:
+    description: >-
+      Install Poetry and the MXCuBE server package on top of the Conda env.
+      Set to "false" for jobs that only need Conda-provided tools (e.g. pnpm/node).
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Conda environment
+      uses: mamba-org/setup-micromamba@v2
+      with:
+        create-args: >-
+          python=${{ inputs.python-version }}
+        micromamba-version: ${{ inputs.micromamba-version }}
+        environment-file: ${{ inputs.environment-file }}
+        cache-environment: true
+        post-cleanup: "all"
+        # We need to install poetry so that it is available from outside of the
+        # micromamba environment. Currently it is not feasible, as poetry does
+        # always choose ot use currently active environment, even if config flags are
+        # set to create a virtualenv inside project.
+        # https://github.com/python-poetry/poetry/issues/4055
+        # Using pipx is reccomended by poetry devs, as it creates a venv for each tool.
+    - name: Install Poetry
+      if: inputs.install-poetry == 'true'
+      shell: bash
+      run: |
+        pipx install "poetry==${{ inputs.poetry-version }}"
+
+    - name: Cache Poetry environment
+      if: inputs.install-poetry == 'true'
+      uses: actions/cache@v4
+      with:
+        path: .venv
+        key: >-
+          poetry-${{ runner.os }}-py${{ inputs.python-version }}-
+          ${{ hashFiles('poetry.lock', inputs.environment-file) }}
+
+    - name: Install MXCuBE
+      if: inputs.install-poetry == 'true'
+      shell: bash
+      run: |
+        CONDA_PY="$("${MAMBA_EXE}" run --name mxcubeweb bash -c 'command -v python')"
+        poetry env use "$CONDA_PY"
+        poetry install

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -56,6 +56,16 @@ jobs:
           cache-environment: true
           post-cleanup: "all"
 
+      # Install the project into Poetry's own virtualenv, NOT the Conda env.
+      # As a result, poetry uses conda environment it has been installed to
+      # instead of creating it's own one.
+      # Poetry documentation heavily discourages such use case, as  may lead
+      # to hard to debug errors.
+      - name: Create Poetry virtualenv
+        run: >-
+          "${MAMBA_EXE}" run --name mxcubeweb
+          poetry env use python${{ matrix.python-version }}
+
       - name: Install MXCuBE
         run: "${MAMBA_EXE} run --name mxcubeweb poetry install"
 

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -38,39 +38,16 @@ jobs:
           - 6379:6379
 
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install MXCuBE server for ${{ matrix.python-version }}
+        uses: ./.github/actions/install_server
         with:
           python-version: ${{ matrix.python-version }}
 
-      # Pin micromamba version because of following issue:
-      # https://github.com/mamba-org/setup-micromamba/issues/225
-      - name: Set up Conda environment
-        uses: mamba-org/setup-micromamba@v2
-        with:
-          create-args: >-
-            python=${{ matrix.python-version }}
-          micromamba-version: 1.5.10-0
-          environment-file: conda-environment.yml
-          cache-environment: true
-          post-cleanup: "all"
-
-      # Install the project into Poetry's own virtualenv, NOT the Conda env.
-      # As a result, poetry uses conda environment it has been installed to
-      # instead of creating it's own one.
-      # Poetry documentation heavily discourages such use case, as  may lead
-      # to hard to debug errors.
-      - name: Create Poetry virtualenv
-        run: >-
-          "${MAMBA_EXE}" run --name mxcubeweb
-          poetry env use python${{ matrix.python-version }}
-
-      - name: Install MXCuBE
-        run: "${MAMBA_EXE} run --name mxcubeweb poetry install"
-
       - name: Linting & Code Quality
-        run: "${MAMBA_EXE} run --name mxcubeweb poetry run pre-commit run --all-files"
+        run: poetry run pre-commit run --all-files
 
       - name: Test with pytest
-        run: "${MAMBA_EXE} run --name mxcubeweb poetry run pytest"
+        run: poetry run pytest

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -46,11 +46,18 @@ jobs:
           environment-file: "conda-environment.yml"
           micromamba-version: 1.5.10-0
 
+      - name: Create Poetry virtualenv
+        run: >-
+          "${MAMBA_EXE}" run --name mxcubeweb sh -c
+          'poetry env use "$(command -v python)"'
+
       - name: "Install dependencies with Poetry"
         run: "${MAMBA_EXE} run --name mxcubeweb poetry install --only=docs,main"
 
       - name: "Build documentation with Sphinx"
-        run: "${MAMBA_EXE} run --name mxcubeweb make --directory=./docs/ html"
+        run: >-
+          "${MAMBA_EXE}" run --name mxcubeweb poetry
+          run make --directory=./docs/ html
 
       - name: "Upload artifact for GitHub Pages"
         # This could potentially be run only when we intent to deploy...

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -46,13 +46,16 @@ jobs:
           environment-file: "conda-environment.yml"
           micromamba-version: 1.5.10-0
 
-      - name: Create Poetry virtualenv
-        run: >-
-          "${MAMBA_EXE}" run --name mxcubeweb sh -c
-          'poetry env use "$(command -v python)"'
+      - name: Install Poetry
+        shell: bash
+        run: |
+          pipx install poetry==2.4.1
 
       - name: "Install dependencies with Poetry"
-        run: "${MAMBA_EXE} run --name mxcubeweb poetry install --only=docs,main"
+        run: |
+          CONDA_PY="$("${MAMBA_EXE}" run --name mxcubeweb bash -c 'command -v python')"
+          poetry env use "$CONDA_PY"
+          poetry install --only=docs,main
 
       - name: "Build documentation with Sphinx"
         run: >-

--- a/.github/workflows/ui.yaml
+++ b/.github/workflows/ui.yaml
@@ -157,6 +157,11 @@ jobs:
           cache-environment: true
           post-cleanup: "all"
 
+      - name: Create Poetry virtualenv
+        run: >-
+          "${MAMBA_EXE}" run --name mxcubeweb sh -c
+          'poetry env use "$(command -v python)"'
+
       - name: Install MXCuBE
         run: "${MAMBA_EXE} run --name mxcubeweb poetry install --only main"
 
@@ -177,7 +182,7 @@ jobs:
 
       - name: Start MXCuBE-Web server (XML config)
         run: |
-          ${MAMBA_EXE} run --name mxcubeweb mxcubeweb-server -r ./demo/ --static-folder $(pwd)/ui/build/ -L debug &
+          ${MAMBA_EXE} run --name mxcubeweb poetry run mxcubeweb-server -r ./demo/ --static-folder $(pwd)/ui/build/ -L debug &
           ${MAMBA_EXE} run --name mxcubeweb pnpm --dir ui exec wait-on http://127.0.0.1:8081
           ${MAMBA_EXE} run --name mxcubeweb pnpm --dir ui e2e
         env:
@@ -186,7 +191,7 @@ jobs:
       - name: Start MXCuBE-Web server (YAML config)
         run: |
           pkill -f mxcubeweb-server || true
-          ${MAMBA_EXE} run --name mxcubeweb mxcubeweb-server -r ./demo.yaml/ --static-folder $(pwd)/ui/build/ -L debug &
+          ${MAMBA_EXE} run --name mxcubeweb poetry run mxcubeweb-server -r ./demo.yaml/ --static-folder $(pwd)/ui/build/ -L debug &
           ${MAMBA_EXE} run --name mxcubeweb pnpm --dir ui exec wait-on http://127.0.0.1:8081
           ${MAMBA_EXE} run --name mxcubeweb pnpm --dir ui e2e
         env:

--- a/.github/workflows/ui.yaml
+++ b/.github/workflows/ui.yaml
@@ -28,21 +28,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Conda environment
-        uses: mamba-org/setup-micromamba@v2
+        uses: ./.github/actions/install_server
         with:
-          micromamba-version: 1.5.10-0
-          environment-file: conda-environment.yml
-          cache-environment: true
-          post-cleanup: "all"
-
-      - name: Cache UI dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/Cypress
-            ~/setup-pnpm/node_modules/.bin/store
-          key: cache-${{ runner.os }}-${{ hashFiles('ui/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-
+          install-poetry: "false"
 
       - name: Install UI dependencies
         run: "${MAMBA_EXE} run --name mxcubeweb pnpm --dir ui install"
@@ -62,21 +50,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Conda environment
-        uses: mamba-org/setup-micromamba@v2
+        uses: ./.github/actions/install_server
         with:
-          micromamba-version: 1.5.10-0
-          environment-file: conda-environment.yml
-          cache-environment: true
-          post-cleanup: "all"
-
-      - name: Cache UI dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/Cypress
-            ~/setup-pnpm/node_modules/.bin/store
-          key: cache-${{ runner.os }}-${{ hashFiles('ui/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-
+          install-poetry: "false"
 
       - name: Install UI dependencies
         run: "${MAMBA_EXE} run --name mxcubeweb pnpm --dir ui install"
@@ -97,21 +73,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Conda environment
-        uses: mamba-org/setup-micromamba@v2
+        uses: ./.github/actions/install_server
         with:
-          micromamba-version: 1.5.10-0
-          environment-file: conda-environment.yml
-          cache-environment: true
-          post-cleanup: "all"
-
-      - name: Cache UI dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/setup-pnpm/node_modules/.bin/store
-            ~/.cache/Cypress
-          key: cache-${{ runner.os }}-${{ hashFiles('ui/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-
+          install-poetry: "false"
 
       - name: Install UI dependencies
         run: "${MAMBA_EXE} run --name mxcubeweb pnpm --prefix ui install"
@@ -149,30 +113,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Conda environment
-        uses: mamba-org/setup-micromamba@v2
-        with:
-          micromamba-version: 1.5.10-0
-          environment-file: conda-environment.yml
-          cache-environment: true
-          post-cleanup: "all"
-
-      - name: Create Poetry virtualenv
-        run: >-
-          "${MAMBA_EXE}" run --name mxcubeweb sh -c
-          'poetry env use "$(command -v python)"'
-
       - name: Install MXCuBE
-        run: "${MAMBA_EXE} run --name mxcubeweb poetry install --only main"
-
-      - name: Cache UI dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/Cypress
-            ~/setup-pnpm/node_modules/.bin/store
-          key: cache-${{ runner.os }}-${{ hashFiles('ui/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-
+        uses: ./.github/actions/install_server
 
       - name: Install UI dependencies
         run: "${MAMBA_EXE} run --name mxcubeweb pnpm --dir ui install"
@@ -182,7 +124,7 @@ jobs:
 
       - name: Start MXCuBE-Web server (XML config)
         run: |
-          ${MAMBA_EXE} run --name mxcubeweb poetry run mxcubeweb-server -r ./demo/ --static-folder $(pwd)/ui/build/ -L debug &
+          poetry run mxcubeweb-server -r ./demo/ --static-folder $(pwd)/ui/build/ -L debug &
           ${MAMBA_EXE} run --name mxcubeweb pnpm --dir ui exec wait-on http://127.0.0.1:8081
           ${MAMBA_EXE} run --name mxcubeweb pnpm --dir ui e2e
         env:
@@ -191,7 +133,7 @@ jobs:
       - name: Start MXCuBE-Web server (YAML config)
         run: |
           pkill -f mxcubeweb-server || true
-          ${MAMBA_EXE} run --name mxcubeweb poetry run mxcubeweb-server -r ./demo.yaml/ --static-folder $(pwd)/ui/build/ -L debug &
+          poetry run mxcubeweb-server -r ./demo.yaml/ --static-folder $(pwd)/ui/build/ -L debug &
           ${MAMBA_EXE} run --name mxcubeweb pnpm --dir ui exec wait-on http://127.0.0.1:8081
           ${MAMBA_EXE} run --name mxcubeweb pnpm --dir ui e2e
         env:


### PR DESCRIPTION
Poetry documentation strongly advises to use a separate environment for invoking poetry and installing the project.
https://python-poetry.org/docs/#ci-recommendations

Currently it is not the case, as poetry detects if it is running inside inside a virtual environment -- which is the case when using conda.

As a result poetry's dependencies may be updated during project installation and lead to hard to debug bugs.


---
I suspect this may fix https://github.com/mxcube/mxcubeweb/issues/2134
