### PR TITLE
Fix & Refactor Context Menu

### DIFF
--- a/ui/cypress/e2e/contextMenu.cy.js
+++ b/ui/cypress/e2e/contextMenu.cy.js
@@ -1,0 +1,18 @@
+/* global cy, it, describe, beforeEach */
+
+describe('Sample view context menu', () => {
+  beforeEach(() => {
+    cy.loginWithControl();
+  });
+
+  it('opens on right-click and closes when clicking outside', () => {
+    cy.get('#insideWrapper').rightclick(100, 100);
+
+    cy.findByRole('menu').should('have.class', 'show');
+    cy.findByText('Go to Beam').should('be.visible');
+    cy.findByText('Measure Distance').should('be.visible');
+    // this would be somewhere outside the context menu; it shall disappear.
+    cy.get('body').click(5, 5);
+    cy.findByRole('menu', { hidden: true }).should('not.have.class', 'show');
+  });
+});

--- a/ui/cypress/e2e/sampleListContextMenu.cy.js
+++ b/ui/cypress/e2e/sampleListContextMenu.cy.js
@@ -1,0 +1,26 @@
+/* global cy, it, describe, beforeEach */
+
+describe('Sample list view context menu', () => {
+  beforeEach(() => {
+    cy.loginWithControl();
+    cy.clearSamples(); // another test may have mounted a sample
+    // clearSamples() navigates to the /samplegrid page via the "Samples"
+    // nav link; mountSample() expects to start from Data collection
+    cy.findByRole('link', { name: /Data collection/u, hidden: true }).click();
+  });
+
+  it('opens on right-click and closes when clicking outside', () => {
+    cy.mountSample();
+
+    cy.findByText('Samples').click();
+
+    // Right-click the mounted sample row to open its generic context menu.
+    cy.findByText('test - test').rightclick();
+
+    cy.findByRole('menu').should('have.class', 'show');
+    cy.findByText('Add to Queue').should('be.visible');
+
+    cy.get('body').click(5, 5);
+    cy.findByRole('menu', { hidden: true }).should('not.have.class', 'show');
+  });
+});

--- a/ui/src/components/GenericContextMenu/MXContextMenu.tsx
+++ b/ui/src/components/GenericContextMenu/MXContextMenu.tsx
@@ -2,15 +2,15 @@ import { useEffect, useRef, useState } from 'react';
 import { Dropdown } from 'react-bootstrap';
 import { useDispatch } from 'react-redux';
 
