### PR TITLE
Fix non-dragable GridForm

### DIFF
--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -9,6 +9,14 @@ export default defineConfig({
     react(),
     { ...eslintPlugin(), apply: 'serve' }, // dev only to reduce build time
   ],
+  define: {
+    // Workaround for a known regression, present since react-draggable@4.6.0,
+    // where process.env is referenced in the browser bundle served by Vite's
+    // development server. It caused `ReferenceError: process is not defined`
+    // when clicking on draggable elements (e.g. GridForm in UI dev).
+    // https://github.com/react-grid-layout/react-draggable/issues/806
+    'process.env': '{}',
+  },
   server: {
     open: true, // open default browser on start
     strictPort: true, // fail if port already in use (must be 5173 to match server's CORS config)


### PR DESCRIPTION
Maybe other were broken as well but I just checked for the GridForm.  
Looks like some recent merge had broken this feature.  To reproduce:
1. Pull develop branch.
2. Remove `node_modules` and `build` packages
3.  `pnpm install && pnpm build`
4. Start mxcube `mxcube-server..`
5. Start develop `pnpm start --host`
6. Login --> Draw grid --> try to drag Grid Form and in the console you will see:
<img width="1889" height="625" alt="image" src="https://github.com/user-attachments/assets/5f2cb6bd-b1b5-432d-baae-74ebbf863df3" />

I based with my solution at: https://github.com/react-grid-layout/react-grid-layout/issues/2266. Sounds reasonable but I'm not very familiar with this topic, so if anybody have any better solution that's even better :) 