### PR TITLE
Guard drawGridPlugin on mouse movement updates and leftClick against non-primary mouse button events.

### DIFF
--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -173,7 +173,7 @@ class SampleImage extends React.Component {
       this.canvas.add(this.centringHorizontalLine);
     }
 
-    if (options.e.buttons > 0 && this.drawGridPlugin.drawing) {
+    if (options.e.buttons === 1 && this.drawGridPlugin.drawing) {
       this.drawGridPlugin.update(
         this.canvas,
         options.e.layerX,
@@ -519,6 +519,9 @@ class SampleImage extends React.Component {
   }
 
   leftClick(option) {
+    if (option.e.buttons !== 1) {
+      return;
+    }
     this.canvas.selection = true; // Enable group selection
     let objectFound = false;
     this.drawGridPlugin.clearMouseOverGridLabel(this.canvas);


### PR DESCRIPTION
After adding one line of logs to each of `rightClick` and `leftClick` methods: "leftClick/righClick", option.e.buttons), I realized that `leftClick` is invoked to often, actually after each mouse button event. 

<img width="1216" height="648" alt="Screenshot from 2026-07-02 10-15-05" src="https://github.com/user-attachments/assets/9b2e55a9-8922-43a2-a2eb-17815001845c" />

Also in `onMouseMove` method the condition `options.e.buttons > 0` was a bit wired, causing together with above the possibility to draw grid with mouse wheel.

If that was not on purpose I propose to improve it a bit. Otherwise, the naming is a bit unfortunate. 