-import { showGenericContextMenu } from '../../reducers/contextMenu';
+import { hideMenu } from '../../reducers/contextMenu';
 import { useAppSelector } from '../../ts-store';
 import styles from './MXContextMenu.module.css';
 
 export default function MXContextMenu(props: React.PropsWithChildren) {
   const { children } = props;
-  const { show, x, y, id } = useAppSelector(
-    (state) => state.contextMenu.genericContextMenu,
-  );
+  const contextMenu = useAppSelector((state) => state.contextMenu);
+  const show = contextMenu.type === 'Generic';
+  const { id, x, y } = show ? contextMenu : { id: '', x: 0, y: 0 };
   const dispatch = useDispatch();
   const menuRef = useRef<HTMLDivElement>(null);
   const [position, setPosition] = useState({ x: 0, y: 0 });
@@ -31,12 +31,12 @@ export default function MXContextMenu(props: React.PropsWithChildren) {
   }, [show, x, y]);
 
   useEffect(() => {
-    function hideContextMenu() {
-      dispatch(showGenericContextMenu({ id: '', show: false, x: 0, y: 0 }));
+    function onDocumentClick() {
+      dispatch(hideMenu());
     }
-    document.addEventListener('click', hideContextMenu);
+    document.addEventListener('click', onDocumentClick);
     return () => {
-      document.removeEventListener('click', hideContextMenu);
+      document.removeEventListener('click', onDocumentClick);
     };
   }, [dispatch]);
 

--- a/ui/src/components/SampleView/ContextMenu.jsx
+++ b/ui/src/components/SampleView/ContextMenu.jsx
@@ -17,7 +17,8 @@ import {
   toggleDrawGrid,
 } from '../../actions/sampleview';
 import { showTaskForm } from '../../actions/taskForm';
-import { showContextMenu } from '../../reducers/contextMenu';
+import { hideMenu } from '../../reducers/contextMenu';
+import { useAppSelector } from '../../ts-store';
 import { getLastUsedParameters } from '../Tasks/fields';
 
 const BESPOKE_TASK_NAMES = new Set([
@@ -45,8 +46,11 @@ export default function ContextMenu() {
   );
   const { clickCentring } = useSelector((state) => state.sampleview);
   const groupFolder = useSelector((state) => state.queue.groupFolder);
-  const contextMenu = useSelector((state) => state.contextMenu);
-  const { sampleViewX, sampleViewY, shape, pageX, pageY, show } = contextMenu;
+  const contextMenu = useAppSelector((state) => state.contextMenu);
+  const { pageX, pageY, sampleViewX, sampleViewY, shape } =
+    contextMenu.type === 'Shape'
+      ? contextMenu
+      : { pageX: 0, pageY: 0, sampleViewX: 0, sampleViewY: 0 };
 
   const isDrawGridAvailable = useSelector(
     (state) =>
@@ -533,12 +537,12 @@ export default function ContextMenu() {
       className="position-absolute"
       style={{ top: `${pageY}px`, left: `${pageX}px` }}
       role="menu"
-      show={show}
+      show={contextMenu.type === 'Shape'}
       autoClose
       onToggle={(nextShow) => {
         if (!nextShow) {
           // Hide menu when clicking outside or selecting option
-          dispatch(showContextMenu(false));
+          dispatch(hideMenu());
         }
       }}
     >

--- a/ui/src/components/SampleView/SampleImage.jsx
+++ b/ui/src/components/SampleView/SampleImage.jsx
@@ -20,7 +20,7 @@ import {
   updateShapes,
 } from '../../actions/sampleview.js';
 import { HW_STATE, QUEUE_RUNNING } from '../../constants';
-import { showContextMenu } from '../../reducers/contextMenu.js';
+import { showShapeMenu } from '../../reducers/contextMenu.js';
 import SampleControls from '../SampleControls/SampleControls';
 import DrawGridPlugin from './DrawGridPlugin';
 import { GridGroup } from './FabricObjects/gridGroup.js';
@@ -508,14 +508,13 @@ class SampleImage extends React.Component {
     }
 
     const { imageRatio } = this.props;
-    this.props.showContextMenu(
-      true,
-      ctxMenuObj,
-      e.pageX,
-      e.pageY,
-      e.offsetX / imageRatio,
-      e.offsetY / imageRatio,
-    );
+    this.props.showShapeMenu({
+      shape: ctxMenuObj,
+      pageX: e.pageX,
+      pageY: e.pageY,
+      sampleViewX: e.offsetX / imageRatio,
+      sampleViewY: e.offsetY / imageRatio,
+    });
   }
 
   leftClick(option) {
@@ -924,7 +923,7 @@ function mapStateToProps(state) {
   return {
     uiproperties: state.uiproperties,
     hardwareObjects: state.beamline.hardwareObjects,
-    contextMenuVisible: state.contextMenu.show,
+    contextMenuVisible: state.contextMenu.type === 'Shape',
     shapes: state.shapes.shapes,
     cellCounting:
       state.taskForm.defaultParameters.mesh.acq_parameters.cell_counting,
@@ -954,7 +953,7 @@ function mapDispatchToProps(dispatch) {
     displayImage: bindActionCreators(displayImage, dispatch),
     setImageRatio: bindActionCreators(setImageRatio, dispatch),
     setOverlay: bindActionCreators(setOverlay, dispatch),
-    showContextMenu: bindActionCreators(showContextMenu, dispatch),
+    showShapeMenu: bindActionCreators(showShapeMenu, dispatch),
     addDistancePoint: bindActionCreators(addDistancePoint, dispatch),
     toggleDrawGrid: bindActionCreators(toggleDrawGrid, dispatch),
     rotateToShape: bindActionCreators(rotateToShape, dispatch),

--- a/ui/src/containers/SampleGridTableContainer.jsx
+++ b/ui/src/containers/SampleGridTableContainer.jsx
@@ -27,7 +27,8 @@ import SampleGridTableItem from '../components/SampleGrid/SampleGridTableItem';
 import { TaskItem } from '../components/SampleGrid/TaskItem';
 import TooltipTrigger from '../components/TooltipTrigger';
 import { isCollected, QUEUE_RUNNING, QUEUE_STOPPED } from '../constants';
-import { showGenericContextMenu } from '../reducers/contextMenu';
+import { hideMenu, showGenericMenu } from '../reducers/contextMenu';
+import { useAppSelector } from '../ts-store';
 import SampleFlexView from './SampleFlexView';
 import styles from './SampleGridTableContainer.module.css';
 
@@ -131,9 +132,7 @@ export default function SampleGridTableContainer(props) {
   );
   const queue = useSelector((state) => state.queue);
   const sampleChanger = useSelector((state) => state.sampleChanger);
-  const contextMenu = useSelector(
-    (state) => state.contextMenu.genericContextMenu,
-  );
+  const contextMenu = useAppSelector((state) => state.contextMenu);
   const workflows = useSelector((state) => state.workflow.workflows);
   const defaultParameters = useSelector(
     (state) => state.taskForm.defaultParameters,
@@ -262,8 +261,8 @@ export default function SampleGridTableContainer(props) {
     selectionRubberBand.style.height = 0;
     setRubberBandVisible(true);
 
-    if (contextMenu.show) {
-      dispatch(showGenericContextMenu(false, null, 0, 0));
+    if (contextMenu.type === 'Generic') {
+      dispatch(hideMenu());
       setRubberBandVisible(false);
       selectionRubberBand.style.display = 'none';
     }
@@ -453,7 +452,7 @@ export default function SampleGridTableContainer(props) {
     e.preventDefault();
     setRubberBandVisible(false);
     if (queue.queueStatus !== QUEUE_RUNNING) {
-      dispatch(showGenericContextMenu(true, contextMenuID, e.pageX, e.pageY));
+      dispatch(showGenericMenu({ id: contextMenuID, x: e.pageX, y: e.pageY }));
     } // else TODO Show Alert
 
     selectItemUnderCursor(e, sampleID);
@@ -461,7 +460,7 @@ export default function SampleGridTableContainer(props) {
 
   function displayPuckCellContextMenu(e, contextMenuID, cellID, puckID) {
     if (queue.queueStatus !== QUEUE_RUNNING) {
-      dispatch(showGenericContextMenu(true, contextMenuID, e.pageX, e.pageY));
+      dispatch(showGenericMenu({ id: contextMenuID, x: e.pageX, y: e.pageY }));
     } // else TODO Show Alert
 
     const [selectedList] = getSampleListFilteredByCellPuck(

--- a/ui/src/containers/SampleGridTableContainer.jsx
+++ b/ui/src/containers/SampleGridTableContainer.jsx
@@ -1,5 +1,5 @@
 import cx from 'classnames';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button, Col, Dropdown, Row, Table } from 'react-bootstrap';
 import Collapsible from 'react-collapsible';
 import { BiMenu } from 'react-icons/bi';
@@ -138,7 +138,7 @@ export default function SampleGridTableContainer(props) {
     (state) => state.taskForm.defaultParameters,
   );
   const availableMethods = new Set(Object.keys(defaultParameters));
-  const selectionRubberBand = document.querySelector('#selectionRubberBand');
+  const selectionRubberBandRef = useRef(null);
 
   const {
     addSelectedSamplesToQueue,
@@ -175,10 +175,10 @@ export default function SampleGridTableContainer(props) {
       if (e.key === 'Escape') {
         dispatch(selectSamplesAction(Object.keys(sampleList), false));
         setRubberBandVisible(false);
-        selectionRubberBand.style.display = 'none';
+        selectionRubberBandRef.current.style.display = 'none';
       }
     },
-    [dispatch, sampleList, selectionRubberBand],
+    [dispatch, sampleList],
   );
 
   useEffect(() => {
@@ -255,6 +255,7 @@ export default function SampleGridTableContainer(props) {
    */
   function onMouseDown(e) {
     e.preventDefault();
+    const selectionRubberBand = selectionRubberBandRef.current;
     selectionRubberBand.style.top = `${e.clientY}px`;
     selectionRubberBand.style.left = `${e.clientX}px`;
     selectionRubberBand.style.width = 0;
@@ -277,6 +278,7 @@ export default function SampleGridTableContainer(props) {
    */
   function onMouseMove(e) {
     if (rubberBandVisible) {
+      const selectionRubberBand = selectionRubberBandRef.current;
       selectionRubberBand.style.display = 'block';
       selectionRubberBand.style.width = `${
         e.clientX - selectionRubberBand.offsetLeft
@@ -300,11 +302,11 @@ export default function SampleGridTableContainer(props) {
         // `sampleItem.key` may include a column (:), so we can't use `querySelector`
         // //eslint-disable-next-line unicorn/prefer-query-selector
         const sampleElement = document.getElementById(sampleItem.key);
-        return checkForOverlap(selectionRubberBand, sampleElement);
+        return checkForOverlap(selectionRubberBandRef.current, sampleElement);
       })
       .map((sampleItem) => sampleItem.key);
 
-    selectionRubberBand.style.display = 'none';
+    selectionRubberBandRef.current.style.display = 'none';
     setRubberBandVisible(false);
 
     // If several samples selected call the handler, otherwise rely on
@@ -971,7 +973,11 @@ export default function SampleGridTableContainer(props) {
         onMouseMove={onMouseMove}
         xs="auto"
       >
-        <div className={styles.selectionRubberBand} id="selectionRubberBand" />
+        <div
+          ref={selectionRubberBandRef}
+          className={styles.selectionRubberBand}
+          id="selectionRubberBand"
+        />
         {getManualSamples()}
         {viewMode === 'Graphical View' ? (
           <>

--- a/ui/src/containers/SampleListViewContainer.jsx
+++ b/ui/src/containers/SampleListViewContainer.jsx
@@ -38,7 +38,7 @@ import {
   SAMPLE_LIST_VIEW_MODES,
 } from '../constants';
 import loader from '../img/loader.gif';
-import { showGenericContextMenu } from '../reducers/contextMenu';
+import { showGenericMenu } from '../reducers/contextMenu';
 import { getSampleName } from '../utils';
 import QueueSettings from './QueueSettings';
 import SampleGridTableContainer from './SampleGridTableContainer';
@@ -509,7 +509,7 @@ export default function SampleListViewContainer() {
 
   function displayContextMenu(e, contextMenuID) {
     if (queue.queueStatus !== QUEUE_RUNNING) {
-      dispatch(showGenericContextMenu(true, contextMenuID, e.pageX, e.pageY));
+      dispatch(showGenericMenu({ id: contextMenuID, x: e.pageX, y: e.pageY }));
     }
 
     e.stopPropagation();

--- a/ui/src/reducers/contextMenu.ts
+++ b/ui/src/reducers/contextMenu.ts
@@ -1,70 +1,54 @@
-/* eslint-disable no-param-reassign */
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 interface Shape {
   type: string;
 }
 
-interface GenericContextMenu {
-  id: string;
-  show: boolean;
-  x: number;
-  y: number;
+interface NoMenu {
+  type: 'None';
 }
-interface ContextMenuState {
-  show: boolean;
+
+interface ShapeMenu {
+  type: 'Shape';
   shape: Shape;
   pageX: number;
   pageY: number;
   sampleViewX: number;
   sampleViewY: number;
-  genericContextMenu: GenericContextMenu;
 }
 
-const INITIAL_STATE: ContextMenuState = {
-  show: false,
-  shape: { type: 'NONE' },
-  pageX: 0,
-  pageY: 0,
-  sampleViewX: 0,
-  sampleViewY: 0,
-  genericContextMenu: {
-    id: '',
-    show: false,
-    x: 0,
-    y: 0,
-  },
-};
+interface GenericMenu {
+  type: 'Generic';
+  id: string;
+  x: number;
+  y: number;
+}
+
+type ContextMenuState = NoMenu | ShapeMenu | GenericMenu;
 
 const contextMenuSlice = createSlice({
   name: 'contextMenu',
-  initialState: INITIAL_STATE,
+  initialState: (): ContextMenuState => ({ type: 'None' }),
   reducers: {
-    showContextMenu(
-      state,
-      action: PayloadAction<{
-        show: boolean;
-        shape: Shape;
-        pageX: number;
-        pageY: number;
-        sampleViewX: number;
-        sampleViewY: number;
-      }>,
-    ) {
-      state.show = action.payload.show;
-      state.shape = action.payload.shape;
-      state.pageX = action.payload.pageX;
-      state.pageY = action.payload.pageY;
-      state.sampleViewX = action.payload.sampleViewX;
-      state.sampleViewY = action.payload.sampleViewY;
+    showShapeMenu(
+      _state,
+      action: PayloadAction<Omit<ShapeMenu, 'type'>>,
+    ): ContextMenuState {
+      return { type: 'Shape', ...action.payload };
     },
-    showGenericContextMenu(state, action: PayloadAction<GenericContextMenu>) {
-      state.genericContextMenu = action.payload;
+    showGenericMenu(
+      _state,
+      action: PayloadAction<Omit<GenericMenu, 'type'>>,
+    ): ContextMenuState {
+      return { type: 'Generic', ...action.payload };
+    },
+    hideMenu(): ContextMenuState {
+      return { type: 'None' };
     },
   },
 });
 
-export const { showContextMenu, showGenericContextMenu } =
+export const { showShapeMenu, showGenericMenu, hideMenu } =
   contextMenuSlice.actions;
 
 export default contextMenuSlice.reducer;


### PR DESCRIPTION
Currently ContextMenu is not working, since some Redux actions have not been ported to the Redux Toolkit API.
Now it is required to pass the object containing action payload like so: `dispatch(action({arg1: ... ,arg2: ...}))`.

The obvious fix of wrapping all arguments in objects would make the types of the redux state diverge from the type definitions, unless all the fields were optional.
I've decided to use discriminated union pattern to model the valid states of the context menu and did a relatively small refactor to clean up the related state.