### PR TITLE
Fix - revert accidental downgrading of vite form 6.4.3 to 6.4.2

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -67,7 +67,7 @@
     "prop-types": "15.8.1",
     "typescript": "6.0.3",
     "typescript-eslint": "8.59.0",
-    "vite": "6.4.2",
+    "vite": "6.4.3",
     "vite-plugin-eslint": "1.8.1",
     "wait-on": "9.0.1"
   }

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -98,7 +98,7 @@ importers:
     devDependencies:
       '@esrf/eslint-config':
         specifier: 2.3.1
-        version: 2.3.1(@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)(typescript@6.0.3))(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.0.0)(vite@6.4.2(@types/node@25.0.3)))(typescript@6.0.3)
+        version: 2.3.1(@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)(typescript@6.0.3))(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.0.0)(vite@6.4.3(@types/node@25.0.3)))(typescript@6.0.3)
       '@testing-library/cypress':
         specifier: 10.1.3
         version: 10.1.3(cypress@15.17.0)
@@ -122,7 +122,7 @@ importers:
         version: 3.0.13
       '@vitejs/plugin-react-swc':
         specifier: 3.8.0
-        version: 3.8.0(@swc/helpers@0.5.23)(vite@6.4.2(@types/node@25.0.3))
+        version: 3.8.0(@swc/helpers@0.5.23)(vite@6.4.3(@types/node@25.0.3))
       cypress:
         specifier: 15.17.0
         version: 15.17.0
@@ -145,11 +145,11 @@ importers:
         specifier: 8.59.0
         version: 8.59.0(eslint@9.39.4)(typescript@6.0.3)
       vite:
-        specifier: 6.4.2
-        version: 6.4.2(@types/node@25.0.3)
+        specifier: 6.4.3
+        version: 6.4.3(@types/node@25.0.3)
       vite-plugin-eslint:
         specifier: 1.8.1
-        version: 1.8.1(eslint@9.39.4)(vite@6.4.2(@types/node@25.0.3))
+        version: 1.8.1(eslint@9.39.4)(vite@6.4.3(@types/node@25.0.3))
       wait-on:
         specifier: 9.0.1
         version: 9.0.1
@@ -3296,8 +3296,8 @@ packages:
       eslint: '>=7'
       vite: '>=2'
 
-  vite@6.4.2:
-    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+  vite@6.4.3:
+    resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -3735,7 +3735,7 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@esrf/eslint-config@2.3.1(@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)(typescript@6.0.3))(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.0.0)(vite@6.4.2(@types/node@25.0.3)))(typescript@6.0.3)':
+  '@esrf/eslint-config@2.3.1(@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)(typescript@6.0.3))(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.0.0)(vite@6.4.3(@types/node@25.0.3)))(typescript@6.0.3)':
     dependencies:
       '@stylistic/eslint-plugin': 5.10.0(eslint@9.39.4)
       '@vitest/eslint-plugin': 1.6.16(@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)(typescript@6.0.3)
@@ -3749,14 +3749,14 @@ snapshots:
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4)
       eslint-plugin-regexp: 3.1.0(eslint@9.39.4)
       eslint-plugin-simple-import-sort: 13.0.0(eslint@9.39.4)
-      eslint-plugin-storybook: 10.3.5(eslint@9.39.4)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.0.0)(vite@6.4.2(@types/node@25.0.3)))(typescript@6.0.3)
+      eslint-plugin-storybook: 10.3.5(eslint@9.39.4)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.0.0)(vite@6.4.3(@types/node@25.0.3)))(typescript@6.0.3)
       eslint-plugin-testing-library: 7.16.2(eslint@9.39.4)(typescript@6.0.3)
       eslint-plugin-unicorn: 64.0.0(eslint@9.39.4)
       globals: 17.5.0
       typescript: 6.0.3
       typescript-eslint: 8.59.0(eslint@9.39.4)(typescript@6.0.3)
     optionalDependencies:
-      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.0.0)(vite@6.4.2(@types/node@25.0.3))
+      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.0.0)(vite@6.4.3(@types/node@25.0.3))
     transitivePeerDependencies:
       - '@typescript-eslint/eslint-plugin'
       - '@typescript-eslint/parser'
@@ -4312,10 +4312,10 @@ snapshots:
       '@typescript-eslint/types': 8.62.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react-swc@3.8.0(@swc/helpers@0.5.23)(vite@6.4.2(@types/node@25.0.3))':
+  '@vitejs/plugin-react-swc@3.8.0(@swc/helpers@0.5.23)(vite@6.4.3(@types/node@25.0.3))':
     dependencies:
       '@swc/core': 1.15.43(@swc/helpers@0.5.23)
-      vite: 6.4.2(@types/node@25.0.3)
+      vite: 6.4.3(@types/node@25.0.3)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -4338,13 +4338,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.4.2(@types/node@25.0.3))':
+  '@vitest/mocker@3.2.4(vite@6.4.3(@types/node@25.0.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.2(@types/node@25.0.3)
+      vite: 6.4.3(@types/node@25.0.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -5194,11 +5194,11 @@ snapshots:
     dependencies:
       eslint: 9.39.4
 
-  eslint-plugin-storybook@10.3.5(eslint@9.39.4)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.0.0)(vite@6.4.2(@types/node@25.0.3)))(typescript@6.0.3):
+  eslint-plugin-storybook@10.3.5(eslint@9.39.4)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.0.0)(vite@6.4.3(@types/node@25.0.3)))(typescript@6.0.3):
     dependencies:
       '@typescript-eslint/utils': 8.62.0(eslint@9.39.4)(typescript@6.0.3)
       eslint: 9.39.4
-      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.0.0)(vite@6.4.2(@types/node@25.0.3))
+      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.0.0)(vite@6.4.3(@types/node@25.0.3))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -6644,13 +6644,13 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.0.0)(vite@6.4.2(@types/node@25.0.3)):
+  storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.0.0)(vite@6.4.3(@types/node@25.0.3)):
     dependencies:
       '@storybook/global': 5.0.0
       '@testing-library/jest-dom': 6.9.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.2(@types/node@25.0.3))
+      '@vitest/mocker': 3.2.4(vite@6.4.3(@types/node@25.0.3))
       '@vitest/spy': 3.2.4
       better-opn: 3.0.2
       esbuild: 0.25.12
@@ -6969,15 +6969,15 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.3.0
 
-  vite-plugin-eslint@1.8.1(eslint@9.39.4)(vite@6.4.2(@types/node@25.0.3)):
+  vite-plugin-eslint@1.8.1(eslint@9.39.4)(vite@6.4.3(@types/node@25.0.3)):
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@types/eslint': 8.56.12
       eslint: 9.39.4
       rollup: 2.80.0
-      vite: 6.4.2(@types/node@25.0.3)
+      vite: 6.4.3(@types/node@25.0.3)
 
-  vite@6.4.2(@types/node@25.0.3):
+  vite@6.4.3(@types/node@25.0.3):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)


### PR DESCRIPTION
As discovered here: https://github.com/mxcube/mxcubeweb/pull/2145#issuecomment-4925980170  
This downgrade seems to be an overlook at some earlier PR.